### PR TITLE
GitHub CI action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: Continuous Integration
+on: # rebuild any PRs and main branch changes
+  pull_request:
+  push:
+    branches:
+      - main
+      - 'releases/*'
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Print build information
+        run: "echo head_ref: ${{ github.head_ref }}, ref: ${{ github.ref }}"
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - uses: actions/setup-go@v2
+        with:
+          go-version: "1.17"
+      - name: Check and unit test
+        run: make check unit-test
+      - name: Get Temporal docker-compose.yml
+        # We intentionally get the latest here
+        run: wget https://raw.githubusercontent.com/temporalio/docker-compose/main/docker-compose.yml
+      - name: Start Temporal Server
+        run: docker-compose up -d
+      - name: Integration tests (without cache)
+        run: make integration-test-zero-cache
+      - name: Integration tests (with cache)
+        run: make integration-test-normal-cache


### PR DESCRIPTION
## What was changed

Added GH CI action for building and testing this project (to eventually replace BuildKite)

## Why?

GH actions are more visible and are easier to contribute to