### PR TITLE
Fix panic when handling version & side effect markers together

### DIFF
--- a/internal/internal_decision_state_machine.go
+++ b/internal/internal_decision_state_machine.go
@@ -811,6 +811,14 @@ func (h *commandsHelper) setCurrentWorkflowTaskStartedEventID(workflowTaskStarte
 
 func (h *commandsHelper) getNextID() int64 {
 	// First check if we have a GetVersion marker in the lookup map
+	h.incrementNextCommandEventIdIfVersionMarker()
+	if h.nextCommandEventID == 0 {
+		panic("Attempt to generate a command before processing WorkflowTaskStarted event")
+	}
+	return h.nextCommandEventID
+}
+
+func (h *commandsHelper) incrementNextCommandEventIdIfVersionMarker() {
 	if _, ok := h.versionMarkerLookup[h.nextCommandEventID]; ok {
 		// Remove the marker from the lookup map and increment nextCommandEventID by 2 because call to GetVersion
 		// results in 2 events in the history.  One is GetVersion marker event for changeID and change version, other
@@ -819,10 +827,6 @@ func (h *commandsHelper) getNextID() int64 {
 		h.incrementNextCommandEventID()
 		h.incrementNextCommandEventID()
 	}
-	if h.nextCommandEventID == 0 {
-		panic("Attempt to generate a command before processing WorkflowTaskStarted event")
-	}
-	return h.nextCommandEventID
 }
 
 func (h *commandsHelper) getCommand(id commandID) commandStateMachine {
@@ -844,6 +848,7 @@ func (h *commandsHelper) addCommand(command commandStateMachine) {
 	h.commands[command.getID()] = element
 
 	// Every time new command is added increment the counter used for generating ID
+	h.incrementNextCommandEventIdIfVersionMarker()
 	h.incrementNextCommandEventID()
 }
 

--- a/internal/internal_decision_state_machine.go
+++ b/internal/internal_decision_state_machine.go
@@ -811,14 +811,14 @@ func (h *commandsHelper) setCurrentWorkflowTaskStartedEventID(workflowTaskStarte
 
 func (h *commandsHelper) getNextID() int64 {
 	// First check if we have a GetVersion marker in the lookup map
-	h.incrementNextCommandEventIdIfVersionMarker()
+	h.incrementNextCommandEventIDIfVersionMarker()
 	if h.nextCommandEventID == 0 {
 		panic("Attempt to generate a command before processing WorkflowTaskStarted event")
 	}
 	return h.nextCommandEventID
 }
 
-func (h *commandsHelper) incrementNextCommandEventIdIfVersionMarker() {
+func (h *commandsHelper) incrementNextCommandEventIDIfVersionMarker() {
 	if _, ok := h.versionMarkerLookup[h.nextCommandEventID]; ok {
 		// Remove the marker from the lookup map and increment nextCommandEventID by 2 because call to GetVersion
 		// results in 2 events in the history.  One is GetVersion marker event for changeID and change version, other
@@ -848,7 +848,7 @@ func (h *commandsHelper) addCommand(command commandStateMachine) {
 	h.commands[command.getID()] = element
 
 	// Every time new command is added increment the counter used for generating ID
-	h.incrementNextCommandEventIdIfVersionMarker()
+	h.incrementNextCommandEventIDIfVersionMarker()
 	h.incrementNextCommandEventID()
 }
 

--- a/internal/internal_task_handlers_test.go
+++ b/internal/internal_task_handlers_test.go
@@ -156,7 +156,7 @@ func createTestEventWorkflowExecutionStarted(eventID int64, attr *historypb.Work
 		Attributes: &historypb.HistoryEvent_WorkflowExecutionStartedEventAttributes{WorkflowExecutionStartedEventAttributes: attr}}
 }
 
-func createTestEventLocalActivity(eventID int64, attr *historypb.MarkerRecordedEventAttributes) *historypb.HistoryEvent {
+func createTestEventMarkerRecorded(eventID int64, attr *historypb.MarkerRecordedEventAttributes) *historypb.HistoryEvent {
 	return &historypb.HistoryEvent{
 		EventId:    eventID,
 		EventType:  enumspb.EVENT_TYPE_MARKER_RECORDED,

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -316,12 +316,12 @@ func (s *internalWorkerTestSuite) TestReplayWorkflowHistory_LocalActivity() {
 		createTestEventWorkflowTaskStarted(3),
 		createTestEventWorkflowTaskCompleted(4, &historypb.WorkflowTaskCompletedEventAttributes{}),
 
-		createTestEventLocalActivity(5, &historypb.MarkerRecordedEventAttributes{
+		createTestEventMarkerRecorded(5, &historypb.MarkerRecordedEventAttributes{
 			MarkerName:                   localActivityMarkerName,
 			Details:                      s.createLocalActivityMarkerDataForTest("1"),
 			WorkflowTaskCompletedEventId: 4,
 		}),
-		createTestEventLocalActivity(6, &historypb.MarkerRecordedEventAttributes{
+		createTestEventMarkerRecorded(6, &historypb.MarkerRecordedEventAttributes{
 			MarkerName:                   localActivityMarkerName,
 			Details:                      s.createLocalActivityMarkerDataForTest("2"),
 			WorkflowTaskCompletedEventId: 4,
@@ -438,12 +438,12 @@ func (s *internalWorkerTestSuite) TestReplayWorkflowHistory_LocalAndRemoteActivi
 		createTestEventVersionMarker(5, 4, "change_id_A", Version(3)),
 		createTestUpsertWorkflowSearchAttributesForChangeVersion(6, 4, "change_id_A", Version(3)),
 
-		createTestEventLocalActivity(7, &historypb.MarkerRecordedEventAttributes{
+		createTestEventMarkerRecorded(7, &historypb.MarkerRecordedEventAttributes{
 			MarkerName:                   localActivityMarkerName,
 			Details:                      s.createLocalActivityMarkerDataForTest("1"),
 			WorkflowTaskCompletedEventId: 4,
 		}),
-		createTestEventLocalActivity(8, &historypb.MarkerRecordedEventAttributes{
+		createTestEventMarkerRecorded(8, &historypb.MarkerRecordedEventAttributes{
 			MarkerName:                   localActivityMarkerName,
 			Details:                      s.createLocalActivityMarkerDataForTest("2"),
 			WorkflowTaskCompletedEventId: 4,
@@ -453,7 +453,7 @@ func (s *internalWorkerTestSuite) TestReplayWorkflowHistory_LocalAndRemoteActivi
 			ActivityType: &commonpb.ActivityType{Name: "testActivity"},
 			TaskQueue:    &taskqueuepb.TaskQueue{Name: taskQueue},
 		}),
-		createTestEventLocalActivity(10, &historypb.MarkerRecordedEventAttributes{
+		createTestEventMarkerRecorded(10, &historypb.MarkerRecordedEventAttributes{
 			MarkerName:                   localActivityMarkerName,
 			Details:                      s.createLocalActivityMarkerDataForTest("3"),
 			WorkflowTaskCompletedEventId: 4,
@@ -676,7 +676,7 @@ func createHistoryForGetVersionTests(workflowType string) []*historypb.HistoryEv
 	}
 }
 
-func testReplayWorkflowGetVersionWithSideEffect(ctx Context) (string, error) {
+func testReplayWorkflowGetVersionWithSideEffect(ctx Context) error {
 	var uniqueID *string
 
 	v := GetVersion(ctx, "UniqueID", DefaultVersion, 1)
@@ -686,20 +686,20 @@ func testReplayWorkflowGetVersionWithSideEffect(ctx Context) (string, error) {
 		})
 		err := encodedUID.Get(&uniqueID)
 		if err != nil {
-			return "", err
+			return err
 		}
 	}
 
 	var result string
 	err := ExecuteActivity(ctx, "testActivityReturnString").Get(ctx, &result)
 	if err != nil {
-		return "", err
+		return err
 	}
 
-	return result, nil
+	return nil
 }
 
-func (s *internalWorkerTestSuite) TestReplayWorkflowHistory_GetVersionWithSideEffectAndQuery() {
+func (s *internalWorkerTestSuite) TestReplayWorkflowHistory_GetVersionWithSideEffect() {
 	taskQueue := "taskQueue1"
 	sideEffectPayloads, seErr := s.dataConverter.ToPayloads("TEST-UNIQUE-ID")
 	s.NoError(seErr)
@@ -714,7 +714,7 @@ func (s *internalWorkerTestSuite) TestReplayWorkflowHistory_GetVersionWithSideEf
 		createTestEventWorkflowTaskCompleted(4, &historypb.WorkflowTaskCompletedEventAttributes{}),
 		createTestEventVersionMarker(5, 4, "UniqueID", Version(1)),
 		createTestUpsertWorkflowSearchAttributesForChangeVersion(6, 4, "UniqueID", Version(1)),
-		createTestEventLocalActivity(7, &historypb.MarkerRecordedEventAttributes{
+		createTestEventMarkerRecorded(7, &historypb.MarkerRecordedEventAttributes{
 			MarkerName:                   sideEffectMarkerName,
 			Details:                      s.createSideEffectMarkerDataForTest(sideEffectPayloads, 1),
 			WorkflowTaskCompletedEventId: 4,
@@ -1173,12 +1173,12 @@ func (s *internalWorkerTestSuite) TestReplayWorkflowHistory_LocalActivity_Result
 		createTestEventWorkflowTaskStarted(3),
 		createTestEventWorkflowTaskCompleted(4, &historypb.WorkflowTaskCompletedEventAttributes{}),
 
-		createTestEventLocalActivity(5, &historypb.MarkerRecordedEventAttributes{
+		createTestEventMarkerRecorded(5, &historypb.MarkerRecordedEventAttributes{
 			MarkerName:                   localActivityMarkerName,
 			Details:                      s.createLocalActivityMarkerDataForTest("1"),
 			WorkflowTaskCompletedEventId: 4,
 		}),
-		createTestEventLocalActivity(6, &historypb.MarkerRecordedEventAttributes{
+		createTestEventMarkerRecorded(6, &historypb.MarkerRecordedEventAttributes{
 			MarkerName:                   localActivityMarkerName,
 			Details:                      s.createLocalActivityMarkerDataForTest("2"),
 			WorkflowTaskCompletedEventId: 4,
@@ -1215,7 +1215,7 @@ func (s *internalWorkerTestSuite) TestReplayWorkflowHistory_LocalActivity_Activi
 		createTestEventWorkflowTaskStarted(3),
 		createTestEventWorkflowTaskCompleted(4, &historypb.WorkflowTaskCompletedEventAttributes{}),
 
-		createTestEventLocalActivity(5, &historypb.MarkerRecordedEventAttributes{
+		createTestEventMarkerRecorded(5, &historypb.MarkerRecordedEventAttributes{
 			MarkerName:                   localActivityMarkerName,
 			Details:                      s.createLocalActivityMarkerDataForTest("0"),
 			WorkflowTaskCompletedEventId: 4,


### PR DESCRIPTION
Fixes https://github.com/temporalio/sdk-go/issues/374

When executing a side effect after calling `GetVersion`, command ids could end up ordered incorrectly. This change fixes that issue by ensuring that every time a command is added, some special-case code regarding version markers is run.