### PR TITLE
Set workflow ID from start options in testsuite if given

### DIFF
--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -2367,6 +2367,9 @@ func (env *testWorkflowEnvironmentImpl) setStartWorkflowOptions(options StartWor
 	if options.WorkflowTaskTimeout > 0 {
 		wf.WorkflowTaskTimeout = options.WorkflowTaskTimeout
 	}
+	if len(options.ID) > 0 {
+		wf.WorkflowExecution.ID = options.ID
+	}
 	if len(options.TaskQueue) > 0 {
 		wf.TaskQueueName = options.TaskQueue
 	}

--- a/internal/workflow_testsuite_test.go
+++ b/internal/workflow_testsuite_test.go
@@ -201,3 +201,26 @@ func TestLocalActivityExecutionByActivityNameAliasMissingRegistration(t *testing
 	}, "Hello")
 	require.NotNil(t, env.GetWorkflowError())
 }
+
+func TestWorkflowIDInsideTestWorkflow(t *testing.T) {
+	var suite WorkflowTestSuite
+	// Default ID
+	env := suite.NewTestWorkflowEnvironment()
+	env.ExecuteWorkflow(func(ctx Context) (string, error) {
+		return "id is: " + GetWorkflowInfo(ctx).WorkflowExecution.ID, nil
+	})
+	require.NoError(t, env.GetWorkflowError())
+	var str string
+	require.NoError(t, env.GetWorkflowResult(&str))
+	require.Equal(t, "id is: "+defaultTestWorkflowID, str)
+
+	// Custom ID
+	env = suite.NewTestWorkflowEnvironment()
+	env.SetStartWorkflowOptions(StartWorkflowOptions{ID: "my-workflow-id"})
+	env.ExecuteWorkflow(func(ctx Context) (string, error) {
+		return "id is: " + GetWorkflowInfo(ctx).WorkflowExecution.ID, nil
+	})
+	require.NoError(t, env.GetWorkflowError())
+	require.NoError(t, env.GetWorkflowResult(&str))
+	require.Equal(t, "id is: my-workflow-id", str)
+}


### PR DESCRIPTION
## What was changed

Set the workflow execution ID as the given ID if present in the given start workflow options

## Why?

We do this with `TaskQueue` and other things, can do here too.

## Checklist

1. Closes #661