### PR TITLE
Retry channel wasn't being initialized properly - fix that.

### DIFF
--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -1043,7 +1043,11 @@ func (w *workflowExecutionContextImpl) retryLocalActivity(lar *localActivityResu
 		// we need a local retry
 		time.AfterFunc(retryBackoff, func() {
 			// Send retry signal
-			lar.task.workflowTask.laRetryCh <- lar.task
+			select {
+			case lar.task.workflowTask.laRetryCh <- lar.task:
+			case <-lar.task.workflowTask.doneCh:
+				// Task is already done. Abort retrying.
+			}
 		})
 		return true
 	}

--- a/test/activity_test.go
+++ b/test/activity_test.go
@@ -27,6 +27,7 @@ package test_test
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -102,9 +103,10 @@ func (a *Activities) fail(_ context.Context) error {
 	return errFailOnPurpose
 }
 
-func (a *Activities) failNTimes(_ context.Context, times int) error {
-	a.append("failNTimes")
-	if a.invokedCount("failNTimes") > times {
+func (a *Activities) failNTimes(_ context.Context, times int, id int) error {
+	invokeid := "failNTimes" + strconv.Itoa(id)
+	a.append(invokeid)
+	if a.invokedCount(invokeid) > times {
 		return nil
 	}
 	return errFailOnPurpose


### PR DESCRIPTION
Relates to https://www.notion.so/temporalio/Unexpected-Non-Deterministic-error-when-running-go-cancellation-bench-test-e507f3b686bf41bfa24c3fd6200c570a

The initial fix wasn't working quite right, and could lead to goroutines getting stuck trying to populate the retry channel. This changes initialization to be just like the result channel, fixing that problem.