### PR TITLE
Fixes additional deadlock issues with respect to local activities

### DIFF
--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -153,7 +153,7 @@ type (
 
 func newLocalActivityTunnel(stopCh <-chan struct{}) *localActivityTunnel {
 	return &localActivityTunnel{
-		taskCh:   make(chan *localActivityTask, 1000),
+		taskCh:   make(chan *localActivityTask, 100000),
 		resultCh: make(chan interface{}),
 		stopCh:   stopCh,
 	}


### PR DESCRIPTION
1) Increases Local Activity Tunnel size from 1000 to 100,000 to reduce the chance of a deadlock occurring because the thread that go-routine that drains local-activity results is blocked on sending to the local activity tunnel channel. This is a stop-gap solution. A better solution will be followed up with, but this is a single channel for the entire worker, so the extra memory usage should be relatively trivial

2) Adds special case logic for handling heartbeat delay duration being less than zero as the timer.After() channel is not always reliably firing even when duration has reached or gone below zero. Now, we always do a check on the duration before the select statement.