### PR TITLE
Prevent panic from reflect

### DIFF
--- a/internal/common/util/stringer.go
+++ b/internal/common/util/stringer.go
@@ -70,7 +70,7 @@ func valueToString(v reflect.Value) string {
 		return valueToString(v.Elem())
 	case reflect.Struct:
 		if v.CanInterface() {
-			anyToString(v.Interface())
+			return anyToString(v.Interface())
 		}
 	case reflect.Invalid:
 		return ""

--- a/internal/common/util/stringer.go
+++ b/internal/common/util/stringer.go
@@ -69,7 +69,9 @@ func valueToString(v reflect.Value) string {
 	case reflect.Ptr:
 		return valueToString(v.Elem())
 	case reflect.Struct:
-		return anyToString(v.Interface())
+		if v.CanInterface() {
+			anyToString(v.Interface())
+		}
 	case reflect.Invalid:
 		return ""
 	case reflect.Slice:
@@ -78,8 +80,12 @@ func valueToString(v reflect.Value) string {
 		}
 		return fmt.Sprintf("[len=%d]", v.Len())
 	default:
-		return fmt.Sprint(v.Interface())
+		if v.CanInterface() {
+			return fmt.Sprint(v.Interface())
+		}
 	}
+
+	return ""
 }
 
 // HistoryEventToString convert HistoryEvent to string

--- a/internal/common/util/stringer_test.go
+++ b/internal/common/util/stringer_test.go
@@ -44,3 +44,71 @@ func Test_byteSliceToString(t *testing.T) {
 
 	require.Equal(t, "[len=3]", strVal2)
 }
+
+func TestValueToString(t *testing.T) {
+
+	testValue := "test"
+	testSlice := []string{"a", "b", "c"}
+	var emptyInter interface{}
+	var testFloat64 float64 = 5.55
+
+	tempStruct := struct {
+		Test string
+	}{
+		"test",
+	}
+
+	tempUnexportedStruct := struct {
+		test string
+	}{
+		"test",
+	}
+
+	tests := []struct {
+		name     string
+		value    reflect.Value
+		expected string
+	}{
+		{
+			name:     "pointer",
+			value:    reflect.ValueOf(&testValue),
+			expected: testValue,
+		},
+		{
+			name:     "invalid",
+			value:    reflect.ValueOf(emptyInter),
+			expected: "",
+		},
+		{
+			name:     "struct",
+			value:    reflect.ValueOf(tempStruct),
+			expected: "(Test:test)",
+		},
+		{
+			name:     "unexported struct",
+			value:    reflect.ValueOf(tempUnexportedStruct),
+			expected: "()",
+		},
+		{
+			name:     "slice",
+			value:    reflect.ValueOf(testSlice),
+			expected: "[len=3]",
+		},
+		{
+			name:     "default",
+			value:    reflect.ValueOf(testFloat64),
+			expected: "5.55",
+		},
+	}
+
+	for _, d := range tests {
+		t.Logf("testing test name %s", d.name)
+		str := valueToString(d.value)
+
+		if str != d.expected {
+			t.Fatalf("%s: expected %s, received %s", d.name, d.expected, str)
+		}
+
+	}
+
+}


### PR DESCRIPTION
Prevent panic from reflect Interface() method. Prevents the symptom of the panic. This bug should probably handled further upstream. 
