### PR TITLE
Change verb to correct type of error 

### DIFF
--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -569,7 +569,7 @@ func (r *registry) registerActivityStructWithOptions(aStruct interface{}, option
 				continue
 			}
 
-			return fmt.Errorf("method %v of %v: %w", name, structType.Name(), err)
+			return fmt.Errorf("method %s of %s: %w", name, structType.Name(), err)
 		}
 		registerName := options.Name + name
 		if !options.DisableAlreadyRegisteredCheck {


### PR DESCRIPTION
Fixes small verb bug (%e is scientific notation), change general %v verbs to specific type

terminal output:
``` suite.go:63: test panicked: method EXPECT of : &{%!e(string=expected function second return value to return error but found ptr)}```
