### PR TITLE
Add task pool slots remaining metric

### DIFF
--- a/internal/common/metrics/capturing_stats_reporter.go
+++ b/internal/common/metrics/capturing_stats_reporter.go
@@ -38,7 +38,7 @@ import (
 func NewMetricsScope(isReplay *bool) (tally.Scope, io.Closer, *CapturingStatsReporter) {
 	reporter := &CapturingStatsReporter{}
 	opts := tally.ScopeOptions{Reporter: reporter}
-	scope, closer := tally.NewRootScope(opts, time.Second)
+	scope, closer := tally.NewRootScope(opts, 100*time.Millisecond)
 	return WrapScope(isReplay, scope, &realClock{}), closer, reporter
 }
 

--- a/internal/common/metrics/capturing_stats_reporter.go
+++ b/internal/common/metrics/capturing_stats_reporter.go
@@ -58,7 +58,7 @@ func (c *realClock) Now() time.Time {
 
 // CapturingStatsReporter is a reporter used by tests to capture the metric so we can verify our tests.
 type CapturingStatsReporter struct {
-	sync.Mutex
+	sync.RWMutex
 	counts                   []CapturedCount
 	gauges                   []CapturedGauge
 	timers                   []CapturedTimer
@@ -70,26 +70,36 @@ type CapturingStatsReporter struct {
 
 // HistogramDurationSamples return HistogramDurationSamples
 func (c *CapturingStatsReporter) HistogramDurationSamples() []CapturedHistogramDurationSamples {
+	c.RLock()
+	defer c.RUnlock()
 	return c.histogramDurationSamples
 }
 
 // HistogramValueSamples return HistogramValueSamples
 func (c *CapturingStatsReporter) HistogramValueSamples() []CapturedHistogramValueSamples {
+	c.RLock()
+	defer c.RUnlock()
 	return c.histogramValueSamples
 }
 
 // Timers return Timers
 func (c *CapturingStatsReporter) Timers() []CapturedTimer {
+	c.RLock()
+	defer c.RUnlock()
 	return c.timers
 }
 
 // Gauges return Gauges
 func (c *CapturingStatsReporter) Gauges() []CapturedGauge {
+	c.RLock()
+	defer c.RUnlock()
 	return c.gauges
 }
 
 // Counts return Counts
 func (c *CapturingStatsReporter) Counts() []CapturedCount {
+	c.RLock()
+	defer c.RUnlock()
 	return c.counts
 }
 

--- a/internal/common/metrics/constants.go
+++ b/internal/common/metrics/constants.go
@@ -59,8 +59,9 @@ const (
 
 	CorruptedSignalsCounter = TemporalMetricsPrefix + "corrupted_signals"
 
-	WorkerStartCounter = TemporalMetricsPrefix + "worker_start"
-	PollerStartCounter = TemporalMetricsPrefix + "poller_start"
+	WorkerStartCounter       = TemporalMetricsPrefix + "worker_start"
+	WorkerTaskSlotsAvailable = TemporalMetricsPrefix + "worker_task_slots_available"
+	PollerStartCounter       = TemporalMetricsPrefix + "poller_start"
 
 	TemporalRequest            = TemporalMetricsPrefix + "request"
 	TemporalRequestFailure     = TemporalRequest + "_failure"

--- a/internal/internal_worker_base.go
+++ b/internal/internal_worker_base.go
@@ -32,6 +32,7 @@ import (
 	"fmt"
 	"os"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/uber-go/tally/v4"
@@ -149,6 +150,10 @@ type (
 		logger               log.Logger
 		metricsScope         tally.Scope
 
+		// Must be atomically accessed
+		taskSlotsAvailable      int32
+		taskSlotsAvailableGauge tally.Gauge
+
 		pollerRequestCh    chan struct{}
 		taskQueueCh        chan interface{}
 		sessionTokenBucket *sessionTokenBucket
@@ -174,19 +179,22 @@ func createPollRetryPolicy() backoff.RetryPolicy {
 func newBaseWorker(options baseWorkerOptions, logger log.Logger, metricsScope tally.Scope, sessionTokenBucket *sessionTokenBucket) *baseWorker {
 	ctx, cancel := context.WithCancel(context.Background())
 	bw := &baseWorker{
-		options:         options,
-		stopCh:          make(chan struct{}),
-		taskLimiter:     rate.NewLimiter(rate.Limit(options.maxTaskPerSecond), 1),
-		retrier:         backoff.NewConcurrentRetrier(pollOperationRetryPolicy),
-		logger:          log.With(logger, tagWorkerType, options.workerType),
-		metricsScope:    metrics.GetWorkerScope(metricsScope, options.workerType),
-		pollerRequestCh: make(chan struct{}, options.maxConcurrentTask),
-		taskQueueCh:     make(chan interface{}), // no buffer, so poller only able to poll new task after previous is dispatched.
+		options:            options,
+		stopCh:             make(chan struct{}),
+		taskLimiter:        rate.NewLimiter(rate.Limit(options.maxTaskPerSecond), 1),
+		retrier:            backoff.NewConcurrentRetrier(pollOperationRetryPolicy),
+		logger:             log.With(logger, tagWorkerType, options.workerType),
+		metricsScope:       metrics.GetWorkerScope(metricsScope, options.workerType),
+		taskSlotsAvailable: int32(options.maxConcurrentTask),
+		pollerRequestCh:    make(chan struct{}, options.maxConcurrentTask),
+		taskQueueCh:        make(chan interface{}), // no buffer, so poller only able to poll new task after previous is dispatched.
 
 		limiterContext:       ctx,
 		limiterContextCancel: cancel,
 		sessionTokenBucket:   sessionTokenBucket,
 	}
+	bw.taskSlotsAvailableGauge = bw.metricsScope.Gauge(metrics.WorkerTaskSlotsAvailable)
+	bw.taskSlotsAvailableGauge.Update(float64(bw.taskSlotsAvailable))
 	if options.pollerRate > 0 {
 		bw.pollLimiter = rate.NewLimiter(rate.Limit(options.pollerRate), 1)
 	}
@@ -321,6 +329,13 @@ func isNonRetriableError(err error) bool {
 
 func (bw *baseWorker) processTask(task interface{}) {
 	defer bw.stopWG.Done()
+
+	// Update availability metric
+	bw.taskSlotsAvailableGauge.Update(float64(atomic.AddInt32(&bw.taskSlotsAvailable, -1)))
+	defer func() {
+		bw.taskSlotsAvailableGauge.Update(float64(atomic.AddInt32(&bw.taskSlotsAvailable, 1)))
+	}()
+
 	// If the task is from poller, after processing it we would need to request a new poll. Otherwise, the task is from
 	// local activity worker, we don't need a new poll from server.
 	polledTask, isPolledTask := task.(*polledTask)

--- a/test/workflow_test.go
+++ b/test/workflow_test.go
@@ -1320,6 +1320,23 @@ func (w *Workflows) ActivityWaitForWorkerStop(ctx workflow.Context, timeout time
 	return s, err
 }
 
+func (w *Workflows) ActivityHeartbeatUntilSignal(ctx workflow.Context) error {
+	ch := workflow.GetSignalChannel(ctx, "cancel")
+	actCtx, actCancel := workflow.WithCancel(workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		StartToCloseTimeout: 5 * time.Hour,
+		RetryPolicy:         &temporal.RetryPolicy{MaximumAttempts: 1},
+		WaitForCancellation: true,
+		HeartbeatTimeout:    1 * time.Second,
+	}))
+	var a *Activities
+	actFut := workflow.ExecuteActivity(actCtx, a.HeartbeatUntilCanceled, 100*time.Millisecond)
+
+	// Wait for signal then cancel
+	ch.Receive(ctx, nil)
+	actCancel()
+	return actFut.Get(ctx, nil)
+}
+
 func (w *Workflows) CancelChildAndExecuteActivityRace(ctx workflow.Context) error {
 	// This workflow replicates an issue where cancel was reported out of order
 	// with when it occurs. Specifically, this workflow creates a long-running
@@ -1489,6 +1506,7 @@ func (w *Workflows) register(worker worker.Worker) {
 	worker.RegisterWorkflow(w.ActivityRetryOnTimeout)
 	worker.RegisterWorkflow(w.ActivityRetryOptionsChange)
 	worker.RegisterWorkflow(w.ActivityWaitForWorkerStop)
+	worker.RegisterWorkflow(w.ActivityHeartbeatUntilSignal)
 	worker.RegisterWorkflow(w.Basic)
 	worker.RegisterWorkflow(w.Deadlocked)
 	worker.RegisterWorkflow(w.DeadlockedWithLocalActivity)


### PR DESCRIPTION
## What was changed

Added worker metric called `temporal_worker_task_slots_available` that shows the remaining available slots for concurrent tasks. This is a "worker" metric as in the internal "worker" concept, not Temporal Workers. This is similar to two other "worker" metrics, `temporal_worker_start` and `temporal_poller_start` in that it has a `worker_type` tag that is either `WorkflowWorker`, `ActivityWorker`, or `LocalActivityWorker`. There are no other meaningful per-worker tags.

## Why?

Requested by users wanting to see if they are using up their max concurrent tasks and waiting.

## Checklist

1. Closes #594