### PR TITLE
Minor doc fixes

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -261,12 +261,11 @@ type (
 		//  - serviceerror.NotFound
 		ListOpenWorkflow(ctx context.Context, request *workflowservice.ListOpenWorkflowExecutionsRequest) (*workflowservice.ListOpenWorkflowExecutionsResponse, error)
 
-		// ListWorkflow gets workflow executions based on query. This API only works with ElasticSearch,
-		// and will return serviceerror.InvalidArgument when using Cassandra or MySQL. The query is basically the SQL WHERE clause,
-		// examples:
+		// ListWorkflow gets workflow executions based on query. The query is basically the SQL WHERE clause, examples:
 		//  - "(WorkflowID = 'wid1' or (WorkflowType = 'type2' and WorkflowID = 'wid2'))".
 		//  - "CloseTime between '2019-08-27T15:04:05+00:00' and '2019-08-28T15:04:05+00:00'".
 		//  - to list only open workflow use "CloseTime = missing"
+		// Advanced queries require ElasticSearch, but simple queries do not.
 		// Retrieved workflow executions are sorted by StartTime in descending order when list open workflow,
 		// and sorted by CloseTime in descending order for other queries.
 		// The errors it can return:

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -418,18 +418,18 @@ func HasLastCompletionResult(ctx Context) bool {
 	return internal.HasLastCompletionResult(ctx)
 }
 
-// GetLastCompletionResult extract last completion result from previous run for this cron workflow.
+// GetLastCompletionResult extract last completion result from the last successful run for this cron workflow.
 // This is used in combination with cron schedule. A workflow can be started with an optional cron schedule.
 // If a cron workflow wants to pass some data to next schedule, it can return any data and that data will become
-// available when next run starts.
+// available when next run starts. This will contain the last successful result even if the most recent run failed.
 // This GetLastCompletionResult() extract the data into expected data structure.
 // See TestWorkflowEnvironment.SetLastCompletionResult() for unit test support.
 func GetLastCompletionResult(ctx Context, d ...interface{}) error {
 	return internal.GetLastCompletionResult(ctx, d...)
 }
 
-// GetLastError extracts the latest failure from any from previous run for this workflow, if one has failed. If none
-// have failed, nil is returned.
+// GetLastError extracts the error from the last run of this workflow. If the last run of this workflow did not fail or
+// this is the first run, this will be nil.
 //
 // See TestWorkflowEnvironment.SetLastError() for unit test support.
 func GetLastError(ctx Context) error {


### PR DESCRIPTION
## What was changed

* Made clear on `workflow.GetLastError` and `workflow.GetLastCompletionResult` that the former doesn't carry over and the latter does
* Updated `client.Client.ListWorkflow` to say that some queries do not require ElasticSearch (while _intentionally_ not documenting all the details of which ones do/don't at the moment).

1. Closes #786
2. Closes #742