### PR TITLE
Add update-go-sum target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,19 +76,24 @@ cover_ci: $(COVER_ROOT)/cover.out
 
 vet: $(ALL_SRC)
 	@for dir in $(MOD_DIRS); do \
-		(cd "$$dir" && go vet ./...) || exit 1; \
+		(cd "$$dir" && echo "In $$dir" && go vet ./...) || exit 1; \
 	done;
 
 staticcheck: $(ALL_SRC)
 	go install honnef.co/go/tools/cmd/staticcheck@latest
 	@for dir in $(MOD_DIRS); do \
-		(cd "$$dir" && staticcheck ./...) || exit 1; \
+		(cd "$$dir" && echo "In $$dir" && staticcheck ./...) || exit 1; \
 	done;
 
 errcheck: $(ALL_SRC)
 	GO111MODULE=off go get -u github.com/kisielk/errcheck
 	@for dir in $(MOD_DIRS); do \
-		(cd "$$dir" && errcheck ./...) || exit 1; \
+		(cd "$$dir" && echo "In $$dir" && errcheck ./...) || exit 1; \
+	done;
+
+update-go-sum: $(ALL_SRC)
+	@for dir in $(MOD_DIRS); do \
+		(cd "$$dir" && echo "In $$dir" && go get ./...) || exit 1; \
 	done;
 
 fmt:


### PR DESCRIPTION
## What was changed
Add `make update-go-sum` to propagate go.sum changes into other modules. It just does `go get ./...` in each module.

Also have the for-each-module loops in the Makefile echo the directory they're running in, which would have saved me a few minutes of confusion.

## Why?
developer experience

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
manually

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
