### PR TITLE
Properly handle absent WFT response for eager activities

### DIFF
--- a/internal/internal_eager_activity.go
+++ b/internal/internal_eager_activity.go
@@ -103,17 +103,17 @@ func (e *eagerActivityExecutor) handleResponse(
 	amountActivitySlotsReserved int,
 ) {
 	// Ignore disabled or none present
-	if e == nil || e.activityWorker == nil || e.disabled || (len(resp.ActivityTasks) == 0 && amountActivitySlotsReserved == 0) {
+	if e == nil || e.activityWorker == nil || e.disabled || (len(resp.GetActivityTasks()) == 0 && amountActivitySlotsReserved == 0) {
 		return
-	} else if len(resp.ActivityTasks) > amountActivitySlotsReserved {
+	} else if len(resp.GetActivityTasks()) > amountActivitySlotsReserved {
 		panic(fmt.Sprintf("Unexpectedly received %v eager activities though we only requested %v",
-			len(resp.ActivityTasks), amountActivitySlotsReserved))
+			len(resp.GetActivityTasks()), amountActivitySlotsReserved))
 	}
 
 	// Update counts under lock
 	e.countLock.Lock()
 	// Give back unfulfilled slots and record for later use
-	unfulfilledSlots := amountActivitySlotsReserved - len(resp.ActivityTasks)
+	unfulfilledSlots := amountActivitySlotsReserved - len(resp.GetActivityTasks())
 	e.heldSlotCount -= unfulfilledSlots
 	e.countLock.Unlock()
 
@@ -125,7 +125,7 @@ func (e *eagerActivityExecutor) handleResponse(
 	}
 
 	// Start each activity asynchronously
-	for _, activity := range resp.ActivityTasks {
+	for _, activity := range resp.GetActivityTasks() {
 		// Before starting the goroutine we have to increase the wait group counter
 		// that the poller would have otherwise increased
 		e.activityWorker.worker.stopWG.Add(1)

--- a/internal/internal_eager_activity_test.go
+++ b/internal/internal_eager_activity_test.go
@@ -144,7 +144,7 @@ func TestEagerActivityCounts(t *testing.T) {
 	require.Equal(t, 2, len(slotsCh))
 
 	// Resolve that saying none came back
-	exec.handleResponse(&workflowservice.RespondWorkflowTaskCompletedResponse{}, 1)
+	exec.handleResponse(nil, 1)
 	require.Equal(t, 2, exec.heldSlotCount)
 	require.Equal(t, 3, len(slotsCh))
 


### PR DESCRIPTION
## What was changed

Work with nil response

## Why?

Sometimes `RespondWorkflowTaskCompleted` errors and we didn't properly account for that when unreserving reserved slots

## Checklist

1. Closes #860