### PR TITLE
Filter out DeadlineExceeded error in retry

### DIFF
--- a/internal/common/backoff/retry.go
+++ b/internal/common/backoff/retry.go
@@ -111,8 +111,7 @@ func Retry(ctx context.Context, operation Operation, policy RetryPolicy, isRetry
 		// Therefore, update lastErr only if it is not set (first attempt) or opErr is not a DeadlineExceeded error.
 		// This lastErr is returned if retry attempts are exhausted.
 		var errDeadlineExceeded *serviceerror.DeadlineExceeded
-		if lastErr == nil ||
-			!(errors.Is(opErr, context.DeadlineExceeded) || errors.As(opErr, &errDeadlineExceeded)) {
+		if lastErr == nil || !(errors.Is(opErr, context.DeadlineExceeded) || errors.As(opErr, &errDeadlineExceeded)) {
 			lastErr = opErr
 		}
 

--- a/internal/common/backoff/retry.go
+++ b/internal/common/backoff/retry.go
@@ -26,8 +26,11 @@ package backoff
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
+
+	"go.temporal.io/api/serviceerror"
 )
 
 type (
@@ -92,24 +95,34 @@ func NewConcurrentRetrier(retryPolicy RetryPolicy) *ConcurrentRetrier {
 
 // Retry function can be used to wrap any call with retry logic using the passed in policy
 func Retry(ctx context.Context, operation Operation, policy RetryPolicy, isRetryable IsRetryable) error {
-	var err error
+	var lastErr error
 	var next time.Duration
 
 	r := NewRetrier(policy, SystemClock)
-RetryLoop:
 	for {
-		// operation completed successfully.  No need to retry.
-		if err = operation(); err == nil {
+		opErr := operation()
+		if opErr == nil {
+			// operation completed successfully. No need to retry.
 			return nil
 		}
 
+		// Usually, after number of retry attempts, last attempt fails with DeadlineExceeded error.
+		// It is not informative and actual error reason is in the error occurred on previous attempt.
+		// Therefore, update lastErr only if it is not set (first attempt) or opErr is not a DeadlineExceeded error.
+		// This lastErr is returned if retry attempts are exhausted.
+		var errDeadlineExceeded *serviceerror.DeadlineExceeded
+		if lastErr == nil ||
+			!(errors.Is(opErr, context.DeadlineExceeded) || errors.As(opErr, &errDeadlineExceeded)) {
+			lastErr = opErr
+		}
+
 		if next = r.NextBackOff(); next == done {
-			return err
+			return lastErr
 		}
 
 		// Check if the error is retryable
-		if isRetryable != nil && !isRetryable(err) {
-			return err
+		if isRetryable != nil && !isRetryable(opErr) {
+			return lastErr
 		}
 
 		// check if ctx is done
@@ -117,9 +130,9 @@ RetryLoop:
 			timer := time.NewTimer(next)
 			select {
 			case <-ctxDone:
-				return err
+				return lastErr
 			case <-timer.C:
-				continue RetryLoop
+				continue
 			}
 		}
 

--- a/internal/common/backoff/retry_test.go
+++ b/internal/common/backoff/retry_test.go
@@ -93,8 +93,7 @@ func TestRetryFailed(t *testing.T) {
 		i++
 
 		if i == 6 {
-			// Should never be called because retry is set to 5 attempts.
-			return nil
+			assert.Fail(t, "Should never be called because retry is set to 5 attempts")
 		}
 
 		return &someError{}

--- a/internal/common/backoff/retrypolicy.go
+++ b/internal/common/backoff/retrypolicy.go
@@ -138,7 +138,7 @@ func (p *ExponentialRetryPolicy) SetMaximumAttempts(maximumAttempts int) {
 // ComputeNextDelay returns the next delay interval.  This is used by Retrier to delay calling the operation again
 func (p *ExponentialRetryPolicy) ComputeNextDelay(elapsedTime time.Duration, numAttempts int) time.Duration {
 	// Check to see if we ran out of maximum number of attempts
-	if p.maximumAttempts != noMaximumAttempts && numAttempts > p.maximumAttempts {
+	if p.maximumAttempts != noMaximumAttempts && numAttempts >= p.maximumAttempts {
 		return done
 	}
 


### PR DESCRIPTION
Usually, after number of retry attempts, last attempt fails with `DeadlineExceeded` error. It is not informative and actual error reason is in the error occurred on previous attempt. Return this `lastErr` instead of `DeadlineExceeded` error provides a better user experience.