### PR TITLE
Fixed WorkflowRunTimeout default value comment

### DIFF
--- a/internal/client.go
+++ b/internal/client.go
@@ -439,7 +439,7 @@ type (
 		// It includes retries and continue as new. Use WorkflowRunTimeout to limit execution time
 		// of a single workflow run.
 		// The resolution is seconds.
-		// Optional: defaulted to 10 years.
+		// Optional: defaulted to unlimited.
 		WorkflowExecutionTimeout time.Duration
 
 		// WorkflowRunTimeout - The timeout for duration of a single workflow run.

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -206,7 +206,7 @@ type (
 
 		// WorkflowExecutionTimeout - The end to end timeout for the child workflow execution including retries
 		// and continue as new.
-		// Optional: defaults to 10 years
+		// Optional: defaults to unlimited.
 		WorkflowExecutionTimeout time.Duration
 
 		// WorkflowRunTimeout - The timeout for a single run of the child workflow execution. Each retry or


### PR DESCRIPTION
## What was changed:
Changed WorkflowRunTimeout default comment to unlimited

## Why?
The old version of the service used 10 years as default. The new versions of the service use unlimited value.
