### PR TITLE
Add num_pollers metric

### DIFF
--- a/internal/common/metrics/constants.go
+++ b/internal/common/metrics/constants.go
@@ -62,6 +62,7 @@ const (
 	WorkerStartCounter       = TemporalMetricsPrefix + "worker_start"
 	WorkerTaskSlotsAvailable = TemporalMetricsPrefix + "worker_task_slots_available"
 	PollerStartCounter       = TemporalMetricsPrefix + "poller_start"
+	NumPoller                = TemporalMetricsPrefix + "num_pollers"
 
 	TemporalRequest                      = TemporalMetricsPrefix + "request"
 	TemporalRequestFailure               = TemporalRequest + "_failure"
@@ -84,6 +85,7 @@ const (
 const (
 	NamespaceTagName        = "namespace"
 	ClientTagName           = "client_name"
+	PollerTypeTagName       = "poller_type"
 	WorkerTypeTagName       = "worker_type"
 	WorkflowTypeNameTagName = "workflow_type"
 	ActivityTypeNameTagName = "activity_type"
@@ -94,6 +96,9 @@ const (
 
 // Metric tag values
 const (
-	NoneTagValue   = "none"
-	ClientTagValue = "temporal_go"
+	NoneTagValue                 = "none"
+	ClientTagValue               = "temporal_go"
+	PollerTypeWorkflowTask       = "workflow_task"
+	PollerTypeWorkflowStickyTask = "workflow_sticky_task"
+	PollerTypeActivityTask       = "activity_task"
 )

--- a/internal/common/metrics/tags.go
+++ b/internal/common/metrics/tags.go
@@ -80,3 +80,10 @@ func WorkerTags(workerType string) map[string]string {
 		WorkerTypeTagName: workerType,
 	}
 }
+
+// PllerTags returns a set of tags for pollers.
+func PollerTags(pollerType string) map[string]string {
+	return map[string]string{
+		PollerTypeTagName: pollerType,
+	}
+}

--- a/internal/common/metrics/tags.go
+++ b/internal/common/metrics/tags.go
@@ -81,7 +81,7 @@ func WorkerTags(workerType string) map[string]string {
 	}
 }
 
-// PllerTags returns a set of tags for pollers.
+// PollerTags returns a set of tags for pollers.
 func PollerTags(pollerType string) map[string]string {
 	return map[string]string{
 		PollerTypeTagName: pollerType,

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -1792,9 +1792,13 @@ func (ts *IntegrationTestSuite) TestNumPollersCounter() {
 		// Will fail
 		ts.Equal(expected, lastCount)
 	}
-
-	assertNumPollersEventually(1, "workflow_task")
-	assertNumPollersEventually(1, "workflow_sticky_task")
+	if ts.config.maxWorkflowCacheSize == 0 {
+		assertNumPollersEventually(2, "workflow_task")
+		assertNumPollersEventually(0, "workflow_sticky_task")
+	} else {
+		assertNumPollersEventually(1, "workflow_task")
+		assertNumPollersEventually(1, "workflow_sticky_task")
+	}
 	assertNumPollersEventually(2, "activity_task")
 }
 

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -1772,6 +1772,32 @@ func (ts *IntegrationTestSuite) waitForQueryTrue(run client.WorkflowRun, query s
 	ts.True(result, "query didn't return true in reasonable amount of time")
 }
 
+func (ts *IntegrationTestSuite) TestNumPollersCounter() {
+	_, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	assertNumPollersEventually := func(expected float64, pollerType string, tags ...string) {
+		// Try for two seconds
+		var lastCount float64
+		for start := time.Now(); time.Since(start) <= 10*time.Second; {
+			lastCount = ts.metricGauge(
+				metrics.NumPoller,
+				"poller_type", pollerType,
+				"task_queue", ts.taskQueueName,
+			)
+			if lastCount == expected {
+				return
+			}
+			time.Sleep(50 * time.Millisecond)
+		}
+		// Will fail
+		ts.Equal(expected, lastCount)
+	}
+
+	assertNumPollersEventually(1, "workflow_task")
+	assertNumPollersEventually(1, "workflow_sticky_task")
+	assertNumPollersEventually(2, "activity_task")
+}
+
 func (ts *IntegrationTestSuite) TestSlotsAvailableCounter() {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()


### PR DESCRIPTION
Closes https://github.com/temporalio/sdk-go/issues/854

Implements the `num_pollers` metric for Go

NOTE:
Once released we need to update the docs to include Go here
https://docs.temporal.io/references/sdk-metrics#num_pollers