### PR TITLE
Health check retry

### DIFF
--- a/test/bindings_test.go
+++ b/test/bindings_test.go
@@ -64,7 +64,6 @@ func TestAsyncBindingsTestSuite(t *testing.T) {
 func (ts *AsyncBindingsTestSuite) SetupSuite() {
 	ts.Assertions = require.New(ts.T())
 	ts.config = NewConfig()
-	ts.NoError(WaitForTCP(time.Minute, ts.config.ServiceAddr))
 	var err error
 	ts.client, err = client.NewClient(client.Options{
 		HostPort:  ts.config.ServiceAddr,


### PR DESCRIPTION
Resolves #438 by adding configurable healthcheck timeout for the client.
Default value is set to 10 seconds, which means that now client creation would block sending health check requests in case if server is not available.