### PR TITLE
Ignore termination event

### DIFF
--- a/internal/internal_event_handlers.go
+++ b/internal/internal_event_handlers.go
@@ -879,6 +879,9 @@ func (weh *workflowExecutionEventHandlerImpl) ProcessEvent(
 	case enumspb.EVENT_TYPE_EXTERNAL_WORKFLOW_EXECUTION_CANCEL_REQUESTED:
 		_ = weh.handleExternalWorkflowExecutionCancelRequested(event)
 
+	case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_TERMINATED:
+		// No Operation
+
 	case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_CONTINUED_AS_NEW:
 		// No Operation.
 


### PR DESCRIPTION
## What was changed

Added ignore for event type `EVENT_TYPE_WORKFLOW_EXECUTION_TERMINATED`

## Why?

Replay was logging an error when this event was received (but it was not stopping/erroring replay)

## Checklist

1. Closes #815

2. How was this tested: This was not tested. Today this only emits a log when this event is received (it doesn't harm running programs), and even then it's only on non-replay which I have struggled to simulate this event type during non-replay.
