### PR TITLE
Properly paginate when using service for replayer

### DIFF
--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -2068,6 +2068,40 @@ func (ts *IntegrationTestSuite) TestSessionOnWorkerFailure() {
 	ts.Truef(strings.HasSuffix(err.Error(), "activity on session #1 failed: canceled"), "wrong error, got: %v", err)
 }
 
+func (ts *IntegrationTestSuite) TestLargeHistoryReplay() {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Start workflow
+	run, err := ts.client.ExecuteWorkflow(
+		ctx,
+		ts.startWorkflowOptions("test-large-history-replay"),
+		ts.workflows.PanicOnSignal,
+	)
+	ts.NoError(err)
+
+	// Send 300 signals to go over page limit
+	for i := 0; i < 300; i++ {
+		ts.NoError(ts.client.SignalWorkflow(ctx, run.GetID(), run.GetRunID(), "unhandled-signal", "some-arg"))
+	}
+
+	// Now cause panic and confirm error
+	var ret string
+	ts.NoError(ts.client.SignalWorkflow(ctx, run.GetID(), run.GetRunID(), "panic-signal", nil))
+	err = run.Get(ctx, &ret)
+	ts.Error(err)
+	ts.Contains(err.Error(), "intentional panic")
+
+	// Try to replay from just service and confirm panic which means it reached
+	// last signal
+	replayer := worker.NewWorkflowReplayer()
+	replayer.RegisterWorkflow(ts.workflows.PanicOnSignal)
+	err = replayer.ReplayWorkflowExecution(ctx, ts.client.WorkflowService(), nil,
+		ts.config.Namespace, workflow.Execution{ID: run.GetID(), RunID: run.GetRunID()})
+	ts.Error(err)
+	ts.Contains(err.Error(), "intentional panic")
+}
+
 func (ts *IntegrationTestSuite) registerNamespace() {
 	client, err := client.NewNamespaceClient(client.Options{
 		HostPort:          ts.config.ServiceAddr,

--- a/test/workflow_test.go
+++ b/test/workflow_test.go
@@ -1737,6 +1737,12 @@ func (w *Workflows) LocalActivityByStringName(ctx workflow.Context) error {
 	return workflow.ExecuteLocalActivity(ctx, "Prefix_ToUpper", "somestring").Get(ctx, nil)
 }
 
+func (w *Workflows) PanicOnSignal(ctx workflow.Context) error {
+	// Wait for signal then panic
+	workflow.GetSignalChannel(ctx, "panic-signal").Receive(ctx, nil)
+	panic("intentional panic")
+}
+
 func (w *Workflows) register(worker worker.Worker) {
 	worker.RegisterWorkflow(w.ActivityCancelRepro)
 	worker.RegisterWorkflow(w.ActivityCompletionUsingID)
@@ -1805,6 +1811,7 @@ func (w *Workflows) register(worker worker.Worker) {
 	worker.RegisterWorkflow(w.ExecuteRemoteActivityToUpper)
 	worker.RegisterWorkflow(w.ReturnCancelError)
 	worker.RegisterWorkflow(w.LocalActivityByStringName)
+	worker.RegisterWorkflow(w.PanicOnSignal)
 
 	worker.RegisterWorkflow(w.child)
 	worker.RegisterWorkflow(w.childForMemoAndSearchAttr)


### PR DESCRIPTION
## What was changed

Added pagination when using `worker.WorkflowReplayer.ReplayWorkflowExecution` which accepts a direct gRPC service

## Why?

This wasn't paginating before (nobody probably used it before because we only exposed the raw gRPC service recently, but this function has been around a long time for some reason).

## Checklist

1. Closes #781 