### PR TITLE
Workers should fail to start if they were stopped before

### DIFF
--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -890,6 +890,7 @@ func (aw *AggregatedWorker) RegisterActivityWithOptions(a interface{}, options R
 
 // Start the worker in a non-blocking fashion.
 func (aw *AggregatedWorker) Start() error {
+	aw.assertNotStopped()
 	if err := initBinaryChecksum(); err != nil {
 		return fmt.Errorf("failed to get executable checksum: %v", err)
 	}
@@ -932,6 +933,18 @@ func (aw *AggregatedWorker) Start() error {
 	}
 	aw.logger.Info("Started Worker")
 	return nil
+}
+
+func (aw *AggregatedWorker) assertNotStopped() {
+	stopped := true
+	select {
+	case <-aw.stopC:
+	default:
+		stopped = false
+	}
+	if stopped {
+		panic("attempted to start a worker that has been stopped before")
+	}
 }
 
 var binaryChecksum string


### PR DESCRIPTION
Resolves #447 by raising a panic in case if start was attempted after worker was stopped.
To achieve this we don't even need a new variable as we can check if stop channel is still open.

This brings go in compliance with java, which [already has](https://github.com/temporalio/sdk-java/blob/30420212a26283cf7cbe6339512058a3186074e8/temporal-sdk/src/test/java/io/temporal/workerFactory/WorkerFactoryTests.java#L104) this type of check.