### PR TITLE
allow clients to specify a unix socket as a connection param

### DIFF
--- a/internal/client.go
+++ b/internal/client.go
@@ -398,6 +398,11 @@ type (
 		// Optional: HeadersProvider will be invoked on every outgoing gRPC request and gives user ability to
 		// set custom request headers. This can be used to set auth headers for example.
 		HeadersProvider HeadersProvider
+
+		// Optional: To proxy connections via a unix socket, set this
+		// to the location of the unix socket. Value should be a valid
+		// path in the filesystem.
+		UnixSocket string
 	}
 
 	// HeadersProvider returns a map of gRPC headers that should be used on every request.
@@ -613,6 +618,7 @@ func newDialParameters(options *ClientOptions) dialParameters {
 	return dialParameters{
 		UserConnectionOptions: options.ConnectionOptions,
 		HostPort:              options.HostPort,
+		UnixSocket:            options.UnixSocket,
 		RequiredInterceptors:  requiredInterceptors(options.MetricsScope, options.HeadersProvider),
 		DefaultServiceConfig:  defaultServiceConfig,
 	}

--- a/internal/grpc_dialer.go
+++ b/internal/grpc_dialer.go
@@ -26,6 +26,7 @@ package internal
 
 import (
 	"context"
+	"net"
 	"time"
 
 	"github.com/gogo/status"
@@ -44,6 +45,7 @@ type (
 	// dialParameters are passed to GRPCDialer and must be used to create gRPC connection.
 	dialParameters struct {
 		HostPort              string
+		UnixSocket            string
 		UserConnectionOptions ConnectionOptions
 		RequiredInterceptors  []grpc.UnaryClientInterceptor
 		DefaultServiceConfig  string
@@ -105,6 +107,13 @@ func dial(params dialParameters) (*grpc.ClientConn, error) {
 		}
 		opts = append(opts, grpc.WithKeepaliveParams(kap))
 	}
+
+	if params.UnixSocket != "" {
+		opts = append(opts, grpc.WithDialer(func(addr string, timeout time.Duration) (net.Conn, error) {
+			return net.DialTimeout("unix", params.UnixSocket, timeout)
+		}))
+	}
+
 	return grpc.Dial(params.HostPort, opts...)
 }
 


### PR DESCRIPTION


## What was changed:
Adds a `UnixSocket` client param to `ClientOptions` to allow for proxying a connection via a unix socket.

I'm happy to adapt the design as is recommended by the team.

To get ahead on some questions:
1. Why not replace `HostPort`?
  Requests via unix-socket can still carry an `:authority` header identifying the server they are trying to talk to. So the `HostPort` is still useful, the same way `curl` commands specifying a unix socket still need a URL.
1. Why not shove this in `ConnectionOptions`?
  I don't have strong feelings here. It seemed to belong well alongside `HostPort` but happy to move it.
1. Why not put a full-fledged `grpc.DialOption` in `dialParameters`?
  We could, so users could specify `grpc.WithDialer` to whatever they want. But there's no real good way to eventually add that to the cli. So somewhere we need to turn a unix socket into a dial option. I don't have strong opinions for what layer is best.

## Why?
Stripe infrastructure leverages unix domain sockets to secure access to services. They're nice because filesystem permissions apply, so you can e.g. mount a UDS into a docker container and disable network access entirely, and the proc in the container can just listen on the UDS.

We'd like to be able to proxy our tctl traffic over a UDS, as we have a trusted proxy that listens on a UDS and handshakes with other infrastructure.

Consider this analogous to `curl`'s `--unix-socket` flag: https://superuser.com/a/925610

## Checklist
### Testing
So! I couldn't find precedent for testing grpc comms from sdk to server. If there is, I'd be happy to add a test, although it'll be a little involved because we'd need to spin up a UDS proxy in the test itself. Doable. GRPC can also listen on a UDS so maybe not that hard.

I did test this with Envoy though. Here's my Envoy config:
```
static_resources:
  listeners:
  - name: listener_0
    address:
      pipe:
        path: /home/envoy/my.sock
    filter_chains:
    - filters:
      - name: envoy.filters.network.http_connection_manager
        typed_config:
          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
          stat_prefix: ingress_http
          access_log:
          - name: envoy.access_loggers.stdout
            typed_config:
              "@type": type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
          codec_type: AUTO
          route_config:
            name: local_route
            virtual_hosts:
            - name: local_service
              domains: ["*"]
              routes:
              - match: { prefix: "/", grpc: {} }
                route: { auto_host_rewrite: true, cluster: remote }
          http_filters:
          - name: envoy.filters.http.router
  clusters:
  - name: remote
    connect_timeout: 1s
    type: STATIC
    lb_policy: ROUND_ROBIN
    http2_protocol_options: {}
    load_assignment:
      cluster_name: remote
      endpoints:
      - lb_endpoints:
        - endpoint:
            address:
              socket_address:
                address: 127.0.0.1
                port_value: 7233
```

Used this Docker command:
```
docker run -it --rm --net=host -v $(pwd)/envoy.yaml:/etc/envoy/envoy.yaml:ro -v $(pwd)/sockets:/home/envoy envoyproxy/envoy-dev:7cd615c262dc1b871812209e37c15a49daea5173
```

Other than that I followed https://docs.temporal.io/docs/server/quick-install/ to get Temporal up.

Then I ran this go program:
```
package main

import (
	"context"
	"log"

	temporalenums "go.temporal.io/api/enums/v1"
	"go.temporal.io/sdk/client"
)

func main() {
	c, err := client.NewClient(client.Options{
		UnixSocket: "/home/choo/temporal/run/sockets/my.sock",
	})
	if err != nil {
		log.Fatalln("Unable to create client", err)
	}
	defer c.Close()

	resp, err := c.DescribeTaskQueue(context.TODO(), "default", temporalenums.TASK_QUEUE_TYPE_UNSPECIFIED)
	if err != nil {
		log.Fatalln("DescribeTaskQueue", err)
	}

	log.Printf("resp: %+v\n", resp)
}
```


And finally!!!!!
```
sudo go run main.go
2021/04/26 19:47:24 INFO  No logger configured for temporal client. Created default one.
2021/04/26 19:47:24 resp: &DescribeTaskQueueResponse{Pollers:[]*PollerInfo{},TaskQueueStatus:nil,}
```


Here's the log from Envoy:
```
[2021-04-26T19:47:24.543Z] "POST /temporal.api.workflowservice.v1.WorkflowService/DescribeTaskQueue HTTP/2" 200 - 27 5 7 5 "-" "grpc-go/1.36.0" "c4644d06-4b45-4cb9-bc2f-d7e30209a277" "localhost:7233" "127.0.0.1:7233"
```
