### PR TITLE
Add keep alive to gRPC connection

### DIFF
--- a/internal/grpc_dialer.go
+++ b/internal/grpc_dialer.go
@@ -34,6 +34,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/backoff"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/keepalive"
 
 	"go.temporal.io/sdk/internal/common/metrics"
 )
@@ -78,11 +79,21 @@ func dial(params dialParameters) (*grpc.ClientConn, error) {
 	cp.Backoff.BaseDelay = retryPollOperationInitialInterval
 	cp.Backoff.MaxDelay = retryPollOperationMaxInterval
 
+	// gRPC utilizes keep alive mechanism to detect dead connections in case if server didn't close them
+	// gracefully. Client would ping the server periodically and expect replies withing the specified timeout.
+	// Learn more by reading https://github.com/grpc/grpc/blob/master/doc/keepalive.md
+	var kap = keepalive.ClientParameters{
+		Time:                30 * time.Second,
+		Timeout:             15 * time.Second,
+		PermitWithoutStream: true,
+	}
+
 	return grpc.Dial(params.HostPort,
 		grpcSecurityOptions,
 		grpc.WithChainUnaryInterceptor(params.RequiredInterceptors...),
 		grpc.WithDefaultServiceConfig(params.DefaultServiceConfig),
 		grpc.WithConnectParams(cp),
+		grpc.WithKeepaliveParams(kap),
 	)
 }
 


### PR DESCRIPTION
Previously workers were getting "stuck" after we upgraded our test cluster.
This could happen if server side dies and doesn't close connection gracefully resulting in client-side connection hanging until TCP times out in 10+ minutes.
This change introduces [keep alive] check into our client, which should help detect orphaned connections faster.