### PR TITLE
Debug mode does not set the DeadlockDetectionTimeout

### DIFF
--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -1468,8 +1468,9 @@ func setWorkerOptionsDefaults(options *WorkerOptions) {
 	if options.DeadlockDetectionTimeout == 0 {
 		if debugMode {
 			options.DeadlockDetectionTimeout = unlimitedDeadlockDetectionTimeout
+		} else {
+			options.DeadlockDetectionTimeout = defaultDeadlockDetectionTimeout
 		}
-		options.DeadlockDetectionTimeout = defaultDeadlockDetectionTimeout
 	}
 	if options.DefaultHeartbeatThrottleInterval == 0 {
 		options.DefaultHeartbeatThrottleInterval = defaultDefaultHeartbeatThrottleInterval

--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -28,7 +28,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"reflect"
 	"strings"
 	"sync"
@@ -258,7 +257,7 @@ func newTestWorkflowEnvironmentImpl(s *WorkflowTestSuite, parentRegistry *regist
 		runTimeout:        maxWorkflowTimeout,
 	}
 
-	if os.Getenv("TEMPORAL_DEBUG") != "" {
+	if debugMode {
 		env.testTimeout = time.Hour * 24
 		env.workerOptions.DeadlockDetectionTimeout = unlimitedDeadlockDetectionTimeout
 	}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
The debug mode now sets correctly the DeadlockDetectionTimeout after fixing coding error and it uses the same variable to detect the debug mode.
## Why?
<!-- Tell your future self why have you made these changes -->
It's a bug and second the package private debugMode variable is set when the program is loaded while the other condition which reads after the new test environment can be inconsistent  if the test calls the `os.SetEnv` just before.
## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->
N/A
2. How was this tested:
Manually.
3. Any docs updates needed?
N/A