### PR TITLE
Panic when Invalid Struct is Registered

### DIFF
--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -531,7 +531,10 @@ func (r *registry) RegisterActivityWithOptions(
 	// Validate that it is a function
 	fnType := reflect.TypeOf(af)
 	if fnType.Kind() == reflect.Ptr && fnType.Elem().Kind() == reflect.Struct {
-		_ = r.registerActivityStructWithOptions(af, options)
+		registerErr := r.registerActivityStructWithOptions(af, options)
+		if registerErr != nil {
+			panic(registerErr)
+		}
 		return
 	}
 	if err := validateFnFormat(fnType, false); err != nil {


### PR DESCRIPTION
Without this, an invalid struct can be partially registered in tests or in workers, which can lead to weird failure when activities are missing but unknown as to why they are missing.

Combines with #360 for solving #356.