### PR TITLE
Update go.temporal.io/api

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/uber-go/tally v3.3.17+incompatible
 	github.com/uber/jaeger-client-go v2.23.1+incompatible
 	github.com/uber/jaeger-lib v2.2.0+incompatible // indirect
-	go.temporal.io/api v1.1.1-0.20201102165954-7c55c58b053e
+	go.temporal.io/api v1.1.1-0.20201104024306-2ac4ba734346
 	go.uber.org/atomic v1.7.0
 	go.uber.org/goleak v1.0.0
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b // indirect

--- a/go.sum
+++ b/go.sum
@@ -92,8 +92,8 @@ github.com/uber/jaeger-client-go v2.23.1+incompatible/go.mod h1:WVhlPFC8FDjOFMMW
 github.com/uber/jaeger-lib v2.2.0+incompatible h1:MxZXOiR2JuoANZ3J6DE/U0kSFv/eJ/GfSYVCjK7dyaw=
 github.com/uber/jaeger-lib v2.2.0+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
-go.temporal.io/api v1.1.1-0.20201102165954-7c55c58b053e h1:xPqjs5wF1BMJ04QxzaArhx6QGH99KvnCAXS17i+yrfI=
-go.temporal.io/api v1.1.1-0.20201102165954-7c55c58b053e/go.mod h1:M+qHXIddPa0ioTvM+tniIiRzXxvks4aixhIH4olwSnk=
+go.temporal.io/api v1.1.1-0.20201104024306-2ac4ba734346 h1:T9u7ptebvSfZ9dhtlo1xFOrDLNFQYdPNOGTRDngMjjU=
+go.temporal.io/api v1.1.1-0.20201104024306-2ac4ba734346/go.mod h1:yOc7xX03usCg0Vh9qV0eQHwWqcEiFbfNpVCUyH7ieKo=
 go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/goleak v1.0.0 h1:qsup4IcBdlmsnGfqyLl4Ntn3C2XCCuKAE7DwHpScyUo=
@@ -165,8 +165,8 @@ google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoA
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55 h1:gSJIx1SDwno+2ElGhA4+qG2zF97qiUzTM+rQ0klBOcE=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
-google.golang.org/genproto v0.0.0-20201102152239-715cce707fb0 h1:d0rYPqjQfVuFe+tZgv4PHt2hNxK79MRXX7PaD/A5ynA=
-google.golang.org/genproto v0.0.0-20201102152239-715cce707fb0/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
+google.golang.org/genproto v0.0.0-20201103154000-415bd0cd5df6 h1:rMoZiLTOobSD3eg30lPMcFkBFNSyKUQQIQlw/hsAXME=
+google.golang.org/genproto v0.0.0-20201103154000-415bd0cd5df6/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/grpc v1.12.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -234,7 +234,7 @@ func verifyNamespaceExist(client workflowservice.WorkflowServiceClient, metricsS
 	descNamespaceOp := func() error {
 		grpcCtx, cancel := newGRPCContext(ctx)
 		defer cancel()
-		_, err := client.DescribeNamespace(grpcCtx, &workflowservice.DescribeNamespaceRequest{Name: namespace})
+		_, err := client.DescribeNamespace(grpcCtx, &workflowservice.DescribeNamespaceRequest{Namespace: namespace})
 		if err != nil {
 			switch err.(type) {
 			case *serviceerror.NotFound:

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -1019,9 +1019,9 @@ func (nc *namespaceClient) Register(ctx context.Context, request *workflowservic
 //	- EntityNotExistsError
 //	- BadRequestError
 //	- InternalServiceError
-func (nc *namespaceClient) Describe(ctx context.Context, name string) (*workflowservice.DescribeNamespaceResponse, error) {
+func (nc *namespaceClient) Describe(ctx context.Context, namespace string) (*workflowservice.DescribeNamespaceResponse, error) {
 	request := &workflowservice.DescribeNamespaceRequest{
-		Name: name,
+		Namespace: namespace,
 	}
 
 	var response *workflowservice.DescribeNamespaceResponse

--- a/test/bindings_test.go
+++ b/test/bindings_test.go
@@ -80,9 +80,8 @@ func (ts *AsyncBindingsTestSuite) registerNamespace() {
 	ts.NoError(err)
 	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
 	defer cancel()
-	name := namespace
 	err = client.Register(ctx, &workflowservice.RegisterNamespaceRequest{
-		Name:                             name,
+		Namespace:                        namespace,
 		WorkflowExecutionRetentionPeriod: common.DurationPtr(1 * 24 * time.Hour),
 	})
 	defer client.Close()

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -662,10 +662,9 @@ func (ts *IntegrationTestSuite) registerNamespace() {
 	ts.NoError(err)
 	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
 	defer cancel()
-	name := namespace
 	retention := 1 * time.Hour * 24
 	err = client.Register(ctx, &workflowservice.RegisterNamespaceRequest{
-		Name:                             name,
+		Namespace:                        namespace,
 		WorkflowExecutionRetentionPeriod: &retention,
 	})
 	client.Close()


### PR DESCRIPTION
Sync with latest API changes https://github.com/temporalio/api/commit/c245225a771227f5ee51bdcbc8d48a26c5c65e9f (`name` to `namespace` rename).