### PR TITLE
Handle Client.Close on cloned clients

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -386,6 +386,11 @@ type (
 		WorkflowService() workflowservice.WorkflowServiceClient
 
 		// Close client and clean up underlying resources.
+		//
+		// If this client was created via NewClientFromExisting or this client has
+		// been used in that call, Close() on may not necessarily close the
+		// underlying connection. Only the final close of all existing clients will
+		// close the underlying connection.
 		Close()
 	}
 
@@ -474,6 +479,11 @@ func NewClient(options Options) (Client, error) {
 // this package and cannot be wrapped. Currently, this always attempts an eager
 // connection even if the existing client was created with NewLazyClient and has
 // not made any calls yet.
+//
+// Close() on the resulting client may not necessarily close the underlying
+// connection if there are any other clients using the connection. All clients
+// associated with the existing client must call Close() and only the last one
+// actually performs the connection close.
 func NewClientFromExisting(existingClient Client, options Options) (Client, error) {
 	return internal.NewClientFromExisting(existingClient, options)
 }

--- a/internal/internal_workflow_client_test.go
+++ b/internal/internal_workflow_client_test.go
@@ -34,10 +34,12 @@ import (
 	workflowpb "go.temporal.io/api/workflow/v1"
 	uberatomic "go.uber.org/atomic"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
 
 	ilog "go.temporal.io/sdk/internal/log"
 
 	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
@@ -1401,4 +1403,46 @@ func serializeEvents(events []*historypb.HistoryEvent) *commonpb.DataBlob {
 		EncodingType: enumspb.ENCODING_TYPE_PROTO3,
 		Data:         blob.Data,
 	}
+}
+
+func TestClientCloseCount(t *testing.T) {
+	// Create primary client
+	server, err := startTestGRPCServer()
+	require.NoError(t, err)
+	defer server.Stop()
+	client, err := DialClient(ClientOptions{HostPort: server.addr})
+	require.NoError(t, err)
+	workflowClient := client.(*WorkflowClient)
+
+	// Confirm there is 1 unclosed client
+	require.EqualValues(t, 1, *workflowClient.unclosedClients)
+
+	// Create two more and confirm counts
+	client2, err := NewClientFromExisting(client, ClientOptions{})
+	require.NoError(t, err)
+	require.EqualValues(t, 2, *workflowClient.unclosedClients)
+	require.Same(t, workflowClient.unclosedClients, client2.(*WorkflowClient).unclosedClients)
+	client3, err := NewClientFromExisting(client, ClientOptions{})
+	require.NoError(t, err)
+	require.EqualValues(t, 3, *workflowClient.unclosedClients)
+	require.Same(t, workflowClient.unclosedClients, client3.(*WorkflowClient).unclosedClients)
+
+	// Close the third one 3 times and confirm counts and that connection not
+	// closed
+	client3.Close()
+	client3.Close()
+	client3.Close()
+	require.EqualValues(t, 2, *workflowClient.unclosedClients)
+	require.NotSame(t, workflowClient.unclosedClients, client3.(*WorkflowClient).unclosedClients)
+	require.Less(t, workflowClient.conn.GetState(), connectivity.Shutdown)
+
+	// Close the primary one and confirm not closed
+	client.Close()
+	require.EqualValues(t, 1, *client2.(*WorkflowClient).unclosedClients)
+	require.NotSame(t, workflowClient.unclosedClients, client2.(*WorkflowClient).unclosedClients)
+	require.Less(t, workflowClient.conn.GetState(), connectivity.Shutdown)
+
+	// Now close the last one (the second) and confirm it actually gets closed
+	client2.Close()
+	require.Equal(t, connectivity.Shutdown, workflowClient.conn.GetState())
 }

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -2474,6 +2474,7 @@ func (ts *IntegrationTestSuite) TestMultiNamespaceClient() {
 	// Make a new client with a different namespace and run again
 	newClient, err := client.NewClientFromExisting(ts.client, client.Options{Namespace: "some-other-namespace"})
 	ts.NoError(err)
+	defer newClient.Close()
 	_, _ = newClient.DescribeWorkflowExecution(ctx, "id-that-does-not-exist", "")
 
 	// Confirm there was no count change to other namespace but there is now a


### PR DESCRIPTION
## What was changed

Use a counter to make sure only the last `Close()` of a shared-connection set of clients applies.

## Checklist

1. Closes #886