### PR TITLE
Add local_activity_execution_failed metric

### DIFF
--- a/internal/common/metrics/constants.go
+++ b/internal/common/metrics/constants.go
@@ -50,13 +50,14 @@ const (
 	ActivitySucceedEndToEndLatency        = TemporalMetricsPrefix + "activity_succeed_endtoend_latency"
 	ActivityTaskErrorCounter              = TemporalMetricsPrefix + "activity_task_error"
 
-	LocalActivityTotalCounter           = TemporalMetricsPrefix + "local_activity_total"
-	LocalActivityCanceledCounter        = TemporalMetricsPrefix + "local_activity_canceled"
-	LocalActivityFailedCounter          = TemporalMetricsPrefix + "local_activity_failed" // Deprecated: Use LocalActivityExecutionFailedCounter instead.
-	LocalActivityExecutionFailedCounter = TemporalMetricsPrefix + "local_activity_execution_failed"
-	LocalActivityErrorCounter           = TemporalMetricsPrefix + "local_activity_error"
-	LocalActivityExecutionLatency       = TemporalMetricsPrefix + "local_activity_execution_latency"
-	LocalActivitySucceedEndToEndLatency = TemporalMetricsPrefix + "local_activity_succeed_endtoend_latency"
+	LocalActivityTotalCounter             = TemporalMetricsPrefix + "local_activity_total"
+	LocalActivityCanceledCounter          = TemporalMetricsPrefix + "local_activity_canceled" // Deprecated: Use LocalActivityExecutionCanceledCounter instead.
+	LocalActivityExecutionCanceledCounter = TemporalMetricsPrefix + "local_activity_execution_cancelled"
+	LocalActivityFailedCounter            = TemporalMetricsPrefix + "local_activity_failed" // Deprecated: Use LocalActivityExecutionFailedCounter instead.
+	LocalActivityExecutionFailedCounter   = TemporalMetricsPrefix + "local_activity_execution_failed"
+	LocalActivityErrorCounter             = TemporalMetricsPrefix + "local_activity_error"
+	LocalActivityExecutionLatency         = TemporalMetricsPrefix + "local_activity_execution_latency"
+	LocalActivitySucceedEndToEndLatency   = TemporalMetricsPrefix + "local_activity_succeed_endtoend_latency"
 
 	CorruptedSignalsCounter = TemporalMetricsPrefix + "corrupted_signals"
 

--- a/internal/common/metrics/constants.go
+++ b/internal/common/metrics/constants.go
@@ -52,7 +52,8 @@ const (
 
 	LocalActivityTotalCounter           = TemporalMetricsPrefix + "local_activity_total"
 	LocalActivityCanceledCounter        = TemporalMetricsPrefix + "local_activity_canceled"
-	LocalActivityFailedCounter          = TemporalMetricsPrefix + "local_activity_failed"
+	LocalActivityFailedCounter          = TemporalMetricsPrefix + "local_activity_failed" // Deprecated: Use LocalActivityExecutionFailedCounter instead.
+	LocalActivityExecutionFailedCounter = TemporalMetricsPrefix + "local_activity_execution_failed"
 	LocalActivityErrorCounter           = TemporalMetricsPrefix + "local_activity_error"
 	LocalActivityExecutionLatency       = TemporalMetricsPrefix + "local_activity_execution_latency"
 	LocalActivitySucceedEndToEndLatency = TemporalMetricsPrefix + "local_activity_succeed_endtoend_latency"

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -556,6 +556,7 @@ func (lath *localActivityTaskHandler) executeLocalActivityTask(task *localActivi
 			}
 			if err != nil {
 				metricsHandler.Counter(metrics.LocalActivityFailedCounter).Inc(1)
+				metricsHandler.Counter(metrics.LocalActivityExecutionFailedCounter).Inc(1)
 			}
 		}()
 

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -587,6 +587,7 @@ WaitResult:
 		// context is done
 		if ctx.Err() == context.Canceled {
 			metricsHandler.Counter(metrics.LocalActivityCanceledCounter).Inc(1)
+			metricsHandler.Counter(metrics.LocalActivityExecutionCanceledCounter).Inc(1)
 			return &localActivityResult{err: ErrCanceled, task: task}
 		} else if ctx.Err() == context.DeadlineExceeded {
 			return &localActivityResult{err: ErrDeadlineExceeded, task: task}


### PR DESCRIPTION
add local_activity_execution_failed to align with java

for https://github.com/temporalio/sdk-features/issues/167
