### PR TITLE
Support trace logger in workflows & activities

### DIFF
--- a/interceptor/tracing_interceptor.go
+++ b/interceptor/tracing_interceptor.go
@@ -27,6 +27,7 @@ import (
 	"fmt"
 
 	commonpb "go.temporal.io/api/common/v1"
+
 	"go.temporal.io/sdk/activity"
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/converter"
@@ -453,7 +454,7 @@ func (t *tracingWorkflowOutboundInterceptor) ExecuteLocalActivity(
 
 func (t *tracingWorkflowOutboundInterceptor) GetLogger(ctx workflow.Context) log.Logger {
 	if span, _ := ctx.Value(t.root.options.SpanContextKey).(TracerSpan); span != nil {
-		t.root.tracer.GetLogger(t.Next.GetLogger(ctx), span)
+		return t.root.tracer.GetLogger(t.Next.GetLogger(ctx), span)
 	}
 	return t.Next.GetLogger(ctx)
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

This PR enables the injection of tracing metadata in the activity logger. This builds on #713 and #655.

## Why?
<!-- Tell your future self why have you made these changes -->

This allows tracing implementations to correlate logs for multiple activities and workflows serving a single request.

## Checklist
<!--- add/delete as needed --->

Tested e2e with our internal tracer implementation.