### PR TITLE
Allow data converters to be created without deadlock detection

### DIFF
--- a/converter/data_converter.go
+++ b/converter/data_converter.go
@@ -35,6 +35,9 @@ type (
 	// To override DataConverter for specific activity or child workflow use workflow.WithDataConverter to create new Context,
 	// and pass that context to ExecuteActivity/ExecuteChildWorkflow calls.
 	// Temporal support using different DataConverters for different activity/childWorkflow in same workflow.
+	// For advanced data converters that may exceed the deadlock detection timeout
+	// for a workflow, such as ones making remote calls, use
+	// workflow.DataConverterWithoutDeadlockDetection.
 	DataConverter interface {
 		// ToPayload converts single value to payload.
 		ToPayload(value interface{}) (*commonpb.Payload, error)

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -1057,7 +1057,8 @@ func signalExternalWorkflow(ctx Context, workflowID, runID, signalName string, a
 		return future
 	}
 
-	input, err := encodeArg(options.DataConverter, arg)
+	dataConverter := getDataConverterFromWorkflowContext(ctx)
+	input, err := encodeArg(dataConverter, arg)
 	if err != nil {
 		settable.Set(nil, err)
 		return future

--- a/internal/workflow_deadlock.go
+++ b/internal/workflow_deadlock.go
@@ -1,0 +1,219 @@
+// The MIT License
+//
+// Copyright (c) 2022 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package internal
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	commonpb "go.temporal.io/api/common/v1"
+	"go.temporal.io/sdk/converter"
+)
+
+type deadlockDetector struct {
+	lock    sync.RWMutex // Applies to all fields below
+	tickers map[*deadlockTicker]struct{}
+	paused  bool
+}
+
+type deadlockTicker struct {
+	d *deadlockDetector
+
+	lock                sync.Mutex // Applies to all fields below
+	t                   *time.Ticker
+	paused              bool
+	expectedExpiration  time.Time
+	pausedWithRemaining time.Duration
+}
+
+// PauseDeadlockDetector pauses the deadlock detector for all coroutines.
+func PauseDeadlockDetector(ctx Context) {
+	if d := getDeadlockDetector(ctx); d != nil {
+		d.pause()
+	}
+}
+
+// ResumeDeadlockDetector resumes the deadlock detector for all coroutines.
+func ResumeDeadlockDetector(ctx Context) {
+	if d := getDeadlockDetector(ctx); d != nil {
+		d.resume()
+	}
+}
+
+// DataConverterWithoutDeadlockDetection returns a data converter that disables
+// workflow deadlock detection for each call on the data converter. This should
+// be used for advanced data converters that may perform remote calls or
+// otherwise intentionally execute longer than the default deadlock detection
+// timeout.
+func DataConverterWithoutDeadlockDetection(c converter.DataConverter) converter.DataConverter {
+	return &dataConverterWithoutDeadlock{underlying: c}
+}
+
+// getDeadlockDetector returns the deadlock detector if the context represents
+// a running workflow or nil if not.
+func getDeadlockDetector(ctx Context) *deadlockDetector {
+	if s := getStateIfRunning(ctx); s != nil {
+		return s.dispatcher.deadlockDetector
+	}
+	return nil
+}
+
+func newDeadlockDetector() *deadlockDetector {
+	return &deadlockDetector{tickers: map[*deadlockTicker]struct{}{}}
+}
+
+// begin starts a new deadlock detection ticker which may start as paused
+// depending on the state of the detector. Callers must call end to clean up the
+// ticker.
+func (d *deadlockDetector) begin(timeout time.Duration) *deadlockTicker {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+	t := &deadlockTicker{d: d, paused: d.paused}
+	// Set different values based on whether paused or not
+	if d.paused {
+		t.t = time.NewTicker(unlimitedDeadlockDetectionTimeout)
+		t.pausedWithRemaining = timeout
+	} else {
+		t.t = time.NewTicker(timeout)
+		t.expectedExpiration = time.Now().Add(timeout)
+	}
+	d.tickers[t] = struct{}{}
+	return t
+}
+
+func (d *deadlockDetector) pause() {
+	d.lock.RLock()
+	defer d.lock.RUnlock()
+	for t := range d.tickers {
+		t.pause()
+	}
+	d.paused = true
+}
+
+func (d *deadlockDetector) resume() {
+	d.lock.RLock()
+	defer d.lock.RUnlock()
+	for t := range d.tickers {
+		t.resume()
+	}
+	d.paused = false
+}
+
+func (d *deadlockTicker) reached() <-chan time.Time {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+	if d.t == nil {
+		return nil
+	}
+	return d.t.C
+}
+
+func (d *deadlockTicker) pause() {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+	if d.paused || d.t == nil {
+		return
+	}
+	d.t.Stop()
+	d.paused = true
+	d.pausedWithRemaining = time.Until(d.expectedExpiration)
+	// To prevent later panic, we make this at least 1
+	if d.pausedWithRemaining < 1 {
+		d.pausedWithRemaining = 1
+	}
+}
+
+func (d *deadlockTicker) resume() {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+	if !d.paused || d.t == nil {
+		return
+	}
+	d.paused = false
+	d.t.Reset(d.pausedWithRemaining)
+	// We intentionally put this after reset and accept that this is later than
+	// the reset time to be safe
+	d.expectedExpiration = time.Now().Add(d.pausedWithRemaining)
+}
+
+func (d *deadlockTicker) end() {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+	d.d.lock.Lock()
+	delete(d.d.tickers, d)
+	d.d.lock.Unlock()
+	d.t.Stop()
+	d.t = nil
+}
+
+type dataConverterWithoutDeadlock struct {
+	context    Context
+	underlying converter.DataConverter
+}
+
+var _ ContextAware = &dataConverterWithoutDeadlock{}
+
+func (d *dataConverterWithoutDeadlock) ToPayload(value interface{}) (*commonpb.Payload, error) {
+	PauseDeadlockDetector(d.context)
+	defer ResumeDeadlockDetector(d.context)
+	return d.underlying.ToPayload(value)
+}
+
+func (d *dataConverterWithoutDeadlock) FromPayload(payload *commonpb.Payload, valuePtr interface{}) error {
+	PauseDeadlockDetector(d.context)
+	defer ResumeDeadlockDetector(d.context)
+	return d.underlying.FromPayload(payload, valuePtr)
+}
+
+func (d *dataConverterWithoutDeadlock) ToPayloads(value ...interface{}) (*commonpb.Payloads, error) {
+	PauseDeadlockDetector(d.context)
+	defer ResumeDeadlockDetector(d.context)
+	return d.underlying.ToPayloads(value...)
+}
+
+func (d *dataConverterWithoutDeadlock) FromPayloads(payloads *commonpb.Payloads, valuePtrs ...interface{}) error {
+	PauseDeadlockDetector(d.context)
+	defer ResumeDeadlockDetector(d.context)
+	return d.underlying.FromPayloads(payloads, valuePtrs...)
+}
+
+func (d *dataConverterWithoutDeadlock) ToString(input *commonpb.Payload) string {
+	PauseDeadlockDetector(d.context)
+	defer ResumeDeadlockDetector(d.context)
+	return d.underlying.ToString(input)
+}
+
+func (d *dataConverterWithoutDeadlock) ToStrings(input *commonpb.Payloads) []string {
+	PauseDeadlockDetector(d.context)
+	defer ResumeDeadlockDetector(d.context)
+	return d.underlying.ToStrings(input)
+}
+
+func (d *dataConverterWithoutDeadlock) WithWorkflowContext(ctx Context) converter.DataConverter {
+	return &dataConverterWithoutDeadlock{context: ctx, underlying: d.underlying}
+}
+
+func (d *dataConverterWithoutDeadlock) WithContext(ctx context.Context) converter.DataConverter {
+	return d
+}

--- a/internal/workflow_deadlock_test.go
+++ b/internal/workflow_deadlock_test.go
@@ -1,0 +1,92 @@
+// The MIT License
+//
+// Copyright (c) 2022 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package internal
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	commonpb "go.temporal.io/api/common/v1"
+	"go.temporal.io/sdk/converter"
+)
+
+func TestDeadlockDetector(t *testing.T) {
+	// Create a 500ms ticker and confirm it pauses/resumes properly. We have
+	// chosen to use real time instead of an abstract clock here for simplicity.
+	d := newDeadlockDetector()
+	ticker := d.begin(500 * time.Millisecond)
+	defer ticker.end()
+	d.pause()
+	// Confirm never reached while paused
+	select {
+	case <-time.After(600 * time.Millisecond):
+	case <-ticker.reached():
+		t.Fatal("unexpectedly reached deadlock")
+	}
+	// Resume and confirm reached
+	d.resume()
+	select {
+	case <-time.After(600 * time.Millisecond):
+		t.Fatal("unexpectedly didn't deadlock")
+	case <-ticker.reached():
+	}
+}
+
+func TestDataConverterWithoutDeadlockDetection(t *testing.T) {
+	conv := converter.GetDefaultDataConverter()
+
+	runWorkflow := func() {
+		var suite WorkflowTestSuite
+		activityFn := func(ctx context.Context, arg string) error {
+			return nil
+		}
+		workflowFn := func(ctx Context) error {
+			ctx = WithDataConverter(ctx, conv)
+			ctx = WithActivityOptions(ctx, ActivityOptions{ScheduleToCloseTimeout: 10 * time.Second})
+			return ExecuteActivity(ctx, activityFn, "some arg").Get(ctx, nil)
+		}
+		env := suite.NewTestWorkflowEnvironment()
+		env.SetWorkerOptions(WorkerOptions{DeadlockDetectionTimeout: 400 * time.Millisecond})
+		env.RegisterWorkflow(workflowFn)
+		env.RegisterActivity(activityFn)
+		env.ExecuteWorkflow(workflowFn)
+		require.True(t, env.IsWorkflowCompleted())
+	}
+
+	// Run with a slow converter and confirm it panics
+	conv = &slowToPayloadsConverter{conv}
+	require.Panics(t, runWorkflow)
+
+	// Run with that same payload converter without deadlock detection
+	conv = DataConverterWithoutDeadlockDetection(conv)
+	require.NotPanics(t, runWorkflow)
+}
+
+type slowToPayloadsConverter struct{ converter.DataConverter }
+
+func (s *slowToPayloadsConverter) ToPayloads(value ...interface{}) (*commonpb.Payloads, error) {
+	time.Sleep(600 * time.Millisecond)
+	return s.DataConverter.ToPayloads(value...)
+}

--- a/internal/workflow_deadlock_test.go
+++ b/internal/workflow_deadlock_test.go
@@ -82,6 +82,12 @@ func TestDataConverterWithoutDeadlockDetection(t *testing.T) {
 	// Run with that same payload converter without deadlock detection
 	conv = DataConverterWithoutDeadlockDetection(conv)
 	require.NotPanics(t, runWorkflow)
+
+	// Also confirm outside of workflow, pause/resume is noop
+	_, err := conv.ToPayload("foo")
+	require.NoError(t, err)
+	_, err = conv.(ContextAware).WithWorkflowContext(Background()).ToPayload("foo")
+	require.NoError(t, err)
 }
 
 type slowToPayloadsConverter struct{ converter.DataConverter }

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -487,3 +487,12 @@ func IsContinueAsNewError(err error) bool {
 	var continueAsNewErr *ContinueAsNewError
 	return errors.As(err, &continueAsNewErr)
 }
+
+// DataConverterWithoutDeadlockDetection returns a data converter that disables
+// workflow deadlock detection for each call on the data converter. This should
+// be used for advanced data converters that may perform remote calls or
+// otherwise intentionally execute longer than the default deadlock detection
+// timeout.
+func DataConverterWithoutDeadlockDetection(c converter.DataConverter) converter.DataConverter {
+	return internal.DataConverterWithoutDeadlockDetection(c)
+}


### PR DESCRIPTION
## What was changed

Added `workflow.DataConverterWithoutDeadlockDetection` to create data converters without deadlock detection. Also reworked deadlock detection internally so it can be paused and resumed.

## Why?

Some data converters need to do advanced things

## Checklist

1. Closes #769