### PR TITLE
Revert "Add support for errors.Is()"

### DIFF
--- a/internal/error.go
+++ b/internal/error.go
@@ -435,14 +435,6 @@ func NewActivityNotRegisteredError(activityType string, supportedTypes []string)
 	return &ActivityNotRegisteredError{activityType: activityType, supportedTypes: supportedTypes}
 }
 
-// Is satisfies the errors interface.
-func (e *ApplicationError) Is(target error) bool {
-	if _, ok := target.(*ApplicationError); !ok {
-		return false
-	}
-	return true
-}
-
 // Error from error interface.
 func (e *ApplicationError) Error() string {
 	msg := e.message()
@@ -489,14 +481,6 @@ func (e *ApplicationError) Unwrap() error {
 	return e.cause
 }
 
-// Is satisfies the errors interface.
-func (e *TimeoutError) Is(target error) bool {
-	if _, ok := target.(*TimeoutError); !ok {
-		return false
-	}
-	return true
-}
-
 // Error from error interface
 func (e *TimeoutError) Error() string {
 	msg := fmt.Sprintf("%s (type: %v)", e.message(), e.timeoutType)
@@ -532,14 +516,6 @@ func (e *TimeoutError) LastHeartbeatDetails(d ...interface{}) error {
 	return e.lastHeartbeatDetails.Get(d...)
 }
 
-// Is satisfies the errors interface.
-func (e *CanceledError) Is(target error) bool {
-	if _, ok := target.(*CanceledError); !ok {
-		return false
-	}
-	return true
-}
-
 // Error from error interface
 func (e *CanceledError) Error() string {
 	return e.message()
@@ -570,14 +546,6 @@ func newWorkflowPanicError(value interface{}, stackTrace string) error {
 	return &workflowPanicError{value: value, stackTrace: stackTrace}
 }
 
-// Is satisfies the errors interface.
-func (e *PanicError) Is(target error) bool {
-	if _, ok := target.(*PanicError); !ok {
-		return false
-	}
-	return true
-}
-
 // Error from error interface
 func (e *PanicError) Error() string {
 	return e.message()
@@ -592,14 +560,6 @@ func (e *PanicError) StackTrace() string {
 	return e.stackTrace
 }
 
-// Is satisfies the errors interface.
-func (e *workflowPanicError) Is(target error) bool {
-	if _, ok := target.(*workflowPanicError); !ok {
-		return false
-	}
-	return true
-}
-
 // Error from error interface
 func (e *workflowPanicError) Error() string {
 	return fmt.Sprintf("%v", e.value)
@@ -608,14 +568,6 @@ func (e *workflowPanicError) Error() string {
 // StackTrace return stack trace of the panic
 func (e *workflowPanicError) StackTrace() string {
 	return e.stackTrace
-}
-
-// Is satisfies the errors interface.
-func (e *ContinueAsNewError) Is(target error) bool {
-	if _, ok := target.(*ContinueAsNewError); !ok {
-		return false
-	}
-	return true
 }
 
 // Error from error interface
@@ -632,14 +584,6 @@ func newTerminatedError() *TerminatedError {
 	return &TerminatedError{}
 }
 
-// Is satisfies the errors interface.
-func (e *TerminatedError) Is(target error) bool {
-	if _, ok := target.(*TerminatedError); !ok {
-		return false
-	}
-	return true
-}
-
 // Error from error interface
 func (e *TerminatedError) Error() string {
 	return e.message()
@@ -654,25 +598,9 @@ func newUnknownExternalWorkflowExecutionError() *UnknownExternalWorkflowExecutio
 	return &UnknownExternalWorkflowExecutionError{}
 }
 
-// Is satisfies the errors interface.
-func (e *UnknownExternalWorkflowExecutionError) Is(target error) bool {
-	if _, ok := target.(*UnknownExternalWorkflowExecutionError); !ok {
-		return false
-	}
-	return true
-}
-
 // Error from error interface
 func (e *UnknownExternalWorkflowExecutionError) Error() string {
 	return "unknown external workflow execution"
-}
-
-// Is satisfies the errors interface.
-func (e *ServerError) Is(target error) bool {
-	if _, ok := target.(*ServerError); !ok {
-		return false
-	}
-	return true
 }
 
 // Error from error interface
@@ -690,14 +618,6 @@ func (e *ServerError) message() string {
 
 func (e *ServerError) Unwrap() error {
 	return e.cause
-}
-
-// Is satisfies the errors interface.
-func (e *ActivityError) Is(target error) bool {
-	if _, ok := target.(*ActivityError); !ok {
-		return false
-	}
-	return true
 }
 
 func (e *ActivityError) Error() string {
@@ -746,14 +666,6 @@ func (e *ActivityError) RetryState() enumspb.RetryState {
 	return e.retryState
 }
 
-// Is satisfies the errors interface.
-func (e *ChildWorkflowExecutionError) Is(target error) bool {
-	if _, ok := target.(*ChildWorkflowExecutionError); !ok {
-		return false
-	}
-	return true
-}
-
 // Error from error interface
 func (e *ChildWorkflowExecutionError) Error() string {
 	msg := fmt.Sprintf("%s (type: %s, workflowID: %s, runID: %s, initiatedEventID: %d, startedEventID: %d)",
@@ -772,14 +684,6 @@ func (e *ChildWorkflowExecutionError) Unwrap() error {
 	return e.cause
 }
 
-// Is satisfies the errors interface.
-func (e *WorkflowExecutionError) Is(target error) bool {
-	if _, ok := target.(*WorkflowExecutionError); !ok {
-		return false
-	}
-	return true
-}
-
 // Error from error interface
 func (e *WorkflowExecutionError) Error() string {
 	msg := fmt.Sprintf("workflow execution error (type: %s, workflowID: %s, runID: %s)",
@@ -792,14 +696,6 @@ func (e *WorkflowExecutionError) Error() string {
 
 func (e *WorkflowExecutionError) Unwrap() error {
 	return e.cause
-}
-
-// Is satisfies the errors interface.
-func (e *ActivityNotRegisteredError) Is(target error) bool {
-	if _, ok := target.(*ActivityNotRegisteredError); !ok {
-		return false
-	}
-	return true
 }
 
 func (e *ActivityNotRegisteredError) Error() string {

--- a/internal/error_test.go
+++ b/internal/error_test.go
@@ -441,102 +441,6 @@ func Test_CanceledError(t *testing.T) {
 	require.Equal(t, testErrorDetails3, b3)
 }
 
-// TestCanceledErrorIs tests whether
-// the errors.Is() method operates as
-// expected.
-func TestCanceledErrorIs(t *testing.T) {
-	workflowErr := NewCanceledError()
-	require.ErrorIs(t, workflowErr, &CanceledError{})
-}
-
-// TestPanicErrorIs tests whether
-// the errors.Is() method operates as
-// expected.
-func TestPanicErrorIs(t *testing.T) {
-	workflowErr := newPanicError("test value", "stacktrace")
-	require.ErrorIs(t, workflowErr, &PanicError{})
-}
-
-// TestApplicationErrorIs tests whether
-// the errors.Is() method operates as
-// expected.
-func TestApplicationErrorIs(t *testing.T) {
-	workflowErr := NewApplicationError("test value", "errType", false, errors.New("error"))
-	require.ErrorIs(t, workflowErr, &ApplicationError{})
-}
-
-// TestTimeoutErrorIs tests whether
-// the errors.Is() method operates as
-// expected.
-func TestTimeoutErrorIs(t *testing.T) {
-	workflowErr := NewTimeoutError("timeout", enumspb.TIMEOUT_TYPE_START_TO_CLOSE, nil)
-	require.ErrorIs(t, workflowErr, &TimeoutError{})
-}
-
-// TestWorkflowPanicErrorIs tests whether
-// the errors.Is() method operates as
-// expected.
-func TestWorkflowPanicErrorIs(t *testing.T) {
-	workflowErr := newWorkflowPanicError("", "")
-	require.ErrorIs(t, workflowErr, &workflowPanicError{})
-}
-
-// TestTeminatedErrorIs tests whether
-// the errors.Is() method operates as
-// expected.
-func TestTeminatedErrorIs(t *testing.T) {
-	workflowErr := newTerminatedError()
-	require.ErrorIs(t, workflowErr, &TerminatedError{})
-}
-
-// TestUnknownExternalWorkflowExecutionErrorIs tests whether
-// the errors.Is() method operates as expected.
-func TestUnknownExternalWorkflowExecutionErrorIs(t *testing.T) {
-	workflowErr := newUnknownExternalWorkflowExecutionError()
-	require.ErrorIs(t, workflowErr, &UnknownExternalWorkflowExecutionError{})
-}
-
-// TestServerErrorIs tests whether
-// the errors.Is() method operates as
-// expected.
-func TestServerErrorIs(t *testing.T) {
-	workflowErr := NewServerError("msg", false, errors.New("error"))
-	require.ErrorIs(t, workflowErr, &ServerError{})
-}
-
-// TestActivityErrorIs tests whether
-// the errors.Is() method operates as
-// expected.
-func TestActivityErrorIs(t *testing.T) {
-	var applicationErr *ApplicationError
-	workflowErr := NewActivityError(8, 22, "alex", &commonpb.ActivityType{Name: "activityType"}, "32283", enumspb.RETRY_STATE_NON_RETRYABLE_FAILURE, applicationErr)
-	require.ErrorIs(t, workflowErr, &ActivityError{})
-}
-
-// TestChildWorkflowExecutionErrorIs tests whether
-// the errors.Is() method operates as
-// expected.
-func TestChildWorkflowExecutionErrorIs(t *testing.T) {
-	applicationErr := NewApplicationError("app err", "", true, nil)
-	workflowErr := NewChildWorkflowExecutionError("namespace", "wID", "rID", "wfType", 8, 22, enumspb.RETRY_STATE_NON_RETRYABLE_FAILURE, applicationErr)
-	require.ErrorIs(t, workflowErr, &ChildWorkflowExecutionError{})
-}
-
-// TestWorkflowExecutionErrorIs tests whether
-// the errors.Is() method operates as
-// expected.
-func TestWorkflowExecutionErrorIs(t *testing.T) {
-	workflowErr := NewWorkflowExecutionError("42", "51", "alex", errors.New("error"))
-	require.ErrorIs(t, workflowErr, &WorkflowExecutionError{})
-}
-
-// TestActivityNotRegisteredErrorIs tests whether
-// the errors.Is() method operates as expected.
-func TestActivityNotRegisteredErrorIs(t *testing.T) {
-	workflowErr := NewActivityNotRegisteredError("42", []string{})
-	require.ErrorIs(t, workflowErr, &ActivityNotRegisteredError{})
-}
-
 func Test_IsCanceledError(t *testing.T) {
 
 	tests := []struct {
@@ -650,8 +554,6 @@ func Test_ContinueAsNewError(t *testing.T) {
 	err = errors.Unwrap(workflowErr)
 	var continueAsNewErr *ContinueAsNewError
 	require.True(t, errors.As(err, &continueAsNewErr))
-	require.True(t, errors.Is(workflowErr, continueAsNewErr), workflowErr)
-
 	require.Equal(t, continueAsNewWfName, continueAsNewErr.WorkflowType.Name)
 
 	input := continueAsNewErr.Input


### PR DESCRIPTION
Reverts temporalio/sdk-go#523
References issue #403 

Reverting due to reasoning brought up by @alexshtin: the current Is() implementation is not sufficient to compare error types without a deep equality. The current implementation simply checks whether the types are the same, not whether the underlying error is the same. The error occurs on line 46 of the [errors source code](https://cs.opensource.google/go/go/+/refs/tags/go1.17:src/errors/wrap.go;l=49).

