### PR TITLE
Invoke startedCallback when child workflow failed to start

### DIFF
--- a/internal/internal_task_handlers_test.go
+++ b/internal/internal_task_handlers_test.go
@@ -262,6 +262,13 @@ func createTestEventChildWorkflowExecutionStarted(eventID int64, attr *historypb
 		Attributes: &historypb.HistoryEvent_ChildWorkflowExecutionStartedEventAttributes{ChildWorkflowExecutionStartedEventAttributes: attr}}
 }
 
+func createTestEventStartChildWorkflowExecutionFailed(eventID int64, attr *historypb.StartChildWorkflowExecutionFailedEventAttributes) *historypb.HistoryEvent {
+	return &historypb.HistoryEvent{
+		EventId:    eventID,
+		EventType:  enumspb.EVENT_TYPE_START_CHILD_WORKFLOW_EXECUTION_FAILED,
+		Attributes: &historypb.HistoryEvent_StartChildWorkflowExecutionFailedEventAttributes{StartChildWorkflowExecutionFailedEventAttributes: attr}}
+}
+
 func createTestEventRequestCancelExternalWorkflowExecutionInitiated(eventID int64, attr *historypb.RequestCancelExternalWorkflowExecutionInitiatedEventAttributes) *historypb.HistoryEvent {
 	return &historypb.HistoryEvent{
 		EventId:    eventID,


### PR DESCRIPTION
This PR addresses a bug described in https://github.com/temporalio/sdk-go/issues/411.
Main issue there is that in case if child workflow fails to start, execution future doesn't get resolved, this means that code like:
```
workflow.ExecuteChildWorkflow(...).GetChildWorkflowExecution().Get(ctx, nil)
```
would block forever, at the same time call on the main future would have succeeded:
```
workflow.ExecuteChildWorkflow(...).Get(ctx, nil)
```

In order to address this we should unblock startedCallback when we receive failed to start error. Trickily enough, this error was misbehaving only in real code, while our test environment [was already invoking this callback](https://github.com/temporalio/sdk-go/blob/429a4a9c4d70a60d7caa52e49484932a8fec702f/internal/internal_workflow_testsuite.go#L2047)