### PR TITLE
Add a helper for serving a payload encoder over HTTP.

### DIFF
--- a/converter/encoding_data_converter_test.go
+++ b/converter/encoding_data_converter_test.go
@@ -23,7 +23,11 @@
 package converter_test
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"reflect"
 	"strings"
 	"testing"
@@ -169,4 +173,60 @@ func (c *captureToPayloadDataConverter) ToPayload(value interface{}) (*commonpb.
 	p, err := c.DataConverter.ToPayload(value)
 	c.lastToPayloadResult = p
 	return p, err
+}
+
+func TestPayloadEncoderHTTPHandler(t *testing.T) {
+	defaultConv := converter.GetDefaultDataConverter()
+	encoder := converter.NewZlibEncoder(converter.ZlibEncoderOptions{AlwaysEncode: true})
+	handler := converter.NewPayloadEncoderHTTPHandler(encoder)
+
+	req, err := http.NewRequest("GET", "/encode", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusNotFound, rr.Code)
+
+	req, err = http.NewRequest("POST", "/missing", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rr = httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	req, err = http.NewRequest("POST", "/encode", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rr = httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+
+	payload, _ := defaultConv.ToPayload("test")
+	payloadJSON, _ := json.Marshal(payload)
+
+	req, err = http.NewRequest("POST", "/encode", bytes.NewReader(payloadJSON))
+	if err != nil {
+		t.Fatal(err)
+	}
+	rr = httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	encodedPayloadJSON := strings.TrimSpace(rr.Body.String())
+	require.NotEqual(t, payloadJSON, encodedPayloadJSON)
+
+	req, err = http.NewRequest("POST", "/decode", strings.NewReader(encodedPayloadJSON))
+	if err != nil {
+		t.Fatal(err)
+	}
+	rr = httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	decodedPayloadJSON := strings.TrimSpace(rr.Body.String())
+	require.Equal(t, string(payloadJSON), decodedPayloadJSON)
 }

--- a/converter/remote_data_converter.go
+++ b/converter/remote_data_converter.go
@@ -1,0 +1,92 @@
+// The MIT License
+//
+// Copyright (c) 2022 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package converter
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/gogo/protobuf/jsonpb"
+	commonpb "go.temporal.io/api/common/v1"
+)
+
+const ENCODE_PATH = "/encode"
+const DECODE_PATH = "/decode"
+
+type RemoteEncoderDataConverterOptions struct {
+	Endpoint string
+}
+
+type remotePayloadConverter struct {
+	options RemoteEncoderDataConverterOptions
+}
+
+func NewRemoteEncoderDataConverter(options RemoteEncoderDataConverterOptions) *EncodingDataConverter {
+	return NewEncodingDataConverter(
+		defaultDataConverter,
+		&remotePayloadConverter{options},
+	)
+}
+
+func (rdc *remotePayloadConverter) sendHTTP(endpoint string, p *commonpb.Payload) error {
+	payload, err := json.Marshal(p)
+	if err != nil {
+		return fmt.Errorf("unable to marshal payload: %w", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("unable to build request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	client := http.Client{}
+	response, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode == 200 {
+		err = jsonpb.Unmarshal(response.Body, p)
+		if err != nil {
+			return fmt.Errorf("unable to unmarshal payload: %w", err)
+		}
+		return nil
+	}
+
+	message, _ := io.ReadAll(response.Body)
+	return fmt.Errorf("%s: %s", http.StatusText(response.StatusCode), message)
+}
+
+func (rdc *remotePayloadConverter) Encode(p *commonpb.Payload) error {
+	return rdc.sendHTTP(rdc.options.Endpoint+ENCODE_PATH, p)
+}
+
+func (rdc *remotePayloadConverter) Decode(p *commonpb.Payload) error {
+	return rdc.sendHTTP(rdc.options.Endpoint+DECODE_PATH, p)
+}


### PR DESCRIPTION
This will be used to replace the data converter plugin infrastructure with a more flexible approach.

## What was changed

A helper was added to implement the ServeHTTP interface for a payload encoder.
A new data converter type is provided to consume the encoder endpoint.

## Why?

This will allow tctl to encode/decode payloads without needing to use plugins, just a flag to configure the remote encoder endpoint. Currently tctl is not able to encode payloads at all, only decode, due to issues with the plugin interface.

## Checklist

2. How was this tested:

Tested by patching tctl include this dataconverter and enabling it when a `--remote-data-encoder ...` flag is given.

3. Any docs updates needed?

Yes, the deployment and configuration of this setup will need to be documented.