### PR TITLE
Fix custom tracer header propagation

### DIFF
--- a/converter/composite_data_converter.go
+++ b/converter/composite_data_converter.go
@@ -41,7 +41,7 @@ type (
 // NewCompositeDataConverter creates new instance of CompositeDataConverter from ordered list of PayloadConverters.
 // Order is important here because during serialization DataConverter will try PayloadsConverters in
 // that order until PayloadConverter returns non nil payload.
-// Last PayloadConverter should always serialize the value (JSONPayloadConverter is good candidate for it),
+// Last PayloadConverter should always serialize the value (JSONPayloadConverter is good candidate for it).
 func NewCompositeDataConverter(payloadConverters ...PayloadConverter) *CompositeDataConverter {
 	dc := &CompositeDataConverter{
 		payloadConverters: make(map[string]PayloadConverter, len(payloadConverters)),

--- a/converter/default_data_converter.go
+++ b/converter/default_data_converter.go
@@ -28,10 +28,11 @@ var (
 	defaultDataConverter = NewCompositeDataConverter(
 		NewNilPayloadConverter(),
 		NewByteSlicePayloadConverter(),
-		// Only one proto converter should be used.
-		// Although they check for different interfaces (proto.Message and proto.Marshaler) all proto messages implements both interfaces.
+
+		// Only one proto converter (JSON or regular) should be used because they check for the same proto.Message interface.
 		NewProtoJSONPayloadConverter(),
 		// NewProtoPayloadConverter(),
+
 		NewJSONPayloadConverter(),
 	)
 )

--- a/internal/client.go
+++ b/internal/client.go
@@ -658,7 +658,8 @@ func NewValues(data *commonpb.Payloads) converter.EncodedValues {
 	return newEncodedValues(data, nil)
 }
 
-// checkHealth checks service health using gRPC health check: // https://github.com/grpc/grpc/blob/master/doc/health-checking.md
+// checkHealth checks service health using gRPC health check:
+// https://github.com/grpc/grpc/blob/master/doc/health-checking.md
 func checkHealth(connection grpc.ClientConnInterface, options ConnectionOptions) error {
 	if options.DisableHealthCheck {
 		return nil

--- a/internal/error_test.go
+++ b/internal/error_test.go
@@ -500,7 +500,7 @@ func Test_ContinueAsNewError(t *testing.T) {
 
 	s := &WorkflowTestSuite{
 		header:             header,
-		contextPropagators: []ContextPropagator{NewStringMapPropagator([]string{"test"})},
+		contextPropagators: []ContextPropagator{NewKeysPropagator([]string{"test"})},
 	}
 	wfEnv := s.NewTestWorkflowEnvironment()
 	wfEnv.RegisterWorkflowWithOptions(continueAsNewWorkflowFn, RegisterWorkflowOptions{

--- a/internal/headers.go
+++ b/internal/headers.go
@@ -26,6 +26,8 @@ package internal
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	commonpb "go.temporal.io/api/common/v1"
 )
@@ -37,6 +39,7 @@ type HeaderWriter interface {
 
 // HeaderReader is an interface to read information from temporal headers
 type HeaderReader interface {
+	Get(string) (*commonpb.Payload, error)
 	ForEachKey(handler func(string, *commonpb.Payload) error) error
 }
 
@@ -72,6 +75,17 @@ func (hr *headerReader) ForEachKey(handler func(string, *commonpb.Payload) error
 		}
 	}
 	return nil
+}
+
+func (hr *headerReader) Get(key string) (*commonpb.Payload, error) {
+	if hr.header == nil {
+		return nil, errors.New("header is nil")
+	}
+	if value, ok := hr.header.Fields[key]; ok {
+		return value, nil
+	}
+
+	return nil, fmt.Errorf("key %s doesn't exist in header fields", key)
 }
 
 // NewHeaderReader returns a header reader interface

--- a/internal/headers.go
+++ b/internal/headers.go
@@ -85,12 +85,12 @@ func (hr *headerReader) Get(key string) (*commonpb.Payload, error) {
 		return value, nil
 	}
 
-	return nil, fmt.Errorf("key %s doesn't exist in header fields", key)
+	return nil, fmt.Errorf("key %q doesn't exist in header fields", key)
 }
 
 // NewHeaderReader returns a header reader interface
 func NewHeaderReader(header *commonpb.Header) HeaderReader {
-	return &headerReader{header}
+	return &headerReader{header: header}
 }
 
 type headerWriter struct {
@@ -109,5 +109,5 @@ func NewHeaderWriter(header *commonpb.Header) HeaderWriter {
 	if header != nil && header.Fields == nil {
 		header.Fields = make(map[string]*commonpb.Payload)
 	}
-	return &headerWriter{header}
+	return &headerWriter{header: header}
 }

--- a/internal/headers.go
+++ b/internal/headers.go
@@ -26,8 +26,6 @@ package internal
 
 import (
 	"context"
-	"errors"
-	"fmt"
 
 	commonpb "go.temporal.io/api/common/v1"
 )
@@ -39,7 +37,7 @@ type HeaderWriter interface {
 
 // HeaderReader is an interface to read information from temporal headers
 type HeaderReader interface {
-	Get(string) (*commonpb.Payload, error)
+	Get(string) (*commonpb.Payload, bool)
 	ForEachKey(handler func(string, *commonpb.Payload) error) error
 }
 
@@ -77,15 +75,12 @@ func (hr *headerReader) ForEachKey(handler func(string, *commonpb.Payload) error
 	return nil
 }
 
-func (hr *headerReader) Get(key string) (*commonpb.Payload, error) {
+func (hr *headerReader) Get(key string) (*commonpb.Payload, bool) {
 	if hr.header == nil {
-		return nil, errors.New("header is nil")
+		panic("headerReader.header is nil")
 	}
-	if value, ok := hr.header.Fields[key]; ok {
-		return value, nil
-	}
-
-	return nil, fmt.Errorf("key %q doesn't exist in header fields", key)
+	payload, ok := hr.header.Fields[key]
+	return payload, ok
 }
 
 // NewHeaderReader returns a header reader interface

--- a/internal/headers_test.go
+++ b/internal/headers_test.go
@@ -175,7 +175,7 @@ func TestHeaderReader_Get(t *testing.T) {
 				},
 			},
 			"key1",
-			false,
+			true,
 		},
 		{
 			"invalid key",
@@ -186,19 +186,13 @@ func TestHeaderReader_Get(t *testing.T) {
 				},
 			},
 			"key3",
-			true,
-		},
-		{
-			"nil header",
-			nil,
-			"",
-			true,
+			false,
 		},
 		{
 			"nil fields",
 			&commonpb.Header{},
-			"",
-			true,
+			"key1",
+			false,
 		},
 	}
 
@@ -215,4 +209,10 @@ func TestHeaderReader_Get(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("nil panic", func(t *testing.T) {
+		reader := NewHeaderReader(nil)
+		assert.Panics(t, func() { reader.Get("") })
+	})
+
 }

--- a/internal/headers_test.go
+++ b/internal/headers_test.go
@@ -161,10 +161,10 @@ func TestHeaderReader_ForEachKey(t *testing.T) {
 func TestHeaderReader_Get(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name    string
-		header  *commonpb.Header
-		key     string
-		isError bool
+		name         string
+		header       *commonpb.Header
+		key          string
+		headerExists bool
 	}{
 		{
 			"valid key",
@@ -207,11 +207,11 @@ func TestHeaderReader_Get(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			reader := NewHeaderReader(test.header)
-			_, err := reader.Get(test.key)
-			if test.isError {
-				assert.Error(t, err)
+			_, headerExist := reader.Get(test.key)
+			if test.headerExists {
+				assert.True(t, headerExist)
 			} else {
-				assert.NoError(t, err)
+				assert.False(t, headerExist)
 			}
 		})
 	}

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -1801,7 +1801,7 @@ func (ath *activityTaskHandlerImpl) Execute(taskQueue string, t *workflowservice
 	for _, ctxProp := range ath.contextPropagators {
 		var err error
 		if ctx, err = ctxProp.Extract(ctx, NewHeaderReader(t.Header)); err != nil {
-			return nil, fmt.Errorf("unable to propagate context %v", err)
+			return nil, fmt.Errorf("unable to propagate context: %w", err)
 		}
 	}
 

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -496,7 +496,7 @@ func (lath *localActivityTaskHandler) executeLocalActivityTask(task *localActivi
 			result = &localActivityResult{
 				task:   task,
 				result: nil,
-				err:    fmt.Errorf("unable to propagate context %v", err),
+				err:    fmt.Errorf("unable to propagate context: %w", err),
 			}
 			return result
 		}

--- a/internal/internal_workflow.go
+++ b/internal/internal_workflow.go
@@ -1192,6 +1192,7 @@ func setWorkflowEnvOptionsIfNotExist(ctx Context) Context {
 	if newOptions.DataConverter == nil {
 		newOptions.DataConverter = converter.GetDefaultDataConverter()
 	}
+
 	return WithValue(ctx, workflowEnvOptionsContextKey, &newOptions)
 }
 

--- a/internal/internal_workflow.go
+++ b/internal/internal_workflow.go
@@ -497,7 +497,7 @@ func (d *syncWorkflowDefinition) Execute(env WorkflowEnvironment, header *common
 	for _, ctxProp := range env.GetContextPropagators() {
 		var err error
 		if rootCtx, err = ctxProp.ExtractToWorkflow(rootCtx, NewHeaderReader(header)); err != nil {
-			panic(fmt.Sprintf("Unable to propagate context %v", err))
+			panic(fmt.Sprintf("Unable to propagate context: %v", err))
 		}
 	}
 

--- a/internal/internal_workflow_client_test.go
+++ b/internal/internal_workflow_client_test.go
@@ -119,36 +119,34 @@ func (s *stringMapPropagator) InjectFromWorkflow(ctx Context, writer HeaderWrite
 
 // Extract extracts values from headers and puts them into context
 func (s *stringMapPropagator) Extract(ctx context.Context, reader HeaderReader) (context.Context, error) {
-	if err := reader.ForEachKey(func(key string, value *commonpb.Payload) error {
-		if _, ok := s.keys[key]; ok {
-			var decodedValue string
-			err := converter.GetDefaultDataConverter().FromPayload(value, &decodedValue)
-			if err != nil {
-				return err
-			}
-			ctx = context.WithValue(ctx, contextKey(key), decodedValue)
+	for key, _ := range s.keys {
+		value, err := reader.Get(key)
+		if err != nil {
+			return ctx, err
 		}
-		return nil
-	}); err != nil {
-		return nil, err
+		var decodedValue string
+		err = converter.GetDefaultDataConverter().FromPayload(value, &decodedValue)
+		if err != nil {
+			return ctx, err
+		}
+		ctx = context.WithValue(ctx, contextKey(key), decodedValue)
 	}
 	return ctx, nil
 }
 
 // ExtractToWorkflow extracts values from headers and puts them into context
 func (s *stringMapPropagator) ExtractToWorkflow(ctx Context, reader HeaderReader) (Context, error) {
-	if err := reader.ForEachKey(func(key string, value *commonpb.Payload) error {
-		if _, ok := s.keys[key]; ok {
-			var decodedValue string
-			err := converter.GetDefaultDataConverter().FromPayload(value, &decodedValue)
-			if err != nil {
-				return err
-			}
-			ctx = WithValue(ctx, contextKey(key), decodedValue)
+	for key, _ := range s.keys {
+		value, err := reader.Get(key)
+		if err != nil {
+			return ctx, err
 		}
-		return nil
-	}); err != nil {
-		return nil, err
+		var decodedValue string
+		err = converter.GetDefaultDataConverter().FromPayload(value, &decodedValue)
+		if err != nil {
+			return ctx, err
+		}
+		ctx = WithValue(ctx, contextKey(key), decodedValue)
 	}
 	return ctx, nil
 }

--- a/internal/internal_workflow_client_test.go
+++ b/internal/internal_workflow_client_test.go
@@ -55,6 +55,7 @@ const (
 	timeoutInSeconds      = 20
 	workflowIDReusePolicy = enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY
 	testHeader            = "test-header"
+	testHeader2           = "test-header2"
 )
 
 // historyEventIteratorSuite
@@ -1015,7 +1016,7 @@ func (s *workflowClientTestSuite) TestStartWorkflow() {
 		WorkflowTaskTimeout:      timeoutInSeconds,
 	}
 	f1 := func(ctx Context, r []byte) string {
-		return "result"
+		panic("this is just a stub")
 	}
 
 	createResponse := &workflowservice.StartWorkflowExecutionResponse{
@@ -1025,37 +1026,6 @@ func (s *workflowClientTestSuite) TestStartWorkflow() {
 
 	resp, err := client.StartWorkflow(context.Background(), options, f1, []byte("test"))
 	s.Equal(converter.GetDefaultDataConverter(), client.dataConverter)
-	s.Nil(err)
-	s.Equal(createResponse.GetRunId(), resp.RunID)
-}
-
-func (s *workflowClientTestSuite) TestStartWorkflow_WithContext() {
-	s.client = NewServiceClient(s.service, nil, ClientOptions{
-		ContextPropagators: []ContextPropagator{NewStringMapPropagator([]string{testHeader})},
-	})
-	client, ok := s.client.(*WorkflowClient)
-	s.True(ok)
-	options := StartWorkflowOptions{
-		ID:                       workflowID,
-		TaskQueue:                taskqueue,
-		WorkflowExecutionTimeout: timeoutInSeconds,
-		WorkflowTaskTimeout:      timeoutInSeconds,
-	}
-	f1 := func(ctx Context, r []byte) error {
-		value := ctx.Value(contextKey(testHeader))
-		if val, ok := value.([]byte); ok {
-			s.Equal("test-data", string(val))
-			return nil
-		}
-		return fmt.Errorf("context did not propagate to workflow")
-	}
-
-	createResponse := &workflowservice.StartWorkflowExecutionResponse{
-		RunId: runID,
-	}
-	s.service.EXPECT().StartWorkflowExecution(gomock.Any(), gomock.Any(), gomock.Any()).Return(createResponse, nil)
-
-	resp, err := client.StartWorkflow(context.Background(), options, f1, []byte("test"))
 	s.Nil(err)
 	s.Equal(createResponse.GetRunId(), resp.RunID)
 }
@@ -1072,7 +1042,7 @@ func (s *workflowClientTestSuite) TestStartWorkflowWithDataConverter() {
 		WorkflowTaskTimeout:      timeoutInSeconds,
 	}
 	f1 := func(ctx Context, r []byte) string {
-		return "result"
+		panic("this is just a stub")
 	}
 	input := []byte("test")
 
@@ -1111,7 +1081,7 @@ func (s *workflowClientTestSuite) TestStartWorkflow_WithMemoAndSearchAttr() {
 		SearchAttributes:         searchAttributes,
 	}
 	wf := func(ctx Context) string {
-		return "result"
+		panic("this is just a stub")
 	}
 	startResp := &workflowservice.StartWorkflowExecutionResponse{}
 
@@ -1145,7 +1115,7 @@ func (s *workflowClientTestSuite) SignalWithStartWorkflowWithMemoAndSearchAttr()
 		SearchAttributes:         searchAttributes,
 	}
 	wf := func(ctx Context) string {
-		return "result"
+		panic("this is just a stub")
 	}
 	startResp := &workflowservice.StartWorkflowExecutionResponse{}
 

--- a/internal/internal_workflow_client_test.go
+++ b/internal/internal_workflow_client_test.go
@@ -55,7 +55,6 @@ const (
 	timeoutInSeconds      = 20
 	workflowIDReusePolicy = enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY
 	testHeader            = "test-header"
-	testHeader2           = "test-header2"
 )
 
 // historyEventIteratorSuite

--- a/internal/internal_workflow_client_test.go
+++ b/internal/internal_workflow_client_test.go
@@ -72,22 +72,18 @@ type (
 // stringMapPropagator propagates the list of keys across a workflow,
 // interpreting the payloads as strings.
 type stringMapPropagator struct {
-	keys map[string]struct{}
+	keys []string
 }
 
 // NewStringMapPropagator returns a context propagator that propagates a set of
 // string key-value pairs across a workflow
 func NewStringMapPropagator(keys []string) ContextPropagator {
-	keyMap := make(map[string]struct{}, len(keys))
-	for _, key := range keys {
-		keyMap[key] = struct{}{}
-	}
-	return &stringMapPropagator{keyMap}
+	return &stringMapPropagator{keys}
 }
 
 // Inject injects values from context into headers for propagation
 func (s *stringMapPropagator) Inject(ctx context.Context, writer HeaderWriter) error {
-	for key := range s.keys {
+	for _, key := range s.keys {
 		value, ok := ctx.Value(contextKey(key)).(string)
 		if !ok {
 			return fmt.Errorf("unable to extract key from context %v", key)
@@ -103,7 +99,7 @@ func (s *stringMapPropagator) Inject(ctx context.Context, writer HeaderWriter) e
 
 // InjectFromWorkflow injects values from context into headers for propagation
 func (s *stringMapPropagator) InjectFromWorkflow(ctx Context, writer HeaderWriter) error {
-	for key := range s.keys {
+	for _, key := range s.keys {
 		value, ok := ctx.Value(contextKey(key)).(string)
 		if !ok {
 			return fmt.Errorf("unable to extract key from context %v", key)
@@ -119,7 +115,7 @@ func (s *stringMapPropagator) InjectFromWorkflow(ctx Context, writer HeaderWrite
 
 // Extract extracts values from headers and puts them into context
 func (s *stringMapPropagator) Extract(ctx context.Context, reader HeaderReader) (context.Context, error) {
-	for key, _ := range s.keys {
+	for _, key := range s.keys {
 		value, err := reader.Get(key)
 		if err != nil {
 			return ctx, err
@@ -136,7 +132,7 @@ func (s *stringMapPropagator) Extract(ctx context.Context, reader HeaderReader) 
 
 // ExtractToWorkflow extracts values from headers and puts them into context
 func (s *stringMapPropagator) ExtractToWorkflow(ctx Context, reader HeaderReader) (Context, error) {
-	for key, _ := range s.keys {
+	for _, key := range s.keys {
 		value, err := reader.Get(key)
 		if err != nil {
 			return ctx, err

--- a/internal/internal_workflow_client_test.go
+++ b/internal/internal_workflow_client_test.go
@@ -115,12 +115,13 @@ func (s *stringMapPropagator) InjectFromWorkflow(ctx Context, writer HeaderWrite
 // Extract extracts values from headers and puts them into context
 func (s *stringMapPropagator) Extract(ctx context.Context, reader HeaderReader) (context.Context, error) {
 	for _, key := range s.keys {
-		value, err := reader.Get(key)
-		if err != nil {
-			return ctx, err
+		value, ok := reader.Get(key)
+		if !ok {
+			// If key that should be propagated doesn't exist in the header, ignore the key.
+			continue
 		}
 		var decodedValue string
-		err = converter.GetDefaultDataConverter().FromPayload(value, &decodedValue)
+		err := converter.GetDefaultDataConverter().FromPayload(value, &decodedValue)
 		if err != nil {
 			return ctx, err
 		}
@@ -132,12 +133,13 @@ func (s *stringMapPropagator) Extract(ctx context.Context, reader HeaderReader) 
 // ExtractToWorkflow extracts values from headers and puts them into context
 func (s *stringMapPropagator) ExtractToWorkflow(ctx Context, reader HeaderReader) (Context, error) {
 	for _, key := range s.keys {
-		value, err := reader.Get(key)
-		if err != nil {
-			return ctx, err
+		value, ok := reader.Get(key)
+		if !ok {
+			// If key that should be propagated doesn't exist in the header, ignore the key.
+			continue
 		}
 		var decodedValue string
-		err = converter.GetDefaultDataConverter().FromPayload(value, &decodedValue)
+		err := converter.GetDefaultDataConverter().FromPayload(value, &decodedValue)
 		if err != nil {
 			return ctx, err
 		}

--- a/internal/internal_workflow_client_test.go
+++ b/internal/internal_workflow_client_test.go
@@ -68,20 +68,20 @@ type (
 	}
 )
 
-// stringMapPropagator propagates the list of keys across a workflow,
+// keysPropagator propagates the list of keys across a workflow,
 // interpreting the payloads as strings.
-type stringMapPropagator struct {
+type keysPropagator struct {
 	keys []string
 }
 
-// NewStringMapPropagator returns a context propagator that propagates a set of
+// NewKeysPropagator returns a context propagator that propagates a set of
 // string key-value pairs across a workflow
-func NewStringMapPropagator(keys []string) ContextPropagator {
-	return &stringMapPropagator{keys}
+func NewKeysPropagator(keys []string) ContextPropagator {
+	return &keysPropagator{keys}
 }
 
 // Inject injects values from context into headers for propagation
-func (s *stringMapPropagator) Inject(ctx context.Context, writer HeaderWriter) error {
+func (s *keysPropagator) Inject(ctx context.Context, writer HeaderWriter) error {
 	for _, key := range s.keys {
 		value, ok := ctx.Value(contextKey(key)).(string)
 		if !ok {
@@ -97,7 +97,7 @@ func (s *stringMapPropagator) Inject(ctx context.Context, writer HeaderWriter) e
 }
 
 // InjectFromWorkflow injects values from context into headers for propagation
-func (s *stringMapPropagator) InjectFromWorkflow(ctx Context, writer HeaderWriter) error {
+func (s *keysPropagator) InjectFromWorkflow(ctx Context, writer HeaderWriter) error {
 	for _, key := range s.keys {
 		value, ok := ctx.Value(contextKey(key)).(string)
 		if !ok {
@@ -113,7 +113,7 @@ func (s *stringMapPropagator) InjectFromWorkflow(ctx Context, writer HeaderWrite
 }
 
 // Extract extracts values from headers and puts them into context
-func (s *stringMapPropagator) Extract(ctx context.Context, reader HeaderReader) (context.Context, error) {
+func (s *keysPropagator) Extract(ctx context.Context, reader HeaderReader) (context.Context, error) {
 	for _, key := range s.keys {
 		value, ok := reader.Get(key)
 		if !ok {
@@ -131,7 +131,7 @@ func (s *stringMapPropagator) Extract(ctx context.Context, reader HeaderReader) 
 }
 
 // ExtractToWorkflow extracts values from headers and puts them into context
-func (s *stringMapPropagator) ExtractToWorkflow(ctx Context, reader HeaderReader) (Context, error) {
+func (s *keysPropagator) ExtractToWorkflow(ctx Context, reader HeaderReader) (Context, error) {
 	for _, key := range s.keys {
 		value, ok := reader.Get(key)
 		if !ok {

--- a/internal/internal_workflow_testsuite_test.go
+++ b/internal/internal_workflow_testsuite_test.go
@@ -66,7 +66,7 @@ func (s *WorkflowTestSuiteUnitTest) SetupSuite() {
 	s.header = &commonpb.Header{
 		Fields: map[string]*commonpb.Payload{"test": encodeString(s.T(), "test-data")},
 	}
-	s.contextPropagators = []ContextPropagator{NewStringMapPropagator([]string{"test"})}
+	s.contextPropagators = []ContextPropagator{NewKeysPropagator([]string{"test"})}
 }
 
 func TestUnitTestSuite(t *testing.T) {
@@ -414,7 +414,7 @@ func (s *WorkflowTestSuiteUnitTest) Test_ActivityWithHeaderContext() {
 			testHeader: encodeString(s.T(), "test-data"),
 		},
 	})
-	env.SetContextPropagators([]ContextPropagator{NewStringMapPropagator([]string{testHeader})})
+	env.SetContextPropagators([]ContextPropagator{NewKeysPropagator([]string{testHeader})})
 
 	env.RegisterActivity(activityWithUserContext)
 	blob, err := env.ExecuteActivity(activityWithUserContext)
@@ -1656,7 +1656,7 @@ func (s *WorkflowTestSuiteUnitTest) Test_WorkflowHeaderContext() {
 			testHeader: encodeString(s.T(), "test-data"),
 		},
 	})
-	env.SetContextPropagators([]ContextPropagator{NewStringMapPropagator([]string{testHeader})})
+	env.SetContextPropagators([]ContextPropagator{NewKeysPropagator([]string{testHeader})})
 
 	env.RegisterWorkflow(workflowFn)
 	env.ExecuteWorkflow(testWorkflowContext)
@@ -1699,7 +1699,7 @@ func (s *WorkflowTestSuiteUnitTest) Test_ChildWorkflowContextPropagation() {
 		Fields: map[string]*commonpb.Payload{
 			testHeader: encodeString(s.T(), "test-data")},
 	})
-	env.SetContextPropagators([]ContextPropagator{NewStringMapPropagator([]string{testHeader})})
+	env.SetContextPropagators([]ContextPropagator{NewKeysPropagator([]string{testHeader})})
 
 	env.RegisterWorkflow(workflowFn)
 	env.RegisterWorkflow(childWorkflowFn)

--- a/internal/internal_workflow_testsuite_test.go
+++ b/internal/internal_workflow_testsuite_test.go
@@ -408,15 +408,15 @@ func (s *WorkflowTestSuiteUnitTest) Test_ActivityWithHeaderContext() {
 		return "", errors.New("value not found from ctx")
 	}
 
-	s.SetHeader(&commonpb.Header{
+	env := s.NewTestActivityEnvironment()
+	env.SetHeader(&commonpb.Header{
 		Fields: map[string]*commonpb.Payload{
 			testHeader: encodeString(s.T(), "test-data"),
 		},
 	})
-
-	env := s.NewTestActivityEnvironment()
-	env.RegisterActivity(activityWithUserContext)
 	env.SetContextPropagators([]ContextPropagator{NewStringMapPropagator([]string{testHeader})})
+
+	env.RegisterActivity(activityWithUserContext)
 	blob, err := env.ExecuteActivity(activityWithUserContext)
 	s.NoError(err)
 	var value string
@@ -1650,14 +1650,14 @@ func (s *WorkflowTestSuiteUnitTest) Test_WorkflowHeaderContext() {
 		return nil
 	}
 
-	s.SetContextPropagators([]ContextPropagator{NewStringMapPropagator([]string{testHeader})})
-	s.SetHeader(&commonpb.Header{
+	env := s.NewTestWorkflowEnvironment()
+	env.SetHeader(&commonpb.Header{
 		Fields: map[string]*commonpb.Payload{
 			testHeader: encodeString(s.T(), "test-data"),
 		},
 	})
+	env.SetContextPropagators([]ContextPropagator{NewStringMapPropagator([]string{testHeader})})
 
-	env := s.NewTestWorkflowEnvironment()
 	env.RegisterWorkflow(workflowFn)
 	env.ExecuteWorkflow(testWorkflowContext)
 
@@ -1694,16 +1694,13 @@ func (s *WorkflowTestSuiteUnitTest) Test_ChildWorkflowContextPropagation() {
 		return nil
 	}
 
-	s.SetContextPropagators([]ContextPropagator{NewStringMapPropagator([]string{testHeader})})
-	testPayload, err := converter.GetDefaultDataConverter().ToPayload("test-data")
-	s.NoError(err)
-
-	s.SetHeader(&commonpb.Header{
-		Fields: map[string]*commonpb.Payload{
-			testHeader: testPayload},
-	})
-
 	env := s.NewTestWorkflowEnvironment()
+	env.SetHeader(&commonpb.Header{
+		Fields: map[string]*commonpb.Payload{
+			testHeader: encodeString(s.T(), "test-data")},
+	})
+	env.SetContextPropagators([]ContextPropagator{NewStringMapPropagator([]string{testHeader})})
+
 	env.RegisterWorkflow(workflowFn)
 	env.RegisterWorkflow(childWorkflowFn)
 	env.ExecuteWorkflow(workflowFn)

--- a/internal/tracer.go
+++ b/internal/tracer.go
@@ -29,7 +29,6 @@ import (
 	"errors"
 
 	"github.com/opentracing/opentracing-go"
-	commonpb "go.temporal.io/api/common/v1"
 
 	"go.temporal.io/sdk/converter"
 	"go.temporal.io/sdk/log"
@@ -161,15 +160,13 @@ func (t *tracingContextPropagator) writeSpanContextToHeader(spanContext opentrac
 }
 
 func (t *tracingContextPropagator) readSpanContextFromHeader(hr HeaderReader) (opentracing.SpanContext, error) {
-	var tracerData map[string]string
-	err := hr.ForEachKey(func(key string, tracerPayload *commonpb.Payload) error {
-		if key == tracerHeaderKey {
-			err := converter.GetDefaultDataConverter().FromPayload(tracerPayload, &tracerData)
-			return err
-		}
-		return nil
-	})
+	tracerPayload, err := hr.Get(tracerHeaderKey)
+	if err != nil {
+		return nil, err
+	}
 
+	var tracerData map[string]string
+	err = converter.GetDefaultDataConverter().FromPayload(tracerPayload, &tracerData)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/workflow_testsuite.go
+++ b/internal/workflow_testsuite.go
@@ -216,6 +216,10 @@ func (t *TestActivityEnvironment) SetContextPropagators(contextPropagators []Con
 	return t
 }
 
+func (t *TestActivityEnvironment) SetHeader(header *commonpb.Header) {
+	t.impl.header = header
+}
+
 // SetTestTimeout sets the wall clock timeout for this activity test run. When test timeout happen, it means activity is
 // taking too long.
 func (t *TestActivityEnvironment) SetTestTimeout(idleTimeout time.Duration) *TestActivityEnvironment {
@@ -502,6 +506,16 @@ func (e *TestWorkflowEnvironment) SetStartWorkflowOptions(options StartWorkflowO
 func (e *TestWorkflowEnvironment) SetDataConverter(dataConverter converter.DataConverter) *TestWorkflowEnvironment {
 	e.impl.setDataConverter(dataConverter)
 	return e
+}
+
+// SetContextPropagators sets context propagators.
+func (e *TestWorkflowEnvironment) SetContextPropagators(contextPropagators []ContextPropagator) *TestWorkflowEnvironment {
+	e.impl.setContextPropagators(contextPropagators)
+	return e
+}
+
+func (e *TestWorkflowEnvironment) SetHeader(header *commonpb.Header) {
+	e.impl.header = header
 }
 
 // SetIdentity sets identity.

--- a/internal/workflow_testsuite.go
+++ b/internal/workflow_testsuite.go
@@ -216,6 +216,7 @@ func (t *TestActivityEnvironment) SetContextPropagators(contextPropagators []Con
 	return t
 }
 
+// SetHeader sets header.
 func (t *TestActivityEnvironment) SetHeader(header *commonpb.Header) {
 	t.impl.header = header
 }
@@ -514,6 +515,7 @@ func (e *TestWorkflowEnvironment) SetContextPropagators(contextPropagators []Con
 	return e
 }
 
+// SetHeader sets header.
 func (e *TestWorkflowEnvironment) SetHeader(header *commonpb.Header) {
 	e.impl.header = header
 }

--- a/test/activity_test.go
+++ b/test/activity_test.go
@@ -118,7 +118,7 @@ func (a *Activities) InspectActivityInfo(ctx context.Context, namespace, taskQue
 }
 
 func (a *Activities) DuplicateStringInContext(ctx context.Context) (string, error) {
-	originalString := ctx.Value(contextKey(testContextKey))
+	originalString := ctx.Value(contextKey(testContextKey1))
 	if originalString == nil {
 		return "", fmt.Errorf("context did not propagate to activity")
 	}
@@ -175,6 +175,28 @@ func (a *Activities) GetMemoAndSearchAttr(_ context.Context, memo, searchAttr st
 func (a *Activities) AsyncComplete(ctx context.Context, input string) error {
 	a.append("asyncComplete")
 	return activity.ErrResultPending
+}
+
+func (a *Activities) PropagateActivity(ctx context.Context) ([]string, error) {
+	var result []string
+
+	if val1 := ctx.Value(contextKey(testContextKey1)); val1 != nil {
+		if val1s, ok := val1.(string); ok {
+			result = append(result, "activity_"+val1s)
+		} else {
+			return nil, fmt.Errorf("%s key is not propagated to activity", testContextKey1)
+		}
+	}
+
+	if val2 := ctx.Value(contextKey(testContextKey2)); val2 != nil {
+		if val2s, ok := val2.(string); ok {
+			result = append(result, "activity_"+val2s)
+		} else {
+			return nil, fmt.Errorf("%s key is not propagated to activity", testContextKey2)
+		}
+	}
+
+	return result, nil
 }
 
 func (a *Activities) register(worker worker.Worker) {

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -129,8 +129,8 @@ func (ts *IntegrationTestSuite) SetupTest() {
 		Namespace: namespace,
 		Logger:    ilog.NewDefaultLogger(),
 		ContextPropagators: []workflow.ContextPropagator{
-			NewStringMapPropagator([]string{testContextKey1}),
-			NewStringMapPropagator([]string{testContextKey2}),
+			NewKeysPropagator([]string{testContextKey1}),
+			NewKeysPropagator([]string{testContextKey2}),
 		},
 		MetricsScope: metricsScope,
 	})

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -76,6 +76,7 @@ const (
 	namespaceCacheRefreshInterval = 20 * time.Second
 	testContextKey1               = "test-context-key1"
 	testContextKey2               = "test-context-key2"
+	testContextKey3               = "test-context-key3"
 )
 
 func TestIntegrationSuite(t *testing.T) {
@@ -646,6 +647,7 @@ func (ts *IntegrationTestSuite) TestContextPropagator() {
 	// Propagate values using different context propagators.
 	ctx = context.WithValue(ctx, contextKey(testContextKey1), "propagatedValue1")
 	ctx = context.WithValue(ctx, contextKey(testContextKey2), "propagatedValue2")
+	ctx = context.WithValue(ctx, contextKey(testContextKey3), "non-propagatedValue")
 	err := ts.executeWorkflowWithContextAndOption(ctx, ts.startWorkflowOptions("test-context-propagator"), ts.workflows.ContextPropagator, &propagatedValues, true)
 	ts.NoError(err)
 	// One copy from workflow and one copy from activity * 2 for child workflow

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -34,7 +34,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/opentracing/opentracing-go"
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -133,7 +132,6 @@ func (ts *IntegrationTestSuite) SetupTest() {
 			NewStringMapPropagator([]string{testContextKey2}),
 		},
 		MetricsScope: metricsScope,
-		Tracer:       opentracing.GlobalTracer(),
 	})
 	ts.NoError(err)
 
@@ -656,6 +654,7 @@ func (ts *IntegrationTestSuite) TestContextPropagator() {
 		"child_propagatedValue1", "child_propagatedValue2", "child_activity_propagatedValue1", "child_activity_propagatedValue2",
 	}, propagatedValues)
 }
+
 func (ts *IntegrationTestSuite) registerNamespace() {
 	client, err := client.NewNamespaceClient(client.Options{HostPort: ts.config.ServiceAddr})
 	ts.NoError(err)

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -34,6 +34,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/opentracing/opentracing-go"
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -74,7 +75,8 @@ const (
 	ctxTimeout                    = 15 * time.Second
 	namespace                     = "integration-test-namespace"
 	namespaceCacheRefreshInterval = 20 * time.Second
-	testContextKey                = "test-context-key"
+	testContextKey1               = "test-context-key1"
+	testContextKey2               = "test-context-key2"
 )
 
 func TestIntegrationSuite(t *testing.T) {
@@ -123,11 +125,15 @@ func (ts *IntegrationTestSuite) SetupTest() {
 
 	var err error
 	ts.client, err = client.NewClient(client.Options{
-		HostPort:           ts.config.ServiceAddr,
-		Namespace:          namespace,
-		Logger:             ilog.NewDefaultLogger(),
-		ContextPropagators: []workflow.ContextPropagator{NewStringMapPropagator([]string{testContextKey})},
-		MetricsScope:       metricsScope,
+		HostPort:  ts.config.ServiceAddr,
+		Namespace: namespace,
+		Logger:    ilog.NewDefaultLogger(),
+		ContextPropagators: []workflow.ContextPropagator{
+			NewStringMapPropagator([]string{testContextKey1}),
+			NewStringMapPropagator([]string{testContextKey2}),
+		},
+		MetricsScope: metricsScope,
+		Tracer:       opentracing.GlobalTracer(),
 	})
 	ts.NoError(err)
 
@@ -636,6 +642,20 @@ func (ts *IntegrationTestSuite) TestAsyncActivityCompletion() {
 	ts.EqualValues([]string{"activityA completed", "activityB completed"}, result)
 }
 
+func (ts *IntegrationTestSuite) TestContextPropagator() {
+	var propagatedValues []string
+	ctx := context.Background()
+	// Propagate values using different context propagators.
+	ctx = context.WithValue(ctx, contextKey(testContextKey1), "propagatedValue1")
+	ctx = context.WithValue(ctx, contextKey(testContextKey2), "propagatedValue2")
+	err := ts.executeWorkflowWithContextAndOption(ctx, ts.startWorkflowOptions("test-context-propagator"), ts.workflows.ContextPropagator, &propagatedValues, true)
+	ts.NoError(err)
+	// One copy from workflow and one copy from activity * 2 for child workflow
+	ts.EqualValues([]string{
+		"propagatedValue1", "propagatedValue2", "activity_propagatedValue1", "activity_propagatedValue2",
+		"child_propagatedValue1", "child_propagatedValue2", "child_activity_propagatedValue1", "child_activity_propagatedValue2",
+	}, propagatedValues)
+}
 func (ts *IntegrationTestSuite) registerNamespace() {
 	client, err := client.NewNamespaceClient(client.Options{HostPort: ts.config.ServiceAddr})
 	ts.NoError(err)
@@ -671,13 +691,16 @@ func (ts *IntegrationTestSuite) registerNamespace() {
 // executeWorkflow executes a given workflow and waits for the result
 func (ts *IntegrationTestSuite) executeWorkflow(
 	wfID string, wfFunc interface{}, retValPtr interface{}, args ...interface{}) error {
-	options := ts.startWorkflowOptions(wfID)
-	return ts.executeWorkflowWithOption(options, wfFunc, retValPtr, args...)
+	return ts.executeWorkflowWithOption(ts.startWorkflowOptions(wfID), wfFunc, retValPtr, args...)
 }
-
 func (ts *IntegrationTestSuite) executeWorkflowWithOption(
 	options client.StartWorkflowOptions, wfFunc interface{}, retValPtr interface{}, args ...interface{}) error {
-	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
+	return ts.executeWorkflowWithContextAndOption(context.Background(), options, wfFunc, retValPtr, args...)
+}
+
+func (ts *IntegrationTestSuite) executeWorkflowWithContextAndOption(
+	ctx context.Context, options client.StartWorkflowOptions, wfFunc interface{}, retValPtr interface{}, args ...interface{}) error {
+	ctx, cancel := context.WithTimeout(ctx, ctxTimeout)
 	defer cancel()
 	run, err := ts.client.ExecuteWorkflow(ctx, options, wfFunc, args...)
 	if err != nil {

--- a/test/test_utils_test.go
+++ b/test/test_utils_test.go
@@ -104,22 +104,18 @@ func WaitForTCP(timeout time.Duration, addr string) error {
 // TODO: BORROWED FROM 'internal' PACKAGE TESTS.
 // TODO: remove code duplication.
 type stringMapPropagator struct {
-	keys map[string]struct{}
+	keys []string
 }
 
 // NewStringMapPropagator returns a context propagator that propagates a set of
 // string key-value pairs across a workflow
 func NewStringMapPropagator(keys []string) workflow.ContextPropagator {
-	keyMap := make(map[string]struct{}, len(keys))
-	for _, key := range keys {
-		keyMap[key] = struct{}{}
-	}
-	return &stringMapPropagator{keyMap}
+	return &stringMapPropagator{keys}
 }
 
 // Inject injects values from context into headers for propagation
 func (s *stringMapPropagator) Inject(ctx context.Context, writer workflow.HeaderWriter) error {
-	for key := range s.keys {
+	for _, key := range s.keys {
 		value, ok := ctx.Value(contextKey(key)).(string)
 		if !ok {
 			return fmt.Errorf("unable to extract key from context %v", key)
@@ -135,7 +131,7 @@ func (s *stringMapPropagator) Inject(ctx context.Context, writer workflow.Header
 
 // InjectFromWorkflow injects values from context into headers for propagation
 func (s *stringMapPropagator) InjectFromWorkflow(ctx workflow.Context, writer workflow.HeaderWriter) error {
-	for key := range s.keys {
+	for _, key := range s.keys {
 		value, ok := ctx.Value(contextKey(key)).(string)
 		if !ok {
 			return fmt.Errorf("unable to extract key from context %v", key)
@@ -151,7 +147,7 @@ func (s *stringMapPropagator) InjectFromWorkflow(ctx workflow.Context, writer wo
 
 // Extract extracts values from headers and puts them into context
 func (s *stringMapPropagator) Extract(ctx context.Context, reader workflow.HeaderReader) (context.Context, error) {
-	for key, _ := range s.keys {
+	for _, key := range s.keys {
 		value, err := reader.Get(key)
 		if err != nil {
 			return ctx, err
@@ -168,7 +164,7 @@ func (s *stringMapPropagator) Extract(ctx context.Context, reader workflow.Heade
 
 // ExtractToWorkflow extracts values from headers and puts them into context
 func (s *stringMapPropagator) ExtractToWorkflow(ctx workflow.Context, reader workflow.HeaderReader) (workflow.Context, error) {
-	for key, _ := range s.keys {
+	for _, key := range s.keys {
 		value, err := reader.Get(key)
 		if err != nil {
 			return ctx, err

--- a/test/test_utils_test.go
+++ b/test/test_utils_test.go
@@ -32,8 +32,6 @@ import (
 	"strings"
 	"time"
 
-	commonpb "go.temporal.io/api/common/v1"
-
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/converter"
 	"go.temporal.io/sdk/workflow"
@@ -103,7 +101,8 @@ func WaitForTCP(timeout time.Duration, addr string) error {
 
 // stringMapPropagator propagates the list of keys across a workflow,
 // interpreting the payloads as strings.
-// BORROWED FROM 'internal' PACKAGE TESTS.
+// TODO: BORROWED FROM 'internal' PACKAGE TESTS.
+// TODO: remove code duplication.
 type stringMapPropagator struct {
 	keys map[string]struct{}
 }
@@ -152,36 +151,34 @@ func (s *stringMapPropagator) InjectFromWorkflow(ctx workflow.Context, writer wo
 
 // Extract extracts values from headers and puts them into context
 func (s *stringMapPropagator) Extract(ctx context.Context, reader workflow.HeaderReader) (context.Context, error) {
-	if err := reader.ForEachKey(func(key string, value *commonpb.Payload) error {
-		if _, ok := s.keys[key]; ok {
-			var decodedValue string
-			err := converter.GetDefaultDataConverter().FromPayload(value, &decodedValue)
-			if err != nil {
-				return err
-			}
-			ctx = context.WithValue(ctx, contextKey(key), decodedValue)
+	for key, _ := range s.keys {
+		value, err := reader.Get(key)
+		if err != nil {
+			return ctx, err
 		}
-		return nil
-	}); err != nil {
-		return nil, err
+		var decodedValue string
+		err = converter.GetDefaultDataConverter().FromPayload(value, &decodedValue)
+		if err != nil {
+			return ctx, err
+		}
+		ctx = context.WithValue(ctx, contextKey(key), decodedValue)
 	}
 	return ctx, nil
 }
 
 // ExtractToWorkflow extracts values from headers and puts them into context
 func (s *stringMapPropagator) ExtractToWorkflow(ctx workflow.Context, reader workflow.HeaderReader) (workflow.Context, error) {
-	if err := reader.ForEachKey(func(key string, value *commonpb.Payload) error {
-		if _, ok := s.keys[key]; ok {
-			var decodedValue string
-			err := converter.GetDefaultDataConverter().FromPayload(value, &decodedValue)
-			if err != nil {
-				return err
-			}
-			ctx = workflow.WithValue(ctx, contextKey(key), decodedValue)
+	for key, _ := range s.keys {
+		value, err := reader.Get(key)
+		if err != nil {
+			return ctx, err
 		}
-		return nil
-	}); err != nil {
-		return nil, err
+		var decodedValue string
+		err = converter.GetDefaultDataConverter().FromPayload(value, &decodedValue)
+		if err != nil {
+			return ctx, err
+		}
+		ctx = workflow.WithValue(ctx, contextKey(key), decodedValue)
 	}
 	return ctx, nil
 }

--- a/test/test_utils_test.go
+++ b/test/test_utils_test.go
@@ -148,12 +148,13 @@ func (s *stringMapPropagator) InjectFromWorkflow(ctx workflow.Context, writer wo
 // Extract extracts values from headers and puts them into context
 func (s *stringMapPropagator) Extract(ctx context.Context, reader workflow.HeaderReader) (context.Context, error) {
 	for _, key := range s.keys {
-		value, err := reader.Get(key)
-		if err != nil {
-			return ctx, err
+		value, ok := reader.Get(key)
+		if !ok {
+			// If key that should be propagated doesn't exist in the header, ignore the key.
+			continue
 		}
 		var decodedValue string
-		err = converter.GetDefaultDataConverter().FromPayload(value, &decodedValue)
+		err := converter.GetDefaultDataConverter().FromPayload(value, &decodedValue)
 		if err != nil {
 			return ctx, err
 		}
@@ -165,12 +166,13 @@ func (s *stringMapPropagator) Extract(ctx context.Context, reader workflow.Heade
 // ExtractToWorkflow extracts values from headers and puts them into context
 func (s *stringMapPropagator) ExtractToWorkflow(ctx workflow.Context, reader workflow.HeaderReader) (workflow.Context, error) {
 	for _, key := range s.keys {
-		value, err := reader.Get(key)
-		if err != nil {
-			return ctx, err
+		value, ok := reader.Get(key)
+		if !ok {
+			// If key that should be propagated doesn't exist in the header, ignore the key.
+			continue
 		}
 		var decodedValue string
-		err = converter.GetDefaultDataConverter().FromPayload(value, &decodedValue)
+		err := converter.GetDefaultDataConverter().FromPayload(value, &decodedValue)
 		if err != nil {
 			return ctx, err
 		}

--- a/test/test_utils_test.go
+++ b/test/test_utils_test.go
@@ -99,22 +99,22 @@ func WaitForTCP(timeout time.Duration, addr string) error {
 	}
 }
 
-// stringMapPropagator propagates the list of keys across a workflow,
+// keysPropagator propagates the list of keys across a workflow,
 // interpreting the payloads as strings.
 // TODO: BORROWED FROM 'internal' PACKAGE TESTS.
 // TODO: remove code duplication.
-type stringMapPropagator struct {
+type keysPropagator struct {
 	keys []string
 }
 
-// NewStringMapPropagator returns a context propagator that propagates a set of
+// NewKeysPropagator returns a context propagator that propagates a set of
 // string key-value pairs across a workflow
-func NewStringMapPropagator(keys []string) workflow.ContextPropagator {
-	return &stringMapPropagator{keys}
+func NewKeysPropagator(keys []string) workflow.ContextPropagator {
+	return &keysPropagator{keys}
 }
 
 // Inject injects values from context into headers for propagation
-func (s *stringMapPropagator) Inject(ctx context.Context, writer workflow.HeaderWriter) error {
+func (s *keysPropagator) Inject(ctx context.Context, writer workflow.HeaderWriter) error {
 	for _, key := range s.keys {
 		value, ok := ctx.Value(contextKey(key)).(string)
 		if !ok {
@@ -130,7 +130,7 @@ func (s *stringMapPropagator) Inject(ctx context.Context, writer workflow.Header
 }
 
 // InjectFromWorkflow injects values from context into headers for propagation
-func (s *stringMapPropagator) InjectFromWorkflow(ctx workflow.Context, writer workflow.HeaderWriter) error {
+func (s *keysPropagator) InjectFromWorkflow(ctx workflow.Context, writer workflow.HeaderWriter) error {
 	for _, key := range s.keys {
 		value, ok := ctx.Value(contextKey(key)).(string)
 		if !ok {
@@ -146,7 +146,7 @@ func (s *stringMapPropagator) InjectFromWorkflow(ctx workflow.Context, writer wo
 }
 
 // Extract extracts values from headers and puts them into context
-func (s *stringMapPropagator) Extract(ctx context.Context, reader workflow.HeaderReader) (context.Context, error) {
+func (s *keysPropagator) Extract(ctx context.Context, reader workflow.HeaderReader) (context.Context, error) {
 	for _, key := range s.keys {
 		value, ok := reader.Get(key)
 		if !ok {
@@ -164,7 +164,7 @@ func (s *stringMapPropagator) Extract(ctx context.Context, reader workflow.Heade
 }
 
 // ExtractToWorkflow extracts values from headers and puts them into context
-func (s *stringMapPropagator) ExtractToWorkflow(ctx workflow.Context, reader workflow.HeaderReader) (workflow.Context, error) {
+func (s *keysPropagator) ExtractToWorkflow(ctx workflow.Context, reader workflow.HeaderReader) (workflow.Context, error) {
 	for _, key := range s.keys {
 		value, ok := reader.Get(key)
 		if !ok {


### PR DESCRIPTION
This PR fixes bug: when custom context propagators are set, custom tracer stops to work (stops to propagate span headers).
First, I added an integration test for two context propagators to make sure they work together. This test passed fine and didn't discover the problem. Then, after some debugging, I figured out that there was an error during deserialization of tracer headers from headers payload. The proper fix is to store entire tracing data as single header and let opentracing to deal with it content.

Note: because header key is changing, workflows started with previous SDK versions will not propagate trace to this version and vice versa.

Tested manually with local Jaeger installation.