### PR TITLE
[Testing] Add IsContinueAsNewError For Checking Errors in Tests

### DIFF
--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -25,6 +25,8 @@
 package workflow
 
 import (
+	"errors"
+
 	"github.com/uber-go/tally"
 
 	"go.temporal.io/sdk/converter"
@@ -477,4 +479,10 @@ func UpsertSearchAttributes(ctx Context, attributes map[string]interface{}) erro
 //
 func NewContinueAsNewError(ctx Context, wfn interface{}, args ...interface{}) *ContinueAsNewError {
 	return internal.NewContinueAsNewError(ctx, wfn, args...)
+}
+
+// IsContinueAsNewError return if the err is a ContinueAsNewError
+func IsContinueAsNewError(err error) bool {
+	var continueAsNewErr *ContinueAsNewError
+	return errors.As(err, &continueAsNewErr)
 }


### PR DESCRIPTION
This adds a helper method to check if it is a continue as new error. I don't see any use cases aside from testing, so happy to close - or happy to put elsewhere. Made this practically copy-paste of temporal.IsCanceledError but I see that this can't exist in `temporal` for cyclic dependency reasons.