### PR TITLE
Propagate retry policy for continue-as-new

### DIFF
--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -579,6 +579,7 @@ func (wth *workflowTaskHandlerImpl) createWorkflowContext(task *workflowservice.
 		ParentWorkflowExecution:  parentWorkflowExecution,
 		Memo:                     attributes.Memo,
 		SearchAttributes:         attributes.SearchAttributes,
+		RetryPolicy:              convertFromPBRetryPolicy(attributes.RetryPolicy),
 	}
 
 	return newWorkflowExecutionContext(workflowInfo, wth), nil
@@ -1474,6 +1475,7 @@ func (wth *workflowTaskHandlerImpl) completeWorkflow(
 			Header:              contErr.Header,
 			Memo:                workflowContext.workflowInfo.Memo,
 			SearchAttributes:    workflowContext.workflowInfo.SearchAttributes,
+			RetryPolicy:         convertToPBRetryPolicy(workflowContext.workflowInfo.RetryPolicy),
 		}}
 	} else if workflowContext.err != nil {
 		// Workflow failures

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -862,6 +862,7 @@ type WorkflowInfo struct {
 	ParentWorkflowExecution *WorkflowExecution
 	Memo                    *commonpb.Memo             // Value can be decoded using data converter (defaultDataConverter, or custom one if set).
 	SearchAttributes        *commonpb.SearchAttributes // Value can be decoded using defaultDataConverter.
+	RetryPolicy             *RetryPolicy
 	BinaryChecksum          string
 }
 

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -504,9 +504,12 @@ func (ts *IntegrationTestSuite) TestContinueAsNewCarryOver() {
 	startOptions.SearchAttributes = map[string]interface{}{
 		"CustomKeywordField": "searchAttr",
 	}
+	startOptions.RetryPolicy = &temporal.RetryPolicy{
+		MaximumAttempts: 123,
+	}
 	err := ts.executeWorkflowWithOption(startOptions, ts.workflows.ContinueAsNewWithOptions, &result, 4, ts.taskQueueName)
 	ts.NoError(err)
-	ts.Equal("memoVal,searchAttr", result)
+	ts.Equal("memoVal,searchAttr,123", result)
 }
 
 func (ts *IntegrationTestSuite) TestCancellation() {

--- a/test/workflow_test.go
+++ b/test/workflow_test.go
@@ -335,8 +335,8 @@ func (w *Workflows) ContinueAsNewWithOptions(ctx workflow.Context, count int, ta
 		return "", fmt.Errorf("invalid taskQueueName name, expected=%v, got=%v", taskQueue, tq)
 	}
 
-	if info.Memo == nil || info.SearchAttributes == nil {
-		return "", errors.New("memo or search attributes are not carried over")
+	if info.Memo == nil || info.SearchAttributes == nil || info.RetryPolicy == nil {
+		return "", errors.New("memo, search attributes, and/or retry policy are not carried over")
 	}
 	var memoVal string
 	err := converter.GetDefaultDataConverter().FromPayload(info.Memo.Fields["memoKey"], &memoVal)
@@ -351,7 +351,7 @@ func (w *Workflows) ContinueAsNewWithOptions(ctx workflow.Context, count int, ta
 	}
 
 	if count == 0 {
-		return memoVal + "," + searchAttrVal, nil
+		return fmt.Sprintf("%v,%v,%v", memoVal, searchAttrVal, info.RetryPolicy.MaximumAttempts), nil
 	}
 	ctx = workflow.WithTaskQueue(ctx, taskQueue)
 


### PR DESCRIPTION
## What was changed

Set the retry policy for continue-as-new based on the workflow's original value

## Why?

Currently we set no value for retry policy on continue-as-new.

@yiminc, @mfateev, et al - Any backwards compatibility concerns for people that weren't expecting the retry policy to propagate?

## Checklist

1. Closes #695