### PR TITLE
Adding debug mode

### DIFF
--- a/internal/internal_workflow.go
+++ b/internal/internal_workflow.go
@@ -262,7 +262,7 @@ var _ WaitGroup = (*waitGroupImpl)(nil)
 var _ dispatcher = (*dispatcherImpl)(nil)
 
 var stackBuf [100000]byte
-var debugMode = os.Getenv("TEMPORAL_DEBUG_MODE") == "true"
+var debugMode = os.Getenv("TEMPORAL_DEBUG") != ""
 
 // Pointer to pointer to workflow result
 func getWorkflowResultPointerPointer(ctx Context) **workflowResult {

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -203,7 +203,7 @@ func (ts *IntegrationTestSuite) TestDeadlockDetection() {
 	wfOpts.WorkflowTaskTimeout = 5 * time.Second
 	wfOpts.WorkflowRunTimeout = 5 * time.Minute
 	err := ts.executeWorkflowWithOption(wfOpts, ts.workflows.Deadlocked, &expected)
-	if os.Getenv("TEMPORAL_DEBUG_MODE") == "true" {
+	if os.Getenv("TEMPORAL_DEBUG") != "" {
 		ts.NoError(err)
 	} else {
 		ts.Error(err)


### PR DESCRIPTION
Similarly to [this change](https://github.com/temporalio/sdk-java/pull/296) in the Java SDK, we are adding debug mode, which can be activated by setting `TEMPORAL_DEBUG` environment variable.
In this mode deadlock detector will be disabled.