### PR TITLE
Ignore workflow package during determinism checks

### DIFF
--- a/contrib/tools/workflowcheck/workflow/checker.go
+++ b/contrib/tools/workflowcheck/workflow/checker.go
@@ -138,6 +138,12 @@ func (c *Checker) Run(pass *analysis.Pass) error {
 		hierarchySeparator, depthRepeat = " -> ", ""
 	}
 
+	// If it's the workflow package, we assume the entire package is deterministic
+	// so we don't run a pass on it
+	if pass.Pkg.Path() == "go.temporal.io/sdk/workflow" {
+		return nil
+	}
+
 	// Run determinism pass
 	if _, err := c.Determinism.Run(pass); err != nil {
 		return err

--- a/contrib/tools/workflowcheck/workflow/testdata/src/a/workflow.go
+++ b/contrib/tools/workflowcheck/workflow/testdata/src/a/workflow.go
@@ -15,6 +15,7 @@ func PrepWorkflow() {
 	wrk.RegisterWorkflow(WorkflowCallTimeTransitively) // want "a.WorkflowCallTimeTransitively is non-deterministic, reason: calls non-deterministic function a.SomeTimeCall"
 	wrk.RegisterWorkflow(WorkflowIterateMap)           // want "a.WorkflowIterateMap is non-deterministic, reason: iterates over map"
 	wrk.RegisterWorkflow(WorkflowWithTemplate)         // want "a.WorkflowWithTemplate is non-deterministic, reason: calls non-deterministic function \\(\\*text/template\\.Template\\)\\.Execute.*"
+	wrk.RegisterWorkflow(WorkflowWithAwait)
 }
 
 func WorkflowNop(ctx workflow.Context) error {
@@ -44,4 +45,10 @@ func WorkflowIterateMap(ctx workflow.Context) error { // want WorkflowIterateMap
 
 func WorkflowWithTemplate(ctx workflow.Context) error { // want WorkflowWithTemplate:"calls non-deterministic function \\(\\*text/template\\.Template\\)\\.Execute.*"
 	return template.New("mytmpl").Execute(nil, nil)
+}
+
+func WorkflowWithAwait(ctx workflow.Context) error {
+	// We do not expect this to fail
+	_, err := workflow.AwaitWithTimeout(ctx, 5*time.Second, func() bool { return true })
+	return err
 }

--- a/contrib/tools/workflowcheck/workflow/testdata/src/go.temporal.io/sdk/workflow/workflow.go
+++ b/contrib/tools/workflowcheck/workflow/testdata/src/go.temporal.io/sdk/workflow/workflow.go
@@ -1,5 +1,13 @@
 package workflow
 
+import "time"
+
 type RegisterOptions struct{}
 
 type Context interface{}
+
+func AwaitWithTimeout(ctx Context, timeout time.Duration, condition func() bool) (ok bool, err error) {
+	// Intentionally simulate non-deterministic call internally
+	time.Sleep(10 * time.Second)
+	return false, nil
+}


### PR DESCRIPTION
## What was changed

Properly ignore all calls to the `go.temporal.io/sdk/workflow` package during determinism check

## Why?

This was giving false positives

## Checklist

1. Closes #818