### PR TITLE
Support executing local activities by name

### DIFF
--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -555,6 +555,7 @@ func (wc *workflowEnvironmentInterceptor) ExecuteLocalActivity(ctx Context, type
 	if activityFnOrName == nil {
 		panic("ExecuteLocalActivity: Expected context key " + localActivityFnContextKey + " is missing")
 	}
+
 	if activityName, ok := activityFnOrName.(string); ok {
 		registry := getRegistryFromWorkflowContext(ctx)
 		activityType, err := getValidatedActivityFunction(typeName, args, registry)
@@ -571,6 +572,11 @@ func (wc *workflowEnvironmentInterceptor) ExecuteLocalActivity(ctx Context, type
 
 		activityFn = activity.GetFunction()
 	} else {
+		if err := validateFunctionArgs(activityFnOrName, args, false); err != nil {
+			settable.Set(nil, err)
+			return future
+		}
+
 		activityFn = activityFnOrName
 	}
 


### PR DESCRIPTION
## What was changed:

The change replicates the behavior of `ExecuteActivity` for `ExecuteLocalActivity` to allow executing local activities by supplying funcs or func names.

In the process, `ExecuteLocalActivity` is using the activity registry to lookup the activity function by name when needed.

~One question I have is that this could be potentially considered a breaking change because right now, it seems local activities executions don't seem to rely on the registry meaning that potentially, you don't have to register local activities in your worker? I still have to test if that is true and if so, if this is a documented behaviour.~ It seems that's indeed the case [when I look at tests](https://github.com/temporalio/sdk-go/blob/master/internal/internal_task_handlers_test.go#L1237-L1239). 

## Why?

This PR attempts to fix #354 to allow executing local activities by using the activity name similarly to non local activities.

## Checklist
<!--- add/delete as needed --->

1. Closes issue: closes #354
2. How was this tested: for now manually by using my fork on my own internal project
3. Any docs updates needed?: I don't think there is any doc around that specific to local activities.

## Todo

- [x] Fix existing tests
- [x] Add tests for local activity execution by name