### PR TITLE
Apply default retry policy for local activities

### DIFF
--- a/internal/activity.go
+++ b/internal/activity.go
@@ -146,7 +146,7 @@ type (
 
 		// RetryPolicy specify how to retry activity if error happens.
 		// Optional: default is to retry according to the default retry policy up to ScheduleToCloseTimeout
-		// with 50ms initial delay between retries and 2x backoff.
+		// with 1sec initial delay between retries and 2x backoff.
 		RetryPolicy *RetryPolicy
 	}
 )

--- a/internal/activity.go
+++ b/internal/activity.go
@@ -146,6 +146,7 @@ type (
 
 		// RetryPolicy specify how to retry activity if error happens.
 		// Optional: default is to retry according to the default retry policy up to ScheduleToCloseTimeout
+		// with 50ms initial delay between retries and 2x backoff.
 		RetryPolicy *RetryPolicy
 	}
 )

--- a/internal/internal_workflow_test.go
+++ b/internal/internal_workflow_test.go
@@ -76,7 +76,7 @@ func (s *WorkflowUnitTest) Test_WorkflowWithLocalActivityDefaultRetryPolicy() {
 	laOpts := LocalActivityOptions{
 		ScheduleToCloseTimeout: 5 * time.Second,
 	}
-	env.ExecuteWorkflow(workflowWithLocalActivityRetriesAndDefaultRetryPolicy, laOpts, 2)
+	env.ExecuteWorkflow(workflowWithFailingLocalActivity, laOpts, 2)
 	s.True(env.IsWorkflowCompleted())
 	s.NoError(env.GetWorkflowError())
 }
@@ -89,7 +89,7 @@ func (s *WorkflowUnitTest) Test_WorkflowWithLocalActivityWithMaxAttempts() {
 			MaximumAttempts: 3,
 		},
 	}
-	env.ExecuteWorkflow(workflowWithLocalActivityRetriesAndDefaultRetryPolicy, laOpts, 2)
+	env.ExecuteWorkflow(workflowWithFailingLocalActivity, laOpts, 2)
 	s.True(env.IsWorkflowCompleted())
 	s.NoError(env.GetWorkflowError())
 }
@@ -102,12 +102,12 @@ func (s *WorkflowUnitTest) Test_WorkflowWithLocalActivityWithMaxAttemptsExceeded
 			MaximumAttempts: 3,
 		},
 	}
-	env.ExecuteWorkflow(workflowWithLocalActivityRetriesAndDefaultRetryPolicy, laOpts, 5)
+	env.ExecuteWorkflow(workflowWithFailingLocalActivity, laOpts, 5)
 	s.True(env.IsWorkflowCompleted())
 	s.Error(env.GetWorkflowError())
 }
 
-func workflowWithLocalActivityRetriesAndDefaultRetryPolicy(ctx Context, laOpts LocalActivityOptions, laTimesToFail int) error {
+func workflowWithFailingLocalActivity(ctx Context, laOpts LocalActivityOptions, laTimesToFail int) error {
 	ctx = WithLocalActivityOptions(ctx, laOpts)
 	activity := &FailNTimesAct{timesToFail: laTimesToFail}
 	f := ExecuteLocalActivity(ctx, activity.run)

--- a/internal/internal_workflow_test.go
+++ b/internal/internal_workflow_test.go
@@ -126,7 +126,7 @@ type FailNTimesAct struct {
 func (a *FailNTimesAct) run(_ context.Context) error {
 	a.timesExecuted++
 	if a.timesExecuted <= a.timesToFail {
-		return errors.New(fmt.Sprintf("simulated activity failure on attempt %v", a.timesExecuted))
+		return fmt.Errorf("simulated activity failure on attempt %v", a.timesExecuted)
 	}
 	return nil
 }

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -1542,7 +1542,7 @@ func applyRetryPolicyDefaultsForLocalActivity(policy *RetryPolicy) *RetryPolicy 
 		policy.BackoffCoefficient = 2
 	}
 	if policy.InitialInterval == 0 {
-		policy.InitialInterval = 50 * time.Millisecond
+		policy.InitialInterval = 1 * time.Second
 	}
 	if policy.MaximumInterval == 0 {
 		policy.MaximumInterval = policy.InitialInterval * 100

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -1530,11 +1530,11 @@ func WithLocalActivityOptions(ctx Context, options LocalActivityOptions) Context
 
 	opts.ScheduleToCloseTimeout = options.ScheduleToCloseTimeout
 	opts.StartToCloseTimeout = options.StartToCloseTimeout
-	opts.RetryPolicy = applyRetryPolicyDefaultsForLocalActivity(options.RetryPolicy, opts.ScheduleToCloseTimeout)
+	opts.RetryPolicy = applyRetryPolicyDefaultsForLocalActivity(options.RetryPolicy)
 	return ctx1
 }
 
-func applyRetryPolicyDefaultsForLocalActivity(policy *RetryPolicy, timeout time.Duration) *RetryPolicy {
+func applyRetryPolicyDefaultsForLocalActivity(policy *RetryPolicy) *RetryPolicy {
 	if policy == nil {
 		policy = &RetryPolicy{}
 	}
@@ -1543,9 +1543,6 @@ func applyRetryPolicyDefaultsForLocalActivity(policy *RetryPolicy, timeout time.
 	}
 	if policy.InitialInterval == 0 {
 		policy.InitialInterval = 50 * time.Millisecond
-	}
-	if policy.MaximumInterval == 0 {
-		policy.MaximumInterval = timeout
 	}
 	return policy
 }

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -1530,8 +1530,24 @@ func WithLocalActivityOptions(ctx Context, options LocalActivityOptions) Context
 
 	opts.ScheduleToCloseTimeout = options.ScheduleToCloseTimeout
 	opts.StartToCloseTimeout = options.StartToCloseTimeout
-	opts.RetryPolicy = options.RetryPolicy
+	opts.RetryPolicy = applyRetryPolicyDefaultsForLocalActivity(options.RetryPolicy, opts.ScheduleToCloseTimeout)
 	return ctx1
+}
+
+func applyRetryPolicyDefaultsForLocalActivity(policy *RetryPolicy, timeout time.Duration) *RetryPolicy {
+	if policy == nil {
+		policy = &RetryPolicy{}
+	}
+	if policy.BackoffCoefficient == 0 {
+		policy.BackoffCoefficient = 2
+	}
+	if policy.InitialInterval == 0 {
+		policy.InitialInterval = 50 * time.Millisecond
+	}
+	if policy.MaximumInterval == 0 {
+		policy.MaximumInterval = timeout
+	}
+	return policy
 }
 
 // WithTaskQueue adds a task queue to the copy of the context.

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -1544,6 +1544,9 @@ func applyRetryPolicyDefaultsForLocalActivity(policy *RetryPolicy) *RetryPolicy 
 	if policy.InitialInterval == 0 {
 		policy.InitialInterval = 50 * time.Millisecond
 	}
+	if policy.MaximumInterval == 0 {
+		policy.MaximumInterval = policy.InitialInterval * 100
+	}
 	return policy
 }
 

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -907,6 +907,14 @@ func (ts *IntegrationTestSuite) TestWorkflowWithLocalActivityRetries() {
 	ts.NoError(ts.executeWorkflow("test-wf-local-activity-retries", ts.workflows.WorkflowWithLocalActivityRetries, nil))
 }
 
+func (ts *IntegrationTestSuite) TestWorkflowWithLocalActivityRetriesDefaultRetryPolicy() {
+	ts.NoError(ts.executeWorkflow("test-wf-local-activity-retries-default-policy", ts.workflows.WorkflowWithLocalActivityRetriesAndDefaultRetryPolicy, nil))
+}
+
+func (ts *IntegrationTestSuite) TestWorkflowWithLocalActivityRetriesPartialPolicy() {
+	ts.NoError(ts.executeWorkflow("test-wf-local-activity-retries-partial-policy", ts.workflows.WorkflowWithLocalActivityRetriesAndPartialRetryPolicy, nil))
+}
+
 func (ts *IntegrationTestSuite) TestWorkflowWithParallelLongLocalActivityAndHeartbeat() {
 	if ts.config.maxWorkflowCacheSize > 0 {
 		ts.NoError(ts.executeWorkflow("test-wf-parallel-long-local-activities-and-heartbeat", ts.workflows.WorkflowWithParallelLongLocalActivityAndHeartbeat, nil))

--- a/test/workflow_test.go
+++ b/test/workflow_test.go
@@ -966,6 +966,50 @@ func (w *Workflows) WorkflowWithLocalActivityRetries(ctx workflow.Context) error
 	return nil
 }
 
+func (w *Workflows) WorkflowWithLocalActivityRetriesAndDefaultRetryPolicy(ctx workflow.Context) error {
+	laOpts := w.defaultLocalActivityOptions()
+	laOpts.RetryPolicy = &internal.RetryPolicy{
+		MaximumAttempts: 3,
+	}
+	ctx = workflow.WithLocalActivityOptions(ctx, laOpts)
+	var activities *Activities
+
+	var futures []workflow.Future
+	for i := 1; i <= 10; i++ {
+		la := workflow.ExecuteLocalActivity(ctx, activities.failNTimes, 2, i)
+		futures = append(futures, la)
+	}
+
+	for _, fut := range futures {
+		err := fut.Get(ctx, nil)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (w *Workflows) WorkflowWithLocalActivityRetriesAndPartialRetryPolicy(ctx workflow.Context) error {
+	laOpts := w.defaultLocalActivityOptions()
+	// Don't set any retry policy
+	ctx = workflow.WithLocalActivityOptions(ctx, laOpts)
+	var activities *Activities
+
+	var futures []workflow.Future
+	for i := 1; i <= 10; i++ {
+		la := workflow.ExecuteLocalActivity(ctx, activities.failNTimes, 2, i)
+		futures = append(futures, la)
+	}
+
+	for _, fut := range futures {
+		err := fut.Get(ctx, nil)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (w *Workflows) WorkflowWithParallelSideEffects(ctx workflow.Context) (string, error) {
 	var futures []workflow.Future
 
@@ -1245,6 +1289,8 @@ func (w *Workflows) register(worker worker.Worker) {
 	worker.RegisterWorkflow(w.WorkflowWithLocalActivityCtxPropagation)
 	worker.RegisterWorkflow(w.WorkflowWithParallelLongLocalActivityAndHeartbeat)
 	worker.RegisterWorkflow(w.WorkflowWithLocalActivityRetries)
+	worker.RegisterWorkflow(w.WorkflowWithLocalActivityRetriesAndDefaultRetryPolicy)
+	worker.RegisterWorkflow(w.WorkflowWithLocalActivityRetriesAndPartialRetryPolicy)
 	worker.RegisterWorkflow(w.WorkflowWithParallelLocalActivities)
 	worker.RegisterWorkflow(w.WorkflowWithLocalActivityStartWhenTimerCancel)
 	worker.RegisterWorkflow(w.WorkflowWithParallelSideEffects)

--- a/test/workflow_test.go
+++ b/test/workflow_test.go
@@ -968,9 +968,7 @@ func (w *Workflows) WorkflowWithLocalActivityRetries(ctx workflow.Context) error
 
 func (w *Workflows) WorkflowWithLocalActivityRetriesAndDefaultRetryPolicy(ctx workflow.Context) error {
 	laOpts := w.defaultLocalActivityOptions()
-	laOpts.RetryPolicy = &internal.RetryPolicy{
-		MaximumAttempts: 3,
-	}
+	// Don't set any retry policy
 	ctx = workflow.WithLocalActivityOptions(ctx, laOpts)
 	var activities *Activities
 
@@ -991,7 +989,10 @@ func (w *Workflows) WorkflowWithLocalActivityRetriesAndDefaultRetryPolicy(ctx wo
 
 func (w *Workflows) WorkflowWithLocalActivityRetriesAndPartialRetryPolicy(ctx workflow.Context) error {
 	laOpts := w.defaultLocalActivityOptions()
-	// Don't set any retry policy
+	// Set only max attempts and use defaults for other parameters.
+	laOpts.RetryPolicy = &internal.RetryPolicy{
+		MaximumAttempts: 3,
+	}
 	ctx = workflow.WithLocalActivityOptions(ctx, laOpts)
 	var activities *Activities
 


### PR DESCRIPTION
## What was changed
Added default retry policy for local activities.

## Why?
Previously local activities would rely on workflow task retries in case if policy hasn't been specified. Also since no defaults were applied invalid/partial policy would cause it to use no retries within workflow task.

## Checklist

1. Closes #563

2. How was this tested:
Integration tests

3. Any docs updates needed?
Updated javadocs, we should also update public documentation.