### PR TITLE
Ability to verify when an activity should not be called

### DIFF
--- a/internal/internal_workflow_testsuite_test.go
+++ b/internal/internal_workflow_testsuite_test.go
@@ -93,7 +93,7 @@ func (s *WorkflowTestSuiteUnitTest) Test_ActivityMockFunction() {
 
 func (s *WorkflowTestSuiteUnitTest) Test_ActivityMockFunctionZero() {
 	env := s.NewTestWorkflowEnvironment()
-	env.OnActivity(testActivityHello, mock.Anything, "world").Zero()
+	env.OnActivity(testActivityHello, mock.Anything, "world").Never()
 	env.RegisterWorkflow(testWorkflowHello)
 	env.ExecuteWorkflow(testWorkflowHello)
 

--- a/internal/internal_workflow_testsuite_test.go
+++ b/internal/internal_workflow_testsuite_test.go
@@ -91,6 +91,18 @@ func (s *WorkflowTestSuiteUnitTest) Test_ActivityMockFunction() {
 	env.AssertExpectations(s.T())
 }
 
+func (s *WorkflowTestSuiteUnitTest) Test_ActivityMockFunctionZero() {
+	env := s.NewTestWorkflowEnvironment()
+	env.OnActivity(testActivityHello, mock.Anything, "world").Zero()
+	env.RegisterWorkflow(testWorkflowHello)
+	env.ExecuteWorkflow(testWorkflowHello)
+
+	s.True(env.IsWorkflowCompleted())
+	s.NotNil(env.GetWorkflowError())
+	s.Contains(env.GetWorkflowError().Error(), "unexpected call: testActivityHello(string,string)")
+	env.AssertExpectations(s.T())
+}
+
 func (s *WorkflowTestSuiteUnitTest) Test_ActivityByNameMockFunction() {
 	mockActivity := func(ctx context.Context, msg string) (string, error) {
 		return "mock_" + msg, nil

--- a/internal/workflow_testsuite.go
+++ b/internal/workflow_testsuite.go
@@ -449,8 +449,8 @@ func (c *MockCallWrapper) Times(i int) *MockCallWrapper {
 	return c
 }
 
-// Zero indicates that the mock should not be called.
-func (c *MockCallWrapper) Zero() *MockCallWrapper {
+// Never indicates that the mock should not be called.
+func (c *MockCallWrapper) Never() *MockCallWrapper {
 	c.call.Maybe()
 	c.call.Panic(fmt.Sprintf("unexpected call: %s(%s)", c.call.Method, c.call.Arguments.String()))
 	return c

--- a/internal/workflow_testsuite.go
+++ b/internal/workflow_testsuite.go
@@ -449,6 +449,13 @@ func (c *MockCallWrapper) Times(i int) *MockCallWrapper {
 	return c
 }
 
+// Zero indicates that the mock should not be called.
+func (c *MockCallWrapper) Zero() *MockCallWrapper {
+	c.call.Maybe()
+	c.call.Panic(fmt.Sprintf("unexpected call: %s(%s)", c.call.Method, c.call.Arguments.String()))
+	return c
+}
+
 // Run sets a handler to be called before returning. It can be used when mocking a method such as unmarshalers that
 // takes a pointer to a struct and sets properties in such struct.
 func (c *MockCallWrapper) Run(fn func(args mock.Arguments)) *MockCallWrapper {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed:
<!-- Describe what has changed in this PR -->

Added to the `MockCallWrapper` a way to specify that we expect Zero calls to the activity.

## Why?
<!-- Tell your future self why have you made these changes -->

This can be helpful to test workflows with branches.

## Checklist
<!--- add/delete as needed --->

1. Closes issue: #427 

2. How was this tested: Unit test added
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->


