### PR TITLE
Fix local activity retry backoff

### DIFF
--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -1023,8 +1023,8 @@ func getRetryBackoffWithNowTime(p *RetryPolicy, attempt int32, err error, now, e
 	if p.MaximumAttempts > 0 && attempt >= p.MaximumAttempts {
 		return noRetryBackoff // max attempt reached
 	}
-
-	backoffInterval := time.Duration(float64(p.InitialInterval) * math.Pow(p.BackoffCoefficient, float64(attempt)))
+	// attempt starts from 1
+	backoffInterval := time.Duration(float64(p.InitialInterval) * math.Pow(p.BackoffCoefficient, float64(attempt-1)))
 	if backoffInterval <= 0 {
 		// math.Pow() could overflow
 		if p.MaximumInterval > 0 {

--- a/internal/internal_workflow_testsuite_test.go
+++ b/internal/internal_workflow_testsuite_test.go
@@ -2967,7 +2967,7 @@ func (s *WorkflowTestSuiteUnitTest) Test_LocalActivityRetry() {
 	var result int32
 	s.NoError(env.GetWorkflowResult(&result))
 	s.Equal(int32(3), result)
-	s.Equal(3 * time.Second, localActivityDuration)
+	s.Equal(3*time.Second, localActivityDuration)
 }
 
 func (s *WorkflowTestSuiteUnitTest) Test_LocalActivityRetry_MaxAttempts_Respected() {


### PR DESCRIPTION
## What was changed
Fix local activity retry backoff calculation.

## Why?
Attempt used to start from 0, then it was changed to start from 1, but backoff calculation wasn't updated accordingly.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
