### PR TITLE
Improve error messages

### DIFF
--- a/internal/context.go
+++ b/internal/context.go
@@ -179,7 +179,7 @@ var ErrCanceled = NewCanceledError()
 
 // ErrDeadlineExceeded is the error returned by Context.Err when the context's
 // deadline passes.
-var ErrDeadlineExceeded = NewTimeoutError(enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE, nil)
+var ErrDeadlineExceeded = NewTimeoutError("Deadline exceeded", enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE, nil)
 
 // A CancelFunc tells an operation to abandon its work.
 // A CancelFunc does not wait for the work to stop.

--- a/internal/context.go
+++ b/internal/context.go
@@ -179,7 +179,7 @@ var ErrCanceled = NewCanceledError()
 
 // ErrDeadlineExceeded is the error returned by Context.Err when the context's
 // deadline passes.
-var ErrDeadlineExceeded = NewTimeoutError("Deadline exceeded", enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE, nil)
+var ErrDeadlineExceeded = NewTimeoutError("deadline exceeded", enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE, nil)
 
 // A CancelFunc tells an operation to abandon its work.
 // A CancelFunc does not wait for the work to stop.

--- a/internal/error.go
+++ b/internal/error.go
@@ -291,7 +291,7 @@ func NewTimeoutError(msg string, timeoutType enumspb.TimeoutType, cause error, l
 
 // NewHeartbeatTimeoutError creates TimeoutError instance.
 func NewHeartbeatTimeoutError(details ...interface{}) *TimeoutError {
-	return NewTimeoutError("Heartbeat timeout", enumspb.TIMEOUT_TYPE_HEARTBEAT, nil, details...)
+	return NewTimeoutError("heartbeat timeout", enumspb.TIMEOUT_TYPE_HEARTBEAT, nil, details...)
 }
 
 // NewCanceledError creates CanceledError instance.

--- a/internal/error.go
+++ b/internal/error.go
@@ -272,11 +272,7 @@ func NewApplicationError(msg string, errType string, nonRetryable bool, cause er
 
 // NewTimeoutError creates TimeoutError instance.
 // Use NewHeartbeatTimeoutError to create heartbeat TimeoutError.
-func NewTimeoutError(timeoutType enumspb.TimeoutType, cause error, lastHeartbeatDetails ...interface{}) *TimeoutError {
-	return newTimeoutError("Timeout", timeoutType, cause, lastHeartbeatDetails...)
-}
-
-func newTimeoutError(msg string, timeoutType enumspb.TimeoutType, cause error, lastHeartbeatDetails ...interface{}) *TimeoutError {
+func NewTimeoutError(msg string, timeoutType enumspb.TimeoutType, cause error, lastHeartbeatDetails ...interface{}) *TimeoutError {
 	timeoutErr := &TimeoutError{
 		msg:         msg,
 		timeoutType: timeoutType,
@@ -295,7 +291,7 @@ func newTimeoutError(msg string, timeoutType enumspb.TimeoutType, cause error, l
 
 // NewHeartbeatTimeoutError creates TimeoutError instance.
 func NewHeartbeatTimeoutError(details ...interface{}) *TimeoutError {
-	return NewTimeoutError(enumspb.TIMEOUT_TYPE_HEARTBEAT, nil, details...)
+	return NewTimeoutError("Heartbeat timeout", enumspb.TIMEOUT_TYPE_HEARTBEAT, nil, details...)
 }
 
 // NewCanceledError creates CanceledError instance.
@@ -507,7 +503,7 @@ func (e *CanceledError) Error() string {
 }
 
 func (e *CanceledError) message() string {
-	return "Canceled"
+	return "canceled"
 }
 
 // HasDetails return if this error has strong typed detail data.
@@ -561,7 +557,7 @@ func (e *ContinueAsNewError) Error() string {
 }
 
 func (e *ContinueAsNewError) message() string {
-	return "Continue as new"
+	return "continue as new"
 }
 
 // WorkflowType return WorkflowType of the new run
@@ -585,7 +581,7 @@ func (e *TerminatedError) Error() string {
 }
 
 func (e *TerminatedError) message() string {
-	return "Terminated"
+	return "terminated"
 }
 
 // newUnknownExternalWorkflowExecutionError creates UnknownExternalWorkflowExecutionError instance
@@ -595,7 +591,7 @@ func newUnknownExternalWorkflowExecutionError() *UnknownExternalWorkflowExecutio
 
 // Error from error interface
 func (e *UnknownExternalWorkflowExecutionError) Error() string {
-	return "UnknownExternalWorkflowExecution"
+	return "unknown external workflow execution"
 }
 
 // Error from error interface
@@ -624,7 +620,7 @@ func (e *ActivityError) Error() string {
 }
 
 func (e *ActivityError) message() string {
-	return "Activity task error"
+	return "activity error"
 }
 
 func (e *ActivityError) Unwrap() error {
@@ -642,7 +638,7 @@ func (e *ChildWorkflowExecutionError) Error() string {
 }
 
 func (e *ChildWorkflowExecutionError) message() string {
-	return "Child workflow execution error"
+	return "child workflow execution error"
 }
 
 func (e *ChildWorkflowExecutionError) Unwrap() error {
@@ -855,7 +851,7 @@ func convertFailureToError(failure *failurepb.Failure, dc converter.DataConverte
 	} else if failure.GetTimeoutFailureInfo() != nil {
 		timeoutFailureInfo := failure.GetTimeoutFailureInfo()
 		lastHeartbeatDetails := newEncodedValues(timeoutFailureInfo.GetLastHeartbeatDetails(), dc)
-		err = newTimeoutError(
+		err = NewTimeoutError(
 			failure.GetMessage(),
 			timeoutFailureInfo.GetTimeoutType(),
 			convertFailureToError(failure.GetCause(), dc),

--- a/internal/error.go
+++ b/internal/error.go
@@ -250,7 +250,7 @@ var (
 )
 
 // NewApplicationError create new instance of *ApplicationError with message, type, and optional details.
-func NewApplicationError(msg, errType string, nonRetryable bool, cause error, details ...interface{}) *ApplicationError {
+func NewApplicationError(msg string, errType string, nonRetryable bool, cause error, details ...interface{}) *ApplicationError {
 	applicationErr := &ApplicationError{
 		msg:          msg,
 		errType:      errType,
@@ -893,7 +893,7 @@ func convertFailureToError(failure *failurepb.Failure, dc converter.DataConverte
 
 	if err == nil {
 		// All unknown types are considered to be retryable ApplicationError.
-		err = NewApplicationError(failure.GetMessage(), "unknown failure", false, convertFailureToError(failure.GetCause(), dc))
+		err = NewApplicationError(failure.GetMessage(), "", false, convertFailureToError(failure.GetCause(), dc))
 	}
 
 	if fh, ok := err.(failureHolder); ok {

--- a/internal/internal_event_handlers.go
+++ b/internal/internal_event_handlers.go
@@ -41,7 +41,6 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	failurepb "go.temporal.io/api/failure/v1"
 	historypb "go.temporal.io/api/history/v1"
-	"go.temporal.io/api/serviceerror"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 
 	"go.temporal.io/sdk/converter"
@@ -1228,10 +1227,22 @@ func (weh *workflowExecutionEventHandlerImpl) handleStartChildWorkflowExecutionF
 		return nil
 	}
 
-	err := serviceerror.NewWorkflowExecutionAlreadyStarted("Workflow execution already started", "", "")
-	childWorkflow.handle(nil, err)
+	if attributes.GetCause() == enumspb.START_CHILD_WORKFLOW_EXECUTION_FAILED_CAUSE_WORKFLOW_ALREADY_EXISTS {
+		err := NewChildWorkflowExecutionError(
+			attributes.GetNamespace(),
+			attributes.GetWorkflowId(),
+			"",
+			attributes.GetWorkflowType().GetName(),
+			attributes.GetInitiatedEventId(),
+			0,
+			enumspb.RETRY_STATE_NON_RETRYABLE_FAILURE,
+			errors.New("workflow execution already started"),
+		)
+		childWorkflow.handle(nil, err)
+		return nil
+	}
 
-	return nil
+	return fmt.Errorf("unknown cause: %v", attributes.GetCause())
 }
 
 func (weh *workflowExecutionEventHandlerImpl) handleChildWorkflowExecutionStarted(event *historypb.HistoryEvent) error {

--- a/internal/internal_event_handlers.go
+++ b/internal/internal_event_handlers.go
@@ -1341,7 +1341,7 @@ func (weh *workflowExecutionEventHandlerImpl) handleChildWorkflowExecutionTimedO
 		attributes.GetInitiatedEventId(),
 		attributes.GetStartedEventId(),
 		attributes.GetRetryState(),
-		NewTimeoutError(enumspb.TIMEOUT_TYPE_START_TO_CLOSE, nil),
+		NewTimeoutError("Child workflow timeout", enumspb.TIMEOUT_TYPE_START_TO_CLOSE, nil),
 	)
 	childWorkflow.handle(nil, childWorkflowExecutionError)
 	return nil

--- a/internal/internal_utils_test.go
+++ b/internal/internal_utils_test.go
@@ -127,13 +127,13 @@ func TestConvertErrorToFailure_TimeoutError(t *testing.T) {
 	require.NoError(t, err)
 
 	val := newEncodedValues(details, dc).(*EncodedValues)
-	timeoutErr1 := NewTimeoutError("Timeout", enumspb.TIMEOUT_TYPE_SCHEDULE_TO_START, nil, val)
+	timeoutErr1 := NewTimeoutError("timeout", enumspb.TIMEOUT_TYPE_SCHEDULE_TO_START, nil, val)
 	failure := convertErrorToFailure(timeoutErr1, dc)
 	require.NotNil(t, failure.GetTimeoutFailureInfo())
 	require.Equal(t, enumspb.TIMEOUT_TYPE_SCHEDULE_TO_START, failure.GetTimeoutFailureInfo().GetTimeoutType())
 	require.Equal(t, val.values, failure.GetTimeoutFailureInfo().GetLastHeartbeatDetails())
 
-	timeoutErr2 := NewTimeoutError("Timeout", enumspb.TIMEOUT_TYPE_HEARTBEAT, nil, testErrorDetails4)
+	timeoutErr2 := NewTimeoutError("timeout", enumspb.TIMEOUT_TYPE_HEARTBEAT, nil, testErrorDetails4)
 	val2, err := encodeArgs(dc, []interface{}{testErrorDetails4})
 	require.NoError(t, err)
 	failure = convertErrorToFailure(timeoutErr2, dc)

--- a/internal/internal_utils_test.go
+++ b/internal/internal_utils_test.go
@@ -127,13 +127,13 @@ func TestConvertErrorToFailure_TimeoutError(t *testing.T) {
 	require.NoError(t, err)
 
 	val := newEncodedValues(details, dc).(*EncodedValues)
-	timeoutErr1 := NewTimeoutError(enumspb.TIMEOUT_TYPE_SCHEDULE_TO_START, nil, val)
+	timeoutErr1 := NewTimeoutError("Timeout", enumspb.TIMEOUT_TYPE_SCHEDULE_TO_START, nil, val)
 	failure := convertErrorToFailure(timeoutErr1, dc)
 	require.NotNil(t, failure.GetTimeoutFailureInfo())
 	require.Equal(t, enumspb.TIMEOUT_TYPE_SCHEDULE_TO_START, failure.GetTimeoutFailureInfo().GetTimeoutType())
 	require.Equal(t, val.values, failure.GetTimeoutFailureInfo().GetLastHeartbeatDetails())
 
-	timeoutErr2 := NewTimeoutError(enumspb.TIMEOUT_TYPE_HEARTBEAT, nil, testErrorDetails4)
+	timeoutErr2 := NewTimeoutError("Timeout", enumspb.TIMEOUT_TYPE_HEARTBEAT, nil, testErrorDetails4)
 	val2, err := encodeArgs(dc, []interface{}{testErrorDetails4})
 	require.NoError(t, err)
 	failure = convertErrorToFailure(timeoutErr2, dc)

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -1151,7 +1151,7 @@ func (workflowRun *workflowRunImpl) Get(ctx context.Context, valuePtr interface{
 	case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_TERMINATED:
 		err = newTerminatedError()
 	case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_TIMED_OUT:
-		err = NewTimeoutError(enumspb.TIMEOUT_TYPE_START_TO_CLOSE, nil)
+		err = NewTimeoutError("Workflow timeout", enumspb.TIMEOUT_TYPE_START_TO_CLOSE, nil)
 	case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_CONTINUED_AS_NEW:
 		attributes := closeEvent.GetWorkflowExecutionContinuedAsNewEventAttributes()
 		workflowRun.currentRunID = attributes.GetNewExecutionRunId()

--- a/internal/internal_workflow_client_test.go
+++ b/internal/internal_workflow_client_test.go
@@ -739,7 +739,7 @@ func (s *workflowRunSuite) TestExecuteWorkflow_NoDup_Failed() {
 	s.True(ok)
 	var applicationErr2 *ApplicationError
 	s.True(errors.As(err, &applicationErr2))
-	s.Equal(applicationError.message, applicationErr2.message)
+	s.Equal(applicationError.msg, applicationErr2.msg)
 	s.Equal(applicationError.nonRetryable, applicationErr2.nonRetryable)
 	s.Equal(time.Minute, decodedResult)
 }

--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -562,7 +562,7 @@ func (env *testWorkflowEnvironmentImpl) executeActivity(
 	if err != nil {
 		if err == context.DeadlineExceeded {
 			env.logger.Debug(fmt.Sprintf("Activity %v timed out", task.ActivityType.Name))
-			return nil, env.wrapActivityError(scheduleTaskAttr.ActivityId, scheduleTaskAttr.ActivityType.Name, enumspb.RETRY_STATE_TIMEOUT, NewTimeoutError(enumspb.TIMEOUT_TYPE_START_TO_CLOSE, err))
+			return nil, env.wrapActivityError(scheduleTaskAttr.ActivityId, scheduleTaskAttr.ActivityType.Name, enumspb.RETRY_STATE_TIMEOUT, NewTimeoutError("Activity timeout", enumspb.TIMEOUT_TYPE_START_TO_CLOSE, err))
 		}
 		topLine := fmt.Sprintf("activity for %s [panic]:", defaultTestTaskQueue)
 		st := getStackTraceRaw(topLine, 7, 0)
@@ -1392,7 +1392,7 @@ func (env *testWorkflowEnvironmentImpl) handleActivityResult(activityID string, 
 				activityID,
 				activityType,
 				enumspb.RETRY_STATE_TIMEOUT,
-				NewTimeoutError(enumspb.TIMEOUT_TYPE_START_TO_CLOSE, context.DeadlineExceeded),
+				NewTimeoutError("Activity timeout", enumspb.TIMEOUT_TYPE_START_TO_CLOSE, context.DeadlineExceeded),
 			)
 			activityHandle.callback(nil, err)
 		} else {

--- a/internal/internal_workflow_testsuite_test.go
+++ b/internal/internal_workflow_testsuite_test.go
@@ -2338,7 +2338,7 @@ func (s *WorkflowTestSuiteUnitTest) Test_ActivityRetry() {
 	attempt1Count := 1
 	activityFailedFn := func(ctx context.Context) (string, error) {
 		attempt1Count++
-		return "", NewApplicationError("bad-bug", "badBugType", true, nil)
+		return "", NewApplicationError("bad-bug", "", true, nil)
 	}
 
 	attempt2Count := 1
@@ -2373,7 +2373,7 @@ func (s *WorkflowTestSuiteUnitTest) Test_ActivityRetry() {
 		err = errors.Unwrap(activityErr)
 		var badBug *ApplicationError
 		s.True(errors.As(err, &badBug))
-		s.Equal("bad-bug (type: badBugType, retryable: false)", badBug.Error())
+		s.Equal("bad-bug", badBug.Error())
 
 		var result string
 		err = ExecuteActivity(ctx, activityFn).Get(ctx, &result)

--- a/internal/internal_workflow_testsuite_test.go
+++ b/internal/internal_workflow_testsuite_test.go
@@ -2338,7 +2338,7 @@ func (s *WorkflowTestSuiteUnitTest) Test_ActivityRetry() {
 	attempt1Count := 1
 	activityFailedFn := func(ctx context.Context) (string, error) {
 		attempt1Count++
-		return "", NewApplicationError("bad-bug", "", true, nil)
+		return "", NewApplicationError("bad-bug", "badBugType", true, nil)
 	}
 
 	attempt2Count := 1
@@ -2373,7 +2373,7 @@ func (s *WorkflowTestSuiteUnitTest) Test_ActivityRetry() {
 		err = errors.Unwrap(activityErr)
 		var badBug *ApplicationError
 		s.True(errors.As(err, &badBug))
-		s.Equal("bad-bug", badBug.Error())
+		s.Equal("bad-bug (type: badBugType, retryable: false)", badBug.Error())
 
 		var result string
 		err = ExecuteActivity(ctx, activityFn).Get(ctx, &result)

--- a/internal/internal_workflow_testsuite_test.go
+++ b/internal/internal_workflow_testsuite_test.go
@@ -3035,7 +3035,7 @@ func (s *WorkflowTestSuiteUnitTest) Test_ActivityTimeoutWithDetails() {
 	count := 0
 	timeoutFn := func() error {
 		count++
-		return NewTimeoutError(enumspb.TIMEOUT_TYPE_START_TO_CLOSE, nil, testErrorDetails1)
+		return NewTimeoutError("Activity timeout", enumspb.TIMEOUT_TYPE_START_TO_CLOSE, nil, testErrorDetails1)
 	}
 
 	timeoutWf := func(ctx Context) error {

--- a/temporal/error.go
+++ b/temporal/error.go
@@ -219,7 +219,7 @@ func IsPanicError(err error) bool {
 // WARNING: This function is public only to support unit testing of workflows.
 // It shouldn't be used by application level code.
 func NewTimeoutError(timeoutType enumspb.TimeoutType, lastErr error, details ...interface{}) *TimeoutError {
-	return internal.NewTimeoutError(timeoutType, lastErr, details...)
+	return internal.NewTimeoutError("Test timeout", timeoutType, lastErr, details...)
 }
 
 // NewHeartbeatTimeoutError creates TimeoutError instance

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -362,7 +362,7 @@ func (ts *IntegrationTestSuite) TestWorkflowIDReuseRejectDuplicate() {
 	var applicationErr *temporal.ApplicationError
 	ok := errors.As(err, &applicationErr)
 	ts.True(ok)
-	ts.Equal("Workflow execution already started", applicationErr.Error())
+	ts.Equal("workflow execution already started", applicationErr.Error())
 	ts.False(applicationErr.NonRetryable())
 }
 

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -381,7 +381,7 @@ func (ts *IntegrationTestSuite) TestWorkflowIDReuseAllowDuplicateFailedOnly1() {
 	var applicationErr *temporal.ApplicationError
 	ok := errors.As(err, &applicationErr)
 	ts.True(ok)
-	ts.Equal("Workflow execution already started", applicationErr.Error())
+	ts.Equal("workflow execution already started", applicationErr.Error())
 	ts.False(applicationErr.NonRetryable())
 }
 


### PR DESCRIPTION
Remove duplicate information from failure messages and add more context to go error messages.