### PR TITLE
Don't use data converter if search attribute value is of Payload type

### DIFF
--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -1214,11 +1214,17 @@ func serializeSearchAttributes(input map[string]interface{}) (*commonpb.SearchAt
 
 	attr := make(map[string]*commonpb.Payload)
 	for k, v := range input {
-		attrBytes, err := converter.GetDefaultDataConverter().ToPayload(v)
+		// If search attribute value is already of Payload type, then use it directly.
+		// This allows to copy search attributes from workflow info to child workflow options.
+		if vp, ok := v.(*commonpb.Payload); ok {
+			attr[k] = vp
+			continue
+		}
+		var err error
+		attr[k], err = converter.GetDefaultDataConverter().ToPayload(v)
 		if err != nil {
 			return nil, fmt.Errorf("encode search attribute [%s] error: %v", k, err)
 		}
-		attr[k] = attrBytes
 	}
 	return &commonpb.SearchAttributes{IndexedFields: attr}, nil
 }

--- a/internal/internal_workflow_client_test.go
+++ b/internal/internal_workflow_client_test.go
@@ -1288,17 +1288,33 @@ func (s *workflowClientTestSuite) TestSerializeSearchAttributes() {
 	s.NotNil(result2)
 	s.Equal(0, len(result2.IndexedFields))
 
-	input1["t1"] = "v1"
+	input1 = map[string]interface{}{
+		"t1": "v1",
+	}
 	result3, err := serializeSearchAttributes(input1)
 	s.NoError(err)
 	s.NotNil(result3)
 	s.Equal(1, len(result3.IndexedFields))
 	var resultString string
-
 	_ = converter.GetDefaultDataConverter().FromPayload(result3.IndexedFields["t1"], &resultString)
 	s.Equal("v1", resultString)
 
-	input1["non-serializable"] = make(chan int)
+	// *Payload type goes through.
+	p, err := converter.GetDefaultDataConverter().ToPayload("5eaf00d")
+	s.NoError(err)
+	input1 = map[string]interface{}{
+		"payload": p,
+	}
+	result4, err := serializeSearchAttributes(input1)
+	s.NoError(err)
+	s.NotNil(result3)
+	s.Equal(1, len(result3.IndexedFields))
+	_ = converter.GetDefaultDataConverter().FromPayload(result4.IndexedFields["payload"], &resultString)
+	s.Equal("5eaf00d", resultString)
+
+	input1 = map[string]interface{}{
+		"non-serializable": make(chan int),
+	}
 	_, err = serializeSearchAttributes(input1)
 	s.Error(err)
 }


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->
Don't use data converter if search attribute value is of `Payload` type.

## Why?
<!-- Tell your future self why have you made these changes -->
`WorkflowInfo` contains search attributes with values encoded in `Payload`. To start child workflow with same search attributes, workflow code needs to decode them and then set it back. To do this, it must know all name and types which is not always possible. This is small workaround which allows to copy search attributes from current workflow to child.