### PR TITLE
Do not serialize empty OpenTracing spans

### DIFF
--- a/interceptor/tracing_interceptor.go
+++ b/interceptor/tracing_interceptor.go
@@ -56,7 +56,8 @@ type Tracer interface {
 	// UnmarshalSpan unmarshals the given map into a span reference.
 	UnmarshalSpan(map[string]string) (TracerSpanRef, error)
 
-	// MarshalSpan marshals the given span into a map.
+	// MarshalSpan marshals the given span into a map. If the map is empty with no
+	// error, the span is simply not set.
 	MarshalSpan(TracerSpan) (map[string]string, error)
 
 	// SpanFromContext returns the span from the general Go context or nil if not
@@ -679,7 +680,7 @@ func (t *tracingInterceptor) readSpanFromHeader(header map[string]*commonpb.Payl
 func (t *tracingInterceptor) writeSpanToHeader(span TracerSpan, header map[string]*commonpb.Payload) error {
 	// Serialize span to map
 	data, err := t.tracer.MarshalSpan(span)
-	if err != nil {
+	if err != nil || len(data) == 0 {
 		return err
 	}
 	// Convert to payload

--- a/test/go.mod
+++ b/test/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/golang/mock v1.6.0
+	github.com/opentracing/opentracing-go v1.2.0
 	github.com/pborman/uuid v1.2.1
 	github.com/stretchr/testify v1.7.0
 	github.com/uber-go/tally/v4 v4.1.1
@@ -12,6 +13,7 @@ require (
 	go.temporal.io/api v1.7.0
 	go.temporal.io/sdk v1.12.0
 	go.temporal.io/sdk/contrib/opentelemetry v0.1.0
+	go.temporal.io/sdk/contrib/opentracing v0.0.0-00010101000000-000000000000
 	go.temporal.io/sdk/contrib/tally v0.1.0
 	go.uber.org/goleak v1.1.11
 )
@@ -19,5 +21,6 @@ require (
 replace (
 	go.temporal.io/sdk => ../
 	go.temporal.io/sdk/contrib/opentelemetry => ../contrib/opentelemetry
+	go.temporal.io/sdk/contrib/opentracing => ../contrib/opentracing
 	go.temporal.io/sdk/contrib/tally => ../contrib/tally
 )

--- a/test/go.sum
+++ b/test/go.sum
@@ -115,6 +115,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRW
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
+github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
+github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
 github.com/pborman/uuid v1.2.1 h1:+ZZIw58t/ozdjRaXh/3awHfmWRbzYxJoAdNJxe/3pvw=
 github.com/pborman/uuid v1.2.1/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=


### PR DESCRIPTION
## What was changed

Added check to not serialize empty span data.

## Why?

OpenTracing's NoopTracer makes empty span which we were serializing causing side extracting other side to fail. We didn't see this before because we improperly assumed those not using a tracer wouldn't configure the interceptor.

## Checklist

1. Closes #712