### PR TITLE
Max eager activities per task

### DIFF
--- a/.github/workflows/docker/dynamic-config-custom.yaml
+++ b/.github/workflows/docker/dynamic-config-custom.yaml
@@ -1,5 +1,5 @@
 system.forceSearchAttributesCacheRefreshOnRead:
   - value: true # Dev setup only. Please don't turn this on in production.
     constraints: {}
-system.enableActivityLocalDispatch:
+system.enableActivityEagerExecution:
   - value: true

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -65,9 +65,8 @@ const (
 	// center. And the poll API latency is about 5ms. With 2 poller, we could achieve around 300~400 RPS.
 	defaultConcurrentPollRoutineSize = 2
 
-	defaultMaxConcurrentActivityExecutionSize      = 1000 // Large concurrent activity execution size (1k)
-	defaultMaxConcurrentEagerActivityExecutionSize = 3
-	defaultWorkerActivitiesPerSecond               = 100000 // Large activity executions/sec (unlimited)
+	defaultMaxConcurrentActivityExecutionSize = 1000   // Large concurrent activity execution size (1k)
+	defaultWorkerActivitiesPerSecond          = 100000 // Large activity executions/sec (unlimited)
 
 	defaultMaxConcurrentLocalActivityExecutionSize = 1000   // Large concurrent activity execution size (1k)
 	defaultWorkerLocalActivitiesPerSecond          = 100000 // Large activity executions/sec (unlimited)
@@ -1602,9 +1601,6 @@ func setWorkerOptionsDefaults(options *WorkerOptions) {
 	}
 	if options.MaxHeartbeatThrottleInterval == 0 {
 		options.MaxHeartbeatThrottleInterval = defaultMaxHeartbeatThrottleInterval
-	}
-	if options.MaxConcurrentEagerActivityExecutionSize == 0 {
-		options.MaxConcurrentEagerActivityExecutionSize = defaultMaxConcurrentEagerActivityExecutionSize
 	}
 }
 

--- a/internal/worker.go
+++ b/internal/worker.go
@@ -209,8 +209,7 @@ type (
 		// workflow task schedules 3 more, only the first 2 will request eager
 		// execution.
 		//
-		// If unset/0, this defaults to 3. Users wanting effectively unlimited can
-		// set this to a high value. This is still bounded by
+		// The default of 0 means unlimited and therefore only bound by
 		// MaxConcurrentActivityExecutionSize.
 		//
 		// See DisableEagerActivities for a description of eager activity execution.


### PR DESCRIPTION
## What was changed

* Removed default limit on `MaxConcurrentEagerActivityExecutionSize`
* Added default limit of 3 eager activities per workflow task

## Why?

My original concern was overloading the worker with lots of eager activities. Others' concerns are only overloading a worker in the rare case of more than 3 activities per task. I think my concern is limits eager activity scope better, but I'm doing what others want here.

## Checklist

1. Closes #950