### PR TITLE
Added validations for Hostport while creating Client and added integration tests for the same

### DIFF
--- a/internal/client.go
+++ b/internal/client.go
@@ -27,6 +27,9 @@ package internal
 import (
 	"context"
 	"crypto/tls"
+	"errors"
+	"strconv"
+	"strings"
 	"time"
 
 	commonpb "go.temporal.io/api/common/v1"
@@ -645,6 +648,13 @@ func NewClient(options ClientOptions) (Client, error) {
 
 	if options.HostPort == "" {
 		options.HostPort = LocalHostPort
+	} else {
+		hostStrArr := strings.Split(options.HostPort, ":")
+		if len(hostStrArr) != 2 {
+			return nil, errors.New("Invalid HostAddress")
+		} else if _, err := strconv.Atoi(hostStrArr[1]); err != nil {
+			return nil, errors.New("Invalid HostPort")
+		}
 	}
 
 	if options.Logger == nil {

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -2391,10 +2391,6 @@ func (ts *IntegrationTestSuite) TestReplayerWithInterceptor() {
 		workflow.Execution{ID: run.GetID(), RunID: run.GetRunID()}))
 }
 func (ts *IntegrationTestSuite) TestClientHostAddressAndPort() {
-	ts.metricsHandler = metrics.NewCapturingHandler()
-	//var metricsHandler client.MetricsHandler = ts.metricsHandler
-	//var error error
-
 	ts.config.ServiceAddr = "localhost:"
 	cli, error := client.Dial(client.Options{
 		HostPort:  ts.config.ServiceAddr,

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -2390,6 +2390,34 @@ func (ts *IntegrationTestSuite) TestReplayerWithInterceptor() {
 	ts.NoError(replayer.ReplayWorkflowExecution(ctx, ts.client.WorkflowService(), nil, ts.config.Namespace,
 		workflow.Execution{ID: run.GetID(), RunID: run.GetRunID()}))
 }
+func (ts *IntegrationTestSuite) TestClientHostAddressAndPort() {
+	ts.metricsHandler = metrics.NewCapturingHandler()
+	//var metricsHandler client.MetricsHandler = ts.metricsHandler
+	//var error error
+
+	ts.config.ServiceAddr = "localhost:"
+	cli, error := client.Dial(client.Options{
+		HostPort:  ts.config.ServiceAddr,
+		Namespace: ts.config.Namespace,
+	})
+
+	if cli != nil {
+		defer cli.Close()
+	}
+	ts.Error(error)
+
+	ts.config.ServiceAddr = "localhost"
+	cli, error = client.Dial(client.Options{
+		HostPort:  ts.config.ServiceAddr,
+		Namespace: ts.config.Namespace,
+	})
+
+	if cli != nil {
+		defer cli.Close()
+	}
+	ts.Error(error)
+
+}
 
 func (ts *IntegrationTestSuite) registerNamespace() {
 	client, err := client.NewNamespaceClient(client.Options{


### PR DESCRIPTION
## What was changed
 Added additional validation check for hostPort while creating the temporal client 

## Why?
To have the respective errors displayed when there is an invalid hostPort while creating the client 

## Checklist
N/A


1. Closes
    #389 
3. How was this tested:
    Added Integration test to check  the additional validation for the hostPort while creating client 

4. Any docs updates needed?
     N/A 
