### PR TITLE
Make deadlock detection timeout configurable

### DIFF
--- a/internal/internal_coroutines_test.go
+++ b/internal/internal_coroutines_test.go
@@ -66,7 +66,7 @@ func TestDispatcher(t *testing.T) {
 	d := createNewDispatcher(func(ctx Context) { value = "bar" })
 	defer d.Close()
 	require.Equal(t, "foo", value)
-	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked())
+	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked(defaultDeadlockDetectionTimeout))
 	require.True(t, d.IsDone())
 	require.Equal(t, "bar", value)
 }
@@ -84,7 +84,7 @@ func TestNonBlockingChildren(t *testing.T) {
 	})
 	defer d.Close()
 	require.EqualValues(t, 0, len(history))
-	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked())
+	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked(defaultDeadlockDetectionTimeout))
 	require.True(t, d.IsDone())
 
 	require.EqualValues(t, 11, len(history))
@@ -108,7 +108,7 @@ func TestNonbufferedChannel(t *testing.T) {
 	})
 	defer d.Close()
 	require.EqualValues(t, 0, len(history))
-	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked())
+	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked(defaultDeadlockDetectionTimeout))
 	require.True(t, d.IsDone())
 
 	expected := []string{
@@ -155,12 +155,12 @@ func TestNonbufferedChannelBlockedReceive(t *testing.T) {
 	})
 	defer d.Close()
 	require.EqualValues(t, 0, len(history))
-	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked())
+	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked(defaultDeadlockDetectionTimeout))
 	c2.SendAsync("value21")
-	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked())
-	_ = d.ExecuteUntilAllBlocked()
+	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked(defaultDeadlockDetectionTimeout))
+	_ = d.ExecuteUntilAllBlocked(defaultDeadlockDetectionTimeout)
 	c2.SendAsync("value22")
-	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked())
+	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked(defaultDeadlockDetectionTimeout))
 
 	require.True(t, d.IsDone(), d.StackTrace())
 }
@@ -187,7 +187,7 @@ func TestBufferedChannelPut(t *testing.T) {
 	})
 	defer d.Close()
 	require.EqualValues(t, 0, len(history))
-	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked())
+	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked(defaultDeadlockDetectionTimeout))
 	require.True(t, d.IsDone())
 
 	expected := []string{
@@ -238,7 +238,7 @@ func TestBufferedChannelGet(t *testing.T) {
 	})
 	defer d.Close()
 	require.EqualValues(t, 0, len(history))
-	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked())
+	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked(defaultDeadlockDetectionTimeout))
 	require.True(t, d.IsDone(), strings.Join(history, "\n")+"\n\n"+d.StackTrace())
 
 	expected := []string{
@@ -290,7 +290,7 @@ func TestNotBlockingSelect(t *testing.T) {
 		require.False(t, s.HasPending())
 	})
 	defer d.Close()
-	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked())
+	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked(defaultDeadlockDetectionTimeout))
 	require.True(t, d.IsDone())
 
 	expected := []string{
@@ -339,7 +339,7 @@ func TestBlockingSelect(t *testing.T) {
 		history = append(history, "done")
 	})
 	defer d.Close()
-	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked())
+	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked(defaultDeadlockDetectionTimeout))
 	require.True(t, d.IsDone(), strings.Join(history, "\n"))
 
 	expected := []string{
@@ -381,7 +381,7 @@ func TestBlockingSelectAsyncSend(t *testing.T) {
 		history = append(history, "done")
 	})
 	defer d.Close()
-	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked())
+	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked(defaultDeadlockDetectionTimeout))
 	require.True(t, d.IsDone(), strings.Join(history, "\n"))
 
 	expected := []string{
@@ -430,7 +430,7 @@ func TestSelectOnClosedChannel(t *testing.T) {
 		require.False(t, selector.HasPending())
 	})
 	defer d.Close()
-	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked())
+	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked(defaultDeadlockDetectionTimeout))
 	require.True(t, d.IsDone(), strings.Join(history, "\n"))
 
 	expected := []string{
@@ -475,7 +475,7 @@ func TestBlockingSelectAsyncSend2(t *testing.T) {
 		history = append(history, "done")
 	})
 	defer d.Close()
-	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked())
+	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked(defaultDeadlockDetectionTimeout))
 	require.True(t, d.IsDone(), strings.Join(history, "\n"))
 
 	expected := []string{
@@ -519,7 +519,7 @@ func TestSendSelect(t *testing.T) {
 		history = append(history, "done")
 	})
 	defer d.Close()
-	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked())
+	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked(defaultDeadlockDetectionTimeout))
 	require.True(t, d.IsDone())
 
 	expected := []string{
@@ -562,7 +562,7 @@ func TestSendSelectWithAsyncReceive(t *testing.T) {
 		history = append(history, "done")
 	})
 	defer d.Close()
-	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked())
+	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked(defaultDeadlockDetectionTimeout))
 	require.True(t, d.IsDone(), strings.Join(history, "\n"))
 
 	expected := []string{
@@ -609,7 +609,7 @@ func TestChannelClose(t *testing.T) {
 	})
 	defer d.Close()
 	require.EqualValues(t, 0, len(history))
-	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked())
+	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked(defaultDeadlockDetectionTimeout))
 	require.True(t, d.IsDone(), d.StackTrace())
 
 	expected := []string{
@@ -638,7 +638,7 @@ func TestSendClosedChannel(t *testing.T) {
 		c.Send(ctx, "baz")
 	})
 	defer d.Close()
-	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked())
+	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked(defaultDeadlockDetectionTimeout))
 	require.True(t, d.IsDone())
 }
 
@@ -653,7 +653,7 @@ func TestBlockedSendClosedChannel(t *testing.T) {
 		c.Send(ctx, "baz")
 	})
 	defer d.Close()
-	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked())
+	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked(defaultDeadlockDetectionTimeout))
 	require.True(t, d.IsDone())
 }
 
@@ -668,7 +668,7 @@ func TestAsyncSendClosedChannel(t *testing.T) {
 		_ = c.SendAsync("baz")
 	})
 	defer d.Close()
-	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked())
+	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked(defaultDeadlockDetectionTimeout))
 	require.True(t, d.IsDone())
 }
 
@@ -687,7 +687,7 @@ func TestDispatchClose(t *testing.T) {
 		c.Receive(ctx, nil) // blocked forever
 	})
 	require.EqualValues(t, 0, len(history))
-	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked())
+	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked(defaultDeadlockDetectionTimeout))
 	require.False(t, d.IsDone())
 	stack := d.StackTrace()
 	// 11 coroutines (3 lines each) + 10 nl
@@ -726,7 +726,7 @@ func TestPanic(t *testing.T) {
 	})
 	defer d.Close()
 	require.EqualValues(t, 0, len(history))
-	err := d.ExecuteUntilAllBlocked()
+	err := d.ExecuteUntilAllBlocked(defaultDeadlockDetectionTimeout)
 	require.Error(t, err)
 	value := err.Error()
 	require.EqualValues(t, "simulated failure", value)
@@ -742,14 +742,14 @@ func TestAwait(t *testing.T) {
 		_ = Await(ctx, func() bool { return flag })
 	})
 	defer d.Close()
-	err := d.ExecuteUntilAllBlocked()
+	err := d.ExecuteUntilAllBlocked(defaultDeadlockDetectionTimeout)
 	require.NoError(t, err)
 	require.False(t, d.IsDone())
-	err = d.ExecuteUntilAllBlocked()
+	err = d.ExecuteUntilAllBlocked(defaultDeadlockDetectionTimeout)
 	require.NoError(t, err)
 	require.False(t, d.IsDone())
 	flag = true
-	err = d.ExecuteUntilAllBlocked()
+	err = d.ExecuteUntilAllBlocked(defaultDeadlockDetectionTimeout)
 	require.NoError(t, err)
 	require.True(t, d.IsDone())
 }
@@ -762,11 +762,11 @@ func TestAwaitCancellation(t *testing.T) {
 		awaitError = Await(ctx, func() bool { return false })
 	})
 	defer d.Close()
-	err := d.ExecuteUntilAllBlocked()
+	err := d.ExecuteUntilAllBlocked(defaultDeadlockDetectionTimeout)
 	require.NoError(t, err)
 	require.False(t, d.IsDone())
 	cancelHandler()
-	err = d.ExecuteUntilAllBlocked()
+	err = d.ExecuteUntilAllBlocked(defaultDeadlockDetectionTimeout)
 	require.NoError(t, err)
 	require.True(t, d.IsDone())
 	require.Error(t, awaitError)
@@ -782,16 +782,16 @@ func TestAwaitWithTimeoutNoTimeout(t *testing.T) {
 		awaitOk, awaitWithTimeoutError = AwaitWithTimeout(ctx, time.Hour, func() bool { return flag })
 	})
 	defer d.Close()
-	err := d.ExecuteUntilAllBlocked()
+	err := d.ExecuteUntilAllBlocked(defaultDeadlockDetectionTimeout)
 	require.NoError(t, err)
 	require.False(t, d.IsDone())
 	require.False(t, awaitOk)
 	require.NoError(t, awaitWithTimeoutError)
-	err = d.ExecuteUntilAllBlocked()
+	err = d.ExecuteUntilAllBlocked(defaultDeadlockDetectionTimeout)
 	require.NoError(t, err)
 	require.False(t, d.IsDone())
 	flag = true
-	err = d.ExecuteUntilAllBlocked()
+	err = d.ExecuteUntilAllBlocked(defaultDeadlockDetectionTimeout)
 	require.NoError(t, err)
 	require.True(t, awaitOk)
 	require.True(t, d.IsDone())
@@ -806,13 +806,13 @@ func TestAwaitWithTimeoutCancellation(t *testing.T) {
 		awaitOk, awaitWithTimeoutError = AwaitWithTimeout(ctx, time.Hour, func() bool { return false })
 	})
 	defer d.Close()
-	err := d.ExecuteUntilAllBlocked()
+	err := d.ExecuteUntilAllBlocked(defaultDeadlockDetectionTimeout)
 	require.NoError(t, err)
 	require.False(t, d.IsDone())
 	require.False(t, awaitOk)
 	require.NoError(t, awaitWithTimeoutError)
 	cancelHandler()
-	err = d.ExecuteUntilAllBlocked()
+	err = d.ExecuteUntilAllBlocked(defaultDeadlockDetectionTimeout)
 	require.NoError(t, err)
 	require.True(t, d.IsDone())
 	require.Error(t, awaitWithTimeoutError)
@@ -845,13 +845,13 @@ func TestFutureSetValue(t *testing.T) {
 	})
 	defer d.Close()
 	require.EqualValues(t, 0, len(history))
-	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked())
+	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked(defaultDeadlockDetectionTimeout))
 	require.False(t, d.IsDone(), fmt.Sprintf("%v", d.StackTrace()))
 	history = append(history, "future-set")
 	require.False(t, f.IsReady())
 	s.SetValue("value1")
 	require.True(t, f.IsReady())
-	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked())
+	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked(defaultDeadlockDetectionTimeout))
 	require.True(t, d.IsDone())
 
 	expected := []string{
@@ -890,13 +890,13 @@ func TestFutureFail(t *testing.T) {
 	})
 	defer d.Close()
 	require.EqualValues(t, 0, len(history))
-	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked())
+	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked(defaultDeadlockDetectionTimeout))
 	require.False(t, d.IsDone(), fmt.Sprintf("%v", d.StackTrace()))
 	history = append(history, "future-set")
 	require.False(t, f.IsReady())
 	s.SetError(errors.New("value1"))
 	assert.True(t, f.IsReady())
-	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked())
+	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked(defaultDeadlockDetectionTimeout))
 	require.True(t, d.IsDone())
 
 	expected := []string{
@@ -949,20 +949,20 @@ func TestFutureSet(t *testing.T) {
 	defer d.Close()
 
 	require.EqualValues(t, 0, len(history))
-	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked())
+	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked(defaultDeadlockDetectionTimeout))
 	require.False(t, d.IsDone(), fmt.Sprintf("%v", d.StackTrace()))
 	history = append(history, "f1-set")
 	require.False(t, f1.IsReady())
 	s1.Set("value-will-be-ignored", errors.New("error1"))
 	assert.True(t, f1.IsReady())
-	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked())
+	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked(defaultDeadlockDetectionTimeout))
 
 	require.False(t, d.IsDone(), fmt.Sprintf("%v", d.StackTrace()))
 	history = append(history, "f2-set")
 	require.False(t, f2.IsReady())
 	s2.Set("value2", nil)
 	assert.True(t, f2.IsReady())
-	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked())
+	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked(defaultDeadlockDetectionTimeout))
 	require.True(t, d.IsDone())
 
 	expected := []string{
@@ -1022,20 +1022,20 @@ func TestFutureChain(t *testing.T) {
 	})
 	defer d.Close()
 	require.EqualValues(t, 0, len(history))
-	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked())
+	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked(defaultDeadlockDetectionTimeout))
 	require.False(t, d.IsDone(), fmt.Sprintf("%v", d.StackTrace()))
 	history = append(history, "f1-set")
 	require.False(t, f1.IsReady())
 	cs1.Set("value1-will-be-ignored", errors.New("error1"))
 	assert.True(t, f1.IsReady())
-	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked())
+	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked(defaultDeadlockDetectionTimeout))
 
 	require.False(t, d.IsDone(), fmt.Sprintf("%v", d.StackTrace()))
 	history = append(history, "f2-set")
 	require.False(t, f2.IsReady())
 	cs2.Set("value2", nil)
 	assert.True(t, f2.IsReady())
-	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked())
+	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked(defaultDeadlockDetectionTimeout))
 
 	require.True(t, d.IsDone())
 
@@ -1088,7 +1088,7 @@ func TestSelectFuture(t *testing.T) {
 		history = append(history, "done")
 	})
 	defer d.Close()
-	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked())
+	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked(defaultDeadlockDetectionTimeout))
 	require.True(t, d.IsDone())
 
 	expected := []string{
@@ -1142,7 +1142,7 @@ func TestSelectDecodeFuture(t *testing.T) {
 		history = append(history, "done")
 	})
 	defer d.Close()
-	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked())
+	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked(defaultDeadlockDetectionTimeout))
 	require.True(t, d.IsDone())
 
 	expected := []string{
@@ -1202,14 +1202,14 @@ func TestDecodeFutureChain(t *testing.T) {
 	})
 	defer d.Close()
 	require.EqualValues(t, 0, len(history))
-	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked())
+	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked(defaultDeadlockDetectionTimeout))
 	// set f1
 	require.False(t, d.IsDone(), fmt.Sprintf("%v", d.StackTrace()))
 	history = append(history, "f1-set")
 	require.False(t, f1.IsReady())
 	cs1.Set([]byte("value-will-be-ignored"), errors.New("error1"))
 	assert.True(t, f1.IsReady())
-	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked())
+	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked(defaultDeadlockDetectionTimeout))
 
 	// set f2
 	require.False(t, d.IsDone(), fmt.Sprintf("%v", d.StackTrace()))
@@ -1219,7 +1219,7 @@ func TestDecodeFutureChain(t *testing.T) {
 	require.NoError(t, err)
 	cs2.Set(v2, nil)
 	assert.True(t, f2.IsReady())
-	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked())
+	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked(defaultDeadlockDetectionTimeout))
 
 	require.True(t, d.IsDone())
 
@@ -1279,7 +1279,7 @@ func TestSelectFuture_WithBatchSets(t *testing.T) {
 		require.False(t, s.HasPending())
 	})
 	defer d.Close()
-	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked())
+	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked(defaultDeadlockDetectionTimeout))
 	require.True(t, d.IsDone())
 
 	expected := []string{

--- a/internal/internal_worker_base.go
+++ b/internal/internal_worker_base.go
@@ -116,7 +116,7 @@ type (
 		// Application level code must be executed from this function only.
 		// Execute call as well as callbacks called from WorkflowEnvironment functions can only schedule callbacks
 		// which can be executed from OnWorkflowTaskStarted().
-		OnWorkflowTaskStarted()
+		OnWorkflowTaskStarted(timeout time.Duration)
 		// StackTrace of all coroutines owned by the Dispatcher instance.
 		StackTrace() string
 		Close()

--- a/internal/internal_worker_base.go
+++ b/internal/internal_worker_base.go
@@ -116,7 +116,7 @@ type (
 		// Application level code must be executed from this function only.
 		// Execute call as well as callbacks called from WorkflowEnvironment functions can only schedule callbacks
 		// which can be executed from OnWorkflowTaskStarted().
-		OnWorkflowTaskStarted(timeout time.Duration)
+		OnWorkflowTaskStarted(deadlockDetectionTimeout time.Duration)
 		// StackTrace of all coroutines owned by the Dispatcher instance.
 		StackTrace() string
 		Close()

--- a/internal/internal_workflow.go
+++ b/internal/internal_workflow.go
@@ -29,8 +29,6 @@ package internal
 import (
 	"errors"
 	"fmt"
-	"math"
-	"os"
 	"reflect"
 	"runtime"
 	"strings"
@@ -84,8 +82,8 @@ type (
 	// Dispatcher is a container of a set of coroutines.
 	dispatcher interface {
 		// ExecuteUntilAllBlocked executes coroutines one by one in deterministic order
-		// until all of them are completed or blocked on Channel or Selector
-		ExecuteUntilAllBlocked() (err error)
+		// until all of them are completed or blocked on Channel or Selector or timeout is reached.
+		ExecuteUntilAllBlocked(timeout time.Duration) (err error)
 		// IsDone returns true when all of coroutines are completed
 		IsDone() bool
 		IsExecuting() bool
@@ -262,7 +260,6 @@ var _ WaitGroup = (*waitGroupImpl)(nil)
 var _ dispatcher = (*dispatcherImpl)(nil)
 
 var stackBuf [100000]byte
-var debugMode = os.Getenv("TEMPORAL_DEBUG") != ""
 
 // Pointer to pointer to workflow result
 func getWorkflowResultPointerPointer(ctx Context) **workflowResult {
@@ -538,8 +535,8 @@ func (d *syncWorkflowDefinition) Execute(env WorkflowEnvironment, header *common
 	})
 }
 
-func (d *syncWorkflowDefinition) OnWorkflowTaskStarted() {
-	executeDispatcher(d.rootCtx, d.dispatcher)
+func (d *syncWorkflowDefinition) OnWorkflowTaskStarted(timeout time.Duration) {
+	executeDispatcher(d.rootCtx, d.dispatcher, timeout)
 }
 
 func (d *syncWorkflowDefinition) StackTrace() string {
@@ -564,9 +561,9 @@ func newDispatcher(rootCtx Context, interceptor *workflowEnvironmentInterceptor,
 
 // executeDispatcher executed coroutines in the calling thread and calls workflow completion callbacks
 // if root workflow function returned
-func executeDispatcher(ctx Context, dispatcher dispatcher) {
+func executeDispatcher(ctx Context, dispatcher dispatcher, timeout time.Duration) {
 	env := getWorkflowEnvironment(ctx)
-	panicErr := dispatcher.ExecuteUntilAllBlocked()
+	panicErr := dispatcher.ExecuteUntilAllBlocked(timeout)
 	if panicErr != nil {
 		env.Complete(nil, panicErr)
 		return
@@ -862,16 +859,21 @@ func (s *coroutineState) unblocked() {
 	s.keptBlocked = false
 }
 
-func (s *coroutineState) call() {
+func (s *coroutineState) call(timeout time.Duration) {
 	s.unblock <- func(status string, stackDepth int) bool {
 		return false // unblock
 	}
 
-	deadlockDetectorTimeout := time.Second
-	if debugMode {
-		deadlockDetectorTimeout = math.MaxInt64
+	// Defaults are populated in the worker options during worker startup, but test environment
+	// may have no default value for the deadlock detection timeout, so we also need to set it here for
+	// backwards compatibility.
+	if timeout == 0 {
+		timeout = defaultDeadlockDetectionTimeout
+		if debugMode {
+			timeout = unlimitedDeadlockDetectionTimeout
+		}
 	}
-	deadlockTimer := time.NewTimer(deadlockDetectorTimeout)
+	deadlockTimer := time.NewTimer(timeout)
 	defer func() { deadlockTimer.Stop() }()
 
 	select {
@@ -941,7 +943,7 @@ func (d *dispatcherImpl) newState(name string) *coroutineState {
 	return c
 }
 
-func (d *dispatcherImpl) ExecuteUntilAllBlocked() (err error) {
+func (d *dispatcherImpl) ExecuteUntilAllBlocked(timeout time.Duration) (err error) {
 	d.mutex.Lock()
 	if d.closed {
 		panic("dispatcher is closed")
@@ -963,7 +965,7 @@ func (d *dispatcherImpl) ExecuteUntilAllBlocked() (err error) {
 			if !c.closed.Load() {
 				// TODO: Support handling of panic in a coroutine by dispatcher.
 				// TODO: Dump all outstanding coroutines if one of them panics
-				c.call()
+				c.call(timeout)
 			}
 			// c.call() can close the context so check again
 			if c.closed.Load() {

--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -263,6 +263,7 @@ func newTestWorkflowEnvironmentImpl(s *WorkflowTestSuite, parentRegistry *regist
 
 	if os.Getenv("TEMPORAL_DEBUG") != "" {
 		env.testTimeout = time.Hour * 24
+		env.workerOptions.DeadlockDetectionTimeout = unlimitedDeadlockDetectionTimeout
 	}
 
 	// move forward the mock clock to start time.
@@ -634,7 +635,7 @@ func (env *testWorkflowEnvironmentImpl) executeLocalActivity(
 
 func (env *testWorkflowEnvironmentImpl) startWorkflowTask() {
 	if !env.isWorkflowCompleted {
-		env.workflowDef.OnWorkflowTaskStarted()
+		env.workflowDef.OnWorkflowTaskStarted(env.workerOptions.DeadlockDetectionTimeout)
 	}
 }
 

--- a/internal/worker.go
+++ b/internal/worker.go
@@ -156,6 +156,9 @@ type (
 		// Optional: If set overwrites the client level Identify value.
 		// default: client identity
 		Identity string
+
+		// Optional: If set defines maximum amount of time that workflow task will be allowed to run. Defaults to 1 sec.
+		DeadlockDetectionTimeout time.Duration
 	}
 )
 

--- a/test/bindings_workflows_test.go
+++ b/test/bindings_workflows_test.go
@@ -52,7 +52,7 @@ func (wd *EmptyWorkflowDefinition) Execute(env bindings.WorkflowEnvironment, hea
 	env.Complete(payload, err)
 }
 
-func (wd *EmptyWorkflowDefinition) OnWorkflowTaskStarted() {
+func (wd *EmptyWorkflowDefinition) OnWorkflowTaskStarted(_ time.Duration) {
 
 }
 
@@ -151,7 +151,7 @@ func (d *SingleActivityWorkflowDefinition) addCallback(callback bindings.ResultH
 	}
 }
 
-func (d *SingleActivityWorkflowDefinition) OnWorkflowTaskStarted() {
+func (d *SingleActivityWorkflowDefinition) OnWorkflowTaskStarted(_ time.Duration) {
 	for _, callback := range d.callbacks {
 		callback()
 	}


### PR DESCRIPTION
## What was changed
Made deadlock detection timeout configurable via WorkerOptions. Default value hasn't changed and is equal to 1 second. `TEMPORAL_DEBUG` environment variable can still be used and will set unlimited deadlock detection timeout IF value is not provided in WorkerOptions.

## Why?
Initially we thought that there were no valid use cases when workflow tasks could take more than 1 second to run. However some users perform heavy, yet deterministic computations which may sometimes take longer. Making this timeout configurable allows for more flexibility on the user end.

## Checklist

1. Closes #404

2. How was this tested:
Unit tests
