### PR TITLE
Adjust HTTP protocol to take Payloads not Payload.

### DIFF
--- a/converter/encoding_data_converter.go
+++ b/converter/encoding_data_converter.go
@@ -418,12 +418,6 @@ func (rdc *remoteDataConverter) ToStrings(payloads *commonpb.Payloads) []string 
 	return strs
 }
 
-// NewRemoteDataConverter creates a DataConverter that wraps an underlying data
-// converter with a remote encoder.
-func NewRemotePayloadEncoder(parent DataConverter, options RemoteDataConverterOptions) DataConverter {
-	return &remoteDataConverter{parent, options}
-}
-
 func (rdc *remoteDataConverter) encodePayload(payload *commonpb.Payload) error {
 	return rdc.encodeOrDecodePayload(rdc.options.Endpoint+remotePayloadEncoderEncodePath, payload)
 }

--- a/converter/encoding_data_converter.go
+++ b/converter/encoding_data_converter.go
@@ -338,8 +338,6 @@ type remoteDataConverter struct {
 	options RemoteDataConverterOptions
 }
 
-var _ DataConverter = &remoteDataConverter{}
-
 // NewRemoteDataConverter wraps the given parent DataConverter and performs
 // encoding/decoding on the payload via the remote endpoint.
 func NewRemoteDataConverter(parent DataConverter, options RemoteDataConverterOptions) DataConverter {

--- a/converter/encoding_data_converter_test.go
+++ b/converter/encoding_data_converter_test.go
@@ -205,12 +205,12 @@ func TestPayloadEncoderHTTPHandler(t *testing.T) {
 
 	require.Equal(t, http.StatusBadRequest, rr.Code)
 
-	payload, _ := defaultConv.ToPayload("test")
-	payloadJSON, _ := json.Marshal(payload)
+	payloads, _ := defaultConv.ToPayloads("test")
+	payloadsJSON, _ := json.Marshal(payloads)
 
-	fmt.Printf("%s", payloadJSON)
+	fmt.Printf("%s", payloadsJSON)
 
-	req, err = http.NewRequest("POST", "/encode", bytes.NewReader(payloadJSON))
+	req, err = http.NewRequest("POST", "/encode", bytes.NewReader(payloadsJSON))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -218,10 +218,10 @@ func TestPayloadEncoderHTTPHandler(t *testing.T) {
 	handler.ServeHTTP(rr, req)
 
 	require.Equal(t, http.StatusOK, rr.Code)
-	encodedPayloadJSON := strings.TrimSpace(rr.Body.String())
-	require.NotEqual(t, payloadJSON, encodedPayloadJSON)
+	encodedPayloadsJSON := strings.TrimSpace(rr.Body.String())
+	require.NotEqual(t, payloadsJSON, encodedPayloadsJSON)
 
-	req, err = http.NewRequest("POST", "/decode", strings.NewReader(encodedPayloadJSON))
+	req, err = http.NewRequest("POST", "/decode", strings.NewReader(encodedPayloadsJSON))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -229,6 +229,6 @@ func TestPayloadEncoderHTTPHandler(t *testing.T) {
 	handler.ServeHTTP(rr, req)
 
 	require.Equal(t, http.StatusOK, rr.Code)
-	decodedPayloadJSON := strings.TrimSpace(rr.Body.String())
-	require.Equal(t, string(payloadJSON), decodedPayloadJSON)
+	decodedPayloadsJSON := strings.TrimSpace(rr.Body.String())
+	require.Equal(t, string(payloadsJSON), decodedPayloadsJSON)
 }


### PR DESCRIPTION
## What was changed
The Remote Encoding protocol is adjusted to take Payloads protobuf, not Payload.

## Why?
This makes for more efficient HTTP traffic.