### PR TITLE
Add workflow.GetInfo(ctx).GetCurrentHistoryLength()

### DIFF
--- a/internal/internal_event_handlers.go
+++ b/internal/internal_event_handlers.go
@@ -826,6 +826,8 @@ func (weh *workflowExecutionEventHandlerImpl) ProcessEvent(
 	case enumspb.EVENT_TYPE_WORKFLOW_TASK_STARTED:
 		// Set replay clock.
 		weh.SetCurrentReplayTime(common.TimeValue(event.GetEventTime()))
+		// Set history length as this event's ID
+		weh.workflowInfo.currentHistoryLength = int(event.EventId)
 		// Reset the counter on command helper used for generating ID for commands
 		weh.commandsHelper.setCurrentWorkflowTaskStartedEventID(event.GetEventId())
 		weh.workflowDefinition.OnWorkflowTaskStarted(weh.deadlockDetectionTimeout)

--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -338,6 +338,10 @@ func (env *testWorkflowEnvironmentImpl) setStartTime(startTime time.Time) {
 	env.workflowInfo.WorkflowStartTime = env.mockClock.Now()
 }
 
+func (env *testWorkflowEnvironmentImpl) setCurrentHistoryLength(length int) {
+	env.workflowInfo.currentHistoryLength = length
+}
+
 func (env *testWorkflowEnvironmentImpl) newTestWorkflowEnvironmentForChild(params *ExecuteWorkflowParams, callback ResultHandler, startedHandler func(r WorkflowExecution, e error)) (*testWorkflowEnvironmentImpl, error) {
 	// create a new test env
 	childEnv := newTestWorkflowEnvironmentImpl(env.testSuite, env.registry)

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -886,6 +886,8 @@ type WorkflowInfo struct {
 	SearchAttributes        *commonpb.SearchAttributes // Value can be decoded using defaultDataConverter.
 	RetryPolicy             *RetryPolicy
 	BinaryChecksum          string
+
+	currentHistoryLength int
 }
 
 // GetBinaryChecksum return binary checksum.
@@ -894,6 +896,12 @@ func (wInfo *WorkflowInfo) GetBinaryChecksum() string {
 		return getBinaryChecksum()
 	}
 	return wInfo.BinaryChecksum
+}
+
+// GetCurrentHistoryLength returns the current length of history when called.
+// This value may change throughout the life of the workflow.
+func (wInfo *WorkflowInfo) GetCurrentHistoryLength() int {
+	return wInfo.currentHistoryLength
 }
 
 // GetWorkflowInfo extracts info of a current workflow from a context.

--- a/internal/workflow_testsuite.go
+++ b/internal/workflow_testsuite.go
@@ -281,6 +281,12 @@ func (e *TestWorkflowEnvironment) SetStartTime(startTime time.Time) {
 	e.impl.setStartTime(startTime)
 }
 
+// SetCurrentHistoryLength sets the value that is returned from
+// GetInfo(ctx).GetCurrentHistoryLength().
+func (e *TestWorkflowEnvironment) SetCurrentHistoryLength(length int) {
+	e.impl.setCurrentHistoryLength(length)
+}
+
 // OnActivity setup a mock call for activity. Parameter activity must be activity function (func) or activity name (string).
 // You must call Return() with appropriate parameters on the returned *MockCallWrapper instance. The supplied parameters to
 // the Return() call should either be a function that has exact same signature as the mocked activity, or it should be

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -2425,25 +2425,30 @@ func (ts *IntegrationTestSuite) registerNamespace() {
 	}
 }
 
+// We count on the no-cache test to test replay conditions here
 func (ts *IntegrationTestSuite) TestHistoryLength() {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	// Run workflow with 3 activities and check history lengths given
 	run, err := ts.client.ExecuteWorkflow(ctx, ts.startWorkflowOptions("test-history-length"),
-		ts.workflows.HistoryLengths, 3)
+		ts.workflows.HistoryLengths, 6)
 	ts.NoError(err)
 	var actual, expected []int
 	ts.NoError(run.Get(ctx, &actual))
 
-	// Get history and grab expected lengths
+	// Get history and record expected length each activity schedule
 	iter := ts.client.GetWorkflowHistory(ctx, run.GetID(), run.GetRunID(),
 		false, enumspb.HISTORY_EVENT_FILTER_TYPE_ALL_EVENT)
+	var lastStartID int
 	for iter.HasNext() {
 		event, err := iter.Next()
 		ts.NoError(err)
 		if event.GetWorkflowTaskStartedEventAttributes() != nil {
-			expected = append(expected, int(event.EventId))
+			lastStartID = int(event.EventId)
+		} else if event.GetActivityTaskScheduledEventAttributes() != nil ||
+			event.GetMarkerRecordedEventAttributes().GetMarkerName() == "LocalActivity" {
+			expected = append(expected, lastStartID)
 		}
 	}
 

--- a/test/workflow_test.go
+++ b/test/workflow_test.go
@@ -1826,6 +1826,19 @@ func (w *Workflows) MutableSideEffect(ctx workflow.Context, startVal int) (currV
 	return
 }
 
+func (w *Workflows) HistoryLengths(ctx workflow.Context, activityCount int) (lengths []int, err error) {
+	ctx = workflow.WithActivityOptions(ctx, w.defaultActivityOptions())
+	var a Activities
+	for i := 0; i < activityCount; i++ {
+		lengths = append(lengths, workflow.GetInfo(ctx).GetCurrentHistoryLength())
+		if err = workflow.ExecuteActivity(ctx, a.Sleep, 1*time.Millisecond).Get(ctx, nil); err != nil {
+			break
+		}
+	}
+	lengths = append(lengths, workflow.GetInfo(ctx).GetCurrentHistoryLength())
+	return
+}
+
 func (w *Workflows) register(worker worker.Worker) {
 	worker.RegisterWorkflow(w.ActivityCancelRepro)
 	worker.RegisterWorkflow(w.ActivityCompletionUsingID)
@@ -1898,6 +1911,7 @@ func (w *Workflows) register(worker worker.Worker) {
 	worker.RegisterWorkflow(w.PanicOnSignal)
 	worker.RegisterWorkflow(w.ForcedNonDeterminism)
 	worker.RegisterWorkflow(w.MutableSideEffect)
+	worker.RegisterWorkflow(w.HistoryLengths)
 
 	worker.RegisterWorkflow(w.child)
 	worker.RegisterWorkflow(w.childForMemoAndSearchAttr)


### PR DESCRIPTION
## What was changed

Added `workflow.GetInfo(ctx).GetCurrentHistoryLength()` and a helper to set during unit tests

## Why?

So people can use it to make continue-as-new determinations

## Checklist

1. Part of #628