### PR TITLE
Fixes issue where a deadlock detected via a Workflow Execution resumed from a Local Activity Completion fails the Workflow

### DIFF
--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -930,60 +930,15 @@ ProcessEvents:
 	// activity task completed), but the corresponding workflow code that start the event has been removed. In that case
 	// the replay of that event will panic on the command state machine and the workflow will be marked as completed
 	// with the panic error.
-	var panicError error
+	var workflowError error
 	if !skipReplayCheck && !w.isWorkflowCompleted {
 		// check if commands from reply matches to the history events
 		if err := matchReplayWithHistory(replayCommands, respondEvents); err != nil {
-			panicError = err
+			workflowError = err
 		}
 	}
 
-	return w.applyPanicPolicy(workflowTask, panicError)
-}
-
-func (w *workflowExecutionContextImpl) applyPanicPolicy(workflowTask *workflowTask, panicError error) (interface{}, error) {
-	task := workflowTask.task
-	eventHandler := w.getEventHandler()
-
-	if panicError == nil && w.err != nil {
-		if panicErr, ok := w.err.(*workflowPanicError); ok {
-			panicError = panicErr
-		}
-	}
-
-	if panicError != nil {
-		if panicErr, ok := w.err.(*workflowPanicError); ok {
-			w.wth.logger.Error("Workflow panic",
-				tagWorkflowType, task.WorkflowType.GetName(),
-				tagWorkflowID, task.WorkflowExecution.GetWorkflowId(),
-				tagRunID, task.WorkflowExecution.GetRunId(),
-				tagError, panicError,
-				tagStackTrace, panicErr.StackTrace())
-		} else {
-			w.wth.logger.Error("Workflow panic",
-				tagWorkflowType, task.WorkflowType.GetName(),
-				tagWorkflowID, task.WorkflowExecution.GetWorkflowId(),
-				tagRunID, task.WorkflowExecution.GetRunId(),
-				tagError, panicError)
-		}
-
-		switch w.wth.workflowPanicPolicy {
-		case FailWorkflow:
-			// complete workflow with custom error will fail the workflow
-			eventHandler.Complete(nil, NewApplicationError(
-				"Workflow failed on panic due to FailWorkflow workflow panic policy",
-				"", false, panicError))
-		case BlockWorkflow:
-			// return error here will be convert to WorkflowTaskFailed for the first time, and ignored for subsequent
-			// attempts which will cause WorkflowTaskTimeout and server will retry forever until issue got fixed or
-			// workflow timeout.
-			return nil, panicError
-		default:
-			panic("unknown mismatched workflow history policy.")
-		}
-	}
-
-	return w.CompleteWorkflowTask(workflowTask, true), nil
+	return w.applyWorkflowPanicPolicy(workflowTask, workflowError)
 }
 
 func (w *workflowExecutionContextImpl) ProcessLocalActivityResult(workflowTask *workflowTask, lar *localActivityResult) (interface{}, error) {
@@ -991,7 +946,51 @@ func (w *workflowExecutionContextImpl) ProcessLocalActivityResult(workflowTask *
 		return nil, nil // nothing to do here as we are retrying...
 	}
 
-	return w.applyPanicPolicy(workflowTask, w.getEventHandler().ProcessLocalActivityResult(lar))
+	return w.applyWorkflowPanicPolicy(workflowTask, w.getEventHandler().ProcessLocalActivityResult(lar))
+}
+
+func (w *workflowExecutionContextImpl) applyWorkflowPanicPolicy(workflowTask *workflowTask, workflowError error) (interface{}, error) {
+	task := workflowTask.task
+
+	if workflowError == nil && w.err != nil {
+		if panicErr, ok := w.err.(*workflowPanicError); ok {
+			workflowError = panicErr
+		}
+	}
+
+	if workflowError != nil {
+		if panicErr, ok := w.err.(*workflowPanicError); ok {
+			w.wth.logger.Error("Workflow panic",
+				tagWorkflowType, task.WorkflowType.GetName(),
+				tagWorkflowID, task.WorkflowExecution.GetWorkflowId(),
+				tagRunID, task.WorkflowExecution.GetRunId(),
+				tagError, workflowError,
+				tagStackTrace, panicErr.StackTrace())
+		} else {
+			w.wth.logger.Error("Workflow panic",
+				tagWorkflowType, task.WorkflowType.GetName(),
+				tagWorkflowID, task.WorkflowExecution.GetWorkflowId(),
+				tagRunID, task.WorkflowExecution.GetRunId(),
+				tagError, workflowError)
+		}
+
+		switch w.wth.workflowPanicPolicy {
+		case FailWorkflow:
+			// complete workflow with custom error will fail the workflow
+			w.getEventHandler().Complete(nil, NewApplicationError(
+				"Workflow failed on panic due to FailWorkflow workflow panic policy",
+				"", false, workflowError))
+		case BlockWorkflow:
+			// return error here will be convert to WorkflowTaskFailed for the first time, and ignored for subsequent
+			// attempts which will cause WorkflowTaskTimeout and server will retry forever until issue got fixed or
+			// workflow timeout.
+			return nil, workflowError
+		default:
+			panic("unknown mismatched workflow history policy.")
+		}
+	}
+
+	return w.CompleteWorkflowTask(workflowTask, true), nil
 }
 
 func (w *workflowExecutionContextImpl) retryLocalActivity(lar *localActivityResult) bool {

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -204,6 +204,19 @@ func (ts *IntegrationTestSuite) TestDeadlockDetection() {
 	ts.True(strings.Contains(applicationErr.Error(), "Potential deadlock detected"))
 }
 
+func (ts *IntegrationTestSuite) TestDeadlockDetectionViaLocalActivity() {
+	var expected []string
+	wfOpts := ts.startWorkflowOptions("test-deadlock-local-activity")
+	wfOpts.WorkflowTaskTimeout = 5 * time.Second
+	wfOpts.WorkflowRunTimeout = 5 * time.Minute
+	err := ts.executeWorkflowWithOption(wfOpts, ts.workflows.DeadlockedWithLocalActivity, &expected)
+	ts.Error(err)
+	var applicationErr *temporal.ApplicationError
+	ok := errors.As(err, &applicationErr)
+	ts.True(ok)
+	ts.True(strings.Contains(applicationErr.Error(), "Potential deadlock detected"))
+}
+
 func (ts *IntegrationTestSuite) TestActivityRetryOnError() {
 	var expected []string
 	err := ts.executeWorkflow("test-activity-retry-on-error", ts.workflows.ActivityRetryOnError, &expected)

--- a/test/workflow_test.go
+++ b/test/workflow_test.go
@@ -71,6 +71,25 @@ func (w *Workflows) Deadlocked(ctx workflow.Context) ([]string, error) {
 	return []string{}, nil
 }
 
+var isDeadlockedWithLocalActivityFirstAttempt bool = true
+
+func (w *Workflows) DeadlockedWithLocalActivity(ctx workflow.Context) ([]string, error) {
+
+	laCtx := workflow.WithLocalActivityOptions(ctx, workflow.LocalActivityOptions{
+		ScheduleToCloseTimeout: 5 * time.Second,
+	})
+
+	_ = workflow.ExecuteLocalActivity(laCtx, LocalSleep, time.Second*2).Get(laCtx, nil)
+
+	if isDeadlockedWithLocalActivityFirstAttempt {
+		// Simulates deadlock. Never call time.Sleep in production code!
+		time.Sleep(2 * time.Second)
+		isDeadlockedWithLocalActivityFirstAttempt = false
+	}
+
+	return []string{}, nil
+}
+
 func (w *Workflows) Panicked(ctx workflow.Context) ([]string, error) {
 	panic("simulated")
 }
@@ -924,6 +943,7 @@ func (w *Workflows) register(worker worker.Worker) {
 	worker.RegisterWorkflow(w.ActivityRetryOptionsChange)
 	worker.RegisterWorkflow(w.Basic)
 	worker.RegisterWorkflow(w.Deadlocked)
+	worker.RegisterWorkflow(w.DeadlockedWithLocalActivity)
 	worker.RegisterWorkflow(w.Panicked)
 	worker.RegisterWorkflow(w.BasicSession)
 	worker.RegisterWorkflow(w.CancelActivity)


### PR DESCRIPTION
Fixes regression introduced by Deadlock Detection PR:

1) A workflow task execution that exceeded 1 second causes a panic.
2) If the task execution was spawned by the completion of a local activity, that would always fail the Workflow.

This fix alters the code to respect the WorkflowPanicPolicy, even in the case where the panic occurs during Local Activity Result completion. It also adds an integration test to exercise this path.