### PR TITLE
fix PanicError when future return value is pointer

### DIFF
--- a/internal/internal_workflow.go
+++ b/internal/internal_workflow.go
@@ -333,7 +333,12 @@ func (f *futureImpl) Get(ctx Context, valuePtr interface{}) error {
 
 	fv := reflect.ValueOf(f.value)
 	if fv.IsValid() {
-		rf.Elem().Set(fv)
+		// fix the PanicError when the return value is pointer
+		if fv.Kind() == reflect.Ptr {
+			rf.Elem().Set(fv.Elem())
+		} else {
+			rf.Elem().Set(fv)
+		}
 	}
 	return f.err
 }


### PR DESCRIPTION
This request fix the Panic Error bug:

How to trigger the bug:

When the activity result is a pointer and settable set a pointer, the code will be Panic.

```go
// Workflow is a Hello World workflow definition.
func Workflow(ctx workflow.Context, name string) (*Result, error) {
	ao := workflow.ActivityOptions{
		ScheduleToStartTimeout: time.Minute,
		StartToCloseTimeout:    time.Minute,
	}
	ctx = workflow.WithActivityOptions(ctx, ao)
	future, settable := workflow.NewFuture(ctx)
	workflow.Go(ctx, func(ctx workflow.Context) {
		result := new(Result)
		err := workflow.ExecuteActivity(ctx, Activity, name).Get(ctx, result)
		if err != nil {
			settable.Set(nil, err)
			return
		}
		settable.Set(result, err)
	})
	var result Result
	err := future.Get(ctx, &result)
	if err != nil {
		return nil, err
	}
	return &result, nil
}
// Result the result object
type Result struct {
	Data string
}

// Activity renturn a pointer
func Activity(ctx context.Context, name string) (*Result, error) {
	return &Result{Data:"Hello " + name + "!"}, nil
}
```

> more info see the code changes