### PR TITLE
Add note for OnActivity about method references

### DIFF
--- a/internal/workflow_testsuite.go
+++ b/internal/workflow_testsuite.go
@@ -278,6 +278,11 @@ func (e *TestWorkflowEnvironment) SetStartTime(startTime time.Time) {
 //   })
 // OR return mock values with same types as activity function's return types:
 //   t.OnActivity(MyActivity, mock.Anything, mock.Anything).Return("mock_result", nil)
+//
+// Note, when using a method reference with a receiver as an activity, the receiver must be an instance the same as if
+// it was being using in RegisterActivity so the parameter types are accurate. In Go, a method reference of
+// (*MyStruct).MyFunc makes the first parameter *MyStruct which will not work, whereas a method reference of
+// new(MyStruct).MyFunc will.
 func (e *TestWorkflowEnvironment) OnActivity(activity interface{}, args ...interface{}) *MockCallWrapper {
 	fType := reflect.TypeOf(activity)
 	var call *mock.Call


### PR DESCRIPTION
## What was changed

Extra doc added for `TestWorkflowEnvironment.OnActivity`

## Why?

Per #688 and #586, people are trying to use references on a struct instead of references on an instance of a struct.

## Checklist

1. Closes #688