### PR TITLE
Skip failing test on Windows

### DIFF
--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -30,6 +30,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -1474,6 +1475,10 @@ func (s *internalWorkerTestSuite) TestCreateWorkerWithDataConverter() {
 }
 
 func (s *internalWorkerTestSuite) TestCreateWorkerRun() {
+	// Windows doesn't support signalling interrupt
+	if runtime.GOOS == "windows" {
+		s.T().Skip("Not supported on windows")
+	}
 	// Create service endpoint
 	mockCtrl := gomock.NewController(s.T())
 	service := workflowservicemock.NewMockWorkflowServiceClient(mockCtrl)

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -1475,7 +1475,7 @@ func (s *internalWorkerTestSuite) TestCreateWorkerWithDataConverter() {
 }
 
 func (s *internalWorkerTestSuite) TestCreateWorkerRun() {
-	// Windows doesn't support signalling interrupt
+	// Windows doesn't support signalling interrupt.
 	if runtime.GOOS == "windows" {
 		s.T().Skip("Not supported on windows")
 	}


### PR DESCRIPTION
## What was changed

Skipped failing Windows test

## Why?

Test sends manual interrupt signal which fails. Full suite now succeeds on Windows.
