### PR TITLE
Fix testsuite child cron job running forever with parent policy abandon

### DIFF
--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -919,7 +919,11 @@ func (env *testWorkflowEnvironmentImpl) handleParentClosePolicy() {
 
 			switch handle.params.ParentClosePolicy {
 			case enumspb.PARENT_CLOSE_POLICY_ABANDON:
-				// noop
+				// If the policy is to abandon, the child workflow would run forever on CronSchedule even after the
+				// parent workflow finishes execution. So we force the child workflow to complete with the parent.
+				if handle.params.CronSchedule != "" {
+					handle.env.Complete(nil, newTerminatedError())
+				}
 			case enumspb.PARENT_CLOSE_POLICY_TERMINATE:
 				handle.env.Complete(nil, newTerminatedError())
 			case enumspb.PARENT_CLOSE_POLICY_REQUEST_CANCEL:


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
The testsuite will force a child cron job with parent policy abandon to terminate as soon as the parent workflow terminates.

## Why?
<!-- Tell your future self why have you made these changes -->
If you start a parent workflow, which creates a child workflow as a cronjob with parent policy abandon it spins forever. This happens because the timer auto-skips forever, which in-turn means the child cron-job will run forever.

## How was this tested
- [x] Ran all testsuites, including the newly added one to test this scenario
