### PR TITLE
Add cloud test to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,24 @@ jobs:
         run: make integration-test-zero-cache
       - name: Integration tests (with cache)
         run: make integration-test-normal-cache
+
+  cloud-test:
+    runs-on: ubuntu-latest
+    env:
+      SERVICE_ADDR: tinycicd.sdk.tmprl.cloud:7233
+      TEMPORAL_NAMESPACE: tinycicd.sdk
+      TEMPORAL_CLIENT_CERT: ${{ secrets.TEMPORAL_CLIENT_CERT }}
+      TEMPORAL_CLIENT_KEY: ${{ secrets.TEMPORAL_CLIENT_KEY }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+        if: ${{ env.TEMPORAL_CLIENT_CERT != '' }}
+      - uses: actions/setup-go@v2
+        with:
+          go-version: "1.17"
+        if: ${{ env.TEMPORAL_CLIENT_CERT != '' }}
+      - name: Single integration test against cloud
+        run: 'go test -v --count 1 -p 1 . -run "TestIntegrationSuite/TestBasic$"'
+        working-directory: test
+        if: ${{ env.TEMPORAL_CLIENT_CERT != '' }}


### PR DESCRIPTION
## What was changed

Allow integration tests to use env-var-based cert/namespace and add cloud test to CI

## Why?

We need to ensure at least the most basic workflows work on cloud always