### PR TITLE
Fix default catchupWindow

### DIFF
--- a/internal/internal_schedule_client.go
+++ b/internal/internal_schedule_client.go
@@ -117,6 +117,13 @@ func (w *workflowClientInterceptor) CreateSchedule(ctx context.Context, in *Sche
 		}
 	}
 
+	catchupWindow := &in.Options.CatchupWindow
+	if in.Options.CatchupWindow == 0 {
+		// Convert to nil so the server uses the default
+		// catchup window,otherwise it will use the minimum (10s).
+		catchupWindow = nil
+	}
+
 	// run propagators to extract information about tracing and other stuff, store in headers field
 	startRequest := &workflowservice.CreateScheduleRequest{
 		Namespace:  w.client.namespace,
@@ -127,14 +134,14 @@ func (w *workflowClientInterceptor) CreateSchedule(ctx context.Context, in *Sche
 			Action: action,
 			Policies: &schedulepb.SchedulePolicies{
 				OverlapPolicy:  in.Options.Overlap,
-				CatchupWindow:  &in.Options.CatchupWindow,
+				CatchupWindow:  catchupWindow,
 				PauseOnFailure: in.Options.PauseOnFailure,
 			},
 			State: &schedulepb.ScheduleState{
 				Notes:            in.Options.Note,
 				Paused:           in.Options.Paused,
 				LimitedActions:   in.Options.RemainingActions != 0,
-				RemainingActions: in.Options.RemainingActions,
+				RemainingActions: int64(in.Options.RemainingActions),
 			},
 		},
 		InitialPatch:     initialPatch,

--- a/internal/schedule_client.go
+++ b/internal/schedule_client.go
@@ -316,7 +316,7 @@ type (
 		// taken when the number is `0` (unless ScheduleHandle.Trigger is called).
 		//
 		// Optional: defaulted to zero
-		RemainingActions int64
+		RemainingActions int
 
 		// TriggerImmediately - Trigger one Action immediately on creating the schedule.
 		// Optional: defaulted to false


### PR DESCRIPTION
Fix a mismatch between the server and SDK around `CatchupWindow`. The SDK uses zero `time.duration` to represent default but the server treated this duration as the minimum (10s). This causes schedule actions to fail more often under load because the catch up window is smaller.