### PR TITLE
Support OpenMetric-style naming

### DIFF
--- a/contrib/tally/handler.go
+++ b/contrib/tally/handler.go
@@ -33,38 +33,15 @@ type metricsHandler struct{ scope tally.Scope }
 // NewMetricsHandler returns a MetricsHandler that is backed by the given Tally
 // scope.
 //
-// Default metrics are Prometheus compatible but default separator (.) should be
-// replaced with some other character:
+// Default metrics are Prometheus compatible, but they should be sanitized and
+// use the Prometheus naming scope so they are cross-SDK compatible with
+// OpenMetrics naming conventions:
 // 	opts := tally.ScopeOptions{
+// 		SanitizeOptions: &contribtally.PrometheusSanitizeOptions,
 // 		Separator: "_",
 // 	}
 // 	scope, _ := tally.NewRootScope(opts, time.Second)
-//
-// If you have custom metrics make sure they are compatible with Prometheus or
-// create tally scope with sanitizer options set:
-// 	var (
-// 		safeCharacters = []rune{'_'}
-// 		sanitizeOptions = tally.SanitizeOptions{
-// 			NameCharacters: tally.ValidCharacters{
-// 				Ranges:     tally.AlphanumericRange,
-// 				Characters: safeCharacters,
-// 			},
-// 			KeyCharacters: tally.ValidCharacters{
-// 				Ranges:     tally.AlphanumericRange,
-// 				Characters: safeCharacters,
-// 			},
-// 			ValueCharacters: tally.ValidCharacters{
-// 				Ranges:     tally.AlphanumericRange,
-// 				Characters: safeCharacters,
-// 			},
-// 			ReplacementCharacter: tally.DefaultReplacementCharacter,
-// 		}
-// 	)
-// 	opts := tally.ScopeOptions{
-// 		SanitizeOptions: &sanitizeOptions,
-// 		Separator: "_",
-// 	}
-// 	scope, _ := tally.NewRootScope(opts, time.Second)
+// 	scope = contribtally.NewPrometheusNamingScope(scope)
 func NewMetricsHandler(scope tally.Scope) client.MetricsHandler {
 	return metricsHandler{scope}
 }

--- a/contrib/tally/prometheus.go
+++ b/contrib/tally/prometheus.go
@@ -1,0 +1,82 @@
+// The MIT License
+//
+// Copyright (c) 2022 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package tally
+
+import (
+	"strings"
+
+	"github.com/uber-go/tally/v4"
+)
+
+// PrometheusSanitizeOptions is the set of sanitize options for
+// tally.ScopeOptions to match Prometheus naming rules.
+var PrometheusSanitizeOptions = tally.SanitizeOptions{
+	NameCharacters:       tally.ValidCharacters{Ranges: tally.AlphanumericRange, Characters: []rune{'_'}},
+	KeyCharacters:        tally.ValidCharacters{Ranges: tally.AlphanumericRange, Characters: []rune{'_'}},
+	ValueCharacters:      tally.ValidCharacters{Ranges: tally.AlphanumericRange, Characters: []rune{'_'}},
+	ReplacementCharacter: tally.DefaultReplacementCharacter,
+}
+
+type prometheusNamingScope struct{ scope tally.Scope }
+
+// NewPrometheusNamingScope makes a scope that appends certain strings to names
+// to conform to OpenMetrics naming standards. This should be used in addition
+// to DefaultPrometheusSanitizeOptions.
+func NewPrometheusNamingScope(scope tally.Scope) tally.Scope { return &prometheusNamingScope{scope} }
+
+func (p *prometheusNamingScope) Counter(name string) tally.Counter {
+	if !strings.HasSuffix(name, "_total") {
+		name += "_total"
+	}
+	return p.scope.Counter(name)
+}
+
+func (p *prometheusNamingScope) Gauge(name string) tally.Gauge {
+	return p.scope.Gauge(name)
+}
+
+func (p *prometheusNamingScope) Timer(name string) tally.Timer {
+	if !strings.HasSuffix(name, "_seconds") {
+		name += "_seconds"
+	}
+	return p.scope.Timer(name)
+}
+
+func (p *prometheusNamingScope) Histogram(name string, buckets tally.Buckets) tally.Histogram {
+	if strings.HasSuffix(name, "_seconds") {
+		name += "_seconds"
+	}
+	return p.scope.Histogram(name, buckets)
+}
+
+func (p *prometheusNamingScope) Tagged(tags map[string]string) tally.Scope {
+	return &prometheusNamingScope{p.scope.Tagged(tags)}
+}
+
+func (p *prometheusNamingScope) SubScope(name string) tally.Scope {
+	return &prometheusNamingScope{p.scope.SubScope(name)}
+}
+
+func (p *prometheusNamingScope) Capabilities() tally.Capabilities {
+	return p.scope.Capabilities()
+}

--- a/contrib/tally/prometheus_test.go
+++ b/contrib/tally/prometheus_test.go
@@ -1,0 +1,66 @@
+// The MIT License
+//
+// Copyright (c) 2022 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package tally_test
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/uber-go/tally/v4"
+	contribtally "go.temporal.io/sdk/contrib/tally"
+)
+
+func TestPrometheusNaming(t *testing.T) {
+	scope, _ := tally.NewRootScope(tally.ScopeOptions{
+		SanitizeOptions: &contribtally.PrometheusSanitizeOptions,
+		Separator:       "_",
+	}, time.Second)
+	testScope := scope.(tally.TestScope)
+	scope = contribtally.NewPrometheusNamingScope(scope)
+	handler := contribtally.NewMetricsHandler(scope)
+
+	handler.Counter("counter_foo.bar").Inc(1)
+	handler.Gauge("gauge_foo.bar").Update(2.0)
+	handler.Timer("timer_foo.bar").Record(3 * time.Second)
+
+	snap := testScope.Snapshot()
+	var metrics []string
+	for _, c := range snap.Counters() {
+		metrics = append(metrics, fmt.Sprintf("%v - %v", c.Name(), c.Value()))
+	}
+	for _, g := range snap.Gauges() {
+		metrics = append(metrics, fmt.Sprintf("%v - %v", g.Name(), g.Value()))
+	}
+	for _, t := range snap.Timers() {
+		metrics = append(metrics, fmt.Sprintf("%v - %v", t.Name(), t.Values()[0]))
+	}
+	sort.Strings(metrics)
+	require.Equal(t, []string{
+		"counter_foo_bar_total - 1",
+		"gauge_foo_bar - 2",
+		"timer_foo_bar_seconds - 3s",
+	}, metrics)
+}


### PR DESCRIPTION
## What was changed

Made the suggested sanitize options a var and added a Prometheus scope wrapper to put proper suffixes on names

## Why?

See #750. We want to match Java SDK naming. Tally unfortunately only lets you sanitize characters with the options so we have to wrap the scope.

Since Prometheus support is an opt-in convention, we changed the documentation on how to do it and will be changing the sample when this is released.

## Checklist

1. Closes #750