### PR TITLE
Add ability to disable workflow worker

### DIFF
--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -2632,3 +2632,14 @@ func TestIsNonRetriableError(t *testing.T) {
 		require.Equal(t, test.expected, isNonRetriableError(test.err))
 	}
 }
+
+func TestWorkerRegisterDisabledWorkflow(t *testing.T) {
+	// Expect panic
+	var recovered interface{}
+	func() {
+		defer func() { recovered = recover() }()
+		worker := NewAggregatedWorker(&WorkflowClient{}, "some-task-queue", WorkerOptions{DisableWorkflowWorker: true})
+		worker.RegisterWorkflow(testReplayWorkflow)
+	}()
+	require.Equal(t, "workflow worker disabled, cannot register workflow", recovered)
+}

--- a/internal/worker.go
+++ b/internal/worker.go
@@ -148,7 +148,8 @@ type (
 		MaxConcurrentSessionExecutionSize int
 
 		// Optional: If set to true, a workflow worker is not started for this
-		// worker and workflows cannot be registered with this worker.
+		// worker and workflows cannot be registered with this worker. Use this if
+		// you only want your worker to execute activities.
 		// default: false
 		DisableWorkflowWorker bool
 

--- a/internal/worker.go
+++ b/internal/worker.go
@@ -147,6 +147,11 @@ type (
 		// default: 1000
 		MaxConcurrentSessionExecutionSize int
 
+		// Optional: If set to true, a workflow worker is not started for this
+		// worker and workflows cannot be registered with this worker.
+		// default: false
+		DisableWorkflowWorker bool
+
 		// Optional: If set to true worker would only handle workflow tasks and local activities.
 		// Non-local activities will not be executed by this worker.
 		// default: false

--- a/test/workflow_test.go
+++ b/test/workflow_test.go
@@ -1591,6 +1591,16 @@ func (w *Workflows) TooFewParams(
 	return ret, workflow.ExecuteActivity(ctx, a.TooFewParams, param1).Get(ctx, &ret.Child)
 }
 
+func (w *Workflows) ExecuteRemoteActivityToUpper(ctx workflow.Context, taskQueue, str string) (string, error) {
+	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		TaskQueue:              taskQueue,
+		ScheduleToCloseTimeout: 5 * time.Second,
+	})
+	var resp string
+	err := workflow.ExecuteActivity(ctx, (*Activities2).ToUpper, str).Get(ctx, &resp)
+	return resp, err
+}
+
 func (w *Workflows) register(worker worker.Worker) {
 	worker.RegisterWorkflow(w.ActivityCancelRepro)
 	worker.RegisterWorkflow(w.ActivityCompletionUsingID)
@@ -1655,6 +1665,7 @@ func (w *Workflows) register(worker worker.Worker) {
 	worker.RegisterWorkflow(w.AdvancedPostCancellation)
 	worker.RegisterWorkflow(w.AdvancedPostCancellationChildWithDone)
 	worker.RegisterWorkflow(w.TooFewParams)
+	worker.RegisterWorkflow(w.ExecuteRemoteActivityToUpper)
 
 	worker.RegisterWorkflow(w.child)
 	worker.RegisterWorkflow(w.childForMemoAndSearchAttr)


### PR DESCRIPTION
## What was changed

Added option to disable workflow worker.

## Why?

For activity-only workers (such as those used by https://github.com/temporalio/samples-go/pull/166), we need to be able to disable unnecessary workflow worker polling and such.

## Checklist

1. Closes #636