### PR TITLE
[WIP] PHP-SDK: PurgeStickyWorkflowCache, worker.Identity

### DIFF
--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -1286,6 +1286,10 @@ func NewAggregatedWorker(client *WorkflowClient, taskQueue string, options Worke
 		cache:                                 cache,
 	}
 
+	if options.Identity != "" {
+		workerParams.Identity = options.Identity
+	}
+
 	ensureRequiredParams(&workerParams)
 	workerParams.Logger = ilog.With(workerParams.Logger,
 		tagNamespace, client.namespace,

--- a/internal/internal_worker_cache.go
+++ b/internal/internal_worker_cache.go
@@ -70,6 +70,15 @@ func SetStickyWorkflowCacheSize(cacheSize int) {
 	desiredWorkflowCacheSize = cacheSize
 }
 
+// PurgeStickyWorkflowCache resets the sticky workflow cache. This must be called only when all workers are stopped.
+func PurgeStickyWorkflowCache() {
+	sharedWorkerCacheLock.Lock()
+	defer sharedWorkerCacheLock.Unlock()
+
+	sharedWorkerCachePtr.workerRefcount = 0
+	sharedWorkerCachePtr.workflowCache = nil
+}
+
 // NewWorkerCache Creates a new WorkerCache, and increases workerRefcount by one. Instances of WorkerCache decrement the refcounter as
 // a hook to runtime.SetFinalizer (ie: When they are freed by the GC). When there are no reachable instances of
 // WorkerCache, shared caches will be cleared

--- a/internal/worker.go
+++ b/internal/worker.go
@@ -149,6 +149,10 @@ type (
 		// Non-local activities will not be executed by this worker.
 		// default: false
 		LocalActivityWorkerOnly bool
+
+		// Optional: If set overwrites the client level Identify value.
+		// default: client identity
+		Identity string
 	}
 )
 

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -238,6 +238,11 @@ func SetStickyWorkflowCacheSize(cacheSize int) {
 	internal.SetStickyWorkflowCacheSize(cacheSize)
 }
 
+// PurgeStickyWorkflowCache resets the sticky workflow cache. This must be called only when all workers are stopped.
+func PurgeStickyWorkflowCache() {
+	internal.PurgeStickyWorkflowCache()
+}
+
 // SetBinaryChecksum sets the identifier of the binary(aka BinaryChecksum).
 // The identifier is mainly used in recording reset points when respondWorkflowTaskCompleted. For each workflow, the very first
 // workflow task completed by a binary will be associated as a auto-reset point for the binary. So that when a customer wants to


### PR DESCRIPTION
This PR contains two modifications into worker and worker cache behavior:

1) worker.Identity
It is now possible to set worker.Identity separately from the client.Identity. This is needed since we can reload the codebase of the application (PHP, Python, any other scripting language) without closing the connection.

2) PurgeStickyWorkflowCache
The destruction of a worker in Temporal leaves the cache open which is causing invalid behavior when a new worker with a new codebase attempts to access the same workflow. This method purges the cache and forcefully resets ref counts which allows new worker instance to start from scratch.

Please let me know if we have to modify this PR somehow.