### PR TITLE
Rename task queue metric tag

### DIFF
--- a/internal/common/metrics/constants.go
+++ b/internal/common/metrics/constants.go
@@ -82,7 +82,7 @@ const (
 	WorkerTypeTagName       = "worker_type"
 	WorkflowTypeNameTagName = "workflow_type"
 	ActivityTypeNameTagName = "activity_type"
-	TaskQueueTagName        = "taskqueue"
+	TaskQueueTagName        = "task_queue"
 	OperationTagName        = "operation"
 )
 


### PR DESCRIPTION
This brings our metric tags in conformance with prometheus naming conventions.