### PR TITLE
Add IdempotencyKey start span option

### DIFF
--- a/interceptor/tracing_interceptor.go
+++ b/interceptor/tracing_interceptor.go
@@ -139,6 +139,17 @@ type TracerStartSpanOptions struct {
 	// ToHeader is used internally, not by tracer implementations, to determine
 	// whether the span should be placed on the Temporal header.
 	ToHeader bool
+
+	// IdempotencyKey may optionally be used by tracing implementations to generate
+	// deterministic span IDs.
+	//
+	// This is useful in workflow contexts where spans may need to be "resumed" before
+	// ultimately being reported. Generating a deterministic span ID ensures that any
+	// child spans created before the parent span is resumed do not become orphaned.
+	//
+	// IdempotencyKey is not guaranteed to be set for all operations; Tracer
+	// implementations MUST therefore ignore zero values for this field.
+	IdempotencyKey string
 }
 
 // TracerSpanRef represents a span reference such as a parent.
@@ -197,7 +208,7 @@ func (t *tracingInterceptor) InterceptWorkflow(
 	ctx workflow.Context,
 	next WorkflowInboundInterceptor,
 ) WorkflowInboundInterceptor {
-	i := &tracingWorkflowInboundInterceptor{root: t}
+	i := &tracingWorkflowInboundInterceptor{root: t, info: workflow.GetInfo(ctx)}
 	i.Next = next
 	return i
 }
