### PR TITLE
Bounds check stack trace line indexes

### DIFF
--- a/internal/internal_workflow.go
+++ b/internal/internal_workflow.go
@@ -860,10 +860,11 @@ func getStackTraceRaw(top string, omitTop, omitBottom int) string {
 		return rawStack
 	}
 	lines := strings.Split(rawStack, "\n")
-	// If the top is after the end, set as same
 	omitEnd := len(lines) - omitBottom
+	// If the start is after the end, the depth was invalid originally so return
+	// the entire raw stack
 	if omitTop > omitEnd {
-		omitTop = omitEnd
+		return rawStack
 	}
 	lines = lines[omitTop:omitEnd]
 	lines = append([]string{top}, lines...)

--- a/internal/internal_workflow.go
+++ b/internal/internal_workflow.go
@@ -860,7 +860,12 @@ func getStackTraceRaw(top string, omitTop, omitBottom int) string {
 		return rawStack
 	}
 	lines := strings.Split(rawStack, "\n")
-	lines = lines[omitTop : len(lines)-omitBottom]
+	// If the top is after the end, set as same
+	omitEnd := len(lines) - omitBottom
+	if omitTop > omitEnd {
+		omitTop = omitEnd
+	}
+	lines = lines[omitTop:omitEnd]
 	lines = append([]string{top}, lines...)
 	return strings.Join(lines, "\n")
 }

--- a/internal/internal_workflow_test.go
+++ b/internal/internal_workflow_test.go
@@ -1440,8 +1440,8 @@ func TestStackTraceInvalidDepthBounded(t *testing.T) {
 	// Confirm at 2 depth there are 3 lines (1 for header, 2 for fn and path)
 	lines := strings.Split(getStackTrace("mycoroutine", "success", 2), "\n")
 	require.Len(t, lines, 3)
-	// But at invalid 100 depth, there is only 1 header line because bound is
-	// trimmed
+	// But at invalid 100 depth, there are more than three lines but less than 100
+	// because we show the full trace when bounds are wrong
 	lines = strings.Split(getStackTrace("mycoroutine", "success", 100), "\n")
-	require.Len(t, lines, 1)
+	require.True(t, len(lines) > 3 && len(lines) < 100)
 }

--- a/internal/internal_workflow_test.go
+++ b/internal/internal_workflow_test.go
@@ -1435,3 +1435,13 @@ func (t *tracingOutboundCallsInterceptor) ExecuteActivity(ctx Context, activityT
 	t.inbound.trace = append(t.inbound.trace, "ExecuteActivity "+activityType)
 	return t.Next.ExecuteActivity(ctx, activityType, args...)
 }
+
+func TestStackTraceInvalidDepthBounded(t *testing.T) {
+	// Confirm at 2 depth there are 3 lines (1 for header, 2 for fn and path)
+	lines := strings.Split(getStackTrace("mycoroutine", "success", 2), "\n")
+	require.Len(t, lines, 3)
+	// But at invalid 100 depth, there is only 1 header line because bound is
+	// trimmed
+	lines = strings.Split(getStackTrace("mycoroutine", "success", 100), "\n")
+	require.Len(t, lines, 1)
+}


### PR DESCRIPTION
## What was changed

A bounds check was done to make sure the start is not after the end when trimming stack indexes.

## Why?

In #624, a panic trace showed that the start passed the end. Despite all attempts to replicate I have not, so we just make sure to limit the bounds.

## Checklist

1. Closes #624