### PR TITLE
Don't add local activity result to the marker if local activity doesn't have return value

### DIFF
--- a/internal/internal_decision_state_machine.go
+++ b/internal/internal_decision_state_machine.go
@@ -191,12 +191,12 @@ const (
 	localActivityMarkerName     = "LocalActivity"
 	mutableSideEffectMarkerName = "MutableSideEffect"
 
-	sideEffectMarkerIDName               = "side-effect-id"
-	sideEffectMarkerDataName             = "data"
-	versionMarkerChangeIDName            = "change-id"
-	versionMarkerDataName                = "version"
-	localActivityMarkerDataDetailsName   = "data"
-	localActivityMarkerResultDetailsName = "result"
+	sideEffectMarkerIDName      = "side-effect-id"
+	sideEffectMarkerDataName    = "data"
+	versionMarkerChangeIDName   = "change-id"
+	versionMarkerDataName       = "version"
+	localActivityMarkerDataName = "data"
+	localActivityResultName     = "result"
 )
 
 func (d commandState) String() string {

--- a/internal/internal_event_handlers.go
+++ b/internal/internal_event_handlers.go
@@ -1166,7 +1166,8 @@ func (weh *workflowExecutionEventHandlerImpl) handleLocalActivityMarker(details 
 			lar.Backoff = lamd.Backoff
 			lar.Err = ConvertFailureToError(failure, weh.GetDataConverter())
 		} else {
-			lar.Result, _ = details[localActivityResultName]
+			// Result might not be there if local activity doesn't have return value.
+			lar.Result = details[localActivityResultName]
 		}
 		la.callback(lar)
 

--- a/internal/internal_event_handlers.go
+++ b/internal/internal_event_handlers.go
@@ -1166,12 +1166,7 @@ func (weh *workflowExecutionEventHandlerImpl) handleLocalActivityMarker(details 
 			lar.Backoff = lamd.Backoff
 			lar.Err = ConvertFailureToError(failure, weh.GetDataConverter())
 		} else {
-			var result *commonpb.Payloads
-			var ok bool
-			if result, ok = details[localActivityResultName]; !ok {
-				return fmt.Errorf("key %q: %w", localActivityResultName, ErrMissingMarkerDataKey)
-			}
-			lar.Result = result
+			lar.Result, _ = details[localActivityResultName]
 		}
 		la.callback(lar)
 

--- a/internal/internal_event_handlers.go
+++ b/internal/internal_event_handlers.go
@@ -1142,8 +1142,8 @@ func (weh *workflowExecutionEventHandlerImpl) handleMarkerRecorded(
 func (weh *workflowExecutionEventHandlerImpl) handleLocalActivityMarker(details map[string]*commonpb.Payloads, failure *failurepb.Failure) error {
 	var markerData *commonpb.Payloads
 	var ok bool
-	if markerData, ok = details[localActivityMarkerDataDetailsName]; !ok {
-		return fmt.Errorf("key %q: %w", localActivityMarkerDataDetailsName, ErrMissingMarkerDataKey)
+	if markerData, ok = details[localActivityMarkerDataName]; !ok {
+		return fmt.Errorf("key %q: %w", localActivityMarkerDataName, ErrMissingMarkerDataKey)
 	}
 
 	lamd := localActivityMarkerData{}
@@ -1168,8 +1168,8 @@ func (weh *workflowExecutionEventHandlerImpl) handleLocalActivityMarker(details 
 		} else {
 			var result *commonpb.Payloads
 			var ok bool
-			if result, ok = details[localActivityMarkerResultDetailsName]; !ok {
-				return fmt.Errorf("key %q: %w", localActivityMarkerResultDetailsName, ErrMissingMarkerDataKey)
+			if result, ok = details[localActivityResultName]; !ok {
+				return fmt.Errorf("key %q: %w", localActivityResultName, ErrMissingMarkerDataKey)
 			}
 			lar.Result = result
 		}
@@ -1197,11 +1197,8 @@ func (weh *workflowExecutionEventHandlerImpl) ProcessLocalActivityResult(lar *lo
 	}
 	if lar.err != nil {
 		lamd.Backoff = lar.backoff
-	} else {
-		details[localActivityMarkerResultDetailsName] = lar.result
-		if details[localActivityMarkerResultDetailsName] == nil {
-			details[localActivityMarkerResultDetailsName] = &commonpb.Payloads{}
-		}
+	} else if lar.result != nil {
+		details[localActivityResultName] = lar.result
 	}
 
 	// encode marker data
@@ -1209,7 +1206,7 @@ func (weh *workflowExecutionEventHandlerImpl) ProcessLocalActivityResult(lar *lo
 	if err != nil {
 		return err
 	}
-	details[localActivityMarkerDataDetailsName] = markerData
+	details[localActivityMarkerDataName] = markerData
 
 	// create marker event for local activity result
 	markerEvent := &historypb.HistoryEvent{

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -169,8 +169,8 @@ func (s *internalWorkerTestSuite) createLocalActivityMarkerDataForTest(activityI
 	s.NoError(err)
 
 	return map[string]*commonpb.Payloads{
-		localActivityMarkerDataDetailsName:   markerData,
-		localActivityMarkerResultDetailsName: {},
+		localActivityMarkerDataName: markerData,
+		localActivityResultName:     {},
 	}
 }
 

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -168,9 +168,12 @@ func (s *internalWorkerTestSuite) createLocalActivityMarkerDataForTest(activityI
 	markerData, err := s.dataConverter.ToPayloads(lamd)
 	s.NoError(err)
 
+	result, err := s.dataConverter.ToPayloads(nil)
+	s.NoError(err)
+
 	return map[string]*commonpb.Payloads{
 		localActivityMarkerDataName: markerData,
-		localActivityResultName:     {},
+		localActivityResultName:     result,
 	}
 }
 

--- a/internal/internal_workers_test.go
+++ b/internal/internal_workers_test.go
@@ -485,6 +485,6 @@ func (s *WorkersTestSuite) createLocalActivityMarkerDataForTest(activityID strin
 
 	s.NoError(err)
 	return map[string]*commonpb.Payloads{
-		localActivityMarkerDataDetailsName: markerData,
+		localActivityMarkerDataName: markerData,
 	}
 }


### PR DESCRIPTION
If local activity function doesn't have return value (returns only `errror`) `lar.result` is `nil` and it shouldn't be added to the marker data. 
Closes #421.
Related to #365.