### PR TITLE
Update docstring to use public alias for `workflow.Execution`

### DIFF
--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -159,7 +159,7 @@ type (
 		// get the WorkflowExecution of the child workflow from the future. Then you can use Workflow ID and RunID of
 		// child workflow to cancel or send signal to child workflow.
 		//  childWorkflowFuture := workflow.ExecuteChildWorkflow(ctx, child, ...)
-		//  var childWE WorkflowExecution
+		//  var childWE workflow.Execution
 		//  if err := childWorkflowFuture.GetChildWorkflowExecution().Get(ctx, &childWE); err == nil {
 		//      // child workflow started, you can use childWE to get the WorkflowID and RunID of child workflow
 		//  }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Changed docstring to refer to `workflow.Execution` instead of `WorkflowExecution`.

## Why?
In the docstring describing the async use of `ChildWorkflowExecution`, there is a reference to a type
called `WorkflowExecution`.  This is available in `internal`, but when it is exported through the `workflow`
package, it is actually renamed to `workflow.Execution`.

See: https://github.com/temporalio/sdk-go/blob/c453756356db4e5ae9fcabd416a6a8e57db5cc35/workflow/workflow.go#L45

## Checklist

- This is a pure documentation change.