### PR TITLE
Add additional hosts client option

### DIFF
--- a/internal/client.go
+++ b/internal/client.go
@@ -339,7 +339,7 @@ type (
 		// HostPort option should still be set or it will still default. Hosts from
 		// HostPort and this setting will be combined to make a set of addresses
 		// that gRPC will round-robin requests to. Neither HostPort nor this setting
-		// should have any "dns:///" prefixed addresses.
+		// can have any "<resolver>:///" prefixed addresses.
 		// default: no additional hosts (only single HostPort)
 		AdditionalHostPorts []string
 


### PR DESCRIPTION
## What was changed

New `AdditionalHostPorts` option was added to allow more addresses.

## Why?

Currently we only round-robin on DNS-based resolution. This allows one to manually provide more addresses beyond the first one.

## Checklist

1. Closes #577