### PR TITLE
Yet further unusual cancellation event ordering fixes

### DIFF
--- a/internal/internal_decision_state_machine.go
+++ b/internal/internal_decision_state_machine.go
@@ -458,7 +458,7 @@ func (d *commandStateMachineBase) handleCompletionEvent() {
 func (d *commandStateMachineBase) handleCancelInitiatedEvent() {
 	d.history = append(d.history, eventCancelInitiated)
 	switch d.state {
-	case commandStateCancellationCommandSent:
+	case commandStateCancellationCommandSent, commandStateCanceledAfterInitiated:
 	// No state change
 	default:
 		d.failStateTransition(eventCancelInitiated)

--- a/internal/internal_decision_state_machine_test.go
+++ b/internal/internal_decision_state_machine_test.go
@@ -276,6 +276,43 @@ func Test_ActivityStateMachine_CompletedAfterCancel(t *testing.T) {
 	require.Equal(t, 0, len(h.getCommands(false)))
 }
 
+func Test_ActivityStateMachine_CancelInitiated_After_CanceledBeforeSent(t *testing.T) {
+	t.Parallel()
+	activityID := "test-activity-1"
+	attributes := &commandpb.ScheduleActivityTaskCommandAttributes{
+		ActivityId: activityID,
+	}
+	h := newCommandsHelper()
+	h.setCurrentWorkflowTaskStartedEventID(3)
+
+	// schedule activity
+	scheduleID := h.getNextID()
+	d := h.scheduleActivityTask(scheduleID, attributes)
+	require.Equal(t, commandStateCreated, d.getState())
+
+	// cancel activity before sent
+	h.requestCancelActivityTask(activityID)
+	require.Equal(t, commandStateCanceledBeforeSent, d.getState())
+	commands := h.getCommands(true)
+	require.Equal(t, 2, len(commands))
+	require.Equal(t, enumspb.COMMAND_TYPE_SCHEDULE_ACTIVITY_TASK, commands[0].GetCommandType())
+	require.Equal(t, enumspb.COMMAND_TYPE_REQUEST_CANCEL_ACTIVITY_TASK, commands[1].GetCommandType())
+
+	// Activity initiated
+	h.handleActivityTaskScheduled(activityID, scheduleID)
+	require.Equal(t, commandStateCanceledAfterInitiated, d.getState())
+	// no commands fetched though!
+
+	// Cancel requested event comes in
+	h.handleActivityTaskCancelRequested(scheduleID)
+	require.Equal(t, commandStateCanceledAfterInitiated, d.getState())
+
+	// activity completed after cancel
+	h.handleActivityTaskClosed(activityID, scheduleID)
+	require.Equal(t, commandStateCompleted, d.getState())
+	require.Equal(t, 0, len(h.getCommands(false)))
+}
+
 func Test_ActivityStateMachine_PanicInvalidStateTransition(t *testing.T) {
 	t.Parallel()
 	activityID := "test-activity-1"


### PR DESCRIPTION
This fix handles another cancellation event ordering that can trigger state machine failures.

Fixes https://github.com/temporalio/temporal/issues/1218 