### PR TITLE
Helper for loading history from JSON

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -31,9 +31,11 @@ package client
 
 import (
 	"context"
+	"io"
 
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
+	historypb "go.temporal.io/api/history/v1"
 	"go.temporal.io/api/workflowservice/v1"
 
 	"go.temporal.io/sdk/converter"
@@ -500,4 +502,16 @@ func NewValue(data *commonpb.Payloads) converter.EncodedValue {
 //   NewValues(data).Get(&result1, &result2)
 func NewValues(data *commonpb.Payloads) converter.EncodedValues {
 	return internal.NewValues(data)
+}
+
+// HistoryJSONOptions are options for HistoryFromJSON.
+type HistoryJSONOptions struct {
+	// LastEventID, if set, will only load history up to this ID (inclusive).
+	LastEventID int64
+}
+
+// HistoryFromJSON deserializes history from a reader of JSON bytes. This does
+// not close the reader if it is closeable.
+func HistoryFromJSON(r io.Reader, options HistoryJSONOptions) (*historypb.History, error) {
+	return internal.HistoryFromJSON(r, options.LastEventID)
 }

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -1265,30 +1265,31 @@ func extractHistoryFromFile(jsonfileName string, lastEventID int64) (*historypb.
 	if err != nil {
 		return nil, err
 	}
+	hist, err := HistoryFromJSON(reader, lastEventID)
+	if closeErr := reader.Close(); closeErr != nil && err == nil {
+		err = closeErr
+	}
+	return hist, err
+}
 
-	var deserializedHistory historypb.History
-	err = jsonpb.Unmarshal(reader, &deserializedHistory)
-
-	if err != nil {
+// HistoryFromJSON deserializes history from a reader of JSON bytes. This does
+// not close the reader if it is closeable.
+func HistoryFromJSON(r io.Reader, lastEventID int64) (*historypb.History, error) {
+	var hist historypb.History
+	if err := jsonpb.Unmarshal(r, &hist); err != nil {
 		return nil, err
 	}
-
-	if lastEventID <= 0 {
-		return &deserializedHistory, nil
-	}
-
-	// Caller is potentially asking for subset of history instead of all history events
-	var events []*historypb.HistoryEvent
-	for _, event := range deserializedHistory.Events {
-		events = append(events, event)
-		if event.GetEventId() == lastEventID {
-			// Copy history up to last event (inclusive)
-			break
+	// If there is a last event ID, slice the rest off
+	if lastEventID > 0 {
+		for i, event := range hist.Events {
+			if event.EventId == lastEventID {
+				// Inclusive
+				hist.Events = hist.Events[:i+1]
+				break
+			}
 		}
 	}
-	history := &historypb.History{Events: events}
-
-	return history, nil
+	return &hist, nil
 }
 
 // NewAggregatedWorker returns an instance to manage both activity and workflow workers

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -2659,3 +2659,21 @@ func TestWorkerRegisterDisabledWorkflow(t *testing.T) {
 	}()
 	require.Equal(t, "workflow worker disabled, cannot register workflow", recovered)
 }
+
+func TestHistoryFromJSON(t *testing.T) {
+	// Load sample history and just make sure it has the right event count
+	r, err := os.Open("testdata/sampleHistory.json")
+	require.NoError(t, err)
+	hist, err := HistoryFromJSON(r, 0)
+	require.NoError(t, err)
+	require.NoError(t, r.Close())
+	require.Len(t, hist.Events, 11)
+
+	// Only load up through event 5 and confirm
+	r, err = os.Open("testdata/sampleHistory.json")
+	require.NoError(t, err)
+	hist, err = HistoryFromJSON(r, 5)
+	require.NoError(t, err)
+	require.NoError(t, r.Close())
+	require.Len(t, hist.Events, 5)
+}

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -160,6 +160,8 @@ type (
 		// ReplayWorkflowHistory executes a single workflow task for the given json history file.
 		// Use for testing the backwards compatibility of code changes and troubleshooting workflows in a debugger.
 		// The logger is an optional parameter. Defaults to the noop logger.
+		//
+		// History can be loaded from a reader with client.HistoryFromJSON.
 		ReplayWorkflowHistory(logger log.Logger, history *historypb.History) error
 
 		// ReplayWorkflowHistoryFromJSONFile executes a single workflow task for the json history file downloaded from the cli.


### PR DESCRIPTION
## What was changed

Added `client.HistoryFromJSON` helper to load history

## Why?

Other forms of obtaining history JSON need to be supported beyond what's in the replayer

## Checklist

1. Closes #808