### PR TITLE
Ability to provide a token provider function

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -62,6 +62,10 @@ type (
 	// ConnectionOptions are optional parameters that can be specified in ClientOptions
 	ConnectionOptions = internal.ConnectionOptions
 
+	// AuthorizationTokenProvider is a function that can be provided to ConnectionOptions, returning a token that will
+	// be injected into the authorization metadata
+	AuthorizationTokenProvider = internal.AuthorizationTokenProvider
+
 	// StartWorkflowOptions configuration parameters for starting a workflow execution.
 	StartWorkflowOptions = internal.StartWorkflowOptions
 

--- a/internal/authorization_token_provider.go
+++ b/internal/authorization_token_provider.go
@@ -1,0 +1,7 @@
+package internal
+
+import "context"
+
+// AuthorizationTokenProvider is a function that can be provided to ConnectionOptions, returning a token that will
+// be injected into the authorization metadata
+type AuthorizationTokenProvider func(ctx context.Context) (string, error)

--- a/internal/client.go
+++ b/internal/client.go
@@ -393,9 +393,10 @@ type (
 
 	// ConnectionOptions is provided by SDK consumers to control optional connection params.
 	ConnectionOptions struct {
-		TLS                *tls.Config
-		DisableHealthCheck bool
-		HealthCheckTimeout time.Duration
+		TLS                        *tls.Config
+		DisableHealthCheck         bool
+		HealthCheckTimeout         time.Duration
+		AuthorizationTokenProvider AuthorizationTokenProvider
 	}
 
 	// StartWorkflowOptions configuration parameters for starting a workflow execution.


### PR DESCRIPTION
In order to use a custom claims mapper in the temporal server, using data from the "authorization" GRPC metadata, we need a way to inject a value into the outgoing GRPC context.  This a first cut at that kind of functionality.

May need some guidance here as to the best place to put tests for this.

This is one possible solution for #353.