### PR TITLE
Fixes self-destruction of LRU cache

### DIFF
--- a/converter/default_data_converter.go
+++ b/converter/default_data_converter.go
@@ -31,7 +31,7 @@ var (
 
 		// Only one proto converter (JSON or regular) should be used because they check for the same proto.Message interface.
 		NewProtoJSONPayloadConverter(),
-		// NewProtoPayloadConverter(),
+		NewProtoPayloadConverter(),
 
 		NewJSONPayloadConverter(),
 	)

--- a/converter/default_data_converter.go
+++ b/converter/default_data_converter.go
@@ -29,7 +29,10 @@ var (
 		NewNilPayloadConverter(),
 		NewByteSlicePayloadConverter(),
 
-		// Only one proto converter (JSON or regular) should be used because they check for the same proto.Message interface.
+		// Order is important here. Both ProtoJsonPayload and ProtoPayload converters check for the same proto.Message
+		// interface. The first match (ProtoJsonPayload in this case) will always be used for serialization.
+		// Deserialization is controlled by metadata, therefore both converters can deserialize corresponding data format
+		// (JSON or binary proto).
 		NewProtoJSONPayloadConverter(),
 		NewProtoPayloadConverter(),
 

--- a/internal/common/cache/lru.go
+++ b/internal/common/cache/lru.go
@@ -228,6 +228,10 @@ func (c *lru) putInternal(key string, value interface{}, allowUpdate bool) (inte
 	if len(c.byKey) == c.maxSize {
 		oldest := c.byAccess.Back().Value.(*cacheEntry)
 
+		if oldest == entry {
+			return nil, nil
+		}
+
 		if oldest.refCount > 0 {
 			// Cache is full with pinned elements
 			// revert the insert and return

--- a/internal/common/cache/lru_test.go
+++ b/internal/common/cache/lru_test.go
@@ -66,6 +66,14 @@ func TestLRU(t *testing.T) {
 	assert.Nil(t, cache.Get("A"))
 }
 
+func TestLRUSingle(t *testing.T) {
+	cache := NewLRU(1)
+
+	cache.Put("A", "Foo")
+	assert.Equal(t, "Foo", cache.Get("A"))
+	assert.Equal(t, 1, cache.Size())
+}
+
 func TestLRUWithTTL(t *testing.T) {
 	cache := New(5, &Options{
 		TTL: time.Millisecond * 100,


### PR DESCRIPTION
This PR fixes the bug and provides the test for the edge case when a single cache entry is returned to LRU. The original logic does will remove the item from the cache once the size hits, even if the entry is the single entry in the cache. This causes various side-effects in logic due to unexpected eviction.

Changes:
- check if the oldest item actually the same item

P.S. Contains another approved PR - https://github.com/temporalio/sdk-go/pull/339