### PR TITLE
enhancement(tracing): export `ActiveSpanContextKey` so consumers can propagate the span context

### DIFF
--- a/internal/context.go
+++ b/internal/context.go
@@ -32,7 +32,8 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 )
 
-const activeSpanContextKey contextKey = "activeSpanContextKey"
+// ActiveSpanContextKey is the key used to set SpanContext in context
+const ActiveSpanContextKey contextKey = "activeSpanContextKey"
 
 // Context is a clone of context.Context with Done() returning Channel instead
 // of native channel.
@@ -434,7 +435,7 @@ func (c *valueCtx) Value(key interface{}) interface{} {
 }
 
 func spanFromContext(ctx Context) opentracing.SpanContext {
-	val := ctx.Value(activeSpanContextKey)
+	val := ctx.Value(ActiveSpanContextKey)
 	if sp, ok := val.(opentracing.SpanContext); ok {
 		return sp
 	}
@@ -442,5 +443,5 @@ func spanFromContext(ctx Context) opentracing.SpanContext {
 }
 
 func contextWithSpan(ctx Context, spanContext opentracing.SpanContext) Context {
-	return WithValue(ctx, activeSpanContextKey, spanContext)
+	return WithValue(ctx, ActiveSpanContextKey, spanContext)
 }

--- a/internal/propagation.go
+++ b/internal/propagation.go
@@ -78,7 +78,7 @@ func createOpenTracingSpan(
 	var parent opentracing.SpanContext
 	if parentSpan := opentracing.SpanFromContext(ctx); parentSpan != nil {
 		parent = parentSpan.Context()
-	} else if spanCtx, ok := ctx.Value(activeSpanContextKey).(opentracing.SpanContext); ok {
+	} else if spanCtx, ok := ctx.Value(ActiveSpanContextKey).(opentracing.SpanContext); ok {
 		parent = spanCtx
 	}
 

--- a/internal/tracer.go
+++ b/internal/tracer.go
@@ -115,7 +115,7 @@ func (t *tracingContextPropagator) Extract(
 	if spanContext == nil {
 		return ctx, nil
 	}
-	return context.WithValue(ctx, activeSpanContextKey, spanContext), nil
+	return context.WithValue(ctx, ActiveSpanContextKey, spanContext), nil
 }
 
 func (t *tracingContextPropagator) InjectFromWorkflow(

--- a/internal/tracer_test.go
+++ b/internal/tracer_test.go
@@ -58,7 +58,7 @@ func TestTracingContextPropagator(t *testing.T) {
 	returnCtx, err = ctxProp.Extract(returnCtx, NewHeaderReader(header))
 	require.NoError(t, err)
 
-	spanCtx := returnCtx.Value(activeSpanContextKey)
+	spanCtx := returnCtx.Value(ActiveSpanContextKey)
 	assert.NotNil(t, spanCtx)
 }
 

--- a/workflow/context_propagator.go
+++ b/workflow/context_propagator.go
@@ -26,6 +26,9 @@ package workflow
 
 import "go.temporal.io/sdk/internal"
 
+// ActiveSpanContextKey is the key used to set SpanContext in context
+const ActiveSpanContextKey = internal.ActiveSpanContextKey
+
 type (
 	// HeaderReader is an interface to read information from temporal headers
 	HeaderReader = internal.HeaderReader


### PR DESCRIPTION
We are trying to trace using opentelemetry bridge https://community.temporal.io/t/trace-temporal-with-opentelemetry-bridge/3226/2. But the each span was in its own trace, after alot of debugging I realized that `ActiveSpanContextKey` is typed `contextKey` so that's why the parent was always `nil`.

Our custom propagater has the `activeSpanContextKey` defined as string where temporal internal have it typed. That's why `createOpenTracingSpan` couldn't get the parent we set in the context.

So this PR suggest exporting it

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
