### PR TITLE
Set workflow start time for tests on workflow info

### DIFF
--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -325,7 +325,7 @@ func (env *testWorkflowEnvironmentImpl) setStartTime(startTime time.Time) {
 		startTime = env.wallClock.Now()
 	}
 	env.mockClock.Add(startTime.Sub(env.mockClock.Now()))
-
+	env.workflowInfo.WorkflowStartTime = env.mockClock.Now()
 }
 
 func (env *testWorkflowEnvironmentImpl) newTestWorkflowEnvironmentForChild(params *ExecuteWorkflowParams, callback ResultHandler, startedHandler func(r WorkflowExecution, e error)) (*testWorkflowEnvironmentImpl, error) {

--- a/internal/workflow_testsuite_test.go
+++ b/internal/workflow_testsuite_test.go
@@ -224,3 +224,15 @@ func TestWorkflowIDInsideTestWorkflow(t *testing.T) {
 	require.NoError(t, env.GetWorkflowResult(&str))
 	require.Equal(t, "id is: my-workflow-id", str)
 }
+
+func TestWorkflowStartTimeInsideTestWorkflow(t *testing.T) {
+	var suite WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+	env.ExecuteWorkflow(func(ctx Context) (int64, error) {
+		return GetWorkflowInfo(ctx).WorkflowStartTime.Unix(), nil
+	})
+	require.NoError(t, env.GetWorkflowError())
+	var timestamp int64
+	require.NoError(t, env.GetWorkflowResult(&timestamp))
+	require.Equal(t, env.Now().Unix(), timestamp)
+}


### PR DESCRIPTION
## What was changed

Set `WorkflowInfo.WorkflowStartTime` for the test suite.

## Why?

It wasn't set before.

## Checklist

1. Closes #730