### PR TITLE
Stop logging poller errors after stop

### DIFF
--- a/internal/internal_worker_base.go
+++ b/internal/internal_worker_base.go
@@ -357,6 +357,13 @@ func (bw *baseWorker) pollTask() {
 }
 
 func (bw *baseWorker) logPollTaskError(err error) {
+	// We do not want to log any errors after we were explicitly stopped
+	select {
+	case <-bw.stopCh:
+		return
+	default:
+	}
+
 	bw.lastPollTaskErrLock.Lock()
 	defer bw.lastPollTaskErrLock.Unlock()
 	// No error means reset the message and time


### PR DESCRIPTION
## What was changed

Remove poll failures on when worker is stopped

## Checklist

1. Closes #882
