### PR TITLE
Schedule fixes

### DIFF
--- a/internal/internal_schedule_client.go
+++ b/internal/internal_schedule_client.go
@@ -553,7 +553,7 @@ func convertFromPBScheduleListEntry(schedule *schedulepb.ScheduleListEntry) *Sch
 
 func convertToPBScheduleAction(ctx context.Context, client *WorkflowClient, scheduleAction ScheduleAction) (*schedulepb.ScheduleAction, error) {
 	switch action := scheduleAction.(type) {
-	case ScheduleWorkflowAction:
+	case *ScheduleWorkflowAction:
 		// Set header before interceptor run
 		dataConverter := WithContext(ctx, client.dataConverter)
 
@@ -636,7 +636,7 @@ func convertFromPBScheduleAction(action *schedulepb.ScheduleAction) (ScheduleAct
 			searchAttributes[key] = element
 		}
 
-		return ScheduleWorkflowAction{
+		return &ScheduleWorkflowAction{
 			ID:                       workflow.GetWorkflowId(),
 			Workflow:                 workflow.WorkflowType.GetName(),
 			Args:                     args,
@@ -761,7 +761,6 @@ func encodeScheduleWorklowArgs(dc converter.DataConverter, args []interface{}) (
 			}
 			payloads[i] = payload
 		}
-
 	}
 	return &commonpb.Payloads{
 		Payloads: payloads,

--- a/internal/internal_schedule_client_test.go
+++ b/internal/internal_schedule_client_test.go
@@ -36,7 +36,7 @@ import (
 )
 
 const (
-	scheduleID            = "some random schedule ID"
+	scheduleID = "some random schedule ID"
 )
 
 // schedule client test suite
@@ -66,7 +66,6 @@ func (s *scheduleClientTestSuite) TearDownTest() {
 	s.mockCtrl.Finish() // assert mock’s expectations
 }
 
-
 func (s *scheduleClientTestSuite) TestCreateScheduleClient() {
 	wf := func(ctx Context) string {
 		panic("this is just a stub")
@@ -76,8 +75,8 @@ func (s *scheduleClientTestSuite) TestCreateScheduleClient() {
 		Spec: ScheduleSpec{
 			CronExpressions: []string{"*"},
 		},
-		Action: ScheduleWorkflowAction{
-			Workflow:        wf,
+		Action: &ScheduleWorkflowAction{
+			Workflow:                 wf,
 			ID:                       workflowID,
 			TaskQueue:                taskqueue,
 			WorkflowExecutionTimeout: timeoutInSeconds,
@@ -90,6 +89,27 @@ func (s *scheduleClientTestSuite) TestCreateScheduleClient() {
 	scheduleHandle, err := s.client.ScheduleClient().Create(context.Background(), options)
 	s.Nil(err)
 	s.Equal(scheduleHandle.GetID(), scheduleID)
+}
+
+func (s *scheduleClientTestSuite) TestCreateScheduleNoID() {
+	wf := func(ctx Context) string {
+		panic("this is just a stub")
+	}
+	options := ScheduleOptions{
+		Spec: ScheduleSpec{
+			CronExpressions: []string{"*"},
+		},
+		Action: &ScheduleWorkflowAction{
+			Workflow:                 wf,
+			ID:                       workflowID,
+			TaskQueue:                taskqueue,
+			WorkflowExecutionTimeout: timeoutInSeconds,
+			WorkflowTaskTimeout:      timeoutInSeconds,
+		},
+	}
+
+	_, err := s.client.ScheduleClient().Create(context.Background(), options)
+	s.NotNil(err)
 }
 
 func (s *scheduleClientTestSuite) TestCreateScheduleWithMemoAndSearchAttr() {
@@ -109,8 +129,8 @@ func (s *scheduleClientTestSuite) TestCreateScheduleWithMemoAndSearchAttr() {
 		Spec: ScheduleSpec{
 			CronExpressions: []string{"*"},
 		},
-		Action: ScheduleWorkflowAction{
-			Workflow:        		  wf,
+		Action: &ScheduleWorkflowAction{
+			Workflow:                 wf,
 			ID:                       "wid",
 			TaskQueue:                taskqueue,
 			WorkflowExecutionTimeout: timeoutInSeconds,
@@ -138,7 +158,7 @@ func (s *scheduleClientTestSuite) TestCreateScheduleWithMemoAndSearchAttr() {
 
 func getListSchedulesRequest() *workflowservice.ListSchedulesRequest {
 	request := &workflowservice.ListSchedulesRequest{
-		Namespace:       DefaultNamespace,
+		Namespace: DefaultNamespace,
 	}
 
 	return request

--- a/internal/schedule_client.go
+++ b/internal/schedule_client.go
@@ -193,7 +193,7 @@ type (
 		EndAt time.Time
 
 		// Jitter - All times will be incremented by a random value from 0 to this amount of jitter, capped
-		// by the time until the next schedule. 
+		// by the time until the next schedule.
 		// Optional: Defaulted to 0
 		Jitter time.Duration
 
@@ -220,6 +220,9 @@ type (
 	// ScheduleWorkflowAction implements ScheduleAction to launch a workflow.
 	ScheduleWorkflowAction struct {
 		// ID - The business identifier of the workflow execution.
+		// The workflow ID of the started workflow may not match this exactly,
+		// it may have a timestamp appended for uniqueness.
+		// Optional: defaulted to a uuid.
 		ID string
 
 		// Workflow - What workflow to run.
@@ -267,7 +270,6 @@ type (
 	// ScheduleOptions configure the parameters for creating a schedule.
 	ScheduleOptions struct {
 		// ID - The business identifier of the schedule.
-		// Optional: defaulted to a uuid.
 		ID string
 
 		// Schedule - Describes when Actions should be taken.
@@ -285,17 +287,17 @@ type (
 
 		// CatchupWindow - The Temporal Server might be down or unavailable at the time when a Schedule should take an Action.
 		// When the Server comes back up, CatchupWindow controls which missed Actions should be taken at that point. The default is one
-   		// minute, which means that the Schedule attempts to take any Actions that wouldn't be more than one minute late. It
-   		// takes those Actions according to the Overlap. An outage that lasts longer than the Catchup
-   		// Window could lead to missed Actions.
+		// minute, which means that the Schedule attempts to take any Actions that wouldn't be more than one minute late. It
+		// takes those Actions according to the Overlap. An outage that lasts longer than the Catchup
+		// Window could lead to missed Actions.
 		// Optional: defaulted to 1 minute
 		CatchupWindow time.Duration
 
 		// PauseOnFailure - When an Action times out or reaches the end of its Retry Policy the Schedule will pause.
 		//
 		// With SCHEDULE_OVERLAP_POLICY_ALLOW_ALL, this pause might not apply to the next Action, because the next Action
-   		// might have already started previous to the failed one finishing. Pausing applies only to Actions that are scheduled
-   		// to start after the failed one finishes.
+		// might have already started previous to the failed one finishing. Pausing applies only to Actions that are scheduled
+		// to start after the failed one finishes.
 		// Optional: defaulted to false
 		PauseOnFailure bool
 
@@ -451,7 +453,7 @@ type (
 	}
 
 	// ScheduleUpdateOptions configure the parameters for updating a schedule.
-	ScheduleUpdateOptions struct{
+	ScheduleUpdateOptions struct {
 		// DoUpdate - Takes a description of the schedule and returns the new desired schedule.
 		// If update returns ErrSkipScheduleUpdate response and no update will occur.
 		// Any other error will be passed through.
@@ -459,27 +461,27 @@ type (
 	}
 
 	// ScheduleTriggerOptions configure the parameters for triggering a schedule.
-	ScheduleTriggerOptions struct{
+	ScheduleTriggerOptions struct {
 		// Overlap - If specified, policy to override the schedules default overlap policy.
 		Overlap enumspb.ScheduleOverlapPolicy
 	}
 
 	// SchedulePauseOptions configure the parameters for pausing a schedule.
-	SchedulePauseOptions struct{
+	SchedulePauseOptions struct {
 		// Note - Informative human-readable message with contextual notes.
 		// Optional: defaulted to 'Paused via Go SDK'
 		Note string
 	}
 
 	// ScheduleUnpauseOptions configure the parameters for unpausing a schedule.
-	ScheduleUnpauseOptions struct{
+	ScheduleUnpauseOptions struct {
 		// Note - Informative human-readable message with contextual notes.
 		// Optional: defaulted to 'Unpaused via Go SDK'
 		Note string
 	}
 
 	// ScheduleBackfillOptions configure the parameters for backfilling a schedule.
-	ScheduleBackfillOptions struct{
+	ScheduleBackfillOptions struct {
 		// Backfill  - Time periods to backfill the schedule.
 		Backfill []ScheduleBackfill
 	}
@@ -489,7 +491,7 @@ type (
 		// GetID returns the schedule ID asssociated with this handle.
 		GetID() string
 
-		// Delete the Schedule 
+		// Delete the Schedule
 		Delete(ctx context.Context) error
 
 		// Backfill the schedule by going though the specified time periods and taking Actions as if that time passed by right now, all at once.
@@ -597,8 +599,7 @@ type (
 		// methods like ScheduleHandle.Describe() will return an error.
 		GetHandle(ctx context.Context, scheduleID string) ScheduleHandle
 	}
-
 )
 
-func (ScheduleWorkflowAction) isScheduleAction() {
+func (*ScheduleWorkflowAction) isScheduleAction() {
 }

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -2682,8 +2682,8 @@ func (ts *IntegrationTestSuite) TestUpsertMemoWithExistingMemo() {
 	ts.Equal(expectedMemo, memo)
 }
 
-func (ts *IntegrationTestSuite) createBasicScheduleWorkflowAction(ID string) client.ScheduleWorkflowAction {
-	return client.ScheduleWorkflowAction{
+func (ts *IntegrationTestSuite) createBasicScheduleWorkflowAction(ID string) client.ScheduleAction {
+	return &client.ScheduleWorkflowAction{
 		Workflow:                 ts.workflows.SimplestWorkflow,
 		ID:                       ID,
 		TaskQueue:                ts.taskQueueName,
@@ -2956,7 +2956,7 @@ func (ts *IntegrationTestSuite) TestScheduleDescribeState() {
 	handle, err := ts.client.ScheduleClient().Create(ctx, client.ScheduleOptions{
 		ID:   "test-schedule-describe-state-schedule",
 		Spec: client.ScheduleSpec{},
-		Action: client.ScheduleWorkflowAction{
+		Action: &client.ScheduleWorkflowAction{
 			Workflow:                 ts.workflows.TwoParameterWorkflow,
 			Args:                     []interface{}{"Test Arg 1", "Test Arg 2"},
 			ID:                       "test-schedule-describe-state-workflow",
@@ -2993,7 +2993,7 @@ func (ts *IntegrationTestSuite) TestScheduleDescribeState() {
 	ts.Equal(testNote, description.Schedule.State.Note)
 	// test action
 	switch action := description.Schedule.Action.(type) {
-	case client.ScheduleWorkflowAction:
+	case *client.ScheduleWorkflowAction:
 		ts.Equal("TwoParameterWorkflow", action.Workflow)
 		ts.Equal(expectedArg1Value, action.Args[0])
 		ts.Equal(expectedArg2Value, action.Args[1])
@@ -3092,7 +3092,6 @@ func (ts *IntegrationTestSuite) TestScheduleTrigger() {
 		ts.NoError(wfRun.Get(ctx, &result))
 		ts.Equal("hello", result)
 	}
-
 }
 
 func (ts *IntegrationTestSuite) TestScheduleBackfillCreate() {
@@ -3192,7 +3191,7 @@ func (ts *IntegrationTestSuite) TestScheduleList() {
 		handle, err := ts.client.ScheduleClient().Create(ctx, client.ScheduleOptions{
 			ID:   scheduleID,
 			Spec: client.ScheduleSpec{},
-			Action: client.ScheduleWorkflowAction{
+			Action: &client.ScheduleWorkflowAction{
 				Workflow:                 ts.workflows.SimplestWorkflow,
 				ID:                       workflowID,
 				TaskQueue:                ts.taskQueueName,
@@ -3271,7 +3270,7 @@ func (ts *IntegrationTestSuite) TestScheduleUpdateCancelUpdate() {
 	}()
 	updateFunc := func(input client.ScheduleUpdateInput) (*client.ScheduleUpdate, error) {
 		switch action := input.Description.Schedule.Action.(type) {
-		case client.ScheduleWorkflowAction:
+		case *client.ScheduleWorkflowAction:
 			action.ID = "new-workflow-id"
 			input.Description.Schedule.Action = action
 			return &client.ScheduleUpdate{
@@ -3289,7 +3288,7 @@ func (ts *IntegrationTestSuite) TestScheduleUpdateCancelUpdate() {
 	description, err := handle.Describe(ctx)
 	ts.NoError(err)
 	switch action := description.Schedule.Action.(type) {
-	case client.ScheduleWorkflowAction:
+	case *client.ScheduleWorkflowAction:
 		ts.Equal("test-schedule-update-workflow", action.ID)
 	default:
 		ts.Fail("schedule action wrong type")
@@ -3318,7 +3317,7 @@ func (ts *IntegrationTestSuite) TestScheduleUpdateError() {
 	err = handle.Update(ctx, client.ScheduleUpdateOptions{
 		DoUpdate: updateFunc,
 	})
-	ts.EqualError(err,"test failure")
+	ts.EqualError(err, "test failure")
 }
 
 func (ts *IntegrationTestSuite) TestScheduleUpdateNewAction() {
@@ -3339,7 +3338,7 @@ func (ts *IntegrationTestSuite) TestScheduleUpdateNewAction() {
 	}()
 	// change workflow type
 	updateFunc := func(input client.ScheduleUpdateInput) (*client.ScheduleUpdate, error) {
-		input.Description.Schedule.Action = client.ScheduleWorkflowAction{
+		input.Description.Schedule.Action = &client.ScheduleWorkflowAction{
 			Workflow:                 ts.workflows.Basic,
 			ID:                       "test-schedule-update-new-action-workflow",
 			TaskQueue:                ts.taskQueueName,
@@ -3357,7 +3356,7 @@ func (ts *IntegrationTestSuite) TestScheduleUpdateNewAction() {
 	description, err := handle.Describe(ctx)
 	ts.NoError(err)
 	switch action := description.Schedule.Action.(type) {
-	case client.ScheduleWorkflowAction:
+	case *client.ScheduleWorkflowAction:
 		ts.Equal("Basic", action.Workflow)
 	default:
 		ts.Fail("schedule action wrong type")
@@ -3382,7 +3381,7 @@ func (ts *IntegrationTestSuite) TestScheduleUpdateAction() {
 	}()
 	updateFunc := func(input client.ScheduleUpdateInput) (*client.ScheduleUpdate, error) {
 		switch action := input.Description.Schedule.Action.(type) {
-		case client.ScheduleWorkflowAction:
+		case *client.ScheduleWorkflowAction:
 			action.ID = "new-workflow-id"
 			input.Description.Schedule.Action = action
 			return &client.ScheduleUpdate{
@@ -3400,7 +3399,7 @@ func (ts *IntegrationTestSuite) TestScheduleUpdateAction() {
 	description, err := handle.Describe(ctx)
 	ts.NoError(err)
 	switch action := description.Schedule.Action.(type) {
-	case client.ScheduleWorkflowAction:
+	case *client.ScheduleWorkflowAction:
 		ts.Equal("new-workflow-id", action.ID)
 	default:
 		ts.Fail("schedule action wrong type")
@@ -3417,7 +3416,7 @@ func (ts *IntegrationTestSuite) TestScheduleUpdateActionParameter() {
 	handle, err := ts.client.ScheduleClient().Create(ctx, client.ScheduleOptions{
 		ID:   "test-schedule-update-action-parameter-schedule",
 		Spec: client.ScheduleSpec{},
-		Action: client.ScheduleWorkflowAction{
+		Action: &client.ScheduleWorkflowAction{
 			Workflow:                 ts.workflows.TwoParameterWorkflow,
 			Args:                     []interface{}{"arg 1", "arg 2"},
 			ID:                       "test-schedule-update-action-parameter-workflow",
@@ -3435,7 +3434,7 @@ func (ts *IntegrationTestSuite) TestScheduleUpdateActionParameter() {
 	}()
 	updateFunc := func(input client.ScheduleUpdateInput) (*client.ScheduleUpdate, error) {
 		switch action := input.Description.Schedule.Action.(type) {
-		case client.ScheduleWorkflowAction:
+		case *client.ScheduleWorkflowAction:
 			action.Workflow = ts.workflows.ThreeParameterWorkflow
 			action.Args = []interface{}{"Test Arg 1", "Test Arg 2", "Test Arg 3"}
 			input.Description.Schedule.Action = action
@@ -3454,7 +3453,7 @@ func (ts *IntegrationTestSuite) TestScheduleUpdateActionParameter() {
 	description, err := handle.Describe(ctx)
 	ts.NoError(err)
 	switch action := description.Schedule.Action.(type) {
-	case client.ScheduleWorkflowAction:
+	case *client.ScheduleWorkflowAction:
 		ts.Equal("ThreeParameterWorkflow", action.Workflow)
 		ts.Equal(expectedArg1Value, action.Args[0])
 		ts.Equal(expectedArg2Value, action.Args[1])
@@ -3480,7 +3479,7 @@ func (ts *IntegrationTestSuite) TestScheduleUpdateWorkflowActionMemo() {
 	handle, err := ts.client.ScheduleClient().Create(ctx, client.ScheduleOptions{
 		ID:   "test-schedule-update-action-memo-schedule",
 		Spec: client.ScheduleSpec{},
-		Action: client.ScheduleWorkflowAction{
+		Action: &client.ScheduleWorkflowAction{
 			Workflow:                 ts.workflows.SimplestWorkflow,
 			ID:                       "test-schedule-update-action-memo-workflow",
 			TaskQueue:                ts.taskQueueName,
@@ -3500,7 +3499,7 @@ func (ts *IntegrationTestSuite) TestScheduleUpdateWorkflowActionMemo() {
 	}()
 	updateFunc := func(input client.ScheduleUpdateInput) (*client.ScheduleUpdate, error) {
 		switch action := input.Description.Schedule.Action.(type) {
-		case client.ScheduleWorkflowAction:
+		case *client.ScheduleWorkflowAction:
 			key2Value, _ := converter.GetDefaultDataConverter().ToPayload(123)
 			action.Memo["key_2"] = key2Value
 			action.Memo["key_3"] = "other value"
@@ -3519,7 +3518,7 @@ func (ts *IntegrationTestSuite) TestScheduleUpdateWorkflowActionMemo() {
 	description, err := handle.Describe(ctx)
 	ts.NoError(err)
 	switch action := description.Schedule.Action.(type) {
-	case client.ScheduleWorkflowAction:
+	case *client.ScheduleWorkflowAction:
 		ts.EqualValues(expectedMemo, action.Memo)
 	default:
 		ts.Fail("schedule action wrong type")
@@ -3528,16 +3527,20 @@ func (ts *IntegrationTestSuite) TestScheduleUpdateWorkflowActionMemo() {
 
 // executeWorkflow executes a given workflow and waits for the result
 func (ts *IntegrationTestSuite) executeWorkflow(
-	wfID string, wfFunc interface{}, retValPtr interface{}, args ...interface{}) error {
+	wfID string, wfFunc interface{}, retValPtr interface{}, args ...interface{},
+) error {
 	return ts.executeWorkflowWithOption(ts.startWorkflowOptions(wfID), wfFunc, retValPtr, args...)
 }
+
 func (ts *IntegrationTestSuite) executeWorkflowWithOption(
-	options client.StartWorkflowOptions, wfFunc interface{}, retValPtr interface{}, args ...interface{}) error {
+	options client.StartWorkflowOptions, wfFunc interface{}, retValPtr interface{}, args ...interface{},
+) error {
 	return ts.executeWorkflowWithContextAndOption(context.Background(), options, wfFunc, retValPtr, args...)
 }
 
 func (ts *IntegrationTestSuite) executeWorkflowWithContextAndOption(
-	ctx context.Context, options client.StartWorkflowOptions, wfFunc interface{}, retValPtr interface{}, args ...interface{}) error {
+	ctx context.Context, options client.StartWorkflowOptions, wfFunc interface{}, retValPtr interface{}, args ...interface{},
+) error {
 	ctx, cancel := context.WithTimeout(ctx, ctxTimeout)
 	defer cancel()
 	run, err := ts.client.ExecuteWorkflow(ctx, options, wfFunc, args...)
@@ -3559,7 +3562,7 @@ func (ts *IntegrationTestSuite) executeWorkflowWithContextAndOption(
 }
 
 func (ts *IntegrationTestSuite) startWorkflowOptions(wfID string) client.StartWorkflowOptions {
-	var wfOptions = client.StartWorkflowOptions{
+	wfOptions := client.StartWorkflowOptions{
 		ID:                       wfID,
 		TaskQueue:                ts.taskQueueName,
 		WorkflowExecutionTimeout: 15 * time.Second,
@@ -3577,9 +3580,11 @@ func (ts *IntegrationTestSuite) registerWorkflowsAndActivities(w worker.Worker) 
 	ts.activities.register(w)
 }
 
-var _ interceptor.WorkerInterceptor = (*tracingInterceptor)(nil)
-var _ interceptor.WorkflowInboundInterceptor = (*tracingWorkflowInboundInterceptor)(nil)
-var _ interceptor.WorkflowOutboundInterceptor = (*tracingWorkflowOutboundInterceptor)(nil)
+var (
+	_ interceptor.WorkerInterceptor           = (*tracingInterceptor)(nil)
+	_ interceptor.WorkflowInboundInterceptor  = (*tracingWorkflowInboundInterceptor)(nil)
+	_ interceptor.WorkflowOutboundInterceptor = (*tracingWorkflowOutboundInterceptor)(nil)
+)
 
 type tracingInterceptor struct {
 	interceptor.WorkerInterceptorBase
@@ -3627,7 +3632,8 @@ func (t *tracingInterceptor) GetTrace(workflowType string) []string {
 
 func (t *tracingWorkflowInboundInterceptor) Init(outbound interceptor.WorkflowOutboundInterceptor) error {
 	return t.Next.Init(&tracingWorkflowOutboundInterceptor{
-		interceptor.WorkflowOutboundInterceptorBase{Next: outbound}, t})
+		interceptor.WorkflowOutboundInterceptorBase{Next: outbound}, t,
+	})
 }
 
 func (t *tracingWorkflowOutboundInterceptor) ExecuteActivity(ctx workflow.Context, activityType string, args ...interface{}) workflow.Future {
@@ -3659,8 +3665,10 @@ func (t *tracingWorkflowInboundInterceptor) HandleQuery(ctx workflow.Context, in
 	return result, err
 }
 
-var _ interceptor.WorkerInterceptor = (*signalInterceptor)(nil)
-var _ interceptor.WorkflowInboundInterceptor = (*signalWorkflowInboundInterceptor)(nil)
+var (
+	_ interceptor.WorkerInterceptor          = (*signalInterceptor)(nil)
+	_ interceptor.WorkflowInboundInterceptor = (*signalWorkflowInboundInterceptor)(nil)
+)
 
 type signalInterceptor struct {
 	interceptor.WorkerInterceptorBase
@@ -3790,7 +3798,8 @@ func (c *coroutineCountingInterceptor) InterceptWorkflow(
 
 func (c *coroutineCountingWorkflowInboundInterceptor) Init(outbound interceptor.WorkflowOutboundInterceptor) error {
 	return c.Next.Init(&coroutineCountingWorkflowOutboundInterceptor{
-		interceptor.WorkflowOutboundInterceptorBase{Next: outbound}, c.root})
+		interceptor.WorkflowOutboundInterceptorBase{Next: outbound}, c.root,
+	})
 }
 
 func (c *coroutineCountingWorkflowOutboundInterceptor) Go(


### PR DESCRIPTION
Fix a few issues @cretz found in the schedules API:
- clean up documentation on schedule ID and workflow ID
- standardize on taking a pointer type for `ScheduleWorkflowAction`

closes:
* https://github.com/temporalio/sdk-go/issues/958
* https://github.com/temporalio/sdk-go/issues/957

Note: This is a breaking change since users can no longer pass a struct for `ScheduleWorkflowAction` to avoid this we could  allow users to pass a pointer or a struct.