### PR TITLE
Expose gRPC Authority in ConnectionOptions

### DIFF
--- a/internal/client.go
+++ b/internal/client.go
@@ -408,6 +408,10 @@ type (
 	// ConnectionOptions is provided by SDK consumers to control optional connection params.
 	ConnectionOptions struct {
 		TLS                *tls.Config
+		// Allows setting the GRPC authority for the request.
+		// By default, when empty, the authority for the GRPC request is not overridden.
+		// If TLS settings are passed in, setting the authority has no effect, as it only works in insecure GRPC mode.
+		GRPCAuthority string
 		DisableHealthCheck bool
 		HealthCheckTimeout time.Duration
 		// Enables keep alive ping from client to the server, which can help detect abruptly closed connections faster.

--- a/internal/client.go
+++ b/internal/client.go
@@ -407,11 +407,11 @@ type (
 
 	// ConnectionOptions is provided by SDK consumers to control optional connection params.
 	ConnectionOptions struct {
-		TLS                *tls.Config
-		// Allows setting the GRPC authority for the request.
-		// By default, when empty, the authority for the GRPC request is not overridden.
-		// If TLS settings are passed in, setting the authority has no effect, as it only works in insecure GRPC mode.
-		GRPCAuthority string
+		TLS *tls.Config
+		// Allows setting the gRPC authority for the request.
+		// By default, when empty, the authority for the gRPC request is not overridden.
+		// If TLS settings are passed in, setting the authority has no effect, as it only works in insecure gRPC mode.
+		Authority          string
 		DisableHealthCheck bool
 		HealthCheckTimeout time.Duration
 		// Enables keep alive ping from client to the server, which can help detect abruptly closed connections faster.

--- a/internal/grpc_dialer.go
+++ b/internal/grpc_dialer.go
@@ -86,8 +86,8 @@ func dial(params dialParameters) (*grpc.ClientConn, error) {
 		grpc.WithConnectParams(cp),
 	}
 
-	if params.UserConnectionOptions.GRPCAuthority != "" {
-		opts = append(opts, grpc.WithAuthority(params.UserConnectionOptions.GRPCAuthority))
+	if params.UserConnectionOptions.Authority != "" {
+		opts = append(opts, grpc.WithAuthority(params.UserConnectionOptions.Authority))
 	}
 
 	if params.UserConnectionOptions.EnableKeepAliveCheck {

--- a/internal/grpc_dialer.go
+++ b/internal/grpc_dialer.go
@@ -86,6 +86,10 @@ func dial(params dialParameters) (*grpc.ClientConn, error) {
 		grpc.WithConnectParams(cp),
 	}
 
+	if params.UserConnectionOptions.GRPCAuthority != "" {
+		opts = append(opts, grpc.WithAuthority(params.UserConnectionOptions.GRPCAuthority))
+	}
+
 	if params.UserConnectionOptions.EnableKeepAliveCheck {
 		// gRPC utilizes keep alive mechanism to detect dead connections in case if server didn't close them
 		// gracefully. Client would ping the server periodically and expect replies withing the specified timeout.


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed:
<!-- Describe what has changed in this PR -->

Exposed the gRPC authority as a connection option.

## Why?
<!-- Tell your future self why have you made these changes -->

gRPC Authority is used for routing in certain scenarios. This is a safe change as gRPC enforces that authority can only be overridden in insecure mode.

## Checklist
<!--- add/delete as needed --->

1. Closes issue: 

N/A.

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

Integration and unit tests.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

N/A.
