### PR TITLE
Use raw JSON to convert payload to string

### DIFF
--- a/converter/data_converter_test.go
+++ b/converter/data_converter_test.go
@@ -116,10 +116,10 @@ func TestToStrings(t *testing.T) {
 
 	want := []string{
 		"dGVzdA",
-		"[hello world]",
-		"hello world",
+		`["hello","world"]`,
+		`"hello world"`,
 		"42",
-		"{A:hi B:3}",
+		`{"A":"hi","B":3}`,
 	}
 
 	require.Equal(t, want, got)

--- a/converter/json_payload_converter.go
+++ b/converter/json_payload_converter.go
@@ -27,7 +27,6 @@ package converter
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	commonpb "go.temporal.io/api/common/v1"
 )
@@ -61,18 +60,7 @@ func (c *JSONPayloadConverter) FromPayload(payload *commonpb.Payload, valuePtr i
 
 // ToString converts payload object into human readable string.
 func (c *JSONPayloadConverter) ToString(payload *commonpb.Payload) string {
-	var value interface{}
-	err := c.FromPayload(payload, &value)
-	if err != nil {
-		return err.Error()
-	}
-	s := fmt.Sprintf("%+v", value)
-	if strings.HasPrefix(s, "map[") {
-		s = strings.TrimPrefix(s, "map[")
-		s = strings.TrimSuffix(s, "]")
-		s = fmt.Sprintf("{%s}", s)
-	}
-	return s
+	return string(payload.GetData())
 }
 
 // Encoding returns MetadataEncodingJSON.

--- a/converter/payload_converter_test.go
+++ b/converter/payload_converter_test.go
@@ -188,7 +188,7 @@ func TestJsonPayloadConverter(t *testing.T) {
 	assert.Equal(t, "qwe", wt4.Name)
 
 	s := pc.ToString(payload)
-	assert.Equal(t, "{Age:0 Name:qwe}", s)
+	assert.Equal(t, `{"Name":"qwe","Age":0}`, s)
 }
 
 func TestProtoJsonPayloadConverter_Nil(t *testing.T) {

--- a/converter/proto_json_payload_converter.go
+++ b/converter/proto_json_payload_converter.go
@@ -159,7 +159,6 @@ func (c *ProtoJSONPayloadConverter) FromPayload(payload *commonpb.Payload, value
 
 // ToString converts payload object into human readable string.
 func (c *ProtoJSONPayloadConverter) ToString(payload *commonpb.Payload) string {
-	// We can't do anything better here.
 	return string(payload.GetData())
 }
 


### PR DESCRIPTION
`ToString` is used for debugging and by `tctl`. I recently discovered that default numeric type is `float64` and long ints end up being `1.6137007538525565e+18` in string representation. I believe just raw JSON will suit better here.