### PR TITLE
Allow Skipping of Invalid Activity Functions in Struct

### DIFF
--- a/internal/activity.go
+++ b/internal/activity.go
@@ -68,6 +68,9 @@ type (
 		// this Name as a prefix + activity function name.
 		Name                          string
 		DisableAlreadyRegisteredCheck bool
+
+		// When registering a struct with activities - skip functions that are not valid activities
+		SkipInvalidStructFunctions bool
 	}
 
 	// ActivityOptions stores all activity-specific parameters that will be stored inside of a context.

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -574,6 +574,10 @@ func (r *registry) registerActivityStructWithOptions(aStruct interface{}, option
 		}
 		name := method.Name
 		if err := validateFnFormat(method.Type, false); err != nil {
+			if options.SkipInvalidStructFunctions {
+				continue
+			}
+
 			return fmt.Errorf("method %v of %v: %e", name, structType.Name(), err)
 		}
 		registerName := options.Name + name

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -87,6 +87,11 @@ func testInternalWorkerRegister(r *registry) {
 	r.RegisterActivity(testActivityReturnStructPtr)
 	r.RegisterActivity(testActivityReturnNilStructPtrPtr)
 	r.RegisterActivity(testActivityReturnStructPtrPtr)
+
+	r.RegisterActivityWithOptions(&testActivityStructWithFns{}, RegisterActivityOptions{
+		Name:                       "testActivityStructWithFns",
+		SkipInvalidStructFunctions: true,
+	})
 }
 
 func testInternalWorkerRegisterWithTestEnv(env *TestWorkflowEnvironment) {
@@ -120,6 +125,11 @@ func testInternalWorkerRegisterWithTestEnv(env *TestWorkflowEnvironment) {
 	env.RegisterActivity(testActivityReturnStructPtr)
 	env.RegisterActivity(testActivityReturnNilStructPtrPtr)
 	env.RegisterActivity(testActivityReturnStructPtrPtr)
+
+	env.RegisterActivityWithOptions(&testActivityStructWithFns{}, RegisterActivityOptions{
+		Name:                       "testActivityStructWithFns",
+		SkipInvalidStructFunctions: true,
+	})
 }
 
 type internalWorkerTestSuite struct {
@@ -1643,6 +1653,10 @@ func (w activitiesCallingOptionsWorkflow) Execute(ctx Context, input []byte) (re
 	require.NoError(w.t, err, err)
 	require.Equal(w.t, testActivityResult{}, r2Struct)
 
+	f = ExecuteActivity(ctx, "testActivityStructWithFns_ValidActivity")
+	err = f.Get(ctx, nil)
+	require.NoError(w.t, err, err)
+
 	return []byte("Done"), nil
 }
 
@@ -1725,6 +1739,12 @@ func testActivityReturnStructPtrPtr() (**testActivityResult, error) {
 	r := &testActivityResult{Index: 10}
 	return &r, nil
 }
+
+type testActivityStructWithFns struct{}
+
+func (t *testActivityStructWithFns) ValidActivity(ctx context.Context) error { return nil }
+
+func (t *testActivityStructWithFns) InvalidActivity(ctx context.Context) { return }
 
 func TestVariousActivitySchedulingOption(t *testing.T) {
 	w := &activitiesCallingOptionsWorkflow{t: t}

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -1744,7 +1744,7 @@ type testActivityStructWithFns struct{}
 
 func (t *testActivityStructWithFns) ValidActivity(ctx context.Context) error { return nil }
 
-func (t *testActivityStructWithFns) InvalidActivity(ctx context.Context) { return }
+func (t *testActivityStructWithFns) InvalidActivity(ctx context.Context) {}
 
 func TestVariousActivitySchedulingOption(t *testing.T) {
 	w := &activitiesCallingOptionsWorkflow{t: t}


### PR DESCRIPTION
This allows activities to be registered that may have some Temporal activities along with other functions.

I couldn't find a way to test the negative case without causing a failure in the test start code that would require a re-run.

Intended to address #356.