### PR TITLE
Add support for non-pointer proto struct

### DIFF
--- a/converter/errors.go
+++ b/converter/errors.go
@@ -47,6 +47,6 @@ var (
 	ErrValueNotImplementProtoMessage = errors.New("value doesn't implement proto.Message")
 	// ErrValueNotImplementProtoUnmarshaler is returned when value doesn't implement proto.Unmarshaler.
 	ErrValueNotImplementProtoUnmarshaler = errors.New("value doesn't implement proto.Unmarshaler")
-	// ErrProtoStructIsNotPointer is returned when proto value is not a pointer.
-	ErrProtoStructIsNotPointer = errors.New("proto struct is not a pointer: proto serialization interface is implemented on pointer receiver only")
+	// ErrValuePtrIsNotPointer is returned when proto value is not a pointer.
+	ErrValuePtrIsNotPointer = errors.New("not a pointer type")
 )

--- a/converter/errors.go
+++ b/converter/errors.go
@@ -45,8 +45,6 @@ var (
 	ErrUnableToFindConverter = errors.New("unable to find converter")
 	// ErrTypeNotImplementProtoMessage is returned when value doesn't implement proto.Message.
 	ErrTypeNotImplementProtoMessage = errors.New("type doesn't implement proto.Message")
-	// ErrTypeNotImplementProtoUnmarshaler is returned when value doesn't implement proto.Unmarshaler.
-	ErrTypeNotImplementProtoUnmarshaler = errors.New("type doesn't implement proto.Unmarshaler")
 	// ErrValuePtrIsNotPointer is returned when proto value is not a pointer.
 	ErrValuePtrIsNotPointer = errors.New("not a pointer type")
 )

--- a/converter/errors.go
+++ b/converter/errors.go
@@ -43,10 +43,10 @@ var (
 	ErrUnableToSetValue = errors.New("unable to set value")
 	// ErrUnableToFindConverter is returned when unable to find converter.
 	ErrUnableToFindConverter = errors.New("unable to find converter")
-	// ErrValueNotImplementProtoMessage is returned when value doesn't implement proto.Message.
-	ErrValueNotImplementProtoMessage = errors.New("value doesn't implement proto.Message")
-	// ErrValueNotImplementProtoUnmarshaler is returned when value doesn't implement proto.Unmarshaler.
-	ErrValueNotImplementProtoUnmarshaler = errors.New("value doesn't implement proto.Unmarshaler")
+	// ErrTypeNotImplementProtoMessage is returned when value doesn't implement proto.Message.
+	ErrTypeNotImplementProtoMessage = errors.New("type doesn't implement proto.Message")
+	// ErrTypeNotImplementProtoUnmarshaler is returned when value doesn't implement proto.Unmarshaler.
+	ErrTypeNotImplementProtoUnmarshaler = errors.New("type doesn't implement proto.Unmarshaler")
 	// ErrValuePtrIsNotPointer is returned when proto value is not a pointer.
 	ErrValuePtrIsNotPointer = errors.New("not a pointer type")
 )

--- a/converter/errors.go
+++ b/converter/errors.go
@@ -43,10 +43,10 @@ var (
 	ErrUnableToSetValue = errors.New("unable to set value")
 	// ErrUnableToFindConverter is returned when unable to find converter.
 	ErrUnableToFindConverter = errors.New("unable to find converter")
-	// ErrValueDoesntImplementProtoMessage is returned when value doesn't implement proto.Message.
-	ErrValueDoesntImplementProtoMessage = errors.New("value doesn't implement proto.Message")
-	// ErrValueDoesntImplementProtoUnmarshaler is returned when value doesn't implement proto.Unmarshaler.
-	ErrValueDoesntImplementProtoUnmarshaler = errors.New("value doesn't implement proto.Unmarshaler")
-	// ErrValueIsNotPointer is returned when value is not a pointer.
-	ErrValueIsNotPointer = errors.New("value is not a pointer")
+	// ErrValueNotImplementProtoMessage is returned when value doesn't implement proto.Message.
+	ErrValueNotImplementProtoMessage = errors.New("value doesn't implement proto.Message")
+	// ErrValueNotImplementProtoUnmarshaler is returned when value doesn't implement proto.Unmarshaler.
+	ErrValueNotImplementProtoUnmarshaler = errors.New("value doesn't implement proto.Unmarshaler")
+	// ErrProtoStructIsNotPointer is returned when proto value is not a pointer.
+	ErrProtoStructIsNotPointer = errors.New("proto struct is not a pointer: proto serialization interface is implemented on pointer receiver only")
 )

--- a/converter/json_payload_converter.go
+++ b/converter/json_payload_converter.go
@@ -72,7 +72,6 @@ func (c *JSONPayloadConverter) ToString(payload *commonpb.Payload) string {
 		s = strings.TrimSuffix(s, "]")
 		s = fmt.Sprintf("{%s}", s)
 	}
-
 	return s
 }
 

--- a/converter/payload_converter_test.go
+++ b/converter/payload_converter_test.go
@@ -196,18 +196,18 @@ func TestProtoJsonPayloadConverter_ToPayload_Errors(t *testing.T) {
 
 	var wt1 *commonpb.WorkflowType
 	_, err := pc.ToPayload(wt1)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Equal(t, "unable to encode: Marshal called with nil", err.Error())
 	assert.True(t, errors.Is(err, ErrUnableToEncode))
 
 	var wt2 interface{}
 	payload, err := pc.ToPayload(wt2)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Nil(t, payload)
 
 	var wt3 *interface{}
 	payload, err = pc.ToPayload(wt3)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Nil(t, payload)
 }
 
@@ -216,17 +216,17 @@ func TestJsonPayloadConverter_ToPayload_Errors(t *testing.T) {
 
 	var wt1 *testStruct
 	payload, err := pc.ToPayload(wt1)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "null", string(payload.Data))
 
 	var wt2 interface{}
 	payload, err = pc.ToPayload(wt2)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "null", string(payload.Data))
 
 	var wt3 *interface{}
 	payload, err = pc.ToPayload(wt3)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "null", string(payload.Data))
 }
 
