### PR TITLE
Fix issue for zero-values of pointer arguments in workflows.

### DIFF
--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -1499,11 +1499,16 @@ func executeFunctionWithContext(ctx context.Context, fn interface{}, args []inte
 // Executes function and ensures that there is always 1 or 2 results and second
 // result is error.
 func executeFunction(fn interface{}, args []interface{}) (interface{}, error) {
+	fnValue := reflect.ValueOf(fn)
 	reflectArgs := make([]reflect.Value, len(args))
 	for i, arg := range args {
-		reflectArgs[i] = reflect.ValueOf(arg)
+		// If the argument is nil, use zero value
+		if arg == nil {
+			reflectArgs[i] = reflect.New(fnValue.Type().In(i)).Elem()
+		} else {
+			reflectArgs[i] = reflect.ValueOf(arg)
+		}
 	}
-	fnValue := reflect.ValueOf(fn)
 	retValues := fnValue.Call(reflectArgs)
 
 	// Expect either error or (result, error)

--- a/test/activity_test.go
+++ b/test/activity_test.go
@@ -291,6 +291,18 @@ func (a *Activities) InterceptorCalls(ctx context.Context, someVal string) (stri
 	return someVal, nil
 }
 
+func (*Activities) TooFewParams(
+	ctx context.Context,
+	param1 string,
+	param2 int,
+	param3 bool,
+	param4 struct{ SomeField string },
+	param5 *ParamsValue,
+	param6 []byte,
+) (*ParamsValue, error) {
+	return &ParamsValue{Param1: param1, Param2: param2, Param3: param3, Param4: param4, Param5: param5, Param6: param6}, nil
+}
+
 func (a *Activities) register(worker worker.Worker) {
 	worker.RegisterActivity(a)
 	// Check reregistration

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -1527,6 +1527,14 @@ func (ts *IntegrationTestSuite) TestAdvancedPostCancellation() {
 	})
 }
 
+func (ts *IntegrationTestSuite) TestTooFewParams() {
+	var res ParamsValue
+	// Only give first param
+	ts.NoError(ts.executeWorkflow("test-too-few-params", "TooFewParams", &res, "first param"))
+	// Confirm workflow and activity were called with zero values
+	ts.Equal(ParamsValue{Param1: "first param", Child: &ParamsValue{Param1: "first param"}}, res)
+}
+
 func (ts *IntegrationTestSuite) registerNamespace() {
 	client, err := client.NewNamespaceClient(client.Options{HostPort: ts.config.ServiceAddr})
 	ts.NoError(err)

--- a/test/workflow_test.go
+++ b/test/workflow_test.go
@@ -1479,6 +1479,32 @@ func (w *Workflows) AdvancedPostCancellation(ctx workflow.Context, in *AdvancedP
 	return nil
 }
 
+type ParamsValue struct {
+	Param1 string
+	Param2 int
+	Param3 bool
+	Param4 struct{ SomeField string }
+	Param5 *ParamsValue
+	Param6 []byte
+	Child  *ParamsValue
+}
+
+func (w *Workflows) TooFewParams(
+	ctx workflow.Context,
+	param1 string,
+	param2 int,
+	param3 bool,
+	param4 struct{ SomeField string },
+	param5 *ParamsValue,
+	param6 []byte,
+) (*ParamsValue, error) {
+	ret := &ParamsValue{Param1: param1, Param2: param2, Param3: param3, Param4: param4, Param5: param5, Param6: param6}
+	// Execute activity with only the first param
+	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{ScheduleToCloseTimeout: 1 * time.Minute})
+	var a *Activities
+	return ret, workflow.ExecuteActivity(ctx, a.TooFewParams, param1).Get(ctx, &ret.Child)
+}
+
 func (w *Workflows) register(worker worker.Worker) {
 	worker.RegisterWorkflow(w.ActivityCancelRepro)
 	worker.RegisterWorkflow(w.ActivityCompletionUsingID)
@@ -1539,6 +1565,7 @@ func (w *Workflows) register(worker worker.Worker) {
 	worker.RegisterWorkflow(w.InterceptorCalls)
 	worker.RegisterWorkflow(w.WaitSignalToStart)
 	worker.RegisterWorkflow(w.AdvancedPostCancellation)
+	worker.RegisterWorkflow(w.TooFewParams)
 
 	worker.RegisterWorkflow(w.child)
 	worker.RegisterWorkflow(w.childForMemoAndSearchAttr)


### PR DESCRIPTION
## What was changed

Properly using the empty nil reflection value with the type instead of trying `reflect.ValueOf` for a nil value.

## Why?

Workflows that were given too few args have zero values automatically created. However, the zero value automatically created for pointers was nil which couldn't be turned back to the proper value in Go reflection with

This was introduced in #610.

## Checklist

1. Closes #639
