### PR TITLE
Adding support for custom gRPC headers

### DIFF
--- a/internal/client.go
+++ b/internal/client.go
@@ -389,6 +389,15 @@ type (
 		// Optional: Sets options for server connection that allow users to control features of connections such as TLS settings.
 		// default: no extra options
 		ConnectionOptions ConnectionOptions
+
+		// Optional: HeadersProvider is getting invoked on every outgoing gRPC request and gives user ability to
+		// set custom request headers. This can be used to set auth headers for example.
+		HeadersProvider HeadersProvider
+	}
+
+	// HeadersProvider returns a map of gRPC headers that should be used on every request.
+	HeadersProvider interface {
+		GetHeaders(ctx context.Context) (map[string]string, error)
 	}
 
 	// ConnectionOptions is provided by SDK consumers to control optional connection params.
@@ -569,7 +578,7 @@ func newDialParameters(options *ClientOptions) dialParameters {
 	return dialParameters{
 		UserConnectionOptions: options.ConnectionOptions,
 		HostPort:              options.HostPort,
-		RequiredInterceptors:  requiredInterceptors(options.MetricsScope),
+		RequiredInterceptors:  requiredInterceptors(options.MetricsScope, options.HeadersProvider),
 		DefaultServiceConfig:  defaultServiceConfig,
 	}
 }

--- a/internal/client.go
+++ b/internal/client.go
@@ -390,7 +390,7 @@ type (
 		// default: no extra options
 		ConnectionOptions ConnectionOptions
 
-		// Optional: HeadersProvider is getting invoked on every outgoing gRPC request and gives user ability to
+		// Optional: HeadersProvider will be invoked on every outgoing gRPC request and gives user ability to
 		// set custom request headers. This can be used to set auth headers for example.
 		HeadersProvider HeadersProvider
 	}

--- a/internal/grpc_dialer.go
+++ b/internal/grpc_dialer.go
@@ -34,6 +34,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/backoff"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/metadata"
 
 	"go.temporal.io/sdk/internal/common/metrics"
 )
@@ -86,8 +87,25 @@ func dial(params dialParameters) (*grpc.ClientConn, error) {
 	)
 }
 
-func requiredInterceptors(metricScope tally.Scope) []grpc.UnaryClientInterceptor {
-	return []grpc.UnaryClientInterceptor{metrics.NewScopeInterceptor(metricScope), errorInterceptor}
+func requiredInterceptors(metricScope tally.Scope, headersProvider HeadersProvider) []grpc.UnaryClientInterceptor {
+	interceptors := []grpc.UnaryClientInterceptor{metrics.NewScopeInterceptor(metricScope), errorInterceptor}
+	if headersProvider != nil {
+		interceptors = append(interceptors, headersProviderInterceptor(headersProvider))
+	}
+	return interceptors
+}
+
+func headersProviderInterceptor(headersProvider HeadersProvider) grpc.UnaryClientInterceptor {
+	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		headers, err := headersProvider.GetHeaders(ctx)
+		if err != nil {
+			return err
+		}
+		for k, v := range headers {
+			ctx = metadata.AppendToOutgoingContext(ctx, k, v)
+		}
+		return invoker(ctx, method, req, reply, cc, opts...)
+	}
 }
 
 func errorInterceptor(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {

--- a/internal/grpc_dialer_test.go
+++ b/internal/grpc_dialer_test.go
@@ -26,6 +26,7 @@ package internal
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/gogo/status"
@@ -34,6 +35,7 @@ import (
 	"go.temporal.io/api/serviceerror"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 )
 
 func TestErrorWrapper_SimpleError(t *testing.T) {
@@ -66,4 +68,39 @@ func TestErrorWrapper_ErrorWithFailure(t *testing.T) {
 	weasErr := svcerr.(*serviceerror.WorkflowExecutionAlreadyStarted)
 	require.Equal("rId", weasErr.RunId)
 	require.Equal("srId", weasErr.StartRequestId)
+}
+
+type authHeadersProvider struct {
+	token string
+}
+
+func (a authHeadersProvider) GetHeaders(context.Context) (map[string]string, error) {
+	headers := make(map[string]string)
+	headers["authorization"] = a.token
+	return headers, nil
+}
+
+func TestHeadersProvider_PopulateAuthToken(t *testing.T) {
+	require.NoError(t, headersProviderInterceptor(authHeadersProvider{token: "test-auth-token"})(context.Background(), "method", "request", "reply", nil,
+		func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
+			md, ok := metadata.FromOutgoingContext(ctx)
+			if !ok {
+				return errors.New("unable to get outgoing context metadata")
+			}
+			require.Equal(t, 1, len(md.Get("authorization")))
+			if md.Get("authorization")[0] != "test-auth-token" {
+				return errors.New("auth token hasn't been set")
+			}
+			return nil
+		}))
+}
+
+func TestHeadersProvider_NotIncludedWhenNil(t *testing.T) {
+	interceptors := requiredInterceptors(nil, nil)
+	require.Equal(t, 2, len(interceptors))
+}
+
+func TestHeadersProvider_IncludedWithHeadersProvider(t *testing.T) {
+	interceptors := requiredInterceptors(nil, authHeadersProvider{token: "test-auth-token"})
+	require.Equal(t, 3, len(interceptors))
 }


### PR DESCRIPTION
Adds ability to set `HeadersProvider` on `ClientOptions` during `Client` creation, which will be invoked in the gRPC interceptor on all outgoing calls.

Users can now implement HeadersProvider interface:
```
	HeadersProvider interface {
		GetHeaders(ctx context.Context) (map[string]string, error)
	}
```
and set authorization or any other headers that backend expects to see.

This solution is a slight refinement of #363, in my opinion we should try to not expose gRPC types to the end user because other newer language SDKs (JavaScript and beyond) will not have direct access to the gRPC layer, which will be done in the core rust sdk.

Another option that I've considered was adding ability to set headers on the `ClientOptions` and adding ability to modify them from the `Client`. But I didn't like this approach as it introduces a function into the `Client` that would be an outlier in terms of the responsibilities (all other functions are wrappers around RPC calls).