### PR TITLE
Fix template recursion in workflowcheck

### DIFF
--- a/contrib/tools/workflowcheck/workflow/checker.go
+++ b/contrib/tools/workflowcheck/workflow/checker.go
@@ -180,7 +180,7 @@ func (c *Checker) Run(pass *analysis.Pass) error {
 				// One report per reason
 				for _, reason := range nonDeterminisms {
 					lines := determinism.NonDeterminisms{reason}.AppendChildReasonLines(
-						fn.FullName(), nil, 0, depthRepeat, c.IncludePosOnMessage, fn.Pkg(), lookupCache)
+						fn.FullName(), nil, 0, depthRepeat, c.IncludePosOnMessage, fn.Pkg(), lookupCache, map[string]bool{})
 					pass.Report(analysis.Diagnostic{Pos: callExpr.Pos(), Message: strings.Join(lines, hierarchySeparator)})
 				}
 			}

--- a/contrib/tools/workflowcheck/workflow/testdata/src/a/workflow.go
+++ b/contrib/tools/workflowcheck/workflow/testdata/src/a/workflow.go
@@ -1,6 +1,7 @@
 package a //want package:"\\d+ non-deterministic vars/funcs"
 
 import (
+	"text/template"
 	"time"
 
 	"go.temporal.io/sdk/worker"
@@ -13,6 +14,7 @@ func PrepWorkflow() {
 	wrk.RegisterWorkflow(WorkflowCallTime)             // want "a.WorkflowCallTime is non-deterministic, reason: calls non-deterministic function time.Now"
 	wrk.RegisterWorkflow(WorkflowCallTimeTransitively) // want "a.WorkflowCallTimeTransitively is non-deterministic, reason: calls non-deterministic function a.SomeTimeCall"
 	wrk.RegisterWorkflow(WorkflowIterateMap)           // want "a.WorkflowIterateMap is non-deterministic, reason: iterates over map"
+	wrk.RegisterWorkflow(WorkflowWithTemplate)         // want "a.WorkflowWithTemplate is non-deterministic, reason: calls non-deterministic function \\(\\*text/template\\.Template\\)\\.Execute.*"
 }
 
 func WorkflowNop(ctx workflow.Context) error {
@@ -38,4 +40,8 @@ func WorkflowIterateMap(ctx workflow.Context) error { // want WorkflowIterateMap
 	for range m {
 	}
 	return nil
+}
+
+func WorkflowWithTemplate(ctx workflow.Context) error { // want WorkflowWithTemplate:"calls non-deterministic function \\(\\*text/template\\.Template\\)\\.Execute.*"
+	return template.New("mytmpl").Execute(nil, nil)
 }


### PR DESCRIPTION
## What was changed

Prevent recursion on outputted lines in `workflowcheck`

## Why?

While Go does not usually allow cross-package recursion, a special case is being triggered by the `text/template` package

## Checklist

1. Closes #767