### PR TITLE
Added mock Call.Panic

### DIFF
--- a/internal/internal_workflow_testsuite_test.go
+++ b/internal/internal_workflow_testsuite_test.go
@@ -1144,7 +1144,9 @@ func (s *WorkflowTestSuiteUnitTest) Test_MockPanic() {
 	s.True(env.IsWorkflowCompleted())
 	err := env.GetWorkflowError()
 	s.Error(err)
-	s.Contains(err.Error(), "mock-panic")
+	var panicErr *PanicError
+	s.True(errors.As(err, &panicErr))
+	s.Equal(panicErr.Error(), "mock-panic")
 	env.AssertExpectations(s.T())
 	s.SetLogger(oldLogger) // restore original logger
 }
@@ -1165,7 +1167,9 @@ func (s *WorkflowTestSuiteUnitTest) Test_MockPanicThoughRun() {
 	s.True(env.IsWorkflowCompleted())
 	err := env.GetWorkflowError()
 	s.Error(err)
-	s.Contains(err.Error(), "mock-panic")
+	var panicErr *PanicError
+	s.True(errors.As(err, &panicErr))
+	s.Equal(panicErr.Error(), "mock-panic")
 	env.AssertExpectations(s.T())
 	s.SetLogger(oldLogger) // restore original logger
 }

--- a/internal/workflow_testsuite.go
+++ b/internal/workflow_testsuite.go
@@ -475,6 +475,12 @@ func (c *MockCallWrapper) Return(returnArguments ...interface{}) *MockCallWrappe
 	return c
 }
 
+// Panic specifies if the function call should fail and the panic message
+func (c *MockCallWrapper) Panic(msg string) *MockCallWrapper {
+	c.call.Panic(msg)
+	return c
+}
+
 // ExecuteWorkflow executes a workflow, wait until workflow complete. It will fail the test if workflow is blocked and
 // cannot complete within TestTimeout (set by SetTestTimeout()).
 func (e *TestWorkflowEnvironment) ExecuteWorkflow(workflowFn interface{}, args ...interface{}) {


### PR DESCRIPTION
Add support for mocking activity mock panicking as:
```
env.OnActivity(testActivityHello, mock.Anything, mock.Anything).Panic("mock-panic")
```
Helps to test that activity shouldn't be called.