### PR TITLE
Printf-style debug of where workflow startup error go during queries...

### DIFF
--- a/internal/internal_event_handlers.go
+++ b/internal/internal_event_handlers.go
@@ -303,6 +303,7 @@ func (wc *workflowEnvironmentImpl) WorkflowInfo() *WorkflowInfo {
 }
 
 func (wc *workflowEnvironmentImpl) Complete(result *commonpb.Payloads, err error) {
+	fmt.Printf("YYY %+v\n", err)
 	wc.completeHandler(result, err)
 }
 

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -460,6 +460,8 @@ func (w *workflowExecutionContextImpl) getEventHandler() *workflowExecutionEvent
 }
 
 func (w *workflowExecutionContextImpl) completeWorkflow(result *commonpb.Payloads, err error) {
+	fmt.Printf("ZZZ %+v\n", err)
+
 	w.isWorkflowCompleted = true
 	w.result = result
 	w.err = err
@@ -794,6 +796,18 @@ processWorkflowLoop:
 			break processWorkflowLoop
 		}
 	}
+
+	if workflowContext.err != nil {
+		wth.logger.Warn("Workflow context held error after processing.",
+			tagWorkflowType, task.WorkflowType.GetName(),
+			tagWorkflowID, workflowID,
+			tagRunID, runID,
+			tagAttempt, task.Attempt,
+			tagPreviousStartedEventID, task.GetPreviousStartedEventId(),
+			tagError, workflowContext.err,
+		)
+	}
+
 	errRet = err
 	completeRequest = response
 	return

--- a/internal/internal_workflow.go
+++ b/internal/internal_workflow.go
@@ -551,6 +551,7 @@ func (d *syncWorkflowDefinition) Execute(env WorkflowEnvironment, header *common
 
 			// TODO: @shreyassrivatsan - add workflow trace span here
 			r.workflowResult, r.error = d.workflow.Execute(d.rootCtx, input)
+			fmt.Printf("HERE %+v\n", r.error)
 			rpp := getWorkflowResultPointerPointer(ctx)
 			*rpp = r
 		})
@@ -677,6 +678,7 @@ func executeDispatcher(ctx Context, dispatcher dispatcher, timeout time.Duration
 		env.GetLogger().Info("Workflow has unhandled signals", "SignalNames", us)
 	}
 
+	fmt.Printf("XXX %+v\n", rp.error)
 	env.Complete(rp.workflowResult, rp.error)
 }
 


### PR DESCRIPTION
## What was changed

When evaluating a query task, but the workflow code no longer accepts the input payload of the StartWorkflowEvent, the resulting error is currently dropped without any logs whatsoever (even with `EnableVerboseLogging`). The list of possible queries against that workflow is then empty (as query handlers would be registered at the start of the workflow code), leading to unexpectedly vanishing queries without any explanation.

This PR outlines the data flow (just follow the `Printf`, 1. `HERE`, 2. `XXX`, 3. `YYY`, 4. `ZZZ`) and adds a warning for _all_ workflow results ending in error, which will also be visible when the evaluated task was just for a query. This is likely too noisy and should be adapted further.

## Why?
If workflow input types are changed and queries stop working, there should be *some* indication in the logs that this is due to incompatible workflow code versions instead of silence.

## Checklist
1. Closes: TBD

2. How was this tested:

We (inadvertently) updated workflow definition code such that the input payload of older executions was no longer able deserialized to the input type of the new workflow code. Then we tried to execute queries (via UI) on the old workflow. However, even the defined query types were gone from the dropdown. We observed no logs indicating any error conditions, neither on the temporal services nor on the workflow worker evaluating the query task.

We used `go.mod` `replace` directive to recompile the workflow worker against the source branch of this PR and observed the new warning message when workflow initialization failed due to failures during input deserialization.