### PR TITLE
Catch panics in local activities

### DIFF
--- a/test/activity_test.go
+++ b/test/activity_test.go
@@ -186,6 +186,10 @@ func (a *Activities) WaitForWorkerStop(ctx context.Context, timeout time.Duratio
 	}
 }
 
+func (a *Activities) Panicked(ctx context.Context) ([]string, error) {
+	panic(fmt.Sprintf("simulated panic on attempt %v", activity.GetInfo(ctx).Attempt))
+}
+
 func (a *Activities) append(name string) {
 	a.mu.Lock()
 	defer a.mu.Unlock()

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -313,6 +313,18 @@ func (ts *IntegrationTestSuite) TestPanicFailWorkflow() {
 	ts.True(strings.Contains(applicationErr.Error(), "simulated"))
 }
 
+func (ts *IntegrationTestSuite) TestPanicActivityWorkflow() {
+	var res []string
+	// Retry once on each activity
+	const maxAttempts int32 = 2
+	err := ts.executeWorkflow("test-panic-activity", ts.workflows.PanickedActivity, &res, maxAttempts)
+	ts.NoError(err)
+	ts.Equal([]string{
+		fmt.Sprintf("act err: simulated panic on attempt %v", maxAttempts),
+		fmt.Sprintf("local act err: simulated panic on attempt %v", maxAttempts),
+	}, res)
+}
+
 func (ts *IntegrationTestSuite) TestDeadlockDetection() {
 	var expected []string
 	wfOpts := ts.startWorkflowOptions("test-deadlock")

--- a/test/workflow_test.go
+++ b/test/workflow_test.go
@@ -96,6 +96,40 @@ func (w *Workflows) Panicked(ctx workflow.Context) ([]string, error) {
 	panic("simulated")
 }
 
+func (w *Workflows) PanickedActivity(ctx workflow.Context, maxAttempts int32) (ret []string, err error) {
+	// Only retry limited number of times on activities
+	oneRetry := &temporal.RetryPolicy{InitialInterval: 1 * time.Nanosecond, MaximumAttempts: maxAttempts}
+	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		StartToCloseTimeout: 5 * time.Second,
+		RetryPolicy:         oneRetry,
+	})
+	ctx = workflow.WithLocalActivityOptions(ctx, workflow.LocalActivityOptions{
+		StartToCloseTimeout: 5 * time.Second,
+		RetryPolicy:         oneRetry,
+	})
+
+	var a Activities
+
+	// Panic activity
+	err = workflow.ExecuteActivity(ctx, a.Panicked).Get(ctx, nil)
+	var actPanicErr *temporal.PanicError
+	if !errors.As(err, &actPanicErr) {
+		return nil, fmt.Errorf("no activity panic error, got: %v", err)
+	}
+
+	// Panic local activity
+	err = workflow.ExecuteLocalActivity(ctx, a.Panicked).Get(ctx, nil)
+	var localActPanicErr *temporal.PanicError
+	if !errors.As(err, &localActPanicErr) {
+		return nil, fmt.Errorf("no local activity error, got: %v", err)
+	}
+
+	return []string{
+		"act err: " + actPanicErr.Error(),
+		"local act err: " + localActPanicErr.Error(),
+	}, nil
+}
+
 func (w *Workflows) ActivityRetryOnError(ctx workflow.Context) ([]string, error) {
 	ctx = workflow.WithActivityOptions(ctx, w.defaultActivityOptionsWithRetry())
 	startTime := workflow.Now(ctx)
@@ -1336,6 +1370,7 @@ func (w *Workflows) register(worker worker.Worker) {
 	worker.RegisterWorkflow(w.Deadlocked)
 	worker.RegisterWorkflow(w.DeadlockedWithLocalActivity)
 	worker.RegisterWorkflow(w.Panicked)
+	worker.RegisterWorkflow(w.PanickedActivity)
 	worker.RegisterWorkflow(w.BasicSession)
 	worker.RegisterWorkflow(w.CancelActivity)
 	worker.RegisterWorkflow(w.CancelActivityImmediately)


### PR DESCRIPTION
## What was changed

Moved local activity panic handler to where it can be used.

## Why?

Panics were not handled in local activities.

## Checklist

1. Closes #621