### PR TITLE
Activity interceptor implementation (architectural preview)

### DIFF
--- a/interceptors/activity_interceptor.go
+++ b/interceptors/activity_interceptor.go
@@ -1,0 +1,8 @@
+package interceptors
+
+import "go.temporal.io/sdk/internal"
+
+type (
+	ActivityInterceptor             = internal.ActivityInterceptor
+	ActivityInboundCallsInterceptor = internal.ActivityInboundCallsInterceptor
+)

--- a/internal/activity.go
+++ b/internal/activity.go
@@ -261,6 +261,7 @@ func WithActivityTask(
 	logger log.Logger,
 	scope tally.Scope,
 	dataConverter converter.DataConverter,
+	interceptors []ActivityInterceptor,
 	workerStopChannel <-chan struct{},
 	contextPropagators []ContextPropagator,
 	tracer opentracing.Tracer,
@@ -319,11 +320,19 @@ func WithActivityTask(
 		workerStopChannel:  workerStopChannel,
 		contextPropagators: contextPropagators,
 		tracer:             tracer,
+		interceptors:       interceptors,
 	})
 }
 
 // WithLocalActivityTask adds local activity specific information into context.
-func WithLocalActivityTask(ctx context.Context, task *localActivityTask, logger log.Logger, scope tally.Scope, dataConverter converter.DataConverter) context.Context {
+func WithLocalActivityTask(
+	ctx context.Context,
+	task *localActivityTask,
+	logger log.Logger,
+	scope tally.Scope,
+	dataConverter converter.DataConverter,
+	interceptors []ActivityInterceptor,
+) context.Context {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -350,6 +359,7 @@ func WithLocalActivityTask(ctx context.Context, task *localActivityTask, logger 
 		isLocalActivity:   true,
 		dataConverter:     dataConverter,
 		attempt:           task.attempt,
+		interceptors:      interceptors,
 	})
 	return ctx
 }

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -1769,7 +1769,19 @@ func (ath *activityTaskHandlerImpl) Execute(taskQueue string, t *workflowservice
 	workflowType := t.WorkflowType.GetName()
 	activityType := t.ActivityType.GetName()
 	activityMetricsScope := metrics.GetMetricsScopeForActivity(ath.metricsScope, workflowType, activityType, ath.taskQueueName)
-	ctx := WithActivityTask(canCtx, t, taskQueue, invoker, ath.logger, activityMetricsScope, ath.dataConverter, ath.workerStopCh, ath.contextPropagators, ath.tracer)
+	ctx := WithActivityTask(
+		canCtx,
+		t,
+		taskQueue,
+		invoker,
+		ath.logger,
+		activityMetricsScope,
+		ath.dataConverter,
+		ath.registry.activityInterceptors,
+		ath.workerStopCh,
+		ath.contextPropagators,
+		ath.tracer,
+	)
 
 	defer func() {
 		_, activityCompleted := result.(*workflowservice.RespondActivityTaskCompletedRequest)

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -471,7 +471,14 @@ func (lath *localActivityTaskHandler) executeLocalActivityTask(task *localActivi
 			tagAttempt, task.attempt,
 		)
 	})
-	ctx := WithLocalActivityTask(lath.userContext, task, lath.logger, lath.metricsScope, lath.dataConverter)
+	ctx := WithLocalActivityTask(
+		lath.userContext,
+		task,
+		lath.logger,
+		lath.metricsScope,
+		lath.dataConverter,
+		task.interceptors,
+	)
 
 	// propagate context information into the local activity activity context from the headers
 	for _, ctxProp := range lath.contextPropagators {

--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -1374,7 +1374,7 @@ func (env *testWorkflowEnvironmentImpl) ExecuteLocalActivity(params ExecuteLocal
 		return aew.ExecuteWithActualArgs(ctx, params.InputArgs)
 	}
 
-	task := newLocalActivityTask(params, callback, activityID)
+	task := newLocalActivityTask(params, callback, activityID, env.registry.activityInterceptors)
 	taskHandler := localActivityTaskHandler{
 		userContext:        env.workerOptions.BackgroundActivityContext,
 		metricsScope:       env.metricsScope,
@@ -2159,12 +2159,12 @@ func (env *testWorkflowEnvironmentImpl) getMockedVersion(mockedChangeID, changeI
 	m := &mockWrapper{name: mockMethodForGetVersion, fn: mockFnGetVersion, interceptors: env.registry.WorkflowInterceptors()}
 	if mockFn := m.getMockFn(mockRet); mockFn != nil {
 		executor := &activityExecutor{name: mockMethodForGetVersion, fn: mockFn}
-		reflectValues := executor.executeWithActualArgsWithoutParseResult(context.TODO(), args)
-		if len(reflectValues) != 1 || !reflect.TypeOf(reflectValues[0].Interface()).AssignableTo(reflect.TypeOf(DefaultVersion)) {
+		results := executor.executeWithActualArgsWithoutParseResult(context.TODO(), args)
+		if len(results) != 1 || !reflect.TypeOf(results[0]).AssignableTo(reflect.TypeOf(DefaultVersion)) {
 			panic(fmt.Sprintf("mock of GetVersion has incorrect return type, expected workflow.Version, but actual is %T (%v)",
-				reflectValues[0].Interface(), reflectValues[0].Interface()))
+				results[0], results[0]))
 		}
-		return reflectValues[0].Interface().(Version), true
+		return results[0].(Version), true
 	}
 
 	if len(mockRet) != 1 || !reflect.TypeOf(mockRet[0]).AssignableTo(reflect.TypeOf(DefaultVersion)) {

--- a/internal/worker.go
+++ b/internal/worker.go
@@ -151,6 +151,8 @@ type (
 		// The chain is instantiated per each replay of a workflow execution
 		WorkflowInterceptorChainFactories []WorkflowInterceptor
 
+		ActivityInterceptorChainFactories []ActivityInterceptor
+
 		// Optional: If set to true worker would only handle workflow tasks and local activities.
 		// Non-local activities will not be executed by this worker.
 		// default: false

--- a/test/activity_test.go
+++ b/test/activity_test.go
@@ -225,6 +225,23 @@ func (a *Activities) PropagateActivity(ctx context.Context) ([]string, error) {
 	return result, nil
 }
 
+func (*Activities) BasicWithArguments(
+	ctx context.Context,
+	stringVal string,
+	bytesVal []byte,
+	intVal int,
+	argVal workflowAdvancedArg,
+	argValPtr *workflowAdvancedArg,
+) (workflowAdvancedArg, error) {
+	return workflowAdvancedArg{
+		StringVal:  stringVal,
+		BytesVal:   bytesVal,
+		IntVal:     intVal,
+		ArgValPtr1: &argVal,
+		ArgValPtr2: argValPtr,
+	}, nil
+}
+
 func (a *Activities) register(worker worker.Worker) {
 	worker.RegisterActivity(a)
 	// Check reregistration


### PR DESCRIPTION
This is a preview PR to get feedback on the activity interceptor architecture. Notes:

* This is intentionally missing some Godoc and better test coverage at this early stage
* The goal was consistency with Java and existing Go interceptor implementations, even at the cost of ergonomics
* There is a test that confirms that today, `ExecuteWorkflow` interceptor has pointers to all arguments instead of the actual arguments like what may be expected (and the activity interceptor follows suit)