### PR TITLE
Ensure default retry policy in test

### DIFF
--- a/internal/client.go
+++ b/internal/client.go
@@ -538,10 +538,10 @@ type (
 	// history only when the activity completes or "finally" timeouts/fails. And the started event only records the last
 	// started time. Because of that, to check an activity has started or not, you cannot rely on history events. Instead,
 	// you can use CLI to describe the workflow to see the status of the activity:
-	//     temporal --do <namespace> wf desc -w <wf-id>
+	//     tctl --ns <namespace> wf desc -w <wf-id>
 	RetryPolicy struct {
 		// Backoff interval for the first retry. If BackoffCoefficient is 1.0 then it is used for all retries.
-		// Required, no default value.
+		// If not set or set to 0, a default internal of 1s will be used.
 		InitialInterval time.Duration
 
 		// Coefficient used to calculate the next retry backoff interval.

--- a/internal/client.go
+++ b/internal/client.go
@@ -541,7 +541,7 @@ type (
 	//     tctl --ns <namespace> wf desc -w <wf-id>
 	RetryPolicy struct {
 		// Backoff interval for the first retry. If BackoffCoefficient is 1.0 then it is used for all retries.
-		// If not set or set to 0, a default internal of 1s will be used.
+		// If not set or set to 0, a default interval of 1s will be used.
 		InitialInterval time.Duration
 
 		// Coefficient used to calculate the next retry backoff interval.

--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -1302,10 +1302,11 @@ func ensureDefaultRetryPolicy(parameters *ExecuteActivityParams) {
 	if parameters.RetryPolicy == nil {
 		parameters.RetryPolicy = &commonpb.RetryPolicy{}
 	}
-	if *parameters.RetryPolicy.InitialInterval == 0 {
+
+	if parameters.RetryPolicy.InitialInterval == nil || *parameters.RetryPolicy.InitialInterval == 0 {
 		parameters.RetryPolicy.InitialInterval = common.DurationPtr(time.Second)
 	}
-	if *parameters.RetryPolicy.MaximumInterval == 0 {
+	if parameters.RetryPolicy.MaximumInterval == nil || *parameters.RetryPolicy.MaximumInterval == 0 {
 		parameters.RetryPolicy.MaximumInterval = common.DurationPtr(*parameters.RetryPolicy.InitialInterval)
 	}
 	if parameters.RetryPolicy.BackoffCoefficient == 0 {

--- a/internal/session_test.go
+++ b/internal/session_test.go
@@ -610,7 +610,8 @@ func (s *SessionTestSuite) TestCompletionFailed() {
 	env.SetWorkerOptions(WorkerOptions{EnableSessionWorker: true})
 	env.RegisterWorkflow(workflowFn)
 	env.OnActivity(sessionCreationActivityName, mock.Anything, mock.Anything).Return(sessionCreationActivity).Once()
-	env.OnActivity(sessionCompletionActivityName, mock.Anything, mock.Anything).Return(errors.New("some random error")).Once()
+	// fail the activity and return non retryable error to avoid retry.
+	env.OnActivity(sessionCompletionActivityName, mock.Anything, mock.Anything).Return(NewApplicationError("some error", "", true, nil)).Once()
 	env.ExecuteWorkflow(workflowFn)
 
 	s.True(env.IsWorkflowCompleted())


### PR DESCRIPTION
## What was changed
Add default retry policy for unit test.

## Why?
Retry policy is optional, server will use a default retry policy if user does not supply one. Also, fields of retry policy are optional, when not set, server would use default for them. The defaults set by server are:
// The default RetryPolicy provided by the server specifies:
// - InitialInterval of 1 second
// - BackoffCoefficient of 2.0
// - MaximumInterval of 100 x InitialInterval
// - MaximumAttempts of 0 (unlimited)

This works when running against temporal server, but won't work for unit test until now.

close#461

2. How was this tested:
Added new unit test to cover the case.

3. Any docs updates needed?
https://docs.temporal.io/docs/go/retries/
The InitialInterval field of retry policy is not required, the default value is 1s.
