### PR TITLE
Fix invalid command ID expectation on child workflow cancel

### DIFF
--- a/internal/internal_decision_state_machine.go
+++ b/internal/internal_decision_state_machine.go
@@ -652,6 +652,9 @@ func (d *childWorkflowCommandStateMachine) handleCancelFailedEvent() {
 func (d *childWorkflowCommandStateMachine) cancel() {
 	switch d.state {
 	case commandStateStarted:
+		if d.helper.workflowExecutionIsCancelling {
+			d.helper.commandsCancelledDuringWFCancellation++
+		}
 		d.moveState(commandStateCanceledAfterStarted, eventCancel)
 		// A child workflow may be canceled _after_ something like an activity start
 		// happens inside a simulated goroutine. However, since the state of the


### PR DESCRIPTION
## What was changed

The same change for #382, but to apply to child workflow cancel that does not call the base.

## Why?

An extra event for cancellation is not being accounted for in event counting when a cancel occurs during un-waited-on child workflow.

## Checklist

1. Closes #644