### PR TITLE
Increase log level of heartbeat errors

### DIFF
--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -1693,7 +1693,7 @@ func (i *temporalInvoker) internalHeartBeat(ctx context.Context, details *common
 
 	if err != nil {
 		logger := GetActivityLogger(ctx)
-		logger.Debug("RecordActivityHeartbeat with error", tagError, err)
+		logger.Warn("RecordActivityHeartbeat with error", tagError, err)
 	}
 
 	// This error won't be returned to user check RecordActivityHeartbeat().


### PR DESCRIPTION
## What was changed

Increase log level of heartbeat errors from debug to warn

## Why?

Many loggers disable debug, but this is something that should be visible

## Checklist

1. Closes #692
