### PR TITLE
Clarify that returning error from Workflow results in Failure

### DIFF
--- a/workflow/doc.go
+++ b/workflow/doc.go
@@ -89,7 +89,7 @@ A workflow can have one or more such parameters. All parameters to an workflow f
 essentially means that params can’t be channels, functions, variadic, or unsafe pointer.
 
 Since it only declares error as the return value it means that the workflow does not return a value. The error return
-value is used to indicate an error was encountered during execution and the workflow should be terminated.
+value is used to indicate an error was encountered during execution and the workflow should be failed.
 
 Implementation
 


### PR DESCRIPTION
## What was changed
Changed one word in Go Workflow documentation to clarify what happens when a Workflow returns an error.

## Why?
The original text, "The error return value is used to indicate an error was encountered during execution and the workflow should be terminated" may be  confusing. 

Although it is true that the Workflow will be terminated in the general sense (i.e., execution stops), the Workflow's status in this case will be failed, not terminated. Since Temporal has a status called "terminated" (i.e., which would result from clicking the Terminate button in the Web UI for a running workflow), I propose changing "terminated" to "failed" here.

## Checklist
1. Closes N/A (no issue for this one-word change)

2. How was this tested:
I reviewed the text before and after the change to verify that my change was present. I used diff to ensure that no unwanted changes were introduced.

3. Any docs updates needed?
No, this only affects the description in the Go SDK documentation. The documentation on `docs.temporal.io` correctly describes that returning an error from a Workflow function will result in failure.