### PR TITLE
Allow replayer to use local activities with string names

### DIFF
--- a/test/workflow_test.go
+++ b/test/workflow_test.go
@@ -1647,6 +1647,11 @@ func (w *Workflows) ReturnCancelError(
 	return temporal.NewCanceledError("some details")
 }
 
+func (w *Workflows) LocalActivityByStringName(ctx workflow.Context) error {
+	ctx = workflow.WithLocalActivityOptions(ctx, w.defaultLocalActivityOptions())
+	return workflow.ExecuteLocalActivity(ctx, "Prefix_ToUpper", "somestring").Get(ctx, nil)
+}
+
 func (w *Workflows) register(worker worker.Worker) {
 	worker.RegisterWorkflow(w.ActivityCancelRepro)
 	worker.RegisterWorkflow(w.ActivityCompletionUsingID)
@@ -1713,6 +1718,7 @@ func (w *Workflows) register(worker worker.Worker) {
 	worker.RegisterWorkflow(w.TooFewParams)
 	worker.RegisterWorkflow(w.ExecuteRemoteActivityToUpper)
 	worker.RegisterWorkflow(w.ReturnCancelError)
+	worker.RegisterWorkflow(w.LocalActivityByStringName)
 
 	worker.RegisterWorkflow(w.child)
 	worker.RegisterWorkflow(w.childForMemoAndSearchAttr)


### PR DESCRIPTION
## What was changed

Added small piece of code to detect whether replayer is being used and to use a dummy workflow in those cases

## Why?

Unfortunately, the SDK has local activity validation logic to check whether the string-named activity is registered that runs even during replay. The replayer does not require activity registration, so this must be skipped. Out of fear of making significant alterations to local activity validation/execution ordering, a very specific exception was added for replayer.

## Checklist

1. Closes #740