### PR TITLE
Make staticcheck happy

### DIFF
--- a/internal/common/metrics/service_wrapper.go
+++ b/internal/common/metrics/service_wrapper.go
@@ -116,7 +116,7 @@ func (w *workflowServiceMetricsWrapper) getOperationScope(scopeName string) *ope
 }
 
 func (s *operationScope) handleError(err error) {
-	s.scope.Timer(CadenceLatency).Record(time.Now().Sub(s.startTime))
+	s.scope.Timer(CadenceLatency).Record(time.Since(s.startTime))
 	if err != nil {
 		errCode := protobufutils.GetCode(err)
 		if errCode == codes.NotFound || errCode == codes.InvalidArgument || errCode == codes.AlreadyExists {

--- a/internal/internal_activity.go
+++ b/internal/internal_activity.go
@@ -409,8 +409,7 @@ func setActivityParametersIfNotExist(ctx Context) Context {
 	if params != nil {
 		newParams = *params
 		if params.RetryPolicy != nil {
-			var newRetryPolicy commonproto.RetryPolicy
-			newRetryPolicy = *newParams.RetryPolicy
+			newRetryPolicy := *newParams.RetryPolicy
 			newParams.RetryPolicy = &newRetryPolicy
 		}
 	}

--- a/internal/internal_decision_state_machine_test.go
+++ b/internal/internal_decision_state_machine_test.go
@@ -339,7 +339,7 @@ func Test_ChildWorkflowStateMachine_CancelSucceed(t *testing.T) {
 	// start child workflow
 	d := h.startChildWorkflowExecution(attributes)
 	// send decision
-	decisions := h.getDecisions(true)
+	_ = h.getDecisions(true)
 	// child workflow initiated
 	h.handleStartChildWorkflowExecutionInitiated(workflowID)
 	// child workflow started
@@ -350,7 +350,7 @@ func Test_ChildWorkflowStateMachine_CancelSucceed(t *testing.T) {
 	require.Equal(t, decisionStateCanceledAfterStarted, d.getState())
 
 	// send cancel request
-	decisions = h.getDecisions(true)
+	decisions := h.getDecisions(true)
 	require.Equal(t, decisionStateCancellationDecisionSent, d.getState())
 	require.Equal(t, 1, len(decisions))
 	require.Equal(t, enums.DecisionTypeRequestCancelExternalWorkflowExecution, decisions[0].GetDecisionType())

--- a/internal/internal_event_handlers.go
+++ b/internal/internal_event_handlers.go
@@ -1114,7 +1114,7 @@ func (weh *workflowExecutionEventHandlerImpl) ProcessLocalActivityResult(lar *lo
 	lamd := localActivityMarkerData{
 		ActivityID:   lar.task.activityID,
 		ActivityType: lar.task.params.ActivityType,
-		ReplayTime:   weh.currentReplayTime.Add(time.Now().Sub(weh.currentLocalTime)),
+		ReplayTime:   weh.currentReplayTime.Add(time.Since(weh.currentLocalTime)),
 		Attempt:      lar.task.attempt,
 	}
 	if lar.err != nil {

--- a/internal/internal_task_handlers_interfaces_test.go
+++ b/internal/internal_task_handlers_interfaces_test.go
@@ -130,12 +130,12 @@ func (s *PollLayerInterfacesTestSuite) TestProcessActivityTaskInterface() {
 	taskHandler := newSampleActivityTaskHandler()
 	request, err := taskHandler.Execute(tasklist, response)
 	s.NoError(err)
-	switch request.(type) {
+	switch request := request.(type) {
 	case *workflowservice.RespondActivityTaskCompletedRequest:
-		_, err = s.service.RespondActivityTaskCompleted(ctx, request.(*workflowservice.RespondActivityTaskCompletedRequest))
+		_, err = s.service.RespondActivityTaskCompleted(ctx, request)
 		s.NoError(err)
 	case *workflowservice.RespondActivityTaskFailedRequest: // shouldn't happen
-		_, err = s.service.RespondActivityTaskFailed(ctx, request.(*workflowservice.RespondActivityTaskFailedRequest))
+		_, err = s.service.RespondActivityTaskFailed(ctx, request)
 		s.NoError(err)
 	}
 }

--- a/internal/internal_utils_test.go
+++ b/internal/internal_utils_test.go
@@ -147,6 +147,7 @@ func TestConstructError_TimeoutError(t *testing.T) {
 	// Backward compatibility test
 	reason = errReasonTimeout
 	details, err = dc.ToData(enums.TimeoutTypeHeartbeat)
+	require.NoError(t, err)
 	constructedErr = constructError(reason, details, dc)
 	timeoutErr, ok = constructedErr.(*TimeoutError)
 	require.True(t, ok)

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -1231,7 +1231,7 @@ func newAggregatedWorker(
 	var workflowWorker *workflowWorker
 	if !wOptions.DisableWorkflowWorker {
 		testTags := getTestTags(wOptions.BackgroundActivityContext)
-		if testTags != nil && len(testTags) > 0 {
+		if len(testTags) > 0 {
 			workflowWorker = newWorkflowWorkerWithPressurePoints(
 				service,
 				domain,

--- a/internal/internal_worker_base.go
+++ b/internal/internal_worker_base.go
@@ -336,5 +336,4 @@ func (bw *baseWorker) Stop() {
 	if bw.options.userContextCancel != nil {
 		bw.options.userContextCancel()
 	}
-	return
 }

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -169,6 +169,9 @@ func testReplayWorkflowFromFileParent(ctx Context) error {
 	cwf := ExecuteChildWorkflow(ctx, testReplayWorkflowFromFile)
 	f1 := cwf.SignalChildWorkflow(ctx, "test-signal", "test-data")
 	err := f1.Get(ctx, nil)
+	if err != nil {
+		return err
+	}
 	err = cwf.Get(ctx, &result)
 	if err != nil {
 		return err

--- a/internal/internal_workflow.go
+++ b/internal/internal_workflow.go
@@ -362,7 +362,6 @@ func (f *futureImpl) Chain(future Future) {
 	f.value = val
 	f.err = err
 	f.ready = true
-	return
 }
 
 func (f *futureImpl) ChainFuture(future Future) {
@@ -764,7 +763,7 @@ func getStackTrace(coroutineName, status string, stackDepth int) string {
 
 func getStackTraceRaw(top string, omitTop, omitBottom int) string {
 	stack := stackBuf[:runtime.Stack(stackBuf[:], false)]
-	rawStack := fmt.Sprintf("%s", strings.TrimRightFunc(string(stack), unicode.IsSpace))
+	rawStack := strings.TrimRightFunc(string(stack), unicode.IsSpace)
 	if disableCleanStackTraces {
 		return rawStack
 	}

--- a/internal/internal_workflow_client_test.go
+++ b/internal/internal_workflow_client_test.go
@@ -1059,7 +1059,7 @@ func (s *workflowClientTestSuite) TestListWorkflow() {
 		Do(func(_ interface{}, req *workflowservice.ListWorkflowExecutionsRequest, _ ...interface{}) {
 			s.Equal("another", request.GetDomain())
 		})
-	resp, err = s.client.ListWorkflow(context.Background(), request)
+	_, err = s.client.ListWorkflow(context.Background(), request)
 	s.Equal(responseErr, err)
 }
 
@@ -1082,7 +1082,7 @@ func (s *workflowClientTestSuite) TestListArchivedWorkflow() {
 		Do(func(_ interface{}, req *workflowservice.ListArchivedWorkflowExecutionsRequest, _ ...interface{}) {
 			s.Equal("another", request.GetDomain())
 		})
-	resp, err = s.client.ListArchivedWorkflow(ctxWithTimeout, request)
+	_, err = s.client.ListArchivedWorkflow(ctxWithTimeout, request)
 	s.Equal(responseErr, err)
 }
 
@@ -1103,7 +1103,7 @@ func (s *workflowClientTestSuite) TestScanWorkflow() {
 		Do(func(_ interface{}, req *workflowservice.ScanWorkflowExecutionsRequest, _ ...interface{}) {
 			s.Equal("another", request.GetDomain())
 		})
-	resp, err = s.client.ScanWorkflow(context.Background(), request)
+	_, err = s.client.ScanWorkflow(context.Background(), request)
 	s.Equal(responseErr, err)
 }
 
@@ -1124,7 +1124,7 @@ func (s *workflowClientTestSuite) TestCountWorkflow() {
 		Do(func(_ interface{}, req *workflowservice.CountWorkflowExecutionsRequest, _ ...interface{}) {
 			s.Equal("another", request.GetDomain())
 		})
-	resp, err = s.client.CountWorkflow(context.Background(), request)
+	_, err = s.client.CountWorkflow(context.Background(), request)
 	s.Equal(responseErr, err)
 }
 
@@ -1137,6 +1137,6 @@ func (s *workflowClientTestSuite) TestGetSearchAttributes() {
 
 	responseErr := protobufutils.NewError(codes.InvalidArgument)
 	s.service.EXPECT().GetSearchAttributes(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, responseErr)
-	resp, err = s.client.GetSearchAttributes(context.Background())
+	_, err = s.client.GetSearchAttributes(context.Background())
 	s.Equal(responseErr, err)
 }

--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -128,7 +128,6 @@ type (
 		ctxProps     []ContextPropagator
 		mockClock    *clock.Mock
 		wallClock    clock.Clock
-		startTime    time.Time
 
 		callbackChannel chan testCallbackHandle
 		testTimeout     time.Duration
@@ -1677,7 +1676,7 @@ func (env *testWorkflowEnvironmentImpl) RequestCancelExternalWorkflow(domainName
 		var err error
 		if mockFn := m.getMockFn(mockRet); mockFn != nil {
 			executor := &activityExecutor{name: mockMethodForRequestCancelExternalWorkflow, fn: mockFn}
-			_, err = executor.ExecuteWithActualArgs(nil, args)
+			_, err = executor.ExecuteWithActualArgs(context.TODO(), args)
 		} else {
 			_, err = m.getMockValue(mockRet)
 		}
@@ -1729,7 +1728,7 @@ func (env *testWorkflowEnvironmentImpl) SignalExternalWorkflow(domainName, workf
 		var err error
 		if mockFn := m.getMockFn(mockRet); mockFn != nil {
 			executor := &activityExecutor{name: mockMethodForSignalExternalWorkflow, fn: mockFn}
-			_, err = executor.ExecuteWithActualArgs(nil, args)
+			_, err = executor.ExecuteWithActualArgs(context.TODO(), args)
 		} else {
 			_, err = m.getMockValue(mockRet)
 		}
@@ -1801,7 +1800,7 @@ func (env *testWorkflowEnvironmentImpl) getMockedVersion(mockedChangeID, changeI
 	m := &mockWrapper{name: mockMethodForGetVersion, fn: mockFnGetVersion}
 	if mockFn := m.getMockFn(mockRet); mockFn != nil {
 		executor := &activityExecutor{name: mockMethodForGetVersion, fn: mockFn}
-		reflectValues := executor.executeWithActualArgsWithoutParseResult(nil, args)
+		reflectValues := executor.executeWithActualArgsWithoutParseResult(context.TODO(), args)
 		if len(reflectValues) != 1 || !reflect.TypeOf(reflectValues[0].Interface()).AssignableTo(reflect.TypeOf(DefaultVersion)) {
 			panic(fmt.Sprintf("mock of GetVersion has incorrect return type, expected workflow.Version, but actual is %T (%v)",
 				reflectValues[0].Interface(), reflectValues[0].Interface()))

--- a/internal/internal_workflow_testsuite_test.go
+++ b/internal/internal_workflow_testsuite_test.go
@@ -1157,6 +1157,9 @@ func (s *WorkflowTestSuiteUnitTest) Test_GetVersion() {
 			f = ExecuteActivity(ctx, newActivity, "new_msg")
 		}
 		err := f.Get(ctx, nil) // wait for result
+		if err != nil {
+			return err
+		}
 
 		// test searchable change version
 		wfInfo := GetWorkflowInfo(ctx)
@@ -1202,6 +1205,9 @@ func (s *WorkflowTestSuiteUnitTest) Test_MockGetVersion() {
 		}
 		var ret1 string
 		err := f.Get(ctx, &ret1) // wait for result
+		if err != nil {
+			return "", err
+		}
 
 		v2 := GetVersion(ctx, "change_2", DefaultVersion, 2)
 		if v2 == DefaultVersion {
@@ -1211,6 +1217,9 @@ func (s *WorkflowTestSuiteUnitTest) Test_MockGetVersion() {
 		}
 		var ret2 string
 		err = f.Get(ctx, &ret2) // wait for result
+		if err != nil {
+			return "", err
+		}
 
 		// test searchable change version
 		wfInfo := GetWorkflowInfo(ctx)
@@ -1627,6 +1636,7 @@ func (s *WorkflowTestSuiteUnitTest) Test_LocalActivity() {
 	s.Equal("hello local_activity", laResult)
 }
 
+// This is flaky test. Rerun if failed.
 func (s *WorkflowTestSuiteUnitTest) Test_WorkflowLocalActivityWithMockAndListeners() {
 	localActivityFn := func(ctx context.Context, name string) (string, error) {
 		return "hello " + name, nil

--- a/internal/json_encoding.go
+++ b/internal/json_encoding.go
@@ -28,12 +28,6 @@ import (
 	"reflect"
 )
 
-// encoding is capable of encoding and decoding objects
-type encoding interface {
-	Marshal([]interface{}) ([]byte, error)
-	Unmarshal([]byte, []interface{}) error
-}
-
 // jsonEncoding encapsulates json encoding and decoding
 type jsonEncoding struct {
 }

--- a/internal/tracer_test.go
+++ b/internal/tracer_test.go
@@ -68,7 +68,7 @@ func TestTracingContextPropagatorNoSpan(t *testing.T) {
 	assert.NoError(t, err)
 
 	returnCtx := context.Background()
-	returnCtx, err = ctxProp.Extract(returnCtx, NewHeaderReader(header))
+	_, err = ctxProp.Extract(returnCtx, NewHeaderReader(header))
 	assert.NoError(t, err)
 }
 
@@ -108,6 +108,6 @@ func TestTracingContextPropagatorWorkflowContextNoSpan(t *testing.T) {
 	assert.NoError(t, err)
 
 	returnCtx := Background()
-	returnCtx, err = ctxProp.ExtractToWorkflow(returnCtx, NewHeaderReader(header))
+	_, err = ctxProp.ExtractToWorkflow(returnCtx, NewHeaderReader(header))
 	assert.NoError(t, err)
 }

--- a/internal/worker.go
+++ b/internal/worker.go
@@ -388,7 +388,7 @@ func replayWorkflowHistory(logger *zap.Logger, service workflowservice.WorkflowS
 					if last.GetEventType() == enums.EventTypeWorkflowExecutionContinuedAsNew {
 						inputA := d.GetContinueAsNewWorkflowExecutionDecisionAttributes().Input
 						inputB := last.GetWorkflowExecutionContinuedAsNewEventAttributes().Input
-						if bytes.Compare(inputA, inputB) == 0 {
+						if bytes.Equal(inputA, inputB) {
 							return nil
 						}
 					}
@@ -397,7 +397,7 @@ func replayWorkflowHistory(logger *zap.Logger, service workflowservice.WorkflowS
 					if last.GetEventType() == enums.EventTypeWorkflowExecutionCompleted {
 						resultA := last.GetWorkflowExecutionCompletedEventAttributes().Result
 						resultB := d.GetCompleteWorkflowExecutionDecisionAttributes().Result
-						if bytes.Compare(resultA, resultB) == 0 {
+						if bytes.Equal(resultA, resultB) {
 							return nil
 						}
 					}

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -543,7 +543,6 @@ func scheduleLocalActivity(ctx Context, params *executeLocalActivityParams) Futu
 
 		// set retry error, and it will be handled by workflow.ExecuteLocalActivity().
 		f.Set(nil, &needRetryError{Backoff: lar.backoff, Attempt: lar.attempt})
-		return
 	})
 
 	if cancellable {

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -377,9 +377,9 @@ func (ts *IntegrationTestSuite) TestChildWFWithParentClosePolicyAbandon() {
 }
 
 func (ts *IntegrationTestSuite) TestActivityCancelUsingReplay() {
-	logger, err := zap.NewDevelopment()
+	logger, _ := zap.NewDevelopment()
 	workflow.RegisterWithOptions(ts.workflows.ActivityCancelRepro, workflow.RegisterOptions{DisableAlreadyRegisteredCheck: true})
-	err = worker.ReplayPartialWorkflowHistoryFromJSONFile(logger, "fixtures/activity.cancel.sm.repro.json", 12)
+	err := worker.ReplayPartialWorkflowHistoryFromJSONFile(logger, "fixtures/activity.cancel.sm.repro.json", 12)
 	ts.NoError(err)
 }
 

--- a/test/replaytests/workflows.go
+++ b/test/replaytests/workflows.go
@@ -60,6 +60,11 @@ func Workflow(ctx workflow.Context, name string) error {
 		}
 	} else {
 		err := workflow.ExecuteActivity(ctx, helloworldActivity, name).Get(ctx, &helloworldResult)
+		if err != nil {
+			logger.Error("Activity failed.", zap.Error(err))
+			return err
+		}
+
 		err = workflow.ExecuteActivity(ctx, helloworldActivity, name).Get(ctx, &helloworldResult)
 		if err != nil {
 			logger.Error("Activity failed.", zap.Error(err))


### PR DESCRIPTION
It was:
```
internal/common/metrics/service_wrapper.go:119:39: should use time.Since instead of time.Now().Sub (S1012)
internal/internal_activity.go:412:4: should merge variable declaration with assignment on next line (S1021)
internal/internal_decision_state_machine_test.go:342:2: this value of decisions is never used (SA4006)
internal/internal_event_handlers.go:1117:43: should use time.Since instead of time.Now().Sub (S1012)
internal/internal_task_handlers.go:677:7: this value of history is never used (SA4006)
internal/internal_task_handlers.go:773:22: should use time.Until instead of t.Sub(time.Now()) (S1024)
internal/internal_task_handlers.go:1248:19: should use !bytes.Equal(eventAttributes.Input, decisionAttributes.Input) instead (S1004)
internal/internal_task_handlers.go:1307:7: should use !bytes.Equal(eventAttributes.Result, decisionAttributes.Result) instead (S1004)
internal/internal_task_handlers.go:1323:5: should use !bytes.Equal(eventAttributes.Details, decisionAttributes.Details) instead (S1004)
internal/internal_task_handlers.go:1376:7: should use !bytes.Equal(eventAttributes.Details, decisionAttributes.Details) instead (S1004)
internal/internal_task_handlers.go:1521:14: should use time.Since instead of time.Now().Sub (S1012)
internal/internal_task_handlers_interfaces_test.go:133:9: assigning the result of this type assertion to a variable (switch request := request.(type)) could eliminate the following type assertions:
        /home/shtin/github.com/alexshtin/temporal-go-client/internal/internal_task_handlers_interfaces_test.go:135:56
        /home/shtin/github.com/alexshtin/temporal-go-client/internal/internal_task_handlers_interfaces_test.go:138:53 (S1034)
internal/internal_task_pollers.go:169:2: should use 'return <expr>' instead of 'if <expr> { return <bool> }; return <bool>' (S1008)
internal/internal_task_pollers.go:252:9: assigning the result of this type assertion to a variable (switch task := task.(type)) could eliminate the following type assertions:
        /home/shtin/github.com/alexshtin/temporal-go-client/internal/internal_task_pollers.go:254:34
        /home/shtin/github.com/alexshtin/temporal-go-client/internal/internal_task_pollers.go:256:41 (S1034)
internal/internal_task_pollers.go:349:66: should use time.Since instead of time.Now().Sub (S1012)
internal/internal_task_pollers.go:356:65: should use time.Since instead of time.Now().Sub (S1012)
internal/internal_task_pollers.go:527:23: should use time.Since instead of time.Now().Sub (S1012)
internal/internal_task_pollers.go:672:61: should use time.Since instead of time.Now().Sub (S1012)
internal/internal_task_pollers.go:753:64: should use time.Since instead of time.Now().Sub (S1012)
internal/internal_task_pollers.go:816:61: should use time.Since instead of time.Now().Sub (S1012)
internal/internal_task_pollers.go:860:62: should use time.Since instead of time.Now().Sub (S1012)
internal/internal_task_pollers.go:881:61: should use time.Since instead of time.Now().Sub (S1012)
internal/internal_task_pollers.go:882:61: should use time.Since instead of time.Now().Sub (S1012)
internal/internal_utils_test.go:149:11: this value of err is never used (SA4006)
internal/internal_worker.go:1234:6: should omit nil check; len() for nil maps is defined as zero (S1009)
internal/internal_worker_base.go:339:2: redundant return statement (S1023)
internal/internal_worker_test.go:171:2: this value of err is never used (SA4006)
internal/internal_workflow.go:365:2: redundant return statement (S1023)
internal/internal_workflow.go:767:14: the argument is already a string, there's no need to use fmt.Sprintf (S1025)
internal/internal_workflow_client_test.go:1062:2: this value of resp is never used (SA4006)
internal/internal_workflow_client_test.go:1085:2: this value of resp is never used (SA4006)
internal/internal_workflow_client_test.go:1106:2: this value of resp is never used (SA4006)
internal/internal_workflow_client_test.go:1127:2: this value of resp is never used (SA4006)
internal/internal_workflow_client_test.go:1140:2: this value of resp is never used (SA4006)
internal/internal_workflow_testsuite.go:131:3: field startTime is unused (U1000)
internal/internal_workflow_testsuite.go:1680:44: do not pass a nil Context, even if a function permits it; pass context.TODO if you are unsure about which Context to use (SA1012)
internal/internal_workflow_testsuite.go:1732:44: do not pass a nil Context, even if a function permits it; pass context.TODO if you are unsure about which Context to use (SA1012)
internal/internal_workflow_testsuite.go:1804:69: do not pass a nil Context, even if a function permits it; pass context.TODO if you are unsure about which Context to use (SA1012)
internal/internal_workflow_testsuite_test.go:1159:3: this value of err is never used (SA4006)
internal/internal_workflow_testsuite_test.go:1204:3: this value of err is never used (SA4006)
internal/internal_workflow_testsuite_test.go:1213:3: this value of err is never used (SA4006)
internal/json_encoding.go:32:6: type encoding is unused (U1000)
internal/tracer_test.go:71:2: this value of returnCtx is never used (SA4006)
internal/tracer_test.go:111:2: this value of returnCtx is never used (SA4006)
internal/worker.go:391:10: should use bytes.Equal(inputA, inputB) instead (S1004)
internal/worker.go:400:10: should use bytes.Equal(resultA, resultB) instead (S1004)
internal/workflow.go:546:3: redundant return statement (S1023)
test/integration_test.go:380:10: this value of err is never used (SA4006)
test/replaytests/workflows.go:62:3: this value of err is never used (SA4006)
```

Now it is empty.