### PR TITLE
Fix spurious nil derefs on retrying local activities

### DIFF
--- a/internal/internal_task_handlers_test.go
+++ b/internal/internal_task_handlers_test.go
@@ -28,6 +28,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"testing"
 	"time"
 
@@ -1214,6 +1215,97 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_PageToken() {
 	t.NotNil(response)
 }
 
+func (t *TaskHandlersTestSuite) TestLocalActivityRetry_Workflow() {
+	backoffInterval := 10 * time.Millisecond
+	workflowComplete := false
+	laFailures := 0
+
+	retryLocalActivityWorkflowFunc := func(ctx Context, input []byte) error {
+		ao := LocalActivityOptions{
+			ScheduleToCloseTimeout: time.Minute,
+			RetryPolicy: &RetryPolicy{
+				InitialInterval:    backoffInterval,
+				BackoffCoefficient: 1.1,
+				MaximumInterval:    time.Minute,
+				MaximumAttempts:    5,
+			},
+		}
+		ctx = WithLocalActivityOptions(ctx, ao)
+
+		err := ExecuteLocalActivity(ctx, func() error {
+			if laFailures > 2 {
+				return nil
+			}
+			laFailures += 1
+			return errors.New("fail number " + strconv.Itoa(laFailures))
+		}).Get(ctx, nil)
+		workflowComplete = true
+		return err
+	}
+	t.registry.RegisterWorkflowWithOptions(
+		retryLocalActivityWorkflowFunc,
+		RegisterWorkflowOptions{Name: "RetryLocalActivityWorkflow"},
+	)
+
+	workflowTaskStartedEvent := createTestEventWorkflowTaskStarted(3)
+	now := time.Now()
+	onesec := 5 * time.Second
+	workflowTaskStartedEvent.EventTime = &now
+	testEvents := []*historypb.HistoryEvent{
+		createTestEventWorkflowExecutionStarted(1, &historypb.WorkflowExecutionStartedEventAttributes{
+			WorkflowTaskTimeout: &onesec,
+			TaskQueue:           &taskqueuepb.TaskQueue{Name: testWorkflowTaskTaskqueue}},
+		),
+		createTestEventWorkflowTaskScheduled(2, &historypb.WorkflowTaskScheduledEventAttributes{}),
+		workflowTaskStartedEvent,
+	}
+
+	task := createWorkflowTask(testEvents, 0, "RetryLocalActivityWorkflow")
+	stopCh := make(chan struct{})
+	params := workerExecutionParameters{
+		Namespace:         testNamespace,
+		TaskQueue:         testWorkflowTaskTaskqueue,
+		Identity:          "test-id-1",
+		Logger:            t.logger,
+		Tracer:            opentracing.NoopTracer{},
+		WorkerStopChannel: stopCh,
+	}
+	defer close(stopCh)
+
+	taskHandler := newWorkflowTaskHandler(params, nil, t.registry)
+	laTunnel := newLocalActivityTunnel(params.WorkerStopChannel)
+	taskHandlerImpl, ok := taskHandler.(*workflowTaskHandlerImpl)
+	t.True(ok)
+	taskHandlerImpl.laTunnel = laTunnel
+
+	laTaskPoller := newLocalActivityPoller(params, laTunnel)
+	go func() {
+		for {
+			task, _ := laTaskPoller.PollTask()
+			_ = laTaskPoller.ProcessTask(task)
+			// Quit after we've polled enough times
+			if laFailures == 4 {
+				return
+			}
+		}
+	}()
+
+	laResultCh := make(chan *localActivityResult)
+	laRetryCh := make(chan *localActivityTask)
+	response, err := taskHandler.ProcessWorkflowTask(
+		&workflowTask{
+			task:       task,
+			laResultCh: laResultCh,
+			laRetryCh:  laRetryCh,
+		},
+		nil)
+	t.NotNil(response)
+	t.NoError(err)
+	// wait long enough for wf to complete
+	time.Sleep(backoffInterval * 3)
+	t.True(workflowComplete)
+}
+
 func (t *TaskHandlersTestSuite) TestLocalActivityRetry_WorkflowTaskHeartbeatFail() {
 	backoffInterval := 1 * time.Second
 	workflowComplete := false
@@ -1238,7 +1330,7 @@ func (t *TaskHandlersTestSuite) TestLocalActivityRetry_WorkflowTaskHeartbeatFail
 	}
 	t.registry.RegisterWorkflowWithOptions(
 		retryLocalActivityWorkflowFunc,
-		RegisterWorkflowOptions{Name: "RetryLocalActivityWorkflow"},
+		RegisterWorkflowOptions{Name: "RetryLocalActivityWorkflowHBFail"},
 	)
 
 	workflowTaskStartedEvent := createTestEventWorkflowTaskStarted(3)
@@ -1254,7 +1346,7 @@ func (t *TaskHandlersTestSuite) TestLocalActivityRetry_WorkflowTaskHeartbeatFail
 		workflowTaskStartedEvent,
 	}
 
-	task := createWorkflowTask(testEvents, 0, "RetryLocalActivityWorkflow")
+	task := createWorkflowTask(testEvents, 0, "RetryLocalActivityWorkflowHBFail")
 	stopCh := make(chan struct{})
 	params := workerExecutionParameters{
 		Namespace:         testNamespace,

--- a/internal/internal_task_handlers_test.go
+++ b/internal/internal_task_handlers_test.go
@@ -1236,7 +1236,7 @@ func (t *TaskHandlersTestSuite) TestLocalActivityRetry_Workflow() {
 			if laFailures > 2 {
 				return nil
 			}
-			laFailures += 1
+			laFailures++
 			return errors.New("fail number " + strconv.Itoa(laFailures))
 		}).Get(ctx, nil)
 		workflowComplete = true

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -713,6 +713,7 @@ func (wtp *workflowTaskPoller) toWorkflowTask(response *workflowservice.PollWork
 	task := &workflowTask{
 		task:            response,
 		historyIterator: historyIterator,
+		laRetryCh:       make(chan *localActivityTask, 1),
 	}
 	return task
 }

--- a/test/activity_test.go
+++ b/test/activity_test.go
@@ -102,6 +102,14 @@ func (a *Activities) fail(_ context.Context) error {
 	return errFailOnPurpose
 }
 
+func (a *Activities) failNTimes(_ context.Context, times int) error {
+	a.append("failNTimes")
+	if a.invokedCount("failNTimes") > times {
+		return nil
+	}
+	return errFailOnPurpose
+}
+
 func (a *Activities) InspectActivityInfo(ctx context.Context, namespace, taskQueue, wfType string) error {
 	a.append("inspectActivityInfo")
 	info := activity.GetInfo(ctx)
@@ -138,6 +146,18 @@ func (a *Activities) append(name string) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	a.invocations = append(a.invocations, name)
+}
+
+func (a *Activities) invokedCount(name string) int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	var res = 0
+	for i := range a.invocations {
+		if a.invocations[i] == name {
+			res++
+		}
+	}
+	return res
 }
 
 func (a *Activities) invoked() []string {
@@ -203,6 +223,7 @@ func (a *Activities) register(worker worker.Worker) {
 	worker.RegisterActivity(a)
 	// Check reregistration
 	worker.RegisterActivityWithOptions(a.fail, activity.RegisterOptions{Name: "Fail", DisableAlreadyRegisteredCheck: true})
+	worker.RegisterActivityWithOptions(a.failNTimes, activity.RegisterOptions{Name: "FailNTimes", DisableAlreadyRegisteredCheck: true})
 	// Check prefix
 	worker.RegisterActivityWithOptions(a.activities2, activity.RegisterOptions{Name: "Prefix_", DisableAlreadyRegisteredCheck: true})
 	worker.RegisterActivityWithOptions(a.InspectActivityInfo, activity.RegisterOptions{Name: "inspectActivityInfo"})

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -617,6 +617,10 @@ func (ts *IntegrationTestSuite) TestActivityStartedAtSameTimeAsTimerCancel_Repla
 	ts.NoError(err)
 }
 
+func (ts *IntegrationTestSuite) TestWorkflowWithLocalActivityRetries() {
+	ts.NoError(ts.executeWorkflow("test-wf-local-activity-retries", ts.workflows.WorkflowWithLocalActivityRetries, nil))
+}
+
 func (ts *IntegrationTestSuite) TestWorkflowWithParallelLongLocalActivityAndHeartbeat() {
 	if !ts.config.IsStickyOff {
 		ts.NoError(ts.executeWorkflow("test-wf-parallel-long-local-activities-and-heartbeat", ts.workflows.WorkflowWithParallelLongLocalActivityAndHeartbeat, nil))


### PR DESCRIPTION
Depends on https://github.com/temporalio/sdk-go/pull/302 being merged first
Relates to https://www.notion.so/Go-SDK-Nil-Reference-Panic-in-Bench-Test-b240b5f0db3b4d8088e3486939a53e78

~It appears my fix in the MR this one depends on also fixes this item. I wasn't able to repro the issue after a variety of bench runs.~ Not quite. Will require a bit of extra fix.