### PR TITLE
Add cloud test to GH action CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,7 @@ on:
   pull_request:
   push:
     branches:
-      - main
-      - 'releases/*'
+      - master
 
 jobs:
   build-and-test:
@@ -33,3 +32,24 @@ jobs:
         run: make integration-test-zero-cache
       - name: Integration tests (with cache)
         run: make integration-test-normal-cache
+
+  cloud-test:
+    runs-on: ubuntu-latest
+    env:
+      SERVICE_ADDR: tinycicd.sdk.tmprl.cloud:7233
+      TEMPORAL_NAMESPACE: tinycicd.sdk
+      TEMPORAL_CLIENT_CERT: ${{ secrets.TEMPORAL_CLIENT_CERT }}
+      TEMPORAL_CLIENT_KEY: ${{ secrets.TEMPORAL_CLIENT_KEY }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+        if: ${{ env.TEMPORAL_CLIENT_CERT != '' }}
+      - uses: actions/setup-go@v2
+        with:
+          go-version: "1.17"
+        if: ${{ env.TEMPORAL_CLIENT_CERT != '' }}
+      - name: Single integration test against cloud
+        run: 'go test -v --count 1 -p 1 . -run "TestIntegrationSuite/TestBasic$"'
+        working-directory: test
+        if: ${{ env.TEMPORAL_CLIENT_CERT != '' }}


### PR DESCRIPTION
## What was changed

Allow integration tests to use env-var-based cert/namespace and add cloud test to CI for GH action

## Why?

We need to ensure at least the most basic workflows work on cloud always

Note: Secrets that are needed by this test cannot be accessed by forks. So this test only runs on branches from this repo. Not only do we run it on master push, but we will also amend the release process to ensure the PR updating the version is done from a branch _on the repo_ to ensure this test failing will hold up a release.