@@ -357,7 +368,20 @@ func (t *tracingActivityInboundInterceptor) ExecuteActivity(
 
 type tracingWorkflowInboundInterceptor struct {
 	WorkflowInboundInterceptorBase
-	root *tracingInterceptor
+	root        *tracingInterceptor
+	spanCounter uint16
+	info        *workflow.Info
+}
+
+// newIdempotencyKey returns a new idempotency key by incrementing the span counter and interpolating
+// this new value into a string that includes the workflow namespace/id/run id and the interceptor type.
+func (t *tracingWorkflowInboundInterceptor) newIdempotencyKey() string {
+	t.spanCounter++
+	return fmt.Sprintf("WorkflowInboundInterceptor:%s:%s:%s:%d",
+		t.info.Namespace,
+		t.info.WorkflowExecution.ID,
+		t.info.WorkflowExecution.RunID,
+		t.spanCounter)
 }
 
 func (t *tracingWorkflowInboundInterceptor) Init(outbound WorkflowOutboundInterceptor) error {
@@ -371,16 +395,16 @@ func (t *tracingWorkflowInboundInterceptor) ExecuteWorkflow(
 	in *ExecuteWorkflowInput,
 ) (interface{}, error) {
 	// Start span reading from header
-	info := workflow.GetInfo(ctx)
 	span, ctx, err := t.root.startSpanFromWorkflowContext(ctx, &TracerStartSpanOptions{
 		Operation: "RunWorkflow",
-		Name:      info.WorkflowType.Name,
+		Name:      t.info.WorkflowType.Name,
 		Tags: map[string]string{
-			workflowIDTagKey: info.WorkflowExecution.ID,
-			runIDTagKey:      info.WorkflowExecution.RunID,
+			workflowIDTagKey: t.info.WorkflowExecution.ID,
+			runIDTagKey:      t.info.WorkflowExecution.RunID,
 		},
-		FromHeader: true,
-		Time:       info.WorkflowStartTime,
+		FromHeader:     true,
+		Time:           t.info.WorkflowStartTime,
+		IdempotencyKey: t.newIdempotencyKey(),
 	})
 	if err != nil {
 		return nil, err
@@ -407,8 +431,9 @@ func (t *tracingWorkflowInboundInterceptor) HandleSignal(ctx workflow.Context, i
 			workflowIDTagKey: info.WorkflowExecution.ID,
 			runIDTagKey:      info.WorkflowExecution.RunID,
 		},
-		FromHeader: true,
-		Time:       time.Now(),
+		FromHeader:     true,
+		Time:           time.Now(),
+		IdempotencyKey: t.newIdempotencyKey(),
 	})
 	if err != nil {
 		return err
@@ -438,8 +463,9 @@ func (t *tracingWorkflowInboundInterceptor) HandleQuery(
 			workflowIDTagKey: info.WorkflowExecution.ID,
 			runIDTagKey:      info.WorkflowExecution.RunID,
 		},
-		FromHeader: true,
-		Time:       time.Now(),
+		FromHeader:     true,
+		Time:           time.Now(),
+		IdempotencyKey: t.newIdempotencyKey(),
 	})
 	if err != nil {
 		return nil, err

--- a/interceptor/tracing_interceptor.go
+++ b/interceptor/tracing_interceptor.go
@@ -149,6 +149,9 @@ type TracerStartSpanOptions struct {
 	//
 	// IdempotencyKey is not guaranteed to be set for all operations; Tracer
 	// implementations MUST therefore ignore zero values for this field.
+	//
+	// IdempotencyKey should be treated as opaque data by Tracer implementations.
+	// Do not attempt to parse it, as the format is subject to change.
 	IdempotencyKey string
 }
 

--- a/interceptor/tracing_interceptor_internal_test.go
+++ b/interceptor/tracing_interceptor_internal_test.go
@@ -1,0 +1,26 @@
+package interceptor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.temporal.io/sdk/workflow"
+)
+
+func TestIdempotencyKeyGeneration(t *testing.T) {
+	i := &tracingWorkflowInboundInterceptor{
+		root: nil,
+		info: &workflow.Info{
+			Namespace: "default",
+			WorkflowExecution: workflow.Execution{
+				ID:    "foo",
+				RunID: "bar",
+			},
+		},
+	}
+
+	// Verify that each call to get an idempotency key results in a deterministic and different result.
+	assert.Equal(t, i.newIdempotencyKey(), "WorkflowInboundInterceptor:default:foo:bar:1")
+	assert.Equal(t, i.newIdempotencyKey(), "WorkflowInboundInterceptor:default:foo:bar:2")
+}

--- a/interceptor/tracing_interceptor_internal_test.go
+++ b/interceptor/tracing_interceptor_internal_test.go
@@ -1,3 +1,27 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package interceptor
 
 import (

--- a/interceptor/tracing_interceptor_internal_test.go
+++ b/interceptor/tracing_interceptor_internal_test.go
@@ -45,6 +45,16 @@ func TestIdempotencyKeyGeneration(t *testing.T) {
 	}
 
 	// Verify that each call to get an idempotency key results in a deterministic and different result.
+	//
+	// XXX(jlegrone): Any change to the idempotency key format in this test constitutes a breaking
+	//                change to the SDK. This is because tracers that were using the old idempotency
+	//                key format will generate new IDs for the same spans after updating, and that
+	//                will lead to disconnected traces for workflows still running at the time of the
+	//                SDK upgrade.
+	//
+	//                If possible, changing the idempotency keys should be avoided. Otherwise at a
+	//                minimum, a description of this upgrade behavior should be included in the next
+	//                SDK version's release notes.
 	assert.Equal(t, i.newIdempotencyKey(), "WorkflowInboundInterceptor:default:foo:bar:1")
 	assert.Equal(t, i.newIdempotencyKey(), "WorkflowInboundInterceptor:default:foo:bar:2")
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

This PR adds a new `IdempotencyKey` field to `TracerStartSpanOptions` and sets this field on spans created from the `WorkflowInboundInterceptor` tracing implementation.

## Why?
<!-- Tell your future self why have you made these changes -->

This option can be used to compute a deterministic span ID automatically for tracing implementations which support specifying an explicit span ID. This is being proposed as an alternative to the way we're computing the `RunWorkflow` span ID in #921.

This approach might also be used to provide a safe interface for handling custom spans created by end users in workflow code.

## Checklist
<!--- add/delete as needed --->

1. Closes

N/A

3. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

See new unit test for creating idempotency keys. There are no existing tracing implementations in tree which support explicit spans, but we may be able to add additional tests in #921 if this is merged.

4. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

No