### PR TITLE
Concurrency and serialization documentation notes

### DIFF
--- a/activity/activity.go
+++ b/activity/activity.go
@@ -86,6 +86,10 @@ func HasHeartbeatDetails(ctx context.Context) bool {
 // details reported by activity from the failed attempt, the details would be delivered along with the activity task for
 // retry attempt. Activity could extract the details by GetHeartbeatDetails() and resume from the progress.
 // See TestActivityEnvironment.SetHeartbeatDetails() for unit test support.
+//
+// Note, values should not be reused for extraction here because merging on top
+// of existing values may result in unexpected behavior similar to
+// json.Unmarshal.
 func GetHeartbeatDetails(ctx context.Context, d ...interface{}) error {
 	return internal.GetHeartbeatDetails(ctx, d...)
 }

--- a/converter/data_converter.go
+++ b/converter/data_converter.go
@@ -42,12 +42,20 @@ type (
 		// ToPayload converts single value to payload.
 		ToPayload(value interface{}) (*commonpb.Payload, error)
 		// FromPayload converts single value from payload.
+		//
+		// Note, values should not be reused for extraction here because merging on
+		// top of existing values may result in unexpected behavior similar to
+		// json.Unmarshal.
 		FromPayload(payload *commonpb.Payload, valuePtr interface{}) error
 
 		// ToPayloads converts a list of values.
 		ToPayloads(value ...interface{}) (*commonpb.Payloads, error)
 		// FromPayloads converts to a list of values of different types.
 		// Useful for deserializing arguments of function invocations.
+		//
+		// Note, values should not be reused for extraction here because merging on
+		// top of existing values may result in unexpected behavior similar to
+		// json.Unmarshal.
 		FromPayloads(payloads *commonpb.Payloads, valuePtrs ...interface{}) error
 
 		// ToString converts payload object into human readable string.

--- a/converter/value.go
+++ b/converter/value.go
@@ -30,6 +30,10 @@ type (
 		// HasValue return whether there is value encoded.
 		HasValue() bool
 		// Get extract the encoded value into strong typed value pointer.
+		//
+		// Note, values should not be reused for extraction here because merging on
+		// top of existing values may result in unexpected behavior similar to
+		// json.Unmarshal.
 		Get(valuePtr interface{}) error
 	}
 
@@ -38,6 +42,10 @@ type (
 		// HasValues return whether there are values encoded.
 		HasValues() bool
 		// Get extract the encoded values into strong typed value pointers.
+		//
+		// Note, values should not be reused for extraction here because merging on
+		// top of existing values may result in unexpected behavior similar to
+		// json.Unmarshal.
 		Get(valuePtr ...interface{}) error
 	}
 )

--- a/internal/activity.go
+++ b/internal/activity.go
@@ -174,6 +174,10 @@ func HasHeartbeatDetails(ctx context.Context) bool {
 // would attempt to dispatch another activity task to retry according to the retry policy. If there was heartbeat
 // details reported by activity from the failed attempt, the details would be delivered along with the activity task for
 // retry attempt. Activity could extract the details by GetHeartbeatDetails() and resume from the progress.
+//
+// Note, values should not be reused for extraction here because merging on top
+// of existing values may result in unexpected behavior similar to
+// json.Unmarshal.
 func GetHeartbeatDetails(ctx context.Context, d ...interface{}) error {
 	return getActivityOutboundInterceptor(ctx).GetHeartbeatDetails(ctx, d...)
 }

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -115,11 +115,19 @@ type (
 		// the result for the latest run in the chain. To strictly get the result
 		// for this run without following to the latest, use GetWithOptions and set
 		// the DisableFollowingRuns option to true.
+		//
+		// Note, values should not be reused for extraction here because merging on
+		// top of existing values may result in unexpected behavior similar to
+		// json.Unmarshal.
 		Get(ctx context.Context, valuePtr interface{}) error
 
 		// GetWithOptions will fill the workflow execution result to valuePtr, if
 		// workflow execution is a success, or return corresponding error. This is a
 		// blocking API.
+		//
+		// Note, values should not be reused for extraction here because merging on
+		// top of existing values may result in unexpected behavior similar to
+		// json.Unmarshal.
 		GetWithOptions(ctx context.Context, valuePtr interface{}, options WorkflowRunGetOptions) error
 	}
 

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -66,14 +66,26 @@ type (
 		// Parameter valuePtr is a pointer to the expected data structure to be received. For example:
 		//  var v string
 		//  c.Receive(ctx, &v)
+		//
+		// Note, values should not be reused for extraction here because merging on
+		// top of existing values may result in unexpected behavior similar to
+		// json.Unmarshal.
 		Receive(ctx Context, valuePtr interface{}) (more bool)
 
 		// ReceiveAsync try to receive from Channel without blocking. If there is data available from the Channel, it
 		// assign the data to valuePtr and returns true. Otherwise, it returns false immediately.
+		//
+		// Note, values should not be reused for extraction here because merging on
+		// top of existing values may result in unexpected behavior similar to
+		// json.Unmarshal.
 		ReceiveAsync(valuePtr interface{}) (ok bool)
 
 		// ReceiveAsyncWithMoreFlag is same as ReceiveAsync with extra return value more to indicate if there could be
 		// more value from the Channel. The more is false when Channel is closed.
+		//
+		// Note, values should not be reused for extraction here because merging on
+		// top of existing values may result in unexpected behavior similar to
+		// json.Unmarshal.
 		ReceiveAsyncWithMoreFlag(valuePtr interface{}) (ok bool, more bool)
 	}
 
@@ -137,6 +149,10 @@ type (
 		// The valuePtr parameter can be nil when the encoded result value is not needed.
 		// Example:
 		//  err = f.Get(ctx, nil)
+		//
+		// Note, values should not be reused for extraction here because merging on
+		// top of existing values may result in unexpected behavior similar to
+		// json.Unmarshal.
 		Get(ctx Context, valuePtr interface{}) error
 
 		// When true Get is guaranteed to not block
@@ -1517,6 +1533,10 @@ func (wc *workflowEnvironmentInterceptor) HasLastCompletionResult(ctx Context) b
 // If a cron workflow wants to pass some data to next schedule, it can return any data and that data will become
 // available when next run starts.
 // This GetLastCompletionResult() extract the data into expected data structure.
+//
+// Note, values should not be reused for extraction here because merging on top
+// of existing values may result in unexpected behavior similar to
+// json.Unmarshal.
 func GetLastCompletionResult(ctx Context, d ...interface{}) error {
 	i := getWorkflowOutboundInterceptor(ctx)
 	return i.GetLastCompletionResult(ctx, d...)

--- a/internal/workflow_testsuite.go
+++ b/internal/workflow_testsuite.go
@@ -299,6 +299,9 @@ func (e *TestWorkflowEnvironment) SetStartTime(startTime time.Time) {
 // it was being using in RegisterActivity so the parameter types are accurate. In Go, a method reference of
 // (*MyStruct).MyFunc makes the first parameter *MyStruct which will not work, whereas a method reference of
 // new(MyStruct).MyFunc will.
+//
+// Mock callbacks here are run on a separate goroutine than the workflow and
+// therefore are not concurrency-safe with workflow code.
 func (e *TestWorkflowEnvironment) OnActivity(activity interface{}, args ...interface{}) *MockCallWrapper {
 	fType := reflect.TypeOf(activity)
 	var call *mock.Call
@@ -347,6 +350,9 @@ var ErrMockStartChildWorkflowFailed = fmt.Errorf("start child workflow failed: %
 //   t.OnWorkflow(MyChildWorkflow, mock.Anything, mock.Anything).Return("mock_result", nil)
 // You could also setup mock to simulate start child workflow failure case by returning ErrMockStartChildWorkflowFailed
 // as error.
+//
+// Mock callbacks here are run on a separate goroutine than the workflow and
+// therefore are not concurrency-safe with workflow code.
 func (e *TestWorkflowEnvironment) OnWorkflow(workflow interface{}, args ...interface{}) *MockCallWrapper {
 	fType := reflect.TypeOf(workflow)
 	var call *mock.Call
@@ -394,6 +400,9 @@ const mockMethodForUpsertSearchAttributes = "workflow.UpsertSearchAttributes"
 //       // you can do differently based on the parameters
 //       return nil
 //     })
+//
+// Mock callbacks here are run on a separate goroutine than the workflow and
+// therefore are not concurrency-safe with workflow code.
 func (e *TestWorkflowEnvironment) OnSignalExternalWorkflow(namespace, workflowID, runID, signalName, arg interface{}) *MockCallWrapper {
 	call := e.mock.On(mockMethodForSignalExternalWorkflow, namespace, workflowID, runID, signalName, arg)
 	return e.wrapCall(call)
@@ -418,6 +427,9 @@ func (e *TestWorkflowEnvironment) OnSignalExternalWorkflow(namespace, workflowID
 //       // you can do differently based on the parameters
 //       return nil
 //     })
+//
+// Mock callbacks here are run on a separate goroutine than the workflow and
+// therefore are not concurrency-safe with workflow code.
 func (e *TestWorkflowEnvironment) OnRequestCancelExternalWorkflow(namespace, workflowID, runID string) *MockCallWrapper {
 	call := e.mock.On(mockMethodForRequestCancelExternalWorkflow, namespace, workflowID, runID)
 	return e.wrapCall(call)

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -424,6 +424,10 @@ func HasLastCompletionResult(ctx Context) bool {
 // available when next run starts. This will contain the last successful result even if the most recent run failed.
 // This GetLastCompletionResult() extract the data into expected data structure.
 // See TestWorkflowEnvironment.SetLastCompletionResult() for unit test support.
+//
+// Note, values should not be reused for extraction here because merging on top
+// of existing values may result in unexpected behavior similar to
+// json.Unmarshal.
 func GetLastCompletionResult(ctx Context, d ...interface{}) error {
 	return internal.GetLastCompletionResult(ctx, d...)
 }


### PR DESCRIPTION
## What was changed

* Added note that unmarshalling on top of existing object can have unexpected behavior
* Added note that some mock callbacks are not thread-safe

## Checklist

1. Closes #843
2. Closes #844