### PR TITLE
Replace panic in headerReader with nil return

### DIFF
--- a/internal/headers.go
+++ b/internal/headers.go
@@ -77,7 +77,7 @@ func (hr *headerReader) ForEachKey(handler func(string, *commonpb.Payload) error
 
 func (hr *headerReader) Get(key string) (*commonpb.Payload, bool) {
 	if hr.header == nil {
-		panic("headerReader.header is nil")
+		return nil, false
 	}
 	payload, ok := hr.header.Fields[key]
 	return payload, ok

--- a/internal/headers_test.go
+++ b/internal/headers_test.go
@@ -194,6 +194,12 @@ func TestHeaderReader_Get(t *testing.T) {
 			"key1",
 			false,
 		},
+		{
+			"nil headers",
+			nil,
+			"key1",
+			false,
+		},
 	}
 
 	for _, test := range tests {
@@ -209,10 +215,4 @@ func TestHeaderReader_Get(t *testing.T) {
 			}
 		})
 	}
-
-	t.Run("nil panic", func(t *testing.T) {
-		reader := NewHeaderReader(nil)
-		assert.Panics(t, func() { reader.Get("") })
-	})
-
 }


### PR DESCRIPTION
It turned out that `header` can be `nil` on request (for example request which came from `tctl`) and it is a valid case. There is no reason to panic on it but return "missing header" response instead.