### PR TITLE
Add gRPC Authority connection option

### DIFF
--- a/internal/client.go
+++ b/internal/client.go
@@ -407,19 +407,35 @@ type (
 
 	// ConnectionOptions is provided by SDK consumers to control optional connection params.
 	ConnectionOptions struct {
-		TLS                *tls.Config
+		// TLS configures a connection level security credentials.
+		TLS *tls.Config
+
+		// Authority specifies the value to be used as the :authority pseudo-header.
+		// This value only works only when TLS is nil.
+		Authority string
+
+		// By default, after gRPC connection to server is created, client will make a request to
+		// health check endpoint to make sure that server is accessible.
+		// Set DisableHealthCheck to true to disable it.
 		DisableHealthCheck bool
+
+		// Specify how to long to wait while checking server connection when creating new client.
+		// Default: 5s.
 		HealthCheckTimeout time.Duration
+
 		// Enables keep alive ping from client to the server, which can help detect abruptly closed connections faster.
 		EnableKeepAliveCheck bool
+
 		// After a duration of this time if the client doesn't see any activity it
 		// pings the server to see if the transport is still alive.
 		// If set below 10s, a minimum value of 10s will be used instead.
 		KeepAliveTime time.Duration
+
 		// After having pinged for keepalive check, the client waits for a duration
 		// of Timeout and if no activity is seen even after that the connection is
 		// closed.
 		KeepAliveTimeout time.Duration
+
 		// If true, client sends keepalive pings even with no active RPCs. If false,
 		// when there are no active RPCs, Time and Timeout will be ignored and no
 		// keepalive pings will be sent.

--- a/internal/client.go
+++ b/internal/client.go
@@ -407,19 +407,19 @@ type (
 
 	// ConnectionOptions is provided by SDK consumers to control optional connection params.
 	ConnectionOptions struct {
-		// TLS configures a connection level security credentials.
+		// TLS configures connection level security credentials.
 		TLS *tls.Config
 
 		// Authority specifies the value to be used as the :authority pseudo-header.
-		// This value only works only when TLS is nil.
+		// This value only used when TLS is nil.
 		Authority string
 
-		// By default, after gRPC connection to server is created, client will make a request to
-		// health check endpoint to make sure that server is accessible.
+		// By default, after gRPC connection to the Server is created, client will make a request to
+		// health check endpoint to make sure that the Server is accessible.
 		// Set DisableHealthCheck to true to disable it.
 		DisableHealthCheck bool
 
-		// Specify how to long to wait while checking server connection when creating new client.
+		// HealthCheckTimeout specifies how to long to wait while checking server connection when creating new client.
 		// Default: 5s.
 		HealthCheckTimeout time.Duration
 


### PR DESCRIPTION
## What was changed:
<!-- Describe what has changed in this PR -->
Add gRPC Authority connection option.

## Why?
<!-- Tell your future self why have you made these changes -->
gRPC Authority is used for routing in certain scenarios. This is a safe change as gRPC enforces that authority can only be overridden in insecure mode.

### How was this tested
Integration and unit tests.
