### PR TITLE
Replaces time.After() usage with time.NewTimer() to reduce memory pressure due to allocated timers

### DIFF
--- a/internal/common/util/util.go
+++ b/internal/common/util/util.go
@@ -57,10 +57,13 @@ func AwaitWaitGroup(wg *sync.WaitGroup, timeout time.Duration) bool {
 		close(doneC)
 	}()
 
+	timer := time.NewTimer(timeout)
+	defer func() { timer.Stop() }()
+
 	select {
 	case <-doneC:
 		return true
-	case <-time.After(timeout):
+	case <-timer.C:
 		return false
 	}
 }

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -794,8 +794,10 @@ processWorkflowLoop:
 			heartbeatLoop:
 				for {
 					if delayDuration <= 0 {
-						heartbeatTimer.Stop()
-						heartbeatTimer = nil
+						if heartbeatTimer != nil {
+							heartbeatTimer.Stop()
+							heartbeatTimer = nil
+						}
 
 						// force complete, call the workflow task heartbeat function
 						workflowTask, err = heartbeatFunc(

--- a/internal/internal_utils.go
+++ b/internal/internal_utils.go
@@ -172,10 +172,13 @@ func awaitWaitGroup(wg *sync.WaitGroup, timeout time.Duration) bool {
 		close(doneC)
 	}()
 
+	timer := time.NewTimer(timeout)
+	defer func() { timer.Stop() }()
+
 	select {
 	case <-doneC:
 		return true
-	case <-time.After(timeout):
+	case <-timer.C:
 		return false
 	}
 }


### PR DESCRIPTION
See this article for an example on when time.After may not be optimal for memory usage purposes: https://medium.com/@oboturov/golang-time-after-is-not-garbage-collected-4cbc94740082

For workflows with a lot of local activities, we will end up unnecessary allocating a whole bunch of timers rather than re-using the same heartbeat one on successive loops. This swaps out time.After() with time.NewTimer() and then explicitly stops the timer when we are done using it.