### PR TITLE
Make Worker.Stop reentrant

### DIFF
--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -1048,7 +1048,13 @@ func (aw *AggregatedWorker) Run(interruptCh <-chan interface{}) error {
 
 // Stop the worker.
 func (aw *AggregatedWorker) Stop() {
-	close(aw.stopC)
+	// Only attempt stop if we haven't attempted before
+	select {
+	case <-aw.stopC:
+		return
+	default:
+		close(aw.stopC)
+	}
 
 	if !util.IsInterfaceNil(aw.workflowWorker) {
 		aw.workflowWorker.Stop()

--- a/internal/internal_workers_test.go
+++ b/internal/internal_workers_test.go
@@ -475,6 +475,19 @@ func (s *WorkersTestSuite) TestMultipleLocalActivities() {
 	s.Equal(2, localActivityCalledCount)
 }
 
+func (s *WorkersTestSuite) TestWorkerMultipleStop() {
+	s.service.EXPECT().DescribeNamespace(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	s.service.EXPECT().PollWorkflowTaskQueue(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(&workflowservice.PollWorkflowTaskQueueResponse{}, nil).AnyTimes()
+	s.service.EXPECT().PollActivityTaskQueue(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(&workflowservice.PollActivityTaskQueueResponse{}, nil).AnyTimes()
+	client := NewServiceClient(s.service, nil, ClientOptions{Identity: "multi-stop-identity"})
+	worker := NewAggregatedWorker(client, "multi-stop-tq", WorkerOptions{})
+	s.NoError(worker.Start())
+	worker.Stop()
+	worker.Stop()
+}
+
 func (s *WorkersTestSuite) createLocalActivityMarkerDataForTest(activityID string) map[string]*commonpb.Payloads {
 	lamd := localActivityMarkerData{
 		ActivityID: activityID,


### PR DESCRIPTION
## What was changed

Need to make worker `Stop()` safe for a second call

## Why?

We call stop internally on fatal error, so a user's stop call should do nothing

## Checklist

1. Closes #903