### PR TITLE
Add missing activity failure metric

### DIFF
--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -241,6 +241,7 @@ func (ts *IntegrationTestSuite) TestActivityRetryOnError() {
 	ts.assertMetricsCounters(
 		"temporal_request", 7,
 		"temporal_request_attempt", 7,
+		"temporal_activity_execution_failed", 2,
 		"temporal_workflow_task_queue_poll_succeed", 1,
 		"temporal_long_request", 8,
 		"temporal_long_request_attempt", 8,


### PR DESCRIPTION
## What was changed
Activity failure doesn't result in error, and previously `temporal_activity_execution_failed` metric hasn't been reported for "normal" failures. This PR fixes it by reporting a metric whenever response type was `RespondActivityTaskFailedRequest`.

## Why?
Metric was incorrect.

## Checklist

1. Closes #457

2. How was this tested:
unit test
