### PR TITLE
Remove pending activity cancellations when activity completion occurs

### DIFF
--- a/internal/version.go
+++ b/internal/version.go
@@ -30,7 +30,7 @@ package internal
 const (
 	// SDKVersion is a semver (https://semver.org/) that represents the version of this Temporal GoSDK.
 	// Server validates if SDKVersion fits its supported range and rejects request if it doesn't.
-	SDKVersion = "1.13.0"
+	SDKVersion = "1.13.1"
 
 	// SupportedServerVersions is a semver rages (https://github.com/blang/semver#ranges) of server versions that
 	// are supported by this Temporal SDK.


### PR DESCRIPTION
## What was changed

We make sure we remove pending activity cancellations when we receive an activity completion from the server, taking care not to incorrectly alter the event sequence identifier incorrectly.

## Why?

This has some history I'll try to explain here in a quick set of bullets.

* The existing implementation in Go SDK collects commands for cancellation before it processes events that may make the cancellation moot
* Therefore, in a racy situation, you can get an activity completion after you've queued up an activity cancellation and if you sent that cancellation, the server fails
* This was mostly fixed in #504 but the special code that handled fixing the event counter when removing the no-longer-needed pending cancel had an issue for activities that were sent after it (e.g. cleanup activities)
* This was mostly fixed in #625 by removing the activity part of #504. In hindsight we instead should have just fixed the event counter issue and left the rest of it alone
* So this issue reinstates the activity-specific no-longer-needed-pending-activity-cancel-removal from #504, which fails the tests from #625 by default, but also adds new logic to make sure the event counter manipulation works correctly

TL;DR - We mostly fixed, we removed part of that fix due to another error, we re-applied the fix and made changes to also fix that other error

## Checklist

1. Closes #724

2. How was this tested:

This relies on a test from #625 to ensure no regressions. Unfortunately the full regression test is a several-second, server-burdening script (see it in #725). Still contemplating where best to put it.