### PR TITLE
Fix data race due to deadlock detector

### DIFF
--- a/internal/internal_workflow.go
+++ b/internal/internal_workflow.go
@@ -953,7 +953,11 @@ func (d *dispatcherImpl) ExecuteUntilAllBlocked(deadlockDetectionTimeout time.Du
 	}
 	d.executing = true
 	d.mutex.Unlock()
-	defer func() { d.executing = false }()
+	defer func() {
+		d.mutex.Lock()
+		d.executing = false
+		d.mutex.Unlock()
+	}()
 	allBlocked := false
 	// Keep executing until at least one goroutine made some progress
 	for !allBlocked {
@@ -992,10 +996,14 @@ func (d *dispatcherImpl) ExecuteUntilAllBlocked(deadlockDetectionTimeout time.Du
 }
 
 func (d *dispatcherImpl) IsDone() bool {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
 	return len(d.coroutines) == 0
 }
 
 func (d *dispatcherImpl) IsExecuting() bool {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
 	return d.executing
 }
 


### PR DESCRIPTION
## What was changed
Added additional locking to avoid data races.

## Why?
Data race has occurred when deadlock detector was terminating the call.

## Checklist

1. Closes #488

2. How was this tested:
unit test

3. Any docs updates needed?
no