### PR TITLE
Added ability to call local activity using nil struct pointer

### DIFF
--- a/internal/internal_activity.go
+++ b/internal/internal_activity.go
@@ -234,7 +234,7 @@ func validateFunctionArgs(workflowFunc interface{}, args []interface{}, isWorkfl
 			workflowFunc)
 	}
 
-	fnName := getFunctionName(workflowFunc)
+	fnName, _ := getFunctionName(workflowFunc)
 	fnArgIndex := 0
 	// Skip Context function argument.
 	if fType.NumIn() > 0 {
@@ -277,7 +277,7 @@ func getValidatedActivityFunction(f interface{}, args []interface{}, registry *r
 		if err := validateFunctionArgs(f, args, false); err != nil {
 			return nil, err
 		}
-		fnName = getFunctionName(f)
+		fnName, _ = getFunctionName(f)
 		if alias, ok := registry.getActivityAlias(fnName); ok {
 			fnName = alias
 		}
@@ -306,7 +306,7 @@ func validateFunctionAndGetResults(f interface{}, values []reflect.Value, dataCo
 	resultSize := len(values)
 
 	if resultSize < 1 || resultSize > 2 {
-		fnName := getFunctionName(f)
+		fnName, _ := getFunctionName(f)
 		return nil, fmt.Errorf(
 			"the function: %v signature returns %d results, it is expecting to return either error or (result, error)",
 			fnName, resultSize)
@@ -348,7 +348,7 @@ func serializeResults(f interface{}, results []interface{}, dataConverter conver
 	resultSize := len(results)
 
 	if resultSize < 1 || resultSize > 2 {
-		fnName := getFunctionName(f)
+		fnName, _ := getFunctionName(f)
 		err = fmt.Errorf(
 			"the function: %v signature returns %d results, it is expecting to return either error or (result, error)",
 			fnName, resultSize)

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -1388,6 +1388,8 @@ func getFunctionName(i interface{}) (name string, isMethod bool) {
 		return fullName, false
 	}
 	fullName := runtime.FuncForPC(reflect.ValueOf(i).Pointer()).Name()
+	// Full function name that has a struct pointer receiver has the following format
+	// <prefix>.(*<type>).<function>
 	isMethod = strings.ContainsAny(fullName, "*")
 	elements := strings.Split(fullName, ".")
 	shortName := elements[len(elements)-1]

--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -1671,7 +1671,7 @@ func (m *mockWrapper) getMockFn(mockRet mock.Arguments) interface{} {
 	mockFnType := reflect.TypeOf(mockFn)
 	if mockFnType != nil && mockFnType.Kind() == reflect.Func {
 		if mockFnType != fnType {
-			fnName := getFunctionName(m.fn)
+			fnName, _ := getFunctionName(m.fn)
 			// mockDummyActivity is used to register mocks by name
 			if fnName != "mockDummyActivity" {
 				panic(fmt.Sprintf("mock of %v has incorrect return function, expected %v, but actual is %v",

--- a/internal/internal_workflow_testsuite_test.go
+++ b/internal/internal_workflow_testsuite_test.go
@@ -1790,7 +1790,8 @@ func (s *WorkflowTestSuiteUnitTest) Test_ActivityFullyQualifiedName() {
 	workflowFn := func(ctx Context) error {
 		ctx = WithActivityOptions(ctx, s.activityOptions)
 		var result string
-		fut := ExecuteActivity(ctx, getFunctionName(testActivityHello), "friendly_name")
+		name, _ := getFunctionName(testActivityHello)
+		fut := ExecuteActivity(ctx, name, "friendly_name")
 		err := fut.Get(ctx, &result)
 		return err
 	}
@@ -1809,8 +1810,8 @@ func (s *WorkflowTestSuiteUnitTest) Test_WorkflowUnknownName() {
 		}
 	}()
 	env := s.NewTestWorkflowEnvironment()
-
-	env.ExecuteWorkflow(getFunctionName(testWorkflowHello))
+	name, _ := getFunctionName(testWorkflowHello)
+	env.ExecuteWorkflow(name)
 	s.Fail("Should have panic'ed at ExecuteWorkflow")
 }
 

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -783,15 +783,18 @@ type WorkflowInfo struct {
 	WorkflowTaskTimeout      time.Duration
 	Namespace                string
 	Attempt                  int32 // Attempt starts from 1 and increased by 1 for every retry if retry policy is specified.
-	lastCompletionResult     *commonpb.Payloads
-	lastFailure              *failurepb.Failure
-	CronSchedule             string
-	ContinuedExecutionRunID  string
-	ParentWorkflowNamespace  string
-	ParentWorkflowExecution  *WorkflowExecution
-	Memo                     *commonpb.Memo             // Value can be decoded using data converter (defaultDataConverter, or custom one if set).
-	SearchAttributes         *commonpb.SearchAttributes // Value can be decoded using defaultDataConverter.
-	BinaryChecksum           string
+	// Time of the workflow start.
+	// workflow.Now at the beginning of a workflow can return a later time if the Workflow Worker was down.
+	WorkflowStartTime       time.Time
+	lastCompletionResult    *commonpb.Payloads
+	lastFailure             *failurepb.Failure
+	CronSchedule            string
+	ContinuedExecutionRunID string
+	ParentWorkflowNamespace string
+	ParentWorkflowExecution *WorkflowExecution
+	Memo                    *commonpb.Memo             // Value can be decoded using data converter (defaultDataConverter, or custom one if set).
+	SearchAttributes        *commonpb.SearchAttributes // Value can be decoded using defaultDataConverter.
+	BinaryChecksum          string
 }
 
 // GetBinaryChecksum return binary checksum.

--- a/test/workflow_test.go
+++ b/test/workflow_test.go
@@ -785,7 +785,7 @@ func (w *Workflows) InspectLocalActivityInfo(ctx workflow.Context) error {
 	wfType := info.WorkflowType.Name
 	taskQueue := info.TaskQueueName
 	ctx = workflow.WithLocalActivityOptions(ctx, w.defaultLocalActivityOptions())
-	activities := Activities{}
+	var activities *Activities
 	return workflow.ExecuteLocalActivity(
 		ctx, activities.InspectActivityInfo, namespace, taskQueue, wfType).Get(ctx, nil)
 }
@@ -793,7 +793,7 @@ func (w *Workflows) InspectLocalActivityInfo(ctx workflow.Context) error {
 func (w *Workflows) WorkflowWithLocalActivityCtxPropagation(ctx workflow.Context) (string, error) {
 	ctx = workflow.WithLocalActivityOptions(ctx, w.defaultLocalActivityOptions())
 	ctx = workflow.WithValue(ctx, contextKey(testContextKey1), "test-data-in-context")
-	activities := Activities{}
+	var activities *Activities
 	var result string
 	err := workflow.ExecuteLocalActivity(ctx, activities.DuplicateStringInContext).Get(ctx, &result)
 	if err != nil {
@@ -804,7 +804,7 @@ func (w *Workflows) WorkflowWithLocalActivityCtxPropagation(ctx workflow.Context
 
 func (w *Workflows) WorkflowWithParallelLocalActivities(ctx workflow.Context) (string, error) {
 	ctx = workflow.WithLocalActivityOptions(ctx, w.defaultLocalActivityOptions())
-	activities := Activities{}
+	var activities *Activities
 	var futures []workflow.Future
 
 	for i := 0; i < 10; i++ {
@@ -828,7 +828,7 @@ func (w *Workflows) WorkflowWithParallelLocalActivities(ctx workflow.Context) (s
 func (w *Workflows) WorkflowWithLocalActivityStartWhenTimerCancel(ctx workflow.Context) (bool, error) {
 	timerCtx, cancelTimer := workflow.WithCancel(ctx)
 	ctx = workflow.WithActivityOptions(ctx, w.defaultActivityOptions())
-	activities := Activities{}
+	var activities *Activities
 	// Start a timer
 	_ = workflow.NewTimer(timerCtx, time.Second*3)
 
@@ -851,6 +851,7 @@ func (w *Workflows) WorkflowWithParallelLongLocalActivityAndHeartbeat(ctx workfl
 	ao := w.defaultLocalActivityOptions()
 	ao.ScheduleToCloseTimeout = 10 * time.Second
 	ctx = workflow.WithLocalActivityOptions(ctx, ao)
+	// Intentionally instantiating to test legacy path of non nil receiver.
 	activities := Activities{}
 	var futures []workflow.Future
 
@@ -880,7 +881,7 @@ func (w *Workflows) WorkflowWithLocalActivityRetries(ctx workflow.Context) error
 		MaximumInterval:    time.Second * 5,
 	}
 	ctx = workflow.WithLocalActivityOptions(ctx, laOpts)
-	activities := Activities{}
+	var activities *Activities
 
 	var futures []workflow.Future
 	for i := 1; i <= 10; i++ {


### PR DESCRIPTION
## What was changed:
Added ability to call local activity using nil struct pointer:
```go
	var activities *Activities
	err := workflow.ExecuteLocalActivity(ctx, activities.Function).Get(ctx, nil)
```
## Why?
It is already supported for normal activities and allows using struct implementation for the local ones.

1. Closes issue: 
https://github.com/temporalio/sdk-go/issues/424

2. How was this tested:
Unit tests updated to cover the legacy and the new way to call local activities.

3. Any docs updates needed?
Yes. The Go SDK needs to be updated to demonstrate this pattern for both normal and local activities.
