### PR TITLE
Allow any value in the OnUpsertSearchAttribute mock

### DIFF
--- a/internal/internal_workflow_testsuite_test.go
+++ b/internal/internal_workflow_testsuite_test.go
@@ -1721,6 +1721,11 @@ func (s *WorkflowTestSuiteUnitTest) Test_MockUpsertSearchAttributes() {
 		err = UpsertSearchAttributes(ctx, attr)
 		s.NoError(err)
 
+		// Falls back to the mock.Anything mock
+		attr["CustomIntField2"] = 2
+		err = UpsertSearchAttributes(ctx, attr)
+		s.NoError(err)
+
 		wfInfo = GetWorkflowInfo(ctx)
 		s.NotNil(wfInfo.SearchAttributes)
 		valBytes := wfInfo.SearchAttributes.IndexedFields["CustomIntField"]
@@ -1744,6 +1749,7 @@ func (s *WorkflowTestSuiteUnitTest) Test_MockUpsertSearchAttributes() {
 	env = s.NewTestWorkflowEnvironment()
 	env.OnUpsertSearchAttributes(map[string]interface{}{}).Return(errors.New("empty")).Once()
 	env.OnUpsertSearchAttributes(map[string]interface{}{"CustomIntField": 1}).Return(nil).Once()
+	env.OnUpsertSearchAttributes(mock.Anything).Return(nil).Once()
 
 	env.ExecuteWorkflow(workflowFn)
 	s.True(env.IsWorkflowCompleted())

--- a/internal/workflow_testsuite.go
+++ b/internal/workflow_testsuite.go
@@ -437,7 +437,7 @@ func (e *TestWorkflowEnvironment) OnGetVersion(changeID string, minSupported, ma
 // OnUpsertSearchAttributes setup a mock for workflow.UpsertSearchAttributes call.
 // If mock is not setup, the UpsertSearchAttributes call will only validate input attributes.
 // If mock is setup, all UpsertSearchAttributes calls in workflow have to be mocked.
-func (e *TestWorkflowEnvironment) OnUpsertSearchAttributes(attributes map[string]interface{}) *MockCallWrapper {
+func (e *TestWorkflowEnvironment) OnUpsertSearchAttributes(attributes interface{}) *MockCallWrapper {
 	call := e.mock.On(mockMethodForUpsertSearchAttributes, attributes)
 	return e.wrapCall(call)
 }


### PR DESCRIPTION
## What was changed

Changed param from `map[string]interface{}` to `interface{} on `OnUpsertSearchAttribute` to support `mock.Anything` or other mock matchers.

## Why?

Current version only supports matching a specific map.

## Checklist

1. Closes #810