### PR TITLE
Enable proto converted by default

### DIFF
--- a/converter/default_data_converter.go
+++ b/converter/default_data_converter.go
@@ -31,7 +31,7 @@ var (
 
 		// Only one proto converter (JSON or regular) should be used because they check for the same proto.Message interface.
 		NewProtoJSONPayloadConverter(),
-		// NewProtoPayloadConverter(),
+		NewProtoPayloadConverter(),
 
 		NewJSONPayloadConverter(),
 	)

--- a/converter/default_data_converter.go
+++ b/converter/default_data_converter.go
@@ -29,7 +29,10 @@ var (
 		NewNilPayloadConverter(),
 		NewByteSlicePayloadConverter(),
 
-		// Only one proto converter (JSON or regular) should be used because they check for the same proto.Message interface.
+		// Order is important here. Both ProtoJsonPayload and ProtoPayload converters check for the same proto.Message
+		// interface. The first match (ProtoJsonPayload in this case) will always be used for serialization.
+		// Deserialization is controlled by metadata, therefore both converters can deserialize corresponding data format
+		// (JSON or binary proto).
 		NewProtoJSONPayloadConverter(),
 		NewProtoPayloadConverter(),
 


### PR DESCRIPTION
This PR enabled proto converter by default. This enabled accepting proto payloads on Golang without affecting the ability to serialize proto messages.

Write:
- Only first proto converter will be used, same behaviour as previously.

Read:
- Now Golang SDK can parse payloads sent in proto/binary format while previously it was turned off.