### PR TITLE
Only respond with activity cancellation when requested by server

### DIFF
--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -395,7 +395,11 @@ func (wc *WorkflowClient) CompleteActivity(ctx context.Context, taskToken []byte
 			return err0
 		}
 	}
-	request := convertActivityResultToRespondRequest(wc.identity, taskToken, data, err, wc.dataConverter, wc.namespace)
+
+	// We do allow canceled error to be passed here
+	cancelAllowed := true
+	request := convertActivityResultToRespondRequest(wc.identity, taskToken,
+		data, err, wc.dataConverter, wc.namespace, cancelAllowed)
 	return reportActivityComplete(ctx, wc.workflowService, request, wc.metricsHandler)
 }
 
@@ -418,7 +422,10 @@ func (wc *WorkflowClient) CompleteActivityByID(ctx context.Context, namespace, w
 		}
 	}
 
-	request := convertActivityResultToRespondRequestByID(wc.identity, namespace, workflowID, runID, activityID, data, err, wc.dataConverter)
+	// We do allow canceled error to be passed here
+	cancelAllowed := true
+	request := convertActivityResultToRespondRequestByID(wc.identity, namespace, workflowID, runID, activityID,
+		data, err, wc.dataConverter, cancelAllowed)
 	return reportActivityCompleteByID(ctx, wc.workflowService, request, wc.metricsHandler)
 }
 

--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -1006,8 +1006,10 @@ func (env *testWorkflowEnvironmentImpl) CompleteActivity(taskToken []byte, resul
 				tagActivityID, activityID)
 			return
 		}
+		// We do allow canceled error to be passed here
+		cancelAllowed := true
 		request := convertActivityResultToRespondRequest("test-identity", taskToken, data, err,
-			env.GetDataConverter(), defaultTestNamespace)
+			env.GetDataConverter(), defaultTestNamespace, cancelAllowed)
 		env.handleActivityResult(activityID, request, activityHandle.activityType, env.GetDataConverter())
 	}, false /* do not auto schedule workflow task, because activity might be still pending */)
 

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -1819,6 +1819,82 @@ func (ts *IntegrationTestSuite) TestTallyScopeAccess() {
 	assertHistDuration("some_histogram", 5*time.Second, 2)
 }
 