@@ -239,55 +239,55 @@ func TestProtoJsonPayloadConverter_FromPayload_Errors(t *testing.T) {
 
 	var wt2 *int
 	err = pc.FromPayload(payload, &wt2)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Equal(t, "type: *int: type doesn't implement proto.Message", err.Error())
 	assert.True(t, errors.Is(err, ErrTypeNotImplementProtoMessage))
 
 	var wt3 *commonpb.WorkflowType
 	err = pc.FromPayload(payload, wt3)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Equal(t, "type: *common.WorkflowType: unable to set value", err.Error())
 	assert.True(t, errors.Is(err, ErrUnableToSetValue))
 
 	// But 31, 32, and 33 work
 	var wt31 commonpb.WorkflowType
 	err = pc.FromPayload(payload, &wt31)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "qwe", wt31.Name)
 
 	wt32 := &commonpb.WorkflowType{}
 	err = pc.FromPayload(payload, wt32)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "qwe", wt32.Name)
 
 	var wt33 *commonpb.WorkflowType
 	wt33 = &commonpb.WorkflowType{}
 	err = pc.FromPayload(payload, wt33)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "qwe", wt33.Name)
 
 	var wt4 commonpb.WorkflowType
 	err = pc.FromPayload(payload, wt4)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Equal(t, "type: common.WorkflowType: not a pointer type", err.Error())
 	assert.True(t, errors.Is(err, ErrValuePtrIsNotPointer))
 
 	var wt5 interface{}
 	err = pc.FromPayload(payload, wt5)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Equal(t, "type: <nil>: not a pointer type", err.Error())
 	assert.True(t, errors.Is(err, ErrValuePtrIsNotPointer))
 
 	var wt6 *interface{}
 	err = pc.FromPayload(payload, wt6)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Equal(t, "type: *interface {}: unable to set value", err.Error())
 	assert.True(t, errors.Is(err, ErrUnableToSetValue))
 
 	// supported by JSON serializer but not by ProtoJson
 	var wt7 interface{}
 	err = pc.FromPayload(payload, &wt7)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Equal(t, "type: <nil>: type doesn't implement proto.Message", err.Error())
 	assert.True(t, errors.Is(err, ErrTypeNotImplementProtoMessage))
 }
@@ -301,49 +301,49 @@ func TestJsonPayloadConverter_FromPayload_Errors(t *testing.T) {
 
 	var wt2 *int
 	err = pc.FromPayload(payload, &wt2)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Equal(t, "unable to decode: json: cannot unmarshal object into Go value of type int", err.Error())
 
 	var wt3 *testStruct
 	err = pc.FromPayload(payload, wt3)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Equal(t, "unable to decode: json: Unmarshal(nil *converter.testStruct)", err.Error())
 
 	// But 31, 32, and 33 work
 	var wt31 testStruct
 	err = pc.FromPayload(payload, &wt31)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "qwe", wt31.Name)
 
 	wt32 := &testStruct{}
 	err = pc.FromPayload(payload, wt32)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "qwe", wt32.Name)
 
 	var wt33 *testStruct
 	wt33 = &testStruct{}
 	err = pc.FromPayload(payload, wt33)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "qwe", wt33.Name)
 
 	var wt4 testStruct
 	err = pc.FromPayload(payload, wt4)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Equal(t, "unable to decode: json: Unmarshal(non-pointer converter.testStruct)", err.Error())
 
 	var wt5 interface{}
 	err = pc.FromPayload(payload, wt5)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Equal(t, "unable to decode: json: Unmarshal(nil)", err.Error())
 
 	var wt6 *interface{}
 	err = pc.FromPayload(payload, wt6)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Equal(t, "unable to decode: json: Unmarshal(nil *interface {})", err.Error())
 
 	// supported by JSON serializer (wt7 will be map[string]interface{})
 	var wt7 interface{}
 	err = pc.FromPayload(payload, &wt7)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "qwe", wt7.(map[string]interface{})["Name"])
 }

--- a/converter/payload_converter_test.go
+++ b/converter/payload_converter_test.go
@@ -174,5 +174,5 @@ func TestProtoJsonPayloadConverter_NotPointer(t *testing.T) {
 	wt2 := commonpb.WorkflowType{} // Note: there is no &
 	err = pc.FromPayload(payload, &wt2)
 	require.Error(t, err)
-	assert.True(t, errors.Is(err, ErrValueIsNotPointer))
+	assert.True(t, errors.Is(err, ErrProtoStructIsNotPointer))
 }

