### PR TITLE
Add workflow/activity start time and activity ID to tracing interceptor spans

### DIFF
--- a/contrib/opentelemetry/tracing_interceptor.go
+++ b/contrib/opentelemetry/tracing_interceptor.go
@@ -32,6 +32,7 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
+
 	"go.temporal.io/sdk/interceptor"
 )
 
@@ -175,7 +176,7 @@ func (t *tracer) StartSpan(opts *interceptor.TracerStartSpanOptions) (intercepto
 	}
 
 	// Create span
-	span := t.options.SpanStarter(ctx, t.options.Tracer, opts.Operation+":"+opts.Name)
+	span := t.options.SpanStarter(ctx, t.options.Tracer, opts.Operation+":"+opts.Name, trace.WithTimestamp(opts.Time))
 
 	// Set tags
 	if len(opts.Tags) > 0 {

--- a/contrib/opentelemetry/tracing_interceptor_test.go
+++ b/contrib/opentelemetry/tracing_interceptor_test.go
@@ -29,6 +29,7 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.opentelemetry.io/otel/trace"
+
 	"go.temporal.io/sdk/contrib/opentelemetry"
 	"go.temporal.io/sdk/interceptor"
 	"go.temporal.io/sdk/internal/interceptortest"
@@ -40,7 +41,10 @@ func TestSpanPropagation(t *testing.T) {
 		Tracer: sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(&rec)).Tracer(""),
 	})
 	require.NoError(t, err)
-	interceptortest.AssertSpanPropagation(t, &testTracer{Tracer: tracer, rec: &rec})
+
+	testTracer := &testTracer{Tracer: tracer, rec: &rec}
+	interceptortest.RunTestWorkflow(t, testTracer)
+	interceptortest.AssertSpanPropagation(t, testTracer)
 }
 
 type testTracer struct {

--- a/contrib/opentracing/interceptor.go
+++ b/contrib/opentracing/interceptor.go
@@ -28,6 +28,7 @@ import (
 	"fmt"
 
 	"github.com/opentracing/opentracing-go"
+
 	"go.temporal.io/sdk/interceptor"
 )
 
@@ -138,7 +139,9 @@ func (t *tracer) ContextWithSpan(ctx context.Context, span interceptor.TracerSpa
 
 func (t *tracer) StartSpan(opts *interceptor.TracerStartSpanOptions) (interceptor.TracerSpan, error) {
 	// Build start options
-	var startOpts []opentracing.StartSpanOption
+	startOpts := []opentracing.StartSpanOption{
+		opentracing.StartTime(opts.Time),
+	}
 
 	// Link parent
 	var parent opentracing.SpanContext

--- a/contrib/opentracing/interceptor_test.go
+++ b/contrib/opentracing/interceptor_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/opentracing/opentracing-go/mocktracer"
 	"github.com/stretchr/testify/require"
+
 	"go.temporal.io/sdk/contrib/opentracing"
 	"go.temporal.io/sdk/interceptor"
 	"go.temporal.io/sdk/internal/interceptortest"
@@ -36,7 +37,10 @@ func TestSpanPropagation(t *testing.T) {
 	mock := mocktracer.New()
 	tracer, err := opentracing.NewTracer(opentracing.TracerOptions{Tracer: mock})
 	require.NoError(t, err)
-	interceptortest.AssertSpanPropagation(t, &testTracer{Tracer: tracer, mock: mock})
+
+	testTracer := &testTracer{Tracer: tracer, mock: mock}
+	interceptortest.RunTestWorkflow(t, testTracer)
+	interceptortest.AssertSpanPropagation(t, testTracer)
 }
 
 type testTracer struct {

--- a/interceptor/tracing_interceptor.go
+++ b/interceptor/tracing_interceptor.go
@@ -28,7 +28,6 @@ import (
 	"time"
 
 	commonpb "go.temporal.io/api/common/v1"
-
 	"go.temporal.io/sdk/activity"
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/converter"
@@ -39,6 +38,7 @@ import (
 const (
 	workflowIDTagKey = "temporalWorkflowID"
 	runIDTagKey      = "temporalRunID"
+	activityIDTagKey = "temporalActivityID"
 )
 
 // Tracer is an interface for tracing implementations as used by
@@ -319,6 +319,7 @@ func (t *tracingActivityInboundInterceptor) ExecuteActivity(
 		Tags: map[string]string{
 			workflowIDTagKey: info.WorkflowExecution.ID,
 			runIDTagKey:      info.WorkflowExecution.RunID,
+			activityIDTagKey: info.ActivityID,
 		},
 		FromHeader: true,
 		Time:       info.StartedTime,

--- a/interceptor/tracing_interceptor_test.go
+++ b/interceptor/tracing_interceptor_test.go
@@ -1,0 +1,84 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package interceptor_test
+
+import (
+	"context"
+	"testing"
+
+	"go.temporal.io/sdk/interceptor"
+	"go.temporal.io/sdk/internal/interceptortest"
+)
+
+type testTracer struct {
+	interceptor.BaseTracer
+	T *testing.T
+}
+
+type testSpan struct{}
+
+func (t testSpan) Finish(options *interceptor.TracerFinishSpanOptions) {}
+
+type testSpanRef struct{}
+
+func (t testTracer) Options() interceptor.TracerOptions {
+	return interceptor.TracerOptions{
+		SpanContextKey:       "test-tracer",
+		HeaderKey:            "test-tracer",
+		DisableSignalTracing: false,
+		DisableQueryTracing:  false,
+	}
+}
+
+func (t *testTracer) UnmarshalSpan(m map[string]string) (interceptor.TracerSpanRef, error) {
+	return testSpanRef{}, nil
+}
+
+func (t *testTracer) MarshalSpan(span interceptor.TracerSpan) (map[string]string, error) {
+	return map[string]string{}, nil
+}
+
+func (t *testTracer) SpanFromContext(ctx context.Context) interceptor.TracerSpan {
+	return testSpan{}
+}
+
+func (t *testTracer) ContextWithSpan(ctx context.Context, span interceptor.TracerSpan) context.Context {
+	return ctx
+}
+
+func (t *testTracer) StartSpan(options *interceptor.TracerStartSpanOptions) (interceptor.TracerSpan, error) {
+	// Require start time to be set
+	if options.Time.IsZero() {
+		switch options.Operation {
+		case "RunWorkflow", "RunActivity":
+		// Do nothing; the test env doesn't set these at the moment.
+		default:
+			t.T.Errorf("Got zero value for span start time: %v", options)
+		}
+	}
+	return testSpan{}, nil
+}
+
+func TestSpanTimestamps(t *testing.T) {
+	interceptortest.RunTestWorkflow(t, &testTracer{T: t})
+}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

* Added a `Time` field to `TracerStartSpanOptions`. This allows tracing implementations to set correct durations for spans that cross process boundaries.
* Added a `temporalActivityID` tag to `RunActivity` spans. This allows filtering for spans that are retries of the same activity within a workflow execution.

## Why?
<!-- Tell your future self why have you made these changes -->

After https://github.com/temporalio/sdk-go/pull/714 these should be the last two changes needed for us to cut over our internal tracing implementation to sdk-go's `interceptor` package.

## Checklist
<!--- add/delete as needed --->

Tested end to end in our environment, but I'm also happy to write some unit tests for this functionality.
