### PR TITLE
Adding an option to allow starting local activity worker only

### DIFF
--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -1302,10 +1302,13 @@ func NewAggregatedWorker(client *WorkflowClient, taskQueue string, options Worke
 	}
 
 	// activity types.
-	activityWorker := newActivityWorker(client.workflowService, workerParams, nil, registry, nil)
+	var activityWorker *activityWorker
+	if !options.LocalActivityWorkerOnly {
+		activityWorker = newActivityWorker(client.workflowService, workerParams, nil, registry, nil)
+	}
 
 	var sessionWorker *sessionWorker
-	if options.EnableSessionWorker {
+	if options.EnableSessionWorker && !options.LocalActivityWorkerOnly {
 		sessionWorker = newSessionWorker(client.workflowService, workerParams, nil, registry, options.MaxConcurrentSessionExecutionSize)
 		registry.RegisterActivityWithOptions(sessionCreationActivity, RegisterActivityOptions{
 			Name: sessionCreationActivityName,

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -1992,6 +1992,45 @@ func TestWorkerOptionNonDefaults(t *testing.T) {
 	assertWorkerExecutionParamsEqual(t, expected, activityWorker.executionParameters)
 }
 
+func TestLocalActivityWorkerOnly(t *testing.T) {
+	client := &WorkflowClient{}
+	taskQueue := "worker-options-tq"
+	aggWorker := NewAggregatedWorker(client, taskQueue, WorkerOptions{LocalActivityWorkerOnly: true})
+
+	workflowWorker := aggWorker.workflowWorker
+	require.True(t, workflowWorker.executionParameters.Identity != "")
+	require.NotNil(t, workflowWorker.executionParameters.Logger)
+	require.NotNil(t, workflowWorker.executionParameters.MetricsScope)
+	require.Nil(t, workflowWorker.executionParameters.ContextPropagators)
+
+	expected := workerExecutionParameters{
+		Namespace:                             DefaultNamespace,
+		TaskQueue:                             taskQueue,
+		MaxConcurrentActivityTaskQueuePollers: defaultConcurrentPollRoutineSize,
+		MaxConcurrentWorkflowTaskQueuePollers: defaultConcurrentPollRoutineSize,
+		ConcurrentLocalActivityExecutionSize:  defaultMaxConcurrentLocalActivityExecutionSize,
+		ConcurrentActivityExecutionSize:       defaultMaxConcurrentActivityExecutionSize,
+		ConcurrentWorkflowTaskExecutionSize:   defaultMaxConcurrentTaskExecutionSize,
+		WorkerActivitiesPerSecond:             defaultTaskQueueActivitiesPerSecond,
+		TaskQueueActivitiesPerSecond:          defaultTaskQueueActivitiesPerSecond,
+		WorkerLocalActivitiesPerSecond:        defaultWorkerLocalActivitiesPerSecond,
+		StickyScheduleToStartTimeout:          stickyWorkflowTaskScheduleToStartTimeoutSeconds * time.Second,
+		DataConverter:                         converter.GetDefaultDataConverter(),
+		Tracer:                                opentracing.NoopTracer{},
+		Logger:                                workflowWorker.executionParameters.Logger,
+		MetricsScope:                          workflowWorker.executionParameters.MetricsScope,
+		Identity:                              workflowWorker.executionParameters.Identity,
+		UserContext:                           workflowWorker.executionParameters.UserContext,
+	}
+
+	assertWorkerExecutionParamsEqual(t, expected, workflowWorker.executionParameters)
+
+	activityWorker := aggWorker.activityWorker
+	require.Nil(t, activityWorker)
+	sessionWorker := aggWorker.sessionWorker
+	require.Nil(t, sessionWorker)
+}
+
 func assertWorkerExecutionParamsEqual(t *testing.T, paramsA workerExecutionParameters, paramsB workerExecutionParameters) {
 	require.Equal(t, paramsA.TaskQueue, paramsA.TaskQueue)
 	require.Equal(t, paramsA.Identity, paramsB.Identity)

--- a/internal/worker.go
+++ b/internal/worker.go
@@ -144,6 +144,11 @@ type (
 		// Optional: Specifies factories used to instantiate workflow interceptor chain
 		// The chain is instantiated per each replay of a workflow execution
 		WorkflowInterceptorChainFactories []WorkflowInterceptor
+
+		// Optional: If set to true worker would only handle workflow tasks and local activities.
+		// Non-local activities will not be executed by this worker.
+		// default: false
+		LocalActivityWorkerOnly bool
 	}
 )
 

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -150,6 +150,10 @@ func (ts *IntegrationTestSuite) SetupTest() {
 		options.EnableSessionWorker = true
 	}
 
+	if strings.Contains(ts.T().Name(), "LocalActivityWorkerOnly") {
+		options.LocalActivityWorkerOnly = true
+	}
+
 	ts.worker = worker.New(ts.client, ts.taskQueueName, options)
 	ts.registerWorkflowsAndActivities(ts.worker)
 	ts.Nil(ts.worker.Start())
@@ -657,8 +661,18 @@ func (ts *IntegrationTestSuite) TestInspectActivityInfo() {
 	ts.Nil(err)
 }
 
+func (ts *IntegrationTestSuite) TestInspectActivityInfoLocalActivityWorkerOnly() {
+	err := ts.executeWorkflow("test-activity-info", ts.workflows.InspectActivityInfo, nil)
+	ts.Error(err)
+}
+
 func (ts *IntegrationTestSuite) TestInspectLocalActivityInfo() {
 	err := ts.executeWorkflow("test-local-activity-info", ts.workflows.InspectLocalActivityInfo, nil)
+	ts.Nil(err)
+}
+
+func (ts *IntegrationTestSuite) TestInspectLocalActivityInfoLocalActivityWorkerOnly() {
+	err := ts.executeWorkflow("test-local-activity-info-local-activity-worker-only", ts.workflows.InspectLocalActivityInfo, nil)
 	ts.Nil(err)
 }
 


### PR DESCRIPTION
Similarly to [this change in Java SDK](https://github.com/temporalio/sdk-java/pull/276) this PR addresses #284 adding ability to set `LocalActivityWorkerOnly` flag in the worker options in order to avoid starting activity and session workers.
This allows running local activity workers only without any overhead for activity polling.