### PR TITLE
Activity success e2e latency metrics

### DIFF
--- a/internal/common/metrics/constants.go
+++ b/internal/common/metrics/constants.go
@@ -47,14 +47,15 @@ const (
 	ActivityExecutionFailedCounter        = TemporalMetricsPrefix + "activity_execution_failed"
 	UnregisteredActivityInvocationCounter = TemporalMetricsPrefix + "unregistered_activity_invocation"
 	ActivityExecutionLatency              = TemporalMetricsPrefix + "activity_execution_latency"
-	ActivityEndToEndLatency               = TemporalMetricsPrefix + "activity_endtoend_latency"
+	ActivitySucceedEndToEndLatency        = TemporalMetricsPrefix + "activity_succeed_endtoend_latency"
 	ActivityTaskErrorCounter              = TemporalMetricsPrefix + "activity_task_error"
 
-	LocalActivityTotalCounter     = TemporalMetricsPrefix + "local_activity_total"
-	LocalActivityCanceledCounter  = TemporalMetricsPrefix + "local_activity_canceled"
-	LocalActivityFailedCounter    = TemporalMetricsPrefix + "local_activity_failed"
-	LocalActivityErrorCounter     = TemporalMetricsPrefix + "local_activity_error"
-	LocalActivityExecutionLatency = TemporalMetricsPrefix + "local_activity_execution_latency"
+	LocalActivityTotalCounter           = TemporalMetricsPrefix + "local_activity_total"
+	LocalActivityCanceledCounter        = TemporalMetricsPrefix + "local_activity_canceled"
+	LocalActivityFailedCounter          = TemporalMetricsPrefix + "local_activity_failed"
+	LocalActivityErrorCounter           = TemporalMetricsPrefix + "local_activity_error"
+	LocalActivityExecutionLatency       = TemporalMetricsPrefix + "local_activity_execution_latency"
+	LocalActivitySucceedEndToEndLatency = TemporalMetricsPrefix + "local_activity_succeed_endtoend_latency"
 
 	CorruptedSignalsCounter = TemporalMetricsPrefix + "corrupted_signals"
 

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -579,6 +579,11 @@ WaitResult:
 		// local activity completed
 	}
 
+	if err == nil {
+		activityMetricsScope.
+			Timer(metrics.LocalActivitySucceedEndToEndLatency).
+			Record(time.Since(task.params.ScheduledTime))
+	}
 	return &localActivityResult{result: laResult, err: err, task: task}
 }
 
@@ -891,8 +896,8 @@ func (atp *activityTaskPoller) ProcessTask(task interface{}) error {
 	}
 
 	activityMetricsScope.
-		Timer(metrics.ActivityEndToEndLatency).
-		Record(time.Since(common.TimeValue(activityTask.task.GetStartedTime())))
+		Timer(metrics.ActivitySucceedEndToEndLatency).
+		Record(time.Since(common.TimeValue(activityTask.task.GetScheduledTime())))
 	return nil
 }
 


### PR DESCRIPTION
## What was changed

Mimicking https://github.com/temporalio/sdk-java/pull/800, changed `activity_endtoend_latency` to `activity_succeed_endtoend_latency`, recording it only on success with the diff from _scheduled_ time, and added `local_activity_succeed_endtoend_latency` to do the same for local activities.

## Checklist

1. Closes #573