### PR TITLE
Start worker even when no workflow/activity registered

### DIFF
--- a/evictiontest/workflow_cache_eviction_test.go
+++ b/evictiontest/workflow_cache_eviction_test.go
@@ -159,7 +159,7 @@ func (s *CacheEvictionSuite) TestResetStickyOnEviction() {
 	s.service.EXPECT().ResetStickyTaskQueue(gomock.Any(), gomock.Any()).DoAndReturn(mockResetStickyTaskQueue).Times(1)
 
 	client := internal.NewServiceClient(s.service, nil, internal.ClientOptions{})
-	workflowWorker := internal.NewAggregatedWorker(client, "taskqueue", worker.Options{})
+	workflowWorker := internal.NewAggregatedWorker(client, "taskqueue", worker.Options{LocalActivityWorkerOnly: true})
 	// this is an arbitrary workflow we use for this test
 	// NOTE: a simple helloworld that doesn't execute an activity
 	// won't work because the workflow will simply just complete

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -884,25 +884,17 @@ func (aw *AggregatedWorker) Start() error {
 	}
 
 	if !util.IsInterfaceNil(aw.workflowWorker) {
-		if len(aw.registry.getRegisteredWorkflowTypes()) == 0 {
-			aw.logger.Debug("No workflows registered. Skipping workflow worker start")
-		} else {
-			if err := aw.workflowWorker.Start(); err != nil {
-				return err
-			}
+		if err := aw.workflowWorker.Start(); err != nil {
+			return err
 		}
 	}
 	if !util.IsInterfaceNil(aw.activityWorker) {
-		if len(aw.registry.getRegisteredActivities()) == 0 {
-			aw.logger.Debug("No activities registered. Skipping activity worker start")
-		} else {
-			if err := aw.activityWorker.Start(); err != nil {
-				// stop workflow worker.
-				if aw.workflowWorker.worker.isWorkerStarted {
-					aw.workflowWorker.Stop()
-				}
-				return err
+		if err := aw.activityWorker.Start(); err != nil {
+			// stop workflow worker.
+			if aw.workflowWorker.worker.isWorkerStarted {
+				aw.workflowWorker.Stop()
 			}
+			return err
 		}
 	}
 

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -1503,8 +1503,8 @@ func (s *internalWorkerTestSuite) TestNoActivitiesOrWorkflows() {
 	assert.Empty(t, w.registry.getRegisteredActivities())
 	assert.Empty(t, w.registry.getRegisteredWorkflowTypes())
 	assert.NoError(t, w.Start())
-	assert.False(t, w.activityWorker.worker.isWorkerStarted)
-	assert.False(t, w.workflowWorker.worker.isWorkerStarted)
+	assert.True(t, w.activityWorker.worker.isWorkerStarted)
+	assert.True(t, w.workflowWorker.worker.isWorkerStarted)
 }
 
 func (s *internalWorkerTestSuite) TestStartWorkerAfterStopped() {


### PR DESCRIPTION
## What was changed
Do not skip worker start when registry is empty.

## Why?
There are uses cases where registry happen after worker is started, for example in integration tests that you want to start worker as part of test setup where you don't know what to register yet.
This check only make sense when the registry was done via golang's init() func. Now registry is per worker and can be done after worker is started. The current behavior of silently skip worker start is inconvenient. 