--- a/converter/payload_converter_test.go
+++ b/converter/payload_converter_test.go
@@ -201,7 +201,7 @@ func TestProtoJsonPayloadConverter_Error(t *testing.T) {
 	var wt2 *int
 	err = pc.FromPayload(payload, &wt2)
 	assert.Error(t, err)
-	assert.Equal(t, "value: <nil> of type: *int: value doesn't implement proto.Message", err.Error())
+	assert.Equal(t, "type: *int: value doesn't implement proto.Message", err.Error())
 	assert.True(t, errors.Is(err, ErrValueNotImplementProtoMessage))
 
 	var wt3 *commonpb.WorkflowType
@@ -210,9 +210,39 @@ func TestProtoJsonPayloadConverter_Error(t *testing.T) {
 	assert.Equal(t, "type: *common.WorkflowType: unable to set value", err.Error())
 	assert.True(t, errors.Is(err, ErrUnableToSetValue))
 
-	// var wt4 commonpb.WorkflowType
-	// err = pc.FromPayload(payload, wt4)
-	// assert.Error(t, err)
-	// assert.Equal(t, "type: common.WorkflowType: unable to set value", err.Error())
-	// assert.True(t, errors.Is(err, ErrUnableToSetValue))
+	// But 31, 32, and 33 work
+	var wt31 commonpb.WorkflowType
+	err = pc.FromPayload(payload, &wt31)
+	assert.NoError(t, err)
+	assert.Equal(t, "qwe", wt31.Name)
+
+	wt32 := &commonpb.WorkflowType{}
+	err = pc.FromPayload(payload, wt32)
+	assert.NoError(t, err)
+	assert.Equal(t, "qwe", wt32.Name)
+
+	var wt33 *commonpb.WorkflowType
+	wt33 = &commonpb.WorkflowType{}
+	err = pc.FromPayload(payload, wt33)
+	assert.NoError(t, err)
+	assert.Equal(t, "qwe", wt33.Name)
+
+	var wt4 commonpb.WorkflowType
+	err = pc.FromPayload(payload, wt4)
+	assert.Error(t, err)
+	assert.Equal(t, "type: common.WorkflowType: not a pointer type", err.Error())
+	assert.True(t, errors.Is(err, ErrValuePtrIsNotPointer))
+
+	var wt5 interface{}
+	err = pc.FromPayload(payload, wt5)
+	assert.Error(t, err)
+	assert.Equal(t, "type: <nil>: not a pointer type", err.Error())
+	assert.True(t, errors.Is(err, ErrValuePtrIsNotPointer))
+
+	var wt6 *interface{}
+	err = pc.FromPayload(payload, wt6)
+	assert.Error(t, err)
+	assert.Equal(t, "type: *interface {}: unable to set value", err.Error())
+	assert.True(t, errors.Is(err, ErrUnableToSetValue))
+
 }

--- a/converter/payload_converter_test.go
+++ b/converter/payload_converter_test.go
@@ -65,6 +65,7 @@ func TestProtoJsonPayloadConverter_Gogo(t *testing.T) {
 
 	var wt4 historypb.HistoryEvent
 	err = pc.FromPayload(payload, &wt4)
+	require.NoError(t, err)
 	assert.Equal(t, int64(1978), wt3.EventId)
 
 	s := pc.ToString(payload)
@@ -259,7 +260,7 @@ func TestProtoJsonPayloadConverter_FromPayload_Errors(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "qwe", wt32.Name)
 
-	var wt33 *commonpb.WorkflowType
+	var wt33 *commonpb.WorkflowType //lint:ignore S1021 as it indicates exactly this case
 	wt33 = &commonpb.WorkflowType{}
 	err = pc.FromPayload(payload, wt33)
 	require.NoError(t, err)
@@ -319,7 +320,7 @@ func TestJsonPayloadConverter_FromPayload_Errors(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "qwe", wt32.Name)
 
-	var wt33 *testStruct
+	var wt33 *testStruct //lint:ignore S1021 as it indicates exactly this case
 	wt33 = &testStruct{}
 	err = pc.FromPayload(payload, wt33)
 	require.NoError(t, err)

--- a/converter/payload_converter_test.go
+++ b/converter/payload_converter_test.go
@@ -203,4 +203,16 @@ func TestProtoJsonPayloadConverter_Error(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, "value: <nil> of type: *int: value doesn't implement proto.Message", err.Error())
 	assert.True(t, errors.Is(err, ErrValueNotImplementProtoMessage))
+
+	var wt3 *commonpb.WorkflowType
+	err = pc.FromPayload(payload, wt3)
+	assert.Error(t, err)
+	assert.Equal(t, "type: *common.WorkflowType: unable to set value", err.Error())
+	assert.True(t, errors.Is(err, ErrUnableToSetValue))
+
+	// var wt4 commonpb.WorkflowType
+	// err = pc.FromPayload(payload, wt4)
+	// assert.Error(t, err)
+	// assert.Equal(t, "type: common.WorkflowType: unable to set value", err.Error())
+	// assert.True(t, errors.Is(err, ErrUnableToSetValue))
 }

--- a/converter/payload_converter_test.go
+++ b/converter/payload_converter_test.go
@@ -25,7 +25,6 @@
 package converter
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -167,12 +166,11 @@ func TestJsonPayloadConverter(t *testing.T) {
 func TestProtoJsonPayloadConverter_NotPointer(t *testing.T) {
 	pc := NewProtoJSONPayloadConverter()
 
-	wt := &commonpb.WorkflowType{Name: "qwe"}
+	wt := commonpb.WorkflowType{Name: "qwe"}
 	payload, err := pc.ToPayload(wt)
 	require.NoError(t, err)
 
 	wt2 := commonpb.WorkflowType{} // Note: there is no &
 	err = pc.FromPayload(payload, &wt2)
-	require.Error(t, err)
-	assert.True(t, errors.Is(err, ErrProtoStructIsNotPointer))
+	assert.Equal(t, "qwe", wt2.Name)
 }

--- a/converter/payload_converter_test.go
+++ b/converter/payload_converter_test.go
@@ -236,7 +236,7 @@ func TestProtoJsonPayloadConverter_Nil(t *testing.T) {
 	assert.Nil(t, wt4)
 }
 
-func TestJsonPayloadConverter_NilToPayload(t *testing.T) {
+func TestJsonPayloadConverter_Nil(t *testing.T) {
 	pc := NewJSONPayloadConverter()
 
 	var wt1 *testStruct
@@ -263,6 +263,41 @@ func TestJsonPayloadConverter_NilToPayload(t *testing.T) {
 	payload, err = pc.ToPayload(wt4)
 	require.NoError(t, err)
 	assert.Equal(t, "null", string(payload.Data))
+
+	i := interface{}(123)
+	wt4 = &i
+	err = pc.FromPayload(payload, &wt4)
+	require.NoError(t, err)
+	assert.Nil(t, wt4)
+}
+
+func TestNilPayloadConverter(t *testing.T) {
+	pc := NewNilPayloadConverter()
+
+	var wt1 *testStruct
+	payload, err := pc.ToPayload(wt1)
+	require.NoError(t, err)
+	assert.Nil(t, payload.Data)
+
+	wt1 = &testStruct{Name: "qwe"}
+	err = pc.FromPayload(payload, &wt1)
+	require.NoError(t, err)
+	assert.Nil(t, wt1)
+
+	var wt3 interface{}
+	payload, err = pc.ToPayload(wt3)
+	require.NoError(t, err)
+	assert.Nil(t, payload.Data)
+
+	wt3 = 123
+	err = pc.FromPayload(payload, &wt3)
+	require.NoError(t, err)
+	assert.Nil(t, wt3)
+
+	var wt4 *interface{}
+	payload, err = pc.ToPayload(wt4)
+	require.NoError(t, err)
+	assert.Nil(t, payload.Data)
 
 	i := interface{}(123)
 	wt4 = &i

--- a/converter/payload_converter_test.go
+++ b/converter/payload_converter_test.go
@@ -89,7 +89,7 @@ func TestProtoJsonPayloadConverter_Google(t *testing.T) {
 	assert.Equal(t, int64(12), wt3.BirthDay)
 
 	s := pc.ToString(payload)
-	assert.Equal(t, `{"name":"qwe","birthDay":"12","type":"TYPEV2_R","valueS":"asd"}`, s)
+	assert.Equal(t, `{"name":"qwe", "birthDay":"12", "type":"TYPEV2_R", "valueS":"asd"}`, s)
 }
 
 func TestProtoPayloadConverter_Gogo(t *testing.T) {

--- a/converter/payload_converter_test.go
+++ b/converter/payload_converter_test.go
@@ -191,27 +191,52 @@ func TestJsonPayloadConverter(t *testing.T) {
 	assert.Equal(t, "{Age:0 Name:qwe}", s)
 }
 
-func TestProtoJsonPayloadConverter_ToPayload_Errors(t *testing.T) {
+func TestProtoJsonPayloadConverter_Nil(t *testing.T) {
 	pc := NewProtoJSONPayloadConverter()
 
-	var wt1 *commonpb.WorkflowType
-	_, err := pc.ToPayload(wt1)
-	require.Error(t, err)
-	assert.Equal(t, "unable to encode: Marshal called with nil", err.Error())
-	assert.True(t, errors.Is(err, ErrUnableToEncode))
-
-	var wt2 interface{}
-	payload, err := pc.ToPayload(wt2)
+	var wt1 *GoV2
+	payload, err := pc.ToPayload(wt1)
 	require.NoError(t, err)
-	assert.Nil(t, payload)
+	assert.Equal(t, "null", string(payload.Data))
 
-	var wt3 *interface{}
+	wt1 = &GoV2{Name: "qwe"}
+	err = pc.FromPayload(payload, &wt1)
+	require.NoError(t, err)
+	assert.Nil(t, wt1)
+
+	var wt2 *commonpb.WorkflowType
+	payload, err = pc.ToPayload(wt2)
+	require.NoError(t, err)
+	assert.Equal(t, "null", string(payload.Data))
+
+	wt2 = &commonpb.WorkflowType{Name: "qwe"}
+	err = pc.FromPayload(payload, &wt2)
+	require.NoError(t, err)
+	assert.Nil(t, wt2)
+
+	var wt3 interface{}
 	payload, err = pc.ToPayload(wt3)
 	require.NoError(t, err)
-	assert.Nil(t, payload)
+	assert.Equal(t, "null", string(payload.Data))
+
+	wt3 = 123
+	err = pc.FromPayload(payload, &wt3)
+	require.NoError(t, err)
+	assert.Nil(t, wt3)
+
+	var wt4 *interface{}
+	payload, err = pc.ToPayload(wt4)
+	require.NoError(t, err)
+	assert.Equal(t, "null", string(payload.Data))
+
+	i := interface{}(123)
+	wt4 = &i
+	err = pc.FromPayload(payload, &wt4)
+	require.NoError(t, err)
+	assert.Nil(t, wt4)
 }
 
-func TestJsonPayloadConverter_ToPayload_Errors(t *testing.T) {
+func TestJsonPayloadConverter_NilToPayload(t *testing.T) {
 	pc := NewJSONPayloadConverter()
 
 	var wt1 *testStruct
@@ -219,15 +244,31 @@ func TestJsonPayloadConverter_ToPayload_Errors(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "null", string(payload.Data))
 
-	var wt2 interface{}
-	payload, err = pc.ToPayload(wt2)
+	wt1 = &testStruct{Name: "qwe"}
+	err = pc.FromPayload(payload, &wt1)
 	require.NoError(t, err)
-	assert.Equal(t, "null", string(payload.Data))
+	assert.Nil(t, wt1)
 
-	var wt3 *interface{}
+	var wt3 interface{}
 	payload, err = pc.ToPayload(wt3)
 	require.NoError(t, err)
 	assert.Equal(t, "null", string(payload.Data))
+
+	wt3 = 123
+	err = pc.FromPayload(payload, &wt3)
+	require.NoError(t, err)
+	assert.Nil(t, wt3)
+
+	var wt4 *interface{}
+	payload, err = pc.ToPayload(wt4)
+	require.NoError(t, err)
+	assert.Equal(t, "null", string(payload.Data))
+
+	i := interface{}(123)
+	wt4 = &i
+	err = pc.FromPayload(payload, &wt4)
+	require.NoError(t, err)
+	assert.Nil(t, wt4)
 }
 
 func TestProtoJsonPayloadConverter_FromPayload_Errors(t *testing.T) {

--- a/converter/payload_converter_test.go
+++ b/converter/payload_converter_test.go
@@ -191,7 +191,46 @@ func TestProtoJsonPayloadConverter_Google_NotPointer(t *testing.T) {
 	assert.Equal(t, "qwe", wt2.Name)
 }
 
-func TestProtoJsonPayloadConverter_Error(t *testing.T) {
+func TestProtoJsonPayloadConverter_ToPayload_Errors(t *testing.T) {
+	pc := NewProtoJSONPayloadConverter()
+
+	var wt1 *commonpb.WorkflowType
+	_, err := pc.ToPayload(wt1)
+	assert.Error(t, err)
+	assert.Equal(t, "unable to encode: Marshal called with nil", err.Error())
+	assert.True(t, errors.Is(err, ErrUnableToEncode))
+
+	var wt2 interface{}
+	payload, err := pc.ToPayload(wt2)
+	assert.NoError(t, err)
+	assert.Nil(t, payload)
+
+	var wt3 *interface{}
+	payload, err = pc.ToPayload(wt3)
+	assert.NoError(t, err)
+	assert.Nil(t, payload)
+}
+
+func TestJsonPayloadConverter_ToPayload_Errors(t *testing.T) {
+	pc := NewJSONPayloadConverter()
+
+	var wt1 *testStruct
+	payload, err := pc.ToPayload(wt1)
+	assert.NoError(t, err)
+	assert.Equal(t, "null", string(payload.Data))
+
+	var wt2 interface{}
+	payload, err = pc.ToPayload(wt2)
+	assert.NoError(t, err)
+	assert.Equal(t, "null", string(payload.Data))
+
+	var wt3 *interface{}
+	payload, err = pc.ToPayload(wt3)
+	assert.NoError(t, err)
+	assert.Equal(t, "null", string(payload.Data))
+}
+
+func TestProtoJsonPayloadConverter_FromPayload_Errors(t *testing.T) {
 	pc := NewProtoJSONPayloadConverter()
 
 	wt := commonpb.WorkflowType{Name: "qwe"}
@@ -201,8 +240,8 @@ func TestProtoJsonPayloadConverter_Error(t *testing.T) {
 	var wt2 *int
 	err = pc.FromPayload(payload, &wt2)
 	assert.Error(t, err)
-	assert.Equal(t, "type: *int: value doesn't implement proto.Message", err.Error())
-	assert.True(t, errors.Is(err, ErrValueNotImplementProtoMessage))
+	assert.Equal(t, "type: *int: type doesn't implement proto.Message", err.Error())
+	assert.True(t, errors.Is(err, ErrTypeNotImplementProtoMessage))
 
 	var wt3 *commonpb.WorkflowType
 	err = pc.FromPayload(payload, wt3)
@@ -245,4 +284,66 @@ func TestProtoJsonPayloadConverter_Error(t *testing.T) {
 	assert.Equal(t, "type: *interface {}: unable to set value", err.Error())
 	assert.True(t, errors.Is(err, ErrUnableToSetValue))
 
+	// supported by JSON serializer but not by ProtoJson
+	var wt7 interface{}
+	err = pc.FromPayload(payload, &wt7)
+	assert.Error(t, err)
+	assert.Equal(t, "type: <nil>: type doesn't implement proto.Message", err.Error())
+	assert.True(t, errors.Is(err, ErrTypeNotImplementProtoMessage))
+}
+
+func TestJsonPayloadConverter_FromPayload_Errors(t *testing.T) {
+	pc := NewJSONPayloadConverter()
+
+	wt := testStruct{Name: "qwe"}
+	payload, err := pc.ToPayload(wt)
+	require.NoError(t, err)
+
+	var wt2 *int
+	err = pc.FromPayload(payload, &wt2)
+	assert.Error(t, err)
+	assert.Equal(t, "unable to decode: json: cannot unmarshal object into Go value of type int", err.Error())
+
+	var wt3 *testStruct
+	err = pc.FromPayload(payload, wt3)
+	assert.Error(t, err)
+	assert.Equal(t, "unable to decode: json: Unmarshal(nil *converter.testStruct)", err.Error())
+
+	// But 31, 32, and 33 work
+	var wt31 testStruct
+	err = pc.FromPayload(payload, &wt31)
+	assert.NoError(t, err)
+	assert.Equal(t, "qwe", wt31.Name)
+
+	wt32 := &testStruct{}
+	err = pc.FromPayload(payload, wt32)
+	assert.NoError(t, err)
+	assert.Equal(t, "qwe", wt32.Name)
+
+	var wt33 *testStruct
+	wt33 = &testStruct{}
+	err = pc.FromPayload(payload, wt33)
+	assert.NoError(t, err)
+	assert.Equal(t, "qwe", wt33.Name)
+
+	var wt4 testStruct
+	err = pc.FromPayload(payload, wt4)
+	assert.Error(t, err)
+	assert.Equal(t, "unable to decode: json: Unmarshal(non-pointer converter.testStruct)", err.Error())
+
+	var wt5 interface{}
+	err = pc.FromPayload(payload, wt5)
+	assert.Error(t, err)
+	assert.Equal(t, "unable to decode: json: Unmarshal(nil)", err.Error())
+
+	var wt6 *interface{}
+	err = pc.FromPayload(payload, wt6)
+	assert.Error(t, err)
+	assert.Equal(t, "unable to decode: json: Unmarshal(nil *interface {})", err.Error())
+
+	// supported by JSON serializer (wt7 will be map[string]interface{})
+	var wt7 interface{}
+	err = pc.FromPayload(payload, &wt7)
+	assert.NoError(t, err)
+	assert.Equal(t, "qwe", wt7.(map[string]interface{})["Name"])
 }

--- a/converter/payload_converter_test.go
+++ b/converter/payload_converter_test.go
@@ -25,6 +25,7 @@
 package converter
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -89,7 +90,7 @@ func TestProtoJsonPayloadConverter_Google(t *testing.T) {
 	assert.Equal(t, int64(12), wt3.BirthDay)
 
 	s := pc.ToString(payload)
-	assert.Equal(t, `{"name":"qwe", "birthDay":"12", "type":"TYPEV2_R", "valueS":"asd"}`, s)
+	assert.Equal(t, `{"name":"qwe","birthDay":"12","type":"TYPEV2_R","valueS":"asd"}`, strings.Replace(s, " ", "", -1))
 }
 
 func TestProtoPayloadConverter_Gogo(t *testing.T) {

--- a/converter/payload_converter_test.go
+++ b/converter/payload_converter_test.go
@@ -63,6 +63,10 @@ func TestProtoJsonPayloadConverter_Gogo(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, int64(1978), wt3.EventId)
 
+	var wt4 historypb.HistoryEvent
+	err = pc.FromPayload(payload, &wt4)
+	assert.Equal(t, int64(1978), wt3.EventId)
+
 	s := pc.ToString(payload)
 	assert.Equal(t, `{"eventId":"1978","eventType":"WorkflowTaskTimedOut","workflowTaskTimedOutEventAttributes":{"scheduledEventId":"2","timeoutType":"ScheduleToStart"}}`, s)
 }
@@ -90,6 +94,12 @@ func TestProtoJsonPayloadConverter_Google(t *testing.T) {
 	assert.Equal(t, "qwe", wt3.Name)
 	assert.Equal(t, int64(12), wt3.BirthDay)
 
+	var wt4 GoV2
+	err = pc.FromPayload(payload, &wt4)
+	require.NoError(t, err)
+	assert.Equal(t, "qwe", wt4.Name)
+	assert.Equal(t, int64(12), wt4.BirthDay)
+
 	s := pc.ToString(payload)
 	assert.Equal(t, `{"name":"qwe","birthDay":"12","type":"TYPEV2_R","valueS":"asd"}`, strings.Replace(s, " ", "", -1))
 }
@@ -116,6 +126,11 @@ func TestProtoPayloadConverter_Gogo(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, int64(1978), wt3.EventId)
 
+	var wt4 historypb.HistoryEvent
+	err = pc.FromPayload(payload, &wt4)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1978), wt4.EventId)
+
 	s := pc.ToString(payload)
 	assert.Equal(t, "CLoPGAhqBAgCGAI", s)
 }
@@ -141,6 +156,11 @@ func TestProtoPayloadConverter_Google(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "qwe", wt3.Name)
 
+	var wt4 GoV2
+	err = pc.FromPayload(payload, &wt4)
+	require.NoError(t, err)
+	assert.Equal(t, "qwe", wt4.Name)
+
 	s := pc.ToString(payload)
 	assert.Equal(t, "CgNxd2UQDDgBQgNhc2Q", s)
 }
@@ -161,34 +181,13 @@ func TestJsonPayloadConverter(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "qwe", wt3.Name)
 
+	var wt4 testStruct
+	err = pc.FromPayload(payload, &wt4)
+	require.NoError(t, err)
+	assert.Equal(t, "qwe", wt4.Name)
+
 	s := pc.ToString(payload)
 	assert.Equal(t, "{Age:0 Name:qwe}", s)
-}
-
-func TestProtoJsonPayloadConverter_Gogo_NotPointer(t *testing.T) {
-	pc := NewProtoJSONPayloadConverter()
-
-	wt := commonpb.WorkflowType{Name: "qwe"}
-	payload, err := pc.ToPayload(wt)
-	require.NoError(t, err)
-
-	wt2 := commonpb.WorkflowType{} // Note: there is no &
-	err = pc.FromPayload(payload, &wt2)
-	assert.Equal(t, "qwe", wt2.Name)
-}
-
-func TestProtoJsonPayloadConverter_Google_NotPointer(t *testing.T) {
-	pc := NewProtoJSONPayloadConverter()
-
-	wt := GoV2{
-		Name: "qwe",
-	}
-	payload, err := pc.ToPayload(wt)
-	require.NoError(t, err)
-
-	wt2 := GoV2{} // Note: there is no &
-	err = pc.FromPayload(payload, &wt2)
-	assert.Equal(t, "qwe", wt2.Name)
 }
 
 func TestProtoJsonPayloadConverter_ToPayload_Errors(t *testing.T) {

--- a/converter/proto_json_payload_converter.go
+++ b/converter/proto_json_payload_converter.go
@@ -106,16 +106,17 @@ func (c *ProtoJSONPayloadConverter) FromPayload(payload *commonpb.Payload, value
 	gogoProtoMessage, isGogoProtoMessage := protoValue.(gogoproto.Message)
 	protoMessage, isProtoMessage := protoValue.(proto.Message)
 	if !isGogoProtoMessage && !isProtoMessage {
-		return fmt.Errorf("value: %v of type: %T: %w", originalValue, originalValue, ErrValueNotImplementProtoMessage)
+		return fmt.Errorf("value: %v of type: %T: %w", originalValue, protoValue, ErrValueNotImplementProtoMessage)
 	}
 
 	// If case if original value is nil, create new instance.
 	if originalValue.Kind() == reflect.Ptr && originalValue.IsNil() {
-		newProtoValue := newOfSameType(originalValue)
+		value = newOfSameType(originalValue)
+		protoValue = value.Interface()
 		if isProtoMessage {
-			protoMessage = newProtoValue.Interface().(proto.Message) // type assertion must always succeed
+			protoMessage = protoValue.(proto.Message) // type assertion must always succeed
 		} else if isGogoProtoMessage {
-			gogoProtoMessage = newProtoValue.Interface().(gogoproto.Message) // type assertion must always succeed
+			gogoProtoMessage = protoValue.(gogoproto.Message) // type assertion must always succeed
 		}
 	}
 

--- a/converter/proto_json_payload_converter.go
+++ b/converter/proto_json_payload_converter.go
@@ -91,7 +91,12 @@ func (c *ProtoJSONPayloadConverter) ToPayload(value interface{}) (*commonpb.Payl
 
 // FromPayload converts single proto value from payload.
 func (c *ProtoJSONPayloadConverter) FromPayload(payload *commonpb.Payload, valuePtr interface{}) error {
-	originalValue := reflect.ValueOf(valuePtr).Elem()
+	originalValue := reflect.ValueOf(valuePtr)
+	if originalValue.Kind() != reflect.Ptr {
+		return fmt.Errorf("type: %T: %w", valuePtr, ErrValuePtrIsNotPointer)
+	}
+
+	originalValue = originalValue.Elem()
 	if !originalValue.CanSet() {
 		return fmt.Errorf("type: %T: %w", valuePtr, ErrUnableToSetValue)
 	}
@@ -106,7 +111,7 @@ func (c *ProtoJSONPayloadConverter) FromPayload(payload *commonpb.Payload, value
 	gogoProtoMessage, isGogoProtoMessage := protoValue.(gogoproto.Message)
 	protoMessage, isProtoMessage := protoValue.(proto.Message)
 	if !isGogoProtoMessage && !isProtoMessage {
-		return fmt.Errorf("value: %v of type: %T: %w", originalValue, protoValue, ErrValueNotImplementProtoMessage)
+		return fmt.Errorf("type: %T: %w", protoValue, ErrValueNotImplementProtoMessage)
 	}
 
 	// If case if original value is nil, create new instance.

--- a/converter/proto_json_payload_converter.go
+++ b/converter/proto_json_payload_converter.go
@@ -97,7 +97,7 @@ func (c *ProtoJSONPayloadConverter) FromPayload(payload *commonpb.Payload, value
 	}
 
 	value := originalValue
-	// In case if value is of value type (i.e. commonpb.WorkflowType), create a pointer to it.
+	// In case if original value is of value type (i.e. commonpb.WorkflowType), create a pointer to it.
 	if originalValue.Kind() != reflect.Ptr {
 		value = pointerTo(originalValue.Interface())
 	}
@@ -109,16 +109,14 @@ func (c *ProtoJSONPayloadConverter) FromPayload(payload *commonpb.Payload, value
 		return fmt.Errorf("value: %v of type: %T: %w", originalValue, originalValue, ErrValueNotImplementProtoMessage)
 	}
 
+	// If case if original value is nil, create new instance.
 	if originalValue.Kind() == reflect.Ptr && originalValue.IsNil() {
-		// If nil is passed then create new instance.
-		protoType := originalValue.Type().Elem() // i.e. commonpb.WorkflowType
-		newProtoValue := reflect.New(protoType)  // is of pointer type (i.e. *commonpb.WorkflowType)
+		newProtoValue := newOfSameType(originalValue)
 		if isProtoMessage {
 			protoMessage = newProtoValue.Interface().(proto.Message) // type assertion must always succeed
 		} else if isGogoProtoMessage {
 			gogoProtoMessage = newProtoValue.Interface().(gogoproto.Message) // type assertion must always succeed
 		}
-		originalValue.Set(newProtoValue) // set newly created value back to passed valuePtr
 	}
 
 	var err error

--- a/converter/proto_json_payload_converter.go
+++ b/converter/proto_json_payload_converter.go
@@ -92,14 +92,14 @@ func (c *ProtoJSONPayloadConverter) FromPayload(payload *commonpb.Payload, value
 	}
 
 	if value.Kind() != reflect.Ptr {
-		return ErrValueIsNotPointer
+		return ErrProtoStructIsNotPointer
 	}
 
 	protoValue := value.Interface() // protoValue is of type i.e. *commonpb.WorkflowType
 	gogoProtoMessage, isGogoProtoMessage := protoValue.(gogoproto.Message)
 	protoMessage, isProtoMessage := protoValue.(proto.Message)
 	if !isGogoProtoMessage && !isProtoMessage {
-		return fmt.Errorf("value: %v of type: %T: %w", value, value, ErrValueDoesntImplementProtoMessage)
+		return fmt.Errorf("value: %v of type: %T: %w", value, value, ErrValueNotImplementProtoMessage)
 	}
 
 	// If nil is passed create new instance

--- a/converter/proto_payload_converter.go
+++ b/converter/proto_payload_converter.go
@@ -55,11 +55,6 @@ func (c *ProtoPayloadConverter) ToPayload(value interface{}) (*commonpb.Payload,
 	// Case 4 implements gogoproto.Message.
 	// It is important to check for proto.Message first because cases 2 and 3 also implements gogoproto.Message.
 
-	// Bypass nil values
-	if value == nil {
-		return nil, nil
-	}
-
 	builtPointer := false
 	for {
 		if valueProto, ok := value.(proto.Message); ok {

--- a/converter/proto_payload_converter.go
+++ b/converter/proto_payload_converter.go
@@ -76,7 +76,7 @@ func (c *ProtoPayloadConverter) ToPayload(value interface{}) (*commonpb.Payload,
 		if builtPointer {
 			break
 		}
-		value = pointerTo(value)
+		value = pointerTo(value).Interface()
 		builtPointer = true
 	}
 

--- a/converter/proto_payload_converter.go
+++ b/converter/proto_payload_converter.go
@@ -57,6 +57,11 @@ func (c *ProtoPayloadConverter) ToPayload(value interface{}) (*commonpb.Payload,
 	// Case 4 implements gogoproto.Message.
 	// It is important to check for proto.Message first because cases 2 and 3 also implements gogoproto.Message.
 
+	// Bypass nil values
+	if value == nil {
+		return nil, nil
+	}
+
 	builtPointer := false
 	for {
 		if valueProto, ok := value.(proto.Message); ok {
@@ -98,7 +103,7 @@ func (c *ProtoPayloadConverter) FromPayload(payload *commonpb.Payload, valuePtr 
 	gogoProtoMessage, isGogoProtoMessage := protoValue.(gogoproto.Unmarshaler)
 	protoMessage, isProtoMessage := protoValue.(proto.Message)
 	if !isGogoProtoMessage && !isProtoMessage {
-		return fmt.Errorf("value: %v of type: %T: %w", value, value, ErrValueNotImplementProtoUnmarshaler)
+		return fmt.Errorf("value: %v of type: %T: %w", value, value, ErrTypeNotImplementProtoUnmarshaler)
 	}
 
 	// If nil is passed create new instance

--- a/converter/proto_payload_converter.go
+++ b/converter/proto_payload_converter.go
@@ -54,8 +54,8 @@ func (c *ProtoPayloadConverter) ToPayload(value interface{}) (*commonpb.Payload,
 	//   4. github.com/gogo/protobuf - any version.
 	// Case 1 is not supported.
 	// Cases 2 and 3 implements proto.Message and are the same in this context.
-	// Case 4 implements gogoproto.Marshaler.
-	// It is important to check for proto.Message first because cases 2 and 3 also implements gogoproto.Marshaler.
+	// Case 4 implements gogoproto.Message.
+	// It is important to check for proto.Message first because cases 2 and 3 also implements gogoproto.Message.
 
 	builtPointer := false
 	for {
@@ -91,7 +91,7 @@ func (c *ProtoPayloadConverter) FromPayload(payload *commonpb.Payload, valuePtr 
 	}
 
 	if value.Kind() != reflect.Ptr {
-		return ErrProtoStructIsNotPointer
+		return ErrValuePtrIsNotPointer
 	}
 
 	protoValue := value.Interface() // protoValue is of type i.e. *commonpb.WorkflowType

--- a/converter/proto_payload_converter.go
+++ b/converter/proto_payload_converter.go
@@ -84,14 +84,14 @@ func (c *ProtoPayloadConverter) FromPayload(payload *commonpb.Payload, valuePtr 
 	}
 
 	if value.Kind() != reflect.Ptr {
-		return ErrValueIsNotPointer
+		return ErrProtoStructIsNotPointer
 	}
 
 	protoValue := value.Interface() // protoValue is of type i.e. *commonpb.WorkflowType
 	gogoProtoMessage, isGogoProtoMessage := protoValue.(gogoproto.Unmarshaler)
 	protoMessage, isProtoMessage := protoValue.(proto.Message)
 	if !isGogoProtoMessage && !isProtoMessage {
-		return fmt.Errorf("value: %v of type: %T: %w", value, value, ErrValueDoesntImplementProtoUnmarshaler)
+		return fmt.Errorf("value: %v of type: %T: %w", value, value, ErrValueNotImplementProtoUnmarshaler)
 	}
 
 	// If nil is passed create new instance

--- a/converter/reflect.go
+++ b/converter/reflect.go
@@ -1,0 +1,39 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package converter
+
+import (
+	"reflect"
+)
+
+func pointerTo(val interface{}) interface{} {
+	return valueOfPointerTo(val).Interface()
+}
+
+func valueOfPointerTo(val interface{}) reflect.Value {
+	valPtr := reflect.New(reflect.TypeOf(val))
+	valPtr.Elem().Set(reflect.ValueOf(val))
+	return valPtr
+}

--- a/converter/reflect.go
+++ b/converter/reflect.go
@@ -28,11 +28,7 @@ import (
 	"reflect"
 )
 
-func pointerTo(val interface{}) interface{} {
-	return valueOfPointerTo(val).Interface()
-}
-
-func valueOfPointerTo(val interface{}) reflect.Value {
+func pointerTo(val interface{}) reflect.Value {
 	valPtr := reflect.New(reflect.TypeOf(val))
 	valPtr.Elem().Set(reflect.ValueOf(val))
 	return valPtr

--- a/converter/reflect.go
+++ b/converter/reflect.go
@@ -40,3 +40,8 @@ func newOfSameType(val reflect.Value) reflect.Value {
 	val.Set(newValue)                // set newly created value back to passed value
 	return newValue
 }
+
+func isInterfaceNil(i interface{}) bool {
+	v := reflect.ValueOf(i)
+	return i == nil || (v.Kind() == reflect.Ptr && v.IsNil())
+}

--- a/converter/reflect.go
+++ b/converter/reflect.go
@@ -33,3 +33,10 @@ func pointerTo(val interface{}) reflect.Value {
 	valPtr.Elem().Set(reflect.ValueOf(val))
 	return valPtr
 }
+
+func newOfSameType(val reflect.Value) reflect.Value {
+	valType := val.Type().Elem()     // i.e. commonpb.WorkflowType
+	newValue := reflect.New(valType) // is of pointer type (i.e. *commonpb.WorkflowType)
+	val.Set(newValue)                // set newly created value back to passed value
+	return newValue
+}

--- a/converter/reflect.go
+++ b/converter/reflect.go
@@ -35,7 +35,7 @@ func pointerTo(val interface{}) reflect.Value {
 }
 
 func newOfSameType(val reflect.Value) reflect.Value {
-	valType := val.Type().Elem()     // i.e. commonpb.WorkflowType
+	valType := val.Type().Elem()     // is value type (i.e. commonpb.WorkflowType)
 	newValue := reflect.New(valType) // is of pointer type (i.e. *commonpb.WorkflowType)
 	val.Set(newValue)                // set newly created value back to passed value
 	return newValue

--- a/go.sum
+++ b/go.sum
@@ -40,8 +40,6 @@ github.com/golang/protobuf v1.4.0-rc.2/go.mod h1:LlEzMj4AhA7rCAGe4KMBDvJI+AwstrU
 github.com/golang/protobuf v1.4.0-rc.4.0.20200313231945-b860323f09d0/go.mod h1:WU3c8KckQ9AFe+yFwt9sWVRKCVIyN9cPHBJSNnbL67w=
 github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvqG2KuDX0=
 github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QDs8UjoX8=
-github.com/golang/protobuf v1.4.2 h1:+Z5KGCizgyZCbGh1KZqA0fcLLkwbsjIzS4aV2v7wJX0=
-github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/protobuf v1.4.3 h1:JjCZWpVbqXDqFVmTfYWEVTMIYrL/NPdPSCHPJ0T/raM=
 github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
@@ -53,8 +51,6 @@ github.com/google/go-cmp v0.5.0 h1:/QaMHBdZ26BB3SSst0Iwl10Epc+xhTquomWX0oZEB6w=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/uuid v1.0.0 h1:b4Gk+7WdP/d3HZH8EJsZpvV7EtDOgaZLtnaNGIu1adA=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
-github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/kisielk/errcheck v1.2.0 h1:reN85Pxc5larApoH1keMBiu2GWtPqXQ1nc9gx+jOU+E=
@@ -96,8 +92,6 @@ github.com/uber/jaeger-client-go v2.23.1+incompatible/go.mod h1:WVhlPFC8FDjOFMMW
 github.com/uber/jaeger-lib v2.2.0+incompatible h1:MxZXOiR2JuoANZ3J6DE/U0kSFv/eJ/GfSYVCjK7dyaw=
 github.com/uber/jaeger-lib v2.2.0+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
-go.temporal.io/api v1.0.0 h1:mWtvS+5ENYvG4ZPZ/4/bxCj4j3gIF4D05C2GVrhLpjc=
-go.temporal.io/api v1.0.0/go.mod h1:AgbKINgV3KR9SlTH8nQRsNadVbxVI+/LnZ1uFModMIA=
 go.temporal.io/api v1.1.1-0.20201016190939-4500d7f12354 h1:O681ZLtDB2EaL13N0Mk1nk7ZFihaxeE4XhC87ICL0Fk=
 go.temporal.io/api v1.1.1-0.20201016190939-4500d7f12354/go.mod h1:WrwsmPOhGVCFCdVSLxvg+qV6RvEnpF2RjVMF7IHNpkI=
 go.uber.org/atomic v1.6.0 h1:Ezj3JGmsOnG1MoRWQkPBsKLe9DwWD9QeXzTRzzldNVk=
@@ -126,8 +120,6 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859 h1:R/3boaszxrf1GEUWTVDzSKVwLmSJpwZ1yqXm8j0v2QI=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.0.0-20200925080053-05aa5d4ee321 h1:lleNcKRbcaC8MqgLwghIkzZ2JBQAb7QQ9MiwRt1BisA=
-golang.org/x/net v0.0.0-20200925080053-05aa5d4ee321/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20201016165138-7b1cca2348c0 h1:5kGOVHlq0euqwzgTC9Vu15p6fV1Wi0ArVi8da2urnVg=
 golang.org/x/net v0.0.0-20201016165138-7b1cca2348c0/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -139,11 +131,8 @@ golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20uW+C3Rm0FD/WLDX8884=
-golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200923182605-d9f96fdee20d h1:L/IKR6COd7ubZrs2oTnTi73IhgqJ71c9s80WsQnh0Es=
-golang.org/x/sys v0.0.0-20200923182605-d9f96fdee20d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201016160150-f659759dc4ca h1:mLWBs1i4Qi5cHWGEtn2jieJQ2qtwV/gT0A2zLrmzaoE=
 golang.org/x/sys v0.0.0-20201016160150-f659759dc4ca/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -175,8 +164,6 @@ google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoA
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55 h1:gSJIx1SDwno+2ElGhA4+qG2zF97qiUzTM+rQ0klBOcE=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
-google.golang.org/genproto v0.0.0-20200925023002-c2d885f95484 h1:Rr9EZdYRq2WLckzJQVtN3ISKoP7dvgwi7jbglILNZ34=
-google.golang.org/genproto v0.0.0-20200925023002-c2d885f95484/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20201015140912-32ed001d685c h1:FM0/YezufKHjM3Y9gndHmhytJuCHW0bExs92Pu3LTQ0=
 google.golang.org/genproto v0.0.0-20201015140912-32ed001d685c/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/grpc v1.12.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
@@ -184,8 +171,6 @@ google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZi
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
-google.golang.org/grpc v1.32.0 h1:zWTV+LMdc3kaiJMSTOFz2UgSBgx8RNQoTGiZu3fR9S0=
-google.golang.org/grpc v1.32.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
 google.golang.org/grpc v1.33.0 h1:IBKSUNL2uBS2DkJBncPP+TwT0sp9tgA8A75NjHt6umg=
 google.golang.org/grpc v1.33.0/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTpR3n0=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=


### PR DESCRIPTION
When Activity/Workflow parameter is a proto object, it had to be a pointer (because `proto.Message` is implemented on pointer receiver only), and now non-pointers are also supported (thanks to reflection magic):
```
ai := datapb.AccountInfo{...} // not &datapb.AccountInfo{...}
f := workflow.ExecuteActivity(ctx, "MakeTransaction", ai)
var tr datapb.TransactionResult // not *datapb.TransactionResult
f.Get(&tr)
```
