### PR TITLE
Fix code samples for workflow.SideEffect

### DIFF
--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -237,7 +237,7 @@ func GetSignalChannel(ctx Context, signalName string) ReceiveChannel {
 // For example this code is BROKEN:
 //  // Bad example:
 //  var random int
-//  workflow.SideEffect(func(ctx workflow.Context) interface{} {
+//  workflow.SideEffect(ctx, func(ctx workflow.Context) interface{} {
 //         random = rand.Intn(100)
 //         return nil
 //  })
@@ -252,7 +252,7 @@ func GetSignalChannel(ctx Context, signalName string) ReceiveChannel {
 //
 // Here is the correct way to use SideEffect:
 //  // Good example:
-//  encodedRandom := SideEffect(func(ctx workflow.Context) interface{} {
+//  encodedRandom := workflow.SideEffect(ctx, func(ctx workflow.Context) interface{} {
 //        return rand.Intn(100)
 //  })
 //  var random int


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
The code samples in the docs for `workflow.SideEffect` where missing `ctx` as the first argument. This PR fixes that.

## Why?
To help developers use the code correctly

