### PR TITLE
Add field accessors for ActivityError

### DIFF
--- a/internal/error.go
+++ b/internal/error.go
@@ -636,26 +636,32 @@ func (e *ActivityError) Unwrap() error {
 	return e.cause
 }
 
+// ScheduledEventID returns event id of the scheduled workflow task corresponding to the activity.
 func (e *ActivityError) ScheduledEventID() int64 {
 	return e.scheduledEventID
 }
 
+// StartedEventID returns event id of the started workflow task corresponding to the activity.
 func (e *ActivityError) StartedEventID() int64 {
 	return e.startedEventID
 }
 
+// Identity returns identity of the worker that attempted activity execution.
 func (e *ActivityError) Identity() string {
 	return e.identity
 }
 
+// ActivityType returns declared type of the activity.
 func (e *ActivityError) ActivityType() *commonpb.ActivityType {
 	return e.activityType
 }
 
+// ActivityID return assigned identifier for the activity.
 func (e *ActivityError) ActivityID() string {
 	return e.activityID
 }
 
+// RetryState returns details on why activity failed.
 func (e *ActivityError) RetryState() enumspb.RetryState {
 	return e.retryState
 }

--- a/internal/error.go
+++ b/internal/error.go
@@ -636,6 +636,30 @@ func (e *ActivityError) Unwrap() error {
 	return e.cause
 }
 
+func (e *ActivityError) ScheduledEventID() int64 {
+	return e.scheduledEventID
+}
+
+func (e *ActivityError) StartedEventID() int64 {
+	return e.startedEventID
+}
+
+func (e *ActivityError) Identity() string {
+	return e.identity
+}
+
+func (e *ActivityError) ActivityType() *commonpb.ActivityType {
+	return e.activityType
+}
+
+func (e *ActivityError) ActivityID() string {
+	return e.activityID
+}
+
+func (e *ActivityError) RetryState() enumspb.RetryState {
+	return e.retryState
+}
+
 // Error from error interface
 func (e *ChildWorkflowExecutionError) Error() string {
 	msg := fmt.Sprintf("%s (type: %s, workflowID: %s, runID: %s, initiatedEventID: %d, startedEventID: %d)",

--- a/internal/error_test.go
+++ b/internal/error_test.go
@@ -102,6 +102,22 @@ func Test_GenericGoError(t *testing.T) {
 	require.Equal(t, "workflow error", err.Error())
 }
 
+func Test_ActivityErrorAccessors(t *testing.T) {
+	require := require.New(t)
+	err := NewApplicationError("app err", "", true, nil)
+	var applicationErr *ApplicationError
+	require.True(errors.As(err, &applicationErr))
+	err = NewActivityError(8, 22, "alex", &commonpb.ActivityType{Name: "activityType"}, "32283", enumspb.RETRY_STATE_NON_RETRYABLE_FAILURE, applicationErr)
+	var activityErr *ActivityError
+	require.True(errors.As(err, &activityErr))
+	require.Equal("32283", activityErr.ActivityID())
+	require.Equal(&commonpb.ActivityType{Name: "activityType"}, activityErr.ActivityType())
+	require.Equal(enumspb.RETRY_STATE_NON_RETRYABLE_FAILURE, activityErr.RetryState())
+	require.Equal("alex", activityErr.Identity())
+	require.Equal(int64(8), activityErr.ScheduledEventID())
+	require.Equal(int64(22), activityErr.StartedEventID())
+}
+
 func Test_ActivityNotRegistered(t *testing.T) {
 	registeredActivityFn, unregisteredActivitFn := "RegisteredActivity", "UnregisteredActivityFn"
 	s := &WorkflowTestSuite{}


### PR DESCRIPTION
Resolves #496 by adding field getters for ActivityError, see details in the linked issue.
It's an open question if we should add getters for other error types as well.