### PR TITLE
Set Local Activity result to empty not nil

### DIFF
--- a/internal/internal_event_handlers.go
+++ b/internal/internal_event_handlers.go
@@ -1186,6 +1186,9 @@ func (weh *workflowExecutionEventHandlerImpl) ProcessLocalActivityResult(lar *lo
 		lamd.Backoff = lar.backoff
 	} else {
 		details[localActivityMarkerResultDetailsName] = lar.result
+		if details[localActivityMarkerResultDetailsName] == nil {
+			details[localActivityMarkerResultDetailsName] = &commonpb.Payloads{}
+		}
 	}
 
 	// encode marker data


### PR DESCRIPTION
some libs (both grpc and @grpc/grpc-js) fail to process `Payloads` equal to `nil`. This sets `Payloads` to empty array instead of nil

![image](https://user-images.githubusercontent.com/11838981/108569721-3cd86000-72c1-11eb-8e45-0092a84257d7.png)
