### PR TITLE
Update broken link to Go quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ go get -u go.temporal.io/sdk
 
 See [samples](https://github.com/temporalio/samples-go) to get started. 
 
-Documentation is available [here](https://docs.temporal.io/docs/go-quick-start). 
+Documentation is available [here](https://docs.temporal.io/docs/get-started). 
 You can also find the API documentation [here](https://pkg.go.dev/go.temporal.io/sdk).
 
 ## Using a custom logger


### PR DESCRIPTION
There isn't an obvious replacement for the broken link so pointed it at the top-level page for the SDK docs.