### PR TITLE
Activity metrics should include task queue name

### DIFF
--- a/internal/common/metrics/utils.go
+++ b/internal/common/metrics/utils.go
@@ -62,9 +62,9 @@ func GetWorkerScope(ts tally.Scope, workerType string) tally.Scope {
 }
 
 // GetMetricsScopeForActivity return properly tagged tally scope for activity
-func GetMetricsScopeForActivity(ts tally.Scope, workflowType, activityType string) tally.Scope {
+func GetMetricsScopeForActivity(ts tally.Scope, workflowType, activityType, taskQueueName string) tally.Scope {
 	return TagScope(ts, WorkflowTypeNameTagName, workflowType, ActivityTypeNameTagName,
-		activityType)
+		activityType, TaskQueueTagName, taskQueueName)
 }
 
 // GetMetricsScopeForLocalActivity return properly tagged tally scope for local activity
@@ -79,9 +79,9 @@ func GetMetricsScopeForWorkflow(ts tally.Scope, workflowType string) tally.Scope
 }
 
 // GetMetricsScopeForRPC return properly tagged tally scope for workflow execution
-func GetMetricsScopeForRPC(ts tally.Scope, workflowType, activityType, taskqueueName string) tally.Scope {
+func GetMetricsScopeForRPC(ts tally.Scope, workflowType, activityType, taskQueueName string) tally.Scope {
 	return TagScope(ts, WorkflowTypeNameTagName, workflowType, ActivityTypeNameTagName,
-		activityType, TaskQueueTagName, taskqueueName)
+		activityType, TaskQueueTagName, taskQueueName)
 }
 
 // getMetricsScopeForOperation return properly tagged tally scope for rpc operation

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -1754,7 +1754,7 @@ func (ath *activityTaskHandlerImpl) Execute(taskQueue string, t *workflowservice
 
 	workflowType := t.WorkflowType.GetName()
 	activityType := t.ActivityType.GetName()
-	activityMetricsScope := metrics.GetMetricsScopeForActivity(ath.metricsScope, workflowType, activityType)
+	activityMetricsScope := metrics.GetMetricsScopeForRPC(ath.metricsScope, workflowType, activityType, taskQueue)
 	ctx := WithActivityTask(canCtx, t, taskQueue, invoker, ath.logger, activityMetricsScope, ath.dataConverter, ath.workerStopCh, ath.contextPropagators, ath.tracer)
 
 	defer func() {

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -1754,7 +1754,7 @@ func (ath *activityTaskHandlerImpl) Execute(taskQueue string, t *workflowservice
 
 	workflowType := t.WorkflowType.GetName()
 	activityType := t.ActivityType.GetName()
-	activityMetricsScope := metrics.GetMetricsScopeForRPC(ath.metricsScope, workflowType, activityType, taskQueue)
+	activityMetricsScope := metrics.GetMetricsScopeForActivity(ath.metricsScope, workflowType, activityType, ath.taskQueueName)
 	ctx := WithActivityTask(canCtx, t, taskQueue, invoker, ath.logger, activityMetricsScope, ath.dataConverter, ath.workerStopCh, ath.contextPropagators, ath.tracer)
 
 	defer func() {

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -846,7 +846,7 @@ func (atp *activityTaskPoller) poll(ctx context.Context) (interface{}, error) {
 
 	workflowType := response.WorkflowType.GetName()
 	activityType := response.ActivityType.GetName()
-	activityMetricsScope := metrics.GetMetricsScopeForRPC(atp.metricsScope, workflowType, activityType, atp.taskQueueName)
+	activityMetricsScope := metrics.GetMetricsScopeForActivity(atp.metricsScope, workflowType, activityType, atp.taskQueueName)
 
 	scheduleToStartLatency := common.TimeValue(response.GetStartedTime()).Sub(common.TimeValue(response.GetCurrentAttemptScheduledTime()))
 	activityMetricsScope.Timer(metrics.ActivityScheduleToStartLatency).Record(scheduleToStartLatency)
@@ -881,7 +881,7 @@ func (atp *activityTaskPoller) ProcessTask(task interface{}) error {
 
 	workflowType := activityTask.task.WorkflowType.GetName()
 	activityType := activityTask.task.ActivityType.GetName()
-	activityMetricsScope := metrics.GetMetricsScopeForRPC(atp.metricsScope, workflowType, activityType, atp.taskQueueName)
+	activityMetricsScope := metrics.GetMetricsScopeForActivity(atp.metricsScope, workflowType, activityType, atp.taskQueueName)
 
 	executionStartTime := time.Now()
 	// Process the activity task.

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -846,7 +846,7 @@ func (atp *activityTaskPoller) poll(ctx context.Context) (interface{}, error) {
 
 	workflowType := response.WorkflowType.GetName()
 	activityType := response.ActivityType.GetName()
-	activityMetricsScope := metrics.GetMetricsScopeForActivity(atp.metricsScope, workflowType, activityType)
+	activityMetricsScope := metrics.GetMetricsScopeForRPC(atp.metricsScope, workflowType, activityType, atp.taskQueueName)
 
 	scheduleToStartLatency := common.TimeValue(response.GetStartedTime()).Sub(common.TimeValue(response.GetCurrentAttemptScheduledTime()))
 	activityMetricsScope.Timer(metrics.ActivityScheduleToStartLatency).Record(scheduleToStartLatency)
@@ -881,7 +881,7 @@ func (atp *activityTaskPoller) ProcessTask(task interface{}) error {
 
 	workflowType := activityTask.task.WorkflowType.GetName()
 	activityType := activityTask.task.ActivityType.GetName()
-	activityMetricsScope := metrics.GetMetricsScopeForActivity(atp.metricsScope, workflowType, activityType)
+	activityMetricsScope := metrics.GetMetricsScopeForRPC(atp.metricsScope, workflowType, activityType, atp.taskQueueName)
 
 	executionStartTime := time.Now()
 	// Process the activity task.


### PR DESCRIPTION
Resolves #449 by tagging several activity related metrics with the task queue
name. This aligns more closely with the behavior of the Java SDK.
