### PR TITLE
Support pointer-to-pointer in channel receive

### DIFF
--- a/internal/encode_args.go
+++ b/internal/encode_args.go
@@ -129,7 +129,7 @@ func decodeAndAssignValue(dc converter.DataConverter, from interface{}, toValueP
 		} else {
 			assignable := fromType.AssignableTo(toType)
 			if !assignable {
-				return fmt.Errorf("%s is not assignable to  %s", fromType.Name(), toType.Name())
+				return fmt.Errorf("%s is not assignable to %s", fromType.Name(), toType.Name())
 			}
 			reflect.ValueOf(toValuePtr).Elem().Set(fv)
 		}


### PR DESCRIPTION
## What was changed / Why?

See #665. Basically calling `Receive` with the same pointer type as `Send` was used with did not work,

## Checklist

1. Closes #665