### PR TITLE
Fix session retry and activity cancellation bug

### DIFF
--- a/internal/internal_worker_interfaces_test.go
+++ b/internal/internal_worker_interfaces_test.go
@@ -218,7 +218,7 @@ func (s *InterfacesTestSuite) TestInterface() {
 	}
 
 	// Register activity instances and launch the worker.
-	activityWorker := newActivityWorker(s.service, activityExecutionParameters, nil, registry, nil)
+	activityWorker := newActivityWorker(s.service, activityExecutionParameters, nil, registry)
 	defer activityWorker.Stop()
 	_ = activityWorker.Start()
 

--- a/internal/internal_workers_test.go
+++ b/internal/internal_workers_test.go
@@ -128,7 +128,7 @@ func (s *WorkersTestSuite) TestActivityWorker() {
 	a := &greeterActivity{}
 	registry := newRegistry()
 	registry.addActivityWithLock(a.ActivityType().Name, a)
-	activityWorker := newActivityWorker(s.service, executionParameters, overrides, registry, nil)
+	activityWorker := newActivityWorker(s.service, executionParameters, overrides, registry)
 	_ = activityWorker.Start()
 	activityWorker.Stop()
 }
@@ -176,7 +176,7 @@ func (s *WorkersTestSuite) TestActivityWorkerStop() {
 	a := &greeterActivity{}
 	registry := newRegistry()
 	registry.addActivityWithLock(a.ActivityType().Name, a)
-	worker := newActivityWorker(s.service, executionParameters, overrides, registry, nil)
+	worker := newActivityWorker(s.service, executionParameters, overrides, registry)
 	_ = worker.Start()
 	_ = activityTaskHandler.BlockedOnExecuteCalled()
 	go worker.Stop()

--- a/test/activity_test.go
+++ b/test/activity_test.go
@@ -40,10 +40,11 @@ import (
 )
 
 type Activities struct {
-	client      client.Client
-	mu          sync.Mutex
-	invocations []string
-	activities2 *Activities2
+	client            client.Client
+	mu                sync.Mutex
+	invocations       []string
+	activities2       *Activities2
+	manualStopContext context.Context
 }
 
 type Activities2 struct {
@@ -186,6 +187,14 @@ func (a *Activities) WaitForWorkerStop(ctx context.Context, timeout time.Duratio
 	case <-time.After(timeout):
 		return "timeout", nil
 	}
+}
+
+func (a *Activities) WaitForManualStop(context.Context) error {
+	if a.manualStopContext == nil {
+		return fmt.Errorf("no manual context set")
+	}
+	<-a.manualStopContext.Done()
+	return nil
 }
 
 func (a *Activities) HeartbeatUntilCanceled(ctx context.Context, heartbeatFreq time.Duration) error {


### PR DESCRIPTION
## What was changed

* Disable retries on session creation activity
* Remove session creation's manual checking of max-session limit and instead reuse the worker activity limit
* Fix additional bug on #726 that surfaced during a session cancellation test

## Why?

See #722

Session creation activity (which is really "session run activity" since it spans the life of the session) was originally developed to retry only on a "too many sessions" error it manually returned when checking session count. It was even meant to not retry timeouts in case of worker death. When Temporal removed the ability to specifically disable retries for timeouts, this affected sessions.

Now, instead of the only reason for sessions to retry being a max-limit error, we disable retries on sessions and move max-limit to the activity worker itself. This allows us to remove in-session-creation-activity limit checks and other code that prevented polling during too many sessions.

Also, during development of an integration test, session cancellation without workflow cancellation was causing activity cancellation to have out-of-order command state machine issues similar to those seen in #726. #726 decremented a counter for all activity cancellations even though it incremented the counter only when the workflow was being cancelled. We added a check to make sure we only decrement that counter in the same scenario it was incremented.

## Checklist

1. Closes #722