### PR TITLE
Set Fossa to run non-blocking in buildkite

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -56,6 +56,7 @@ steps:
       queue: "default"
       docker: "*"
     command: "make fossa-init fossa-analyze fossa-test"
+    branches: "master"
     retry:
       automatic:
         limit: 2


### PR DESCRIPTION
## What was changed
Updated buildkite config to run Fossa non-blocking (only on merge to master)

## Why?
Fossa has too many false positives to run in blocking mode
