### PR TITLE
Do not set idempotency key for HandleQuery

### DIFF
--- a/interceptor/tracing_interceptor.go
+++ b/interceptor/tracing_interceptor.go
@@ -466,9 +466,12 @@ func (t *tracingWorkflowInboundInterceptor) HandleQuery(
 			workflowIDTagKey: info.WorkflowExecution.ID,
 			runIDTagKey:      info.WorkflowExecution.RunID,
 		},
-		FromHeader:     true,
-		Time:           time.Now(),
-		IdempotencyKey: t.newIdempotencyKey(),
+		FromHeader: true,
+		Time:       time.Now(),
+		// We intentionally do not set IdempotencyKey here because queries are not recorded in
+		// workflow history. When the tracing interceptor's span counter is reset between workflow
+		// replays, old queries will not be processed which could result in idempotency key
+		// collisions with other queries or signals.
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

This PR skips setting `IdempotencyKey` for query spans. Followup to #931.

## Why?
<!-- Tell your future self why have you made these changes -->

Queries aren’t included in workflow history, so the counter can be reset in between workflow replays and we can end up with an idempotency key collision with another query or signal.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
