### PR TITLE
Unit test fix for Go 1.19

### DIFF
--- a/internal/internal_workflow_testsuite_test.go
+++ b/internal/internal_workflow_testsuite_test.go
@@ -2978,9 +2978,14 @@ func (s *WorkflowTestSuiteUnitTest) Test_ActivityRetry_NoRetries() {
 	s.True(env.IsWorkflowCompleted())
 	err := env.GetWorkflowError()
 	s.Error(err)
+
 	var workflowErr *WorkflowExecutionError
-	s.True(errors.As(err, &workflowErr))
-	s.True(errors.As(err, &fakeError))
+	s.ErrorAs(err, &workflowErr)
+
+	var appErr *ApplicationError
+	s.ErrorAs(err, &appErr)
+
+	s.ErrorContains(err, fakeError.Error())
 }
 
 func (s *WorkflowTestSuiteUnitTest) Test_ActivityHeartbeatRetry() {


### PR DESCRIPTION


<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Updated a unit test to compile with Go 1.19

## Why?
<!-- Tell your future self why have you made these changes -->
Go 1.19 (correctly) notices that the following is basically useless as
it tests that an error can be converted to the error interface (which is
always the case).

```
err := NewWorkflowError(...)
target := errors.New("...")

errors.As(err, &tarter)
```

The broken test further broken in that it expected the base Go error to
make it through the failure conversion machinery intact when in truth
the expectation is that it gets converted to an instance of
ApplicationError.

## Checklist
<!--- add/delete as needed --->

1. Closes 
<!-- add issue number here -->
n/a

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
n/a

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
No
