### PR TITLE
Disallow MaxConcurrentWorkflowTaskPollers to be set to 1

### DIFF
--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -1273,6 +1273,13 @@ func NewAggregatedWorker(client *WorkflowClient, taskQueue string, options Worke
 	}
 	backgroundActivityContext, backgroundActivityContextCancel := context.WithCancel(ctx)
 
+	// If max-concurrent workflow pollers is 1, the worker will only do
+	// sticky-queue requests and never regular-queue requests. We disallow the
+	// value of 1 here.
+	if options.MaxConcurrentWorkflowTaskPollers == 1 {
+		panic("cannot set MaxConcurrentWorkflowTaskPollers to 1")
+	}
+
 	cache := NewWorkerCache()
 	workerParams := workerExecutionParameters{
 		Namespace:                             client.namespace,

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -2444,6 +2444,12 @@ func TestActivityNilArgs(t *testing.T) {
 	require.Equal(t, nilErr, reflectResults[0].Interface())
 }
 
+func TestWorkerOptionInvalid(t *testing.T) {
+	require.Panics(t, func() {
+		NewAggregatedWorker(&WorkflowClient{}, "worker-options-tq", WorkerOptions{MaxConcurrentWorkflowTaskPollers: 1})
+	})
+}
+
 func TestWorkerOptionDefaults(t *testing.T) {
 	client := &WorkflowClient{}
 	taskQueue := "worker-options-tq"

--- a/internal/worker.go
+++ b/internal/worker.go
@@ -85,7 +85,9 @@ type (
 
 		// Optional: Sets the maximum number of goroutines that will concurrently poll the
 		// temporal-server to retrieve workflow tasks. Changing this value will affect the
-		// rate at which the worker is able to consume tasks from a task queue.
+		// rate at which the worker is able to consume tasks from a task queue. Due to
+		// internal logic where pollers alternate between stick and non-sticky queues, this
+		// value cannot be 1 and will panic if set to that value.
 		// default: 2
 		MaxConcurrentWorkflowTaskPollers int
 


### PR DESCRIPTION
## What was changed

Disallow MaxConcurrentWorkflowTaskPollers to be set to 1

## Why?

Because worker polling is built to require at least 2 due to how stickiness preference is implemented.

## Checklist

1. Closes #719