### PR TITLE
Fixes leak if client is able to open gRPC connection to server, but health check subsequently fails.

### DIFF
--- a/internal/client.go
+++ b/internal/client.go
@@ -603,6 +603,9 @@ func NewClient(options ClientOptions) (Client, error) {
 	}
 
 	if err = checkHealth(connection, options.ConnectionOptions); err != nil {
+		if err := connection.Close(); err != nil {
+			options.Logger.Warn("Unable to close connection on health check failure.", "error", err)
+		}
 		return nil, err
 	}
 
@@ -668,6 +671,9 @@ func NewNamespaceClient(options ClientOptions) (NamespaceClient, error) {
 	}
 
 	if err = checkHealth(connection, options.ConnectionOptions); err != nil {
+		if err := connection.Close(); err != nil {
+			options.Logger.Warn("Unable to close connection on health check failure.", "error", err)
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed:
During creation of the client, if we successfully create a gRPC connection, but cannot validate the health check, we error out without actually closing the gRPC connection. This results in a temporary leak. This PR fixes that leak.

