### PR TITLE
Indicate RegisterDelayedCallback with 0 delay does not work with queries

### DIFF
--- a/internal/workflow_testsuite.go
+++ b/internal/workflow_testsuite.go
@@ -732,7 +732,7 @@ func (e *TestWorkflowEnvironment) QueryWorkflowByID(workflowID, queryType string
 // signal or workflow cancellation) at desired time.
 //
 // Use 0 delayDuration to send a signal to simulate SignalWithStart. Note that a 0 duration delay will *not* work with
-// Queries.
+// Queries, as the workflow will not have had a chance to register any query handlers.
 func (e *TestWorkflowEnvironment) RegisterDelayedCallback(callback func(), delayDuration time.Duration) {
 	e.impl.registerDelayedCallback(callback, delayDuration)
 }

--- a/internal/workflow_testsuite.go
+++ b/internal/workflow_testsuite.go
@@ -730,7 +730,9 @@ func (e *TestWorkflowEnvironment) QueryWorkflowByID(workflowID, queryType string
 // the timer fires, the callback will be called. By default, this test suite uses mock clock which automatically move
 // forward to fire next timer when workflow is blocked. Use this API to make some event (like activity completion,
 // signal or workflow cancellation) at desired time.
-// Use 0 delayDuration to send a signal to simulate SignalWithStart.
+//
+// Use 0 delayDuration to send a signal to simulate SignalWithStart. Note that a 0 duration delay will *not* work with
+// Queries.
 func (e *TestWorkflowEnvironment) RegisterDelayedCallback(callback func(), delayDuration time.Duration) {
 	e.impl.registerDelayedCallback(callback, delayDuration)
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Updated docstring

## Why?
Queries with zero delay to a workflow can't really be performed in a real situation, and aren't supported in the unit testing framework. Make that more clear.

## Checklist
<!--- add/delete as needed --->

1. Closes issue: 
#433 

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