+func (ts *IntegrationTestSuite) TestReturnCancelError() {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	wfIDPrefix := "test-return-cancel-error-"
+
+	// For most tests we don't return the raw error since it loses context
+	rawActivityError := false
+
+	// Activity using temporal canceled error when not canceled should return
+	// "unexpected activity cancel error"
+	fromActivity, waitForCancel, goCancelError := true, false, false
+	err := ts.executeWorkflow(wfIDPrefix+"1", ts.workflows.ReturnCancelError, nil,
+		fromActivity, rawActivityError, waitForCancel, goCancelError)
+	ts.Error(err)
+	ts.Contains(err.Error(), "unexpected activity cancel error")
+
+	// Activity using Go canceled error when not canceled should return a context
+	// canceled error
+	fromActivity, waitForCancel, goCancelError = true, false, true
+	err = ts.executeWorkflow(wfIDPrefix+"2", ts.workflows.ReturnCancelError, nil,
+		fromActivity, rawActivityError, waitForCancel, goCancelError)
+	ts.Error(err)
+	ts.Contains(err.Error(), "context canceled")
+
+	// Activity using temporal canceled error after cancel should return normal
+	// cancel error
+	fromActivity, waitForCancel, goCancelError = true, true, false
+	err = ts.executeWorkflow(wfIDPrefix+"3", ts.workflows.ReturnCancelError, nil,
+		fromActivity, rawActivityError, waitForCancel, goCancelError)
+	ts.Error(err)
+	ts.NotContains(err.Error(), "unexpected")
+	ts.Contains(err.Error(), "canceled")
+	// We also check that, since rawActivityError is false, this is _not_ a
+	// canceled workflow since just the error string is used. This assertion is
+	// only made here to show it's the opposite of the raw one later.
+	ts.False(temporal.IsCanceledError(err))
+	resp, err := ts.client.DescribeWorkflowExecution(ctx, wfIDPrefix+"3", "")
+	ts.NoError(err)
+	ts.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_FAILED, resp.GetWorkflowExecutionInfo().GetStatus())
+
+	// Activity using Go canceled error after cancel should return normal cancel
+	// error
+	fromActivity, waitForCancel, goCancelError = true, true, true
+	err = ts.executeWorkflow(wfIDPrefix+"4", ts.workflows.ReturnCancelError, nil,
+		fromActivity, rawActivityError, waitForCancel, goCancelError)
+	ts.Error(err)
+	ts.NotContains(err.Error(), "context canceled")
+	ts.Contains(err.Error(), "canceled")
+
+	// Workflow using temporal canceled error when not canceled will consider the
+	// workflow canceled
+	// TODO(cretz): Note, this is observed behavior, not necessarily desired
+	// behavior
+	fromActivity, waitForCancel, goCancelError = false, false, false
+	err = ts.executeWorkflow(wfIDPrefix+"5", ts.workflows.ReturnCancelError, nil,
+		fromActivity, rawActivityError, waitForCancel, goCancelError)
+	ts.Error(err)
+	ts.True(temporal.IsCanceledError(err))
+	resp, err = ts.client.DescribeWorkflowExecution(ctx, wfIDPrefix+"5", "")
+	ts.NoError(err)
+	ts.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_CANCELED, resp.GetWorkflowExecutionInfo().GetStatus())
+
+	// Workflow just returning the raw activity cancel itself appears canceled
+	// TODO(cretz): Note, this is observed behavior, not necessarily desired
+	// behavior
+	rawActivityError = true
+	fromActivity, waitForCancel, goCancelError = true, true, false
+	err = ts.executeWorkflow(wfIDPrefix+"6", ts.workflows.ReturnCancelError, nil,
+		fromActivity, rawActivityError, waitForCancel, goCancelError)
+	ts.Error(err)
+	ts.True(temporal.IsCanceledError(err))
+	resp, err = ts.client.DescribeWorkflowExecution(ctx, wfIDPrefix+"6", "")
+	ts.NoError(err)
+	ts.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_CANCELED, resp.GetWorkflowExecutionInfo().GetStatus())
+}
+
 func (ts *IntegrationTestSuite) registerNamespace() {
 	client, err := client.NewNamespaceClient(client.Options{HostPort: ts.config.ServiceAddr})
 	ts.NoError(err)

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -1866,6 +1866,7 @@ func (ts *IntegrationTestSuite) TestReturnCancelError() {
 		fromActivity, rawActivityError, waitForCancel, goCancelError)
 	ts.Error(err)
 	ts.NotContains(err.Error(), "context canceled")
+	ts.NotContains(err.Error(), "unexpected")
 	ts.Contains(err.Error(), "canceled")
 
 	// Workflow using temporal canceled error when not canceled will consider the

--- a/test/workflow_test.go
+++ b/test/workflow_test.go
@@ -1611,7 +1611,7 @@ func (w *Workflows) ReturnCancelError(
 		actFut := workflow.ExecuteActivity(actCtx, a.ReturnCancelError, waitForCancel, goCancelError)
 		// If waiting for cancel, sleep a bit then cancel
 		if waitForCancel {
-			workflow.Sleep(ctx, 100*time.Millisecond)
+			_ = workflow.Sleep(ctx, 100*time.Millisecond)
 			actCancel()
 		}
 		if err := actFut.Get(ctx, nil); err != nil {


### PR DESCRIPTION
## What was changed

Do not send `RespondActivityTaskCanceledRequest` on return cancel error unless the server initiated the cancel. Also added tests confirming behavior for activities and workflows when manually returning cancellation errors.

## Why?

See #686. Basically the server has to be expecting the cancellation to handle it.

## Checklist

1. Closes #686