### PR TITLE
Add ability to not wait on child workflows in test suite.

### DIFF
--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -132,12 +132,13 @@ type (
 
 		taskQueueSpecificActivities map[string]*taskQueueSpecificActivity
 
-		mock               *mock.Mock
-		service            workflowservice.WorkflowServiceClient
-		logger             log.Logger
-		metricsScope       tally.Scope
-		contextPropagators []ContextPropagator
-		identity           string
+		mock                      *mock.Mock
+		service                   workflowservice.WorkflowServiceClient
+		logger                    log.Logger
+		metricsScope              tally.Scope
+		contextPropagators        []ContextPropagator
+		identity                  string
+		detachedChildWaitDisabled bool
 
 		mockClock *clock.Mock
 		wallClock clock.Clock
@@ -337,6 +338,7 @@ func (env *testWorkflowEnvironmentImpl) newTestWorkflowEnvironmentForChild(param
 	childEnv.workerOptions = env.workerOptions
 	childEnv.dataConverter = params.DataConverter
 	childEnv.registry = env.registry
+	childEnv.detachedChildWaitDisabled = env.detachedChildWaitDisabled
 
 	if params.TaskQueueName == "" {
 		return nil, serviceerror.NewWorkflowExecutionAlreadyStarted("Empty task queue name", "", "")
@@ -411,6 +413,10 @@ func (env *testWorkflowEnvironmentImpl) setContextPropagators(contextPropagators
 
 func (env *testWorkflowEnvironmentImpl) setWorkerStopChannel(c chan struct{}) {
 	env.workerStopChannel = c
+}
+
+func (env *testWorkflowEnvironmentImpl) setDetachedChildWaitDisabled(detachedChildWaitDisabled bool) {
+	env.detachedChildWaitDisabled = detachedChildWaitDisabled
 }
 
 func (env *testWorkflowEnvironmentImpl) setActivityTaskQueue(taskqueue string, activityFns ...interface{}) {
@@ -675,15 +681,18 @@ func (env *testWorkflowEnvironmentImpl) startMainLoop() {
 }
 
 func (env *testWorkflowEnvironmentImpl) shouldStopEventLoop() bool {
-	for _, handle := range env.runningWorkflows {
-		if env.workflowInfo.WorkflowExecution.ID == handle.env.workflowInfo.WorkflowExecution.ID {
-			// ignore root workflow
-			continue
-		}
+	// Check if any detached children are still running if not disabled.
+	if !env.detachedChildWaitDisabled {
+		for _, handle := range env.runningWorkflows {
+			if env.workflowInfo.WorkflowExecution.ID == handle.env.workflowInfo.WorkflowExecution.ID {
+				// ignore root workflow
+				continue
+			}
 
-		if !handle.handled && (handle.params.ParentClosePolicy == enumspb.PARENT_CLOSE_POLICY_ABANDON ||
-			handle.params.ParentClosePolicy == enumspb.PARENT_CLOSE_POLICY_REQUEST_CANCEL) {
-			return false
+			if !handle.handled && (handle.params.ParentClosePolicy == enumspb.PARENT_CLOSE_POLICY_ABANDON ||
+				handle.params.ParentClosePolicy == enumspb.PARENT_CLOSE_POLICY_REQUEST_CANCEL) {
+				return false
+			}
 		}
 	}
 

--- a/internal/internal_workflow_testsuite_test.go
+++ b/internal/internal_workflow_testsuite_test.go
@@ -38,11 +38,10 @@ import (
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
-	"go.uber.org/atomic"
-
 	"go.temporal.io/sdk/converter"
 	iconverter "go.temporal.io/sdk/internal/converter"
 	ilog "go.temporal.io/sdk/internal/log"
+	uberatomic "go.uber.org/atomic"
 )
 
 type WorkflowTestSuiteUnitTest struct {
@@ -2145,8 +2144,8 @@ func (s *WorkflowTestSuiteUnitTest) Test_LocalActivity() {
 }
 
 func (s *WorkflowTestSuiteUnitTest) Test_WorkflowLocalActivityWithMockAndListeners() {
-	var localActivityFnCanceled atomic.Bool
-	var startedCount, completedCount, canceledCount atomic.Int32
+	var localActivityFnCanceled uberatomic.Bool
+	var startedCount, completedCount, canceledCount uberatomic.Int32
 	env := s.NewTestWorkflowEnvironment()
 
 	localActivityFn := func(_ context.Context, _ string) (string, error) {
@@ -3688,67 +3687,47 @@ func (s *WorkflowTestSuiteUnitTest) Test_AwaitWithTimeoutTimeout() {
 	s.False(result)
 }
 
-func (s *WorkflowTestSuiteUnitTest) Test_DetachedChildWait() {
-	failedCount, successCount, lastCompletionResult := 0, 0, 0
-	cronWorkflow := func(ctx Context) (int, error) {
-		info := GetWorkflowInfo(ctx)
-		var result int
-		if HasLastCompletionResult(ctx) {
-			_ = GetLastCompletionResult(ctx, &result)
-		}
-		_ = Sleep(ctx, time.Second*3)
-		if info.Attempt == 1 {
-			failedCount++
-			return 0, errors.New("please-retry")
-		}
-
-		successCount++
-		result++
-		lastCompletionResult = result
-		return result, nil
-	}
-
-	testWorkflow := func(ctx Context) error {
-		ctx1 := WithChildWorkflowOptions(ctx, ChildWorkflowOptions{
+func (s *WorkflowTestSuiteUnitTest) Test_NoDetachedChildWait() {
+	// One cron+abandon and one request-cancel
+	childOptionSet := []ChildWorkflowOptions{
+		{
 			WorkflowRunTimeout: time.Minute * 10,
-			RetryPolicy: &RetryPolicy{
-				MaximumAttempts:        5,
-				InitialInterval:        time.Second,
-				MaximumInterval:        time.Second * 10,
-				BackoffCoefficient:     2,
-				NonRetryableErrorTypes: []string{"bad-bug"},
-			},
-			ParentClosePolicy: enumspb.PARENT_CLOSE_POLICY_ABANDON,
-			// Hourly
-			CronSchedule: "0 * * * *",
-		})
-
-		// Cron never stops, so future will not return
-		cronFuture := ExecuteChildWorkflow(ctx1, cronWorkflow)
-
-		timeoutTimer := NewTimer(ctx, time.Hour*3)
-		selector := NewSelector(ctx)
-		var err error
-		selector.AddFuture(cronFuture, func(f Future) {
-			err = errors.New("cron workflow returns, this is not expected")
-		}).AddFuture(timeoutTimer, func(f Future) {
-			// err will be nil
-		}).Select(ctx)
-
-		return err
+			ParentClosePolicy:  enumspb.PARENT_CLOSE_POLICY_ABANDON,
+			CronSchedule:       "0 * * * *",
+		},
+		{
+			WorkflowRunTimeout: time.Minute * 10,
+			ParentClosePolicy:  enumspb.PARENT_CLOSE_POLICY_REQUEST_CANCEL,
+		},
 	}
+	for _, childOptions := range childOptionSet {
+		var childCalledCount int
+		childWorkflow := func(ctx Context) error {
+			childCalledCount++
+			return Sleep(ctx, 1000*time.Hour)
+		}
 
-	env := s.NewTestWorkflowEnvironment()
-	// Without this, "ExecuteWorkflow" would run forever
-	env.SetDetachedChildWait(false)
-	env.RegisterWorkflow(cronWorkflow)
-	env.RegisterWorkflow(testWorkflow)
-	env.ExecuteWorkflow(testWorkflow)
+		workflow := func(ctx Context) error {
+			childFut := ExecuteChildWorkflow(WithChildWorkflowOptions(ctx, childOptions), childWorkflow)
+			// Since the child future is _in front_ of the timer future, the child
+			// will be called once
+			NewSelector(ctx).
+				AddFuture(childFut, func(Future) {}).
+				AddFuture(NewTimer(ctx, time.Hour*3), func(Future) {}).
+				Select(ctx)
+			return nil
+		}
 
-	s.True(env.IsWorkflowCompleted())
-	s.NoError(env.GetWorkflowError())
+		env := s.NewTestWorkflowEnvironment()
+		// Without this, "ExecuteWorkflow" would run a long time
+		env.SetDetachedChildWait(false)
+		env.RegisterWorkflow(workflow)
+		env.RegisterWorkflow(childWorkflow)
+		env.ExecuteWorkflow(workflow)
 
-	s.Equal(4, failedCount)
-	s.Equal(4, successCount)
-	s.Equal(4, lastCompletionResult)
+		s.True(env.IsWorkflowCompleted())
+		s.NoError(env.GetWorkflowError())
+
+		s.GreaterOrEqual(childCalledCount, 1)
+	}
 }

--- a/internal/workflow_testsuite.go
+++ b/internal/workflow_testsuite.go
@@ -541,10 +541,10 @@ func (e *TestWorkflowEnvironment) SetIdentity(identity string) *TestWorkflowEnvi
 
 // SetDetachedChildWait, if true, will make ExecuteWorkflow wait on all child
 // workflows to complete even if their close policy is set to abandon or request
-// cancel. If false, ExecuteWorkflow will wait on all children to complete
-// regardless of detached child. In situations with interminable cron-based
-// child workflows, setting this to false will allow the child to run once but
-// not continuously.
+// cancel, meaning they are "detached". If false, ExecuteWorkflow will block
+// until only all attached child workflows have completed. This is useful when
+// testing endless detached child workflows, as without it ExecuteWorkflow may
+// not return while detached children are still running.
 //
 // Default is true.
 func (e *TestWorkflowEnvironment) SetDetachedChildWait(detachedChildWait bool) *TestWorkflowEnvironment {

--- a/internal/workflow_testsuite.go
+++ b/internal/workflow_testsuite.go
@@ -539,6 +539,19 @@ func (e *TestWorkflowEnvironment) SetIdentity(identity string) *TestWorkflowEnvi
 	return e
 }
 
+// SetDetachedChildWait, if true, will make ExecuteWorkflow wait on all child
+// workflows to complete even if their close policy is set to abandon or request
+// cancel. If false, ExecuteWorkflow will wait on all children to complete
+// regardless of detached child. In situations with interminable cron-based
+// child workflows, setting this to false will allow the child to run once but
+// not continuously.
+//
+// Default is true.
+func (e *TestWorkflowEnvironment) SetDetachedChildWait(detachedChildWait bool) *TestWorkflowEnvironment {
+	e.impl.setDetachedChildWaitDisabled(!detachedChildWait)
+	return e
+}
+
 // SetWorkerStopChannel sets the activity worker stop channel to be returned from activity.GetWorkerStopChannel(context)
 // You can use this function to set the activity worker stop channel and use close(channel) to test your activity execution
 // from workflow execution.


### PR DESCRIPTION
## What was changed

Added `TestWorkflowEnvironment.SetDetachedChildWait` that lets test environments not wait on detached (i.e. abandoned or request-cancel) children before finishing workflow.

## Why?

In #470, we introduced a change that causes a parent `ExecuteWorkflow` to not return until all of its children are completely done. This caused issues for people testing interminable child workflows such as ones started on cron because they never finish.

Alternatively, we could have done something like expose child test workflow environments so people could cancel children themselves. This seems more straightforward however.

## Checklist

1. Closes #614