### PR TITLE
Support really short heartbeat throttling interval

### DIFF
--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -1730,9 +1730,9 @@ func (i *temporalInvoker) internalHeartBeat(ctx context.Context, details *common
 	// Therefore, we'll make sure not to timeout the context faster than the
 	// minimum RPC timeout.
 	recordTimeout := i.heartbeatThrottleInterval
-	// if recordTimeout < minRPCTimeout {
-	// 	recordTimeout = minRPCTimeout
-	// }
+	if recordTimeout < minRPCTimeout {
+		recordTimeout = minRPCTimeout
+	}
 	ctx, cancel := context.WithTimeout(ctx, recordTimeout)
 	defer cancel()
 

--- a/internal/worker.go
+++ b/internal/worker.go
@@ -168,7 +168,8 @@ type (
 		DeadlockDetectionTimeout time.Duration
 
 		// Optional: The maximum amount of time between sending each pending heartbeat to the server. Regardless of
-		// heartbeat timeout, no pending heartbeat will wait longer than this amount of time to send.
+		// heartbeat timeout, no pending heartbeat will wait longer than this amount of time to send. To effectively disable
+		// heartbeat throttling, this can be set to something like 1 nanosecond, but it is not recommended.
 		// default: 60 seconds
 		MaxHeartbeatThrottleInterval time.Duration
 

--- a/test/activity_test.go
+++ b/test/activity_test.go
@@ -105,6 +105,14 @@ func (a *Activities) LongRunningHeartbeat(ctx context.Context, delay time.Durati
 	return nil
 }
 
+func (a *Activities) HeartbeatSpecificCount(ctx context.Context, interval time.Duration, count int) error {
+	for i := 0; i < count; i++ {
+		time.Sleep(interval)
+		activity.RecordHeartbeat(ctx)
+	}
+	return nil
+}
+
 func (a *Activities) HeartbeatTwiceAndFailNTimes(
 	ctx context.Context,
 	times int,

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -2456,6 +2456,34 @@ func (ts *IntegrationTestSuite) TestHistoryLength() {
 	ts.Equal(expected, actual)
 }
 
+func (ts *IntegrationTestSuite) TestHeartbeatThrottleDisabled() {
+	// Heartbeat 4 times, 100ms apart
+	ts.NoError(ts.executeWorkflow("test-heartbeat-throttle-disabled-1", ts.workflows.HeartbeatSpecificCount, nil,
+		100*time.Millisecond, 4))
+
+	// That short of time by default on non-failure would only record the first
+	// one
+	ts.assertReportedOperationCount("temporal_request_attempt", "RecordActivityTaskHeartbeat", 1)
+
+	// Restart worker with heartbeat throttling effectively disabled
+	ts.worker.Stop()
+	ts.workerStopped = true
+	newWorker := worker.New(ts.client, ts.taskQueueName, worker.Options{
+		MaxHeartbeatThrottleInterval: 1 * time.Nanosecond,
+	})
+	ts.registerWorkflowsAndActivities(newWorker)
+	ts.NoError(newWorker.Start())
+	defer newWorker.Stop()
+
+	// Try that again
+	ts.metricsHandler.Clear()
+	ts.NoError(ts.executeWorkflow("test-heartbeat-throttle-disabled-2", ts.workflows.HeartbeatSpecificCount, nil,
+		100*time.Millisecond, 4))
+
+	// Now that heartbeat throttling was disabled, it should have sent all 4 times
+	ts.assertReportedOperationCount("temporal_request_attempt", "RecordActivityTaskHeartbeat", 4)
+}
+
 // executeWorkflow executes a given workflow and waits for the result
 func (ts *IntegrationTestSuite) executeWorkflow(
 	wfID string, wfFunc interface{}, retValPtr interface{}, args ...interface{}) error {

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -2481,7 +2481,8 @@ func (ts *IntegrationTestSuite) TestHeartbeatThrottleDisabled() {
 		100*time.Millisecond, 4))
 
 	// Now that heartbeat throttling was disabled, it should have sent all 4 times
-	ts.assertReportedOperationCount("temporal_request_attempt", "RecordActivityTaskHeartbeat", 4)
+	ts.assertReportedOperationCount("temporal_request", "RecordActivityTaskHeartbeat", 4)
+	ts.assertReportedOperationCount("temporal_request_failure", "RecordActivityTaskHeartbeat", 0)
 }
 
 // executeWorkflow executes a given workflow and waits for the result

--- a/test/workflow_test.go
+++ b/test/workflow_test.go
@@ -1842,6 +1842,12 @@ func (w *Workflows) HistoryLengths(ctx workflow.Context, activityCount int) (len
 	return
 }
 
+func (w *Workflows) HeartbeatSpecificCount(ctx workflow.Context, interval time.Duration, count int) error {
+	ctx = workflow.WithActivityOptions(ctx, w.defaultActivityOptionsWithRetry())
+	var activities *Activities
+	return workflow.ExecuteActivity(ctx, activities.HeartbeatSpecificCount, interval, count).Get(ctx, nil)
+}
+
 func (w *Workflows) register(worker worker.Worker) {
 	worker.RegisterWorkflow(w.ActivityCancelRepro)
 	worker.RegisterWorkflow(w.ActivityCompletionUsingID)
@@ -1915,6 +1921,7 @@ func (w *Workflows) register(worker worker.Worker) {
 	worker.RegisterWorkflow(w.ForcedNonDeterminism)
 	worker.RegisterWorkflow(w.MutableSideEffect)
 	worker.RegisterWorkflow(w.HistoryLengths)
+	worker.RegisterWorkflow(w.HeartbeatSpecificCount)
 
 	worker.RegisterWorkflow(w.child)
 	worker.RegisterWorkflow(w.childForMemoAndSearchAttr)


### PR DESCRIPTION
## What was changed

Stop timing out the RPC context for recording heartbeat before it can even record

## Why?

Really short timeouts were preventing calls from being made properly

## Checklist

1. Closes #859