### PR TITLE
Fix doc formatting

### DIFF
--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -1401,9 +1401,9 @@ func (wc *workflowEnvironmentInterceptor) SideEffect(ctx Context, f func(ctx Con
 
 // MutableSideEffect executes the provided function once, then it looks up the history for the value with the given id.
 // If there is no existing value, then it records the function result as a value with the given id on history;
-// otherwise, it compares whether the existing value from history has changed from the new function result by calling the
-// provided equals function. If they are equal, it returns the value without recording a new one in history;
-//   otherwise, it records the new value with the same id on history.
+// otherwise, it compares whether the existing value from history has changed from the new function result by calling
+// the provided equals function. If they are equal, it returns the value without recording a new one in history;
+// otherwise, it records the new value with the same id on history.
 //
 // Caution: do not use MutableSideEffect to modify closures. Always retrieve result from MutableSideEffect's encoded
 // return value.

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -268,9 +268,9 @@ func SideEffect(ctx Context, f func(ctx Context) interface{}) converter.EncodedV
 
 // MutableSideEffect executes the provided function once, then it looks up the history for the value with the given id.
 // If there is no existing value, then it records the function result as a value with the given id on history;
-// otherwise, it compares whether the existing value from history has changed from the new function result by calling the
-// provided equals function. If they are equal, it returns the value without recording a new one in history;
-//   otherwise, it records the new value with the same id on history.
+// otherwise, it compares whether the existing value from history has changed from the new function result by calling
+// the provided equals function. If they are equal, it returns the value without recording a new one in history;
+// otherwise, it records the new value with the same id on history.
 //
 // Caution: do not use MutableSideEffect to modify closures. Always retrieve result from MutableSideEffect's encoded
 // return value.


### PR DESCRIPTION
I don't imagine this `otherwise...` code block was intentional:

<img width="656" alt="image" src="https://user-images.githubusercontent.com/251288/186764064-20f12c79-cd11-4147-a0ca-e43f359d80c9.png">
