### PR TITLE
Added ContextAware DataConverter extension

### DIFF
--- a/internal/internal_workflow.go
+++ b/internal/internal_workflow.go
@@ -1238,10 +1238,13 @@ func setWorkflowEnvOptionsIfNotExist(ctx Context) Context {
 
 func getDataConverterFromWorkflowContext(ctx Context) converter.DataConverter {
 	options := getWorkflowEnvOptions(ctx)
-	if options == nil || options.DataConverter == nil {
-		return converter.GetDefaultDataConverter()
+	var dataConverter converter.DataConverter
+	if options != nil && options.DataConverter != nil {
+		dataConverter = options.DataConverter
+	} else {
+		dataConverter = converter.GetDefaultDataConverter()
 	}
-	return options.DataConverter
+	return WithWorkflowContext(ctx, dataConverter)
 }
 
 func getRegistryFromWorkflowContext(ctx Context) *registry {

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -171,9 +171,10 @@ func (wc *WorkflowClient) StartWorkflow(
 	executionTimeout := options.WorkflowExecutionTimeout
 	runTimeout := options.WorkflowRunTimeout
 	workflowTaskTimeout := options.WorkflowTaskTimeout
+	dataConverter := WithContext(ctx, wc.dataConverter)
 
 	// Validate type and its arguments.
-	workflowType, input, err := getValidatedWorkflowFunction(workflowFunc, args, wc.dataConverter, wc.registry)
+	workflowType, input, err := getValidatedWorkflowFunction(workflowFunc, args, dataConverter, wc.registry)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/stateful_data_converter_test.go
+++ b/internal/stateful_data_converter_test.go
@@ -1,0 +1,152 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package internal
+
+import (
+	"context"
+	"go.temporal.io/sdk/converter"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	commonpb "go.temporal.io/api/common/v1"
+)
+
+type ContextAwareDataConverter struct {
+	dataConverter converter.DataConverter
+	prefix        string
+}
+
+type contextKeyType int
+
+const (
+	prefixContextKey contextKeyType = iota
+)
+
+func (dc *ContextAwareDataConverter) ToPayload(value interface{}) (*commonpb.Payload, error) {
+	return dc.dataConverter.ToPayload(value)
+}
+
+func (dc *ContextAwareDataConverter) ToPayloads(values ...interface{}) (*commonpb.Payloads, error) {
+	return dc.dataConverter.ToPayloads(values)
+}
+
+func (dc *ContextAwareDataConverter) FromPayload(payload *commonpb.Payload, valuePtr interface{}) error {
+	return dc.dataConverter.FromPayload(payload, valuePtr)
+}
+
+func (dc *ContextAwareDataConverter) FromPayloads(payloads *commonpb.Payloads, valuePtrs ...interface{}) error {
+	return dc.dataConverter.FromPayloads(payloads, valuePtrs...)
+}
+
+func (dc *ContextAwareDataConverter) ToString(payload *commonpb.Payload) string {
+	if dc.prefix != "" {
+		return dc.prefix + ": " + dc.dataConverter.ToString(payload)
+	}
+
+	return dc.dataConverter.ToString(payload)
+}
+
+func (dc *ContextAwareDataConverter) ToStrings(payloads *commonpb.Payloads) []string {
+	var result []string
+	for _, payload := range payloads.GetPayloads() {
+		result = append(result, dc.ToString(payload))
+	}
+
+	return result
+}
+
+func (dc *ContextAwareDataConverter) WithContext(ctx context.Context) converter.DataConverter {
+	v := ctx.Value(prefixContextKey)
+	prefix, ok := v.(string)
+	if !ok {
+		return dc
+	}
+
+	return &ContextAwareDataConverter{
+		dataConverter: dc.dataConverter,
+		prefix:        prefix,
+	}
+}
+
+func (dc *ContextAwareDataConverter) WithWorkflowContext(ctx Context) converter.DataConverter {
+	v := ctx.Value(prefixContextKey)
+	prefix, ok := v.(string)
+	if !ok {
+		return dc
+	}
+
+	return &ContextAwareDataConverter{
+		dataConverter: dc.dataConverter,
+		prefix:        prefix,
+	}
+}
+
+func newContextAwareDataConverter(dataConverter converter.DataConverter) converter.DataConverter {
+	return &ContextAwareDataConverter{
+		dataConverter: dataConverter,
+	}
+}
+
+var contextAwareDataConverter = newContextAwareDataConverter(converter.GetDefaultDataConverter())
+
+func TestContextAwareDataConverter(t *testing.T) {
+	t.Parallel()
+	t.Run("default", func(t *testing.T) {
+		t.Parallel()
+		payload, _ := contextAwareDataConverter.ToPayload("test")
+		result := contextAwareDataConverter.ToString(payload)
+
+		require.Equal(t, `"test"`, result)
+	})
+	t.Run("implements ContextAware", func(t *testing.T) {
+		t.Parallel()
+		_, ok := contextAwareDataConverter.(ContextAware)
+		require.True(t, ok)
+	})
+	t.Run("with activity context", func(t *testing.T) {
+		t.Parallel()
+		ctx := context.Background()
+		ctx = context.WithValue(ctx, prefixContextKey, "testing")
+
+		dc := WithContext(ctx, contextAwareDataConverter)
+
+		payload, _ := dc.ToPayload("test")
+		result := dc.ToString(payload)
+
+		require.Equal(t, `testing: "test"`, result)
+	})
+	t.Run("with workflow context", func(t *testing.T) {
+		t.Parallel()
+		ctx := Background()
+		ctx = WithValue(ctx, prefixContextKey, "testing")
+
+		dc := WithWorkflowContext(ctx, contextAwareDataConverter)
+
+		payload, _ := dc.ToPayload("test")
+		result := dc.ToString(payload)
+
+		require.Equal(t, `testing: "test"`, result)
+	})
+}

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -679,7 +679,7 @@ func (wc *workflowEnvironmentInterceptor) ExecuteChildWorkflow(ctx Context, chil
 		executionFuture:  executionFuture.(*futureImpl),
 	}
 	workflowOptionsFromCtx := getWorkflowEnvOptions(ctx)
-	dc := workflowOptionsFromCtx.DataConverter
+	dc := WithWorkflowContext(ctx, workflowOptionsFromCtx.DataConverter)
 	env := getWorkflowEnvironment(ctx)
 	wfType, input, err := getValidatedWorkflowFunction(childWorkflowType, args, dc, env.GetRegistry())
 	if err != nil {

--- a/workflow/context_propagator.go
+++ b/workflow/context_propagator.go
@@ -24,7 +24,9 @@
 
 package workflow
 
-import "go.temporal.io/sdk/internal"
+import (
+	"go.temporal.io/sdk/internal"
+)
 
 type (
 	// HeaderReader is an interface to read information from temporal headers
@@ -36,4 +38,9 @@ type (
 	// ContextPropagator is an interface that determines what information from
 	// context to pass along
 	ContextPropagator = internal.ContextPropagator
+
+	// ContextAware is an optional interface that can be implemented alongside DataConverter.
+	// This interface allows Temporal to pass Workflow/Activity contexts to the DataConverter
+	// so that it may tailor it's behaviour.
+	ContextAware = internal.ContextAware
 )


### PR DESCRIPTION
## What was changed:
A new API was added so that DataConverter implementations can receive Workflow/Activity context and return a stateful version of themselves.

## Why?
This can be used to vary behavior of the data converter, for example, to vary encryption keys used by a converter based on workflow context (which should also be propagated to the activity context).

## How has this been tested?
UnitTested