### PR TITLE
Return workflow trace logger

### DIFF
--- a/interceptor/tracing_interceptor.go
+++ b/interceptor/tracing_interceptor.go
@@ -27,6 +27,7 @@ import (
 	"fmt"
 
 	commonpb "go.temporal.io/api/common/v1"
+
 	"go.temporal.io/sdk/activity"
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/converter"
@@ -453,7 +454,7 @@ func (t *tracingWorkflowOutboundInterceptor) ExecuteLocalActivity(
 
 func (t *tracingWorkflowOutboundInterceptor) GetLogger(ctx workflow.Context) log.Logger {
 	if span, _ := ctx.Value(t.root.options.SpanContextKey).(TracerSpan); span != nil {
-		t.root.tracer.GetLogger(t.Next.GetLogger(ctx), span)
+		return t.root.tracer.GetLogger(t.Next.GetLogger(ctx), span)
 	}
 	return t.Next.GetLogger(ctx)
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Fixes a bug in https://github.com/temporalio/sdk-go/pull/655 where a custom tracing logger was instantiated but never used. Realized my silly mistake when we cut over our tracing implementation and logs disappeared from APM.

This has now been tested e2e for workflow logs. I'll open a second patch to implement GetLogger for activities.