### PR TITLE
Do not allow starting child workflows from an already-cancelled context

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/golang/mock v1.5.0
 	github.com/golang/protobuf v1.5.2
 	github.com/google/uuid v1.2.0 // indirect
-	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
+	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/kr/text v0.2.0 // indirect
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/opentracing/opentracing-go v1.2.0

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -735,8 +735,8 @@ func (wc *workflowEnvironmentInterceptor) ExecuteChildWorkflow(ctx Context, chil
 		executionFuture:  executionFuture.(*futureImpl),
 	}
 
-	// Immediately return if the context is already cancelled without spawning the child workflow
-	if ctx.Err() == ErrCanceled {
+	// Immediately return if the context has an error without spawning the child workflow
+	if ctx.Err() != nil {
 		executionSettable.Set(nil, ctx.Err())
 		mainSettable.Set(nil, ctx.Err())
 		return result

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -734,6 +734,14 @@ func (wc *workflowEnvironmentInterceptor) ExecuteChildWorkflow(ctx Context, chil
 		decodeFutureImpl: mainFuture.(*decodeFutureImpl),
 		executionFuture:  executionFuture.(*futureImpl),
 	}
+
+	// Immediately return if the context is already cancelled without spawning the child workflow
+	if ctx.Err() == ErrCanceled {
+		executionSettable.Set(nil, ctx.Err())
+		mainSettable.Set(nil, ctx.Err())
+		return result
+	}
+
 	workflowOptionsFromCtx := getWorkflowEnvOptions(ctx)
 	dc := WithWorkflowContext(ctx, workflowOptionsFromCtx.DataConverter)
 	env := getWorkflowEnvironment(ctx)

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -372,7 +372,7 @@ func (ts *IntegrationTestSuite) TestCascadingCancellation() {
 		started <- true
 	}()
 	select {
-	case _ = <-started:
+	case <-started:
 		// Nothing to do
 	case <-time.After(5 * time.Second):
 		ts.Fail("Timed out waiting for child workflow to start")

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -360,6 +360,14 @@ func (ts *IntegrationTestSuite) TestCascadingCancellation() {
 	ts.NotNil(run)
 	ts.NoError(err)
 
+	// Need to give workflow time to start its child
+	for {
+		_, err := ts.client.DescribeWorkflowExecution(ctx, childWorkflowID, "")
+		if err == nil {
+			break
+		}
+	}
+
 	ts.Nil(ts.client.CancelWorkflow(ctx, workflowID, ""))
 	err = run.Get(ctx, nil)
 	ts.Error(err)


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Previously, calls to start a child workflow using an already-cancelled context would still start the child and then immediately cancel it. Now, the child isn't started at all and the future immediately resolves w/ cancelled error.

## Why?
Starting child workflows with a cancelled context is a nonsense operation

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-go/issues/483

2. How was this tested:
Added UT and IT

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
