### PR TITLE
Update sdk-go for latest interaction API

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -157,7 +157,7 @@ type (
 
 	// ScheduleDescription describes the current Schedule details from ScheduleHandle.Describe.
 	// NOTE: Experimental
-	ScheduleDescription = internal.ScheduleDescription 
+	ScheduleDescription = internal.ScheduleDescription
 
 	// Schedule describes a created schedule.
 	// NOTE: Experimental
@@ -186,6 +186,11 @@ type (
 	// ScheduleBackfillOptions configure the parameters for backfilling a schedule.
 	// NOTE: Experimental
 	ScheduleBackfillOptions = internal.ScheduleBackfillOptions
+
+	// UpdateWorkflowExecutionOptions encapsulates the optional parameters for
+	// sending an update to a workflow execution.
+	// NOTE: Experimental
+	UpdateWorkflowExecutionOptions = internal.UpdateWorkflowExecutionOptions
 
 	// Client is the client for starting and getting information about a workflow executions as well as
 	// completing activities asynchronously.
@@ -477,6 +482,11 @@ type (
 		// API. If the check fails, an error is returned.
 		CheckHealth(ctx context.Context, request *CheckHealthRequest) (*CheckHealthResponse, error)
 
+		// UpdateWorkflowExecution issues an update request to the specified
+		// workflow execution and returns the result synchronously.
+		// NOTE: Experimental
+		UpdateWorkflowExecution(ctx context.Context, workflowID string, updateName string, args []interface{}, opts UpdateWorkflowExecutionOptions) (converter.EncodedValue, error)
+
 		// WorkflowService provides access to the underlying gRPC service. This should only be used for advanced use cases
 		// that cannot be accomplished via other Client methods. Unlike calls to other Client methods, calls directly to the
 		// service are not configured with internal semantics such as automatic retries.
@@ -611,8 +621,9 @@ var _ internal.NamespaceClient = NamespaceClient(nil)
 // User had Activity.RecordHeartbeat(ctx, "my-heartbeat") and then got response from calling Client.DescribeWorkflowExecution.
 // The response contains binary field PendingActivityInfo.HeartbeatDetails,
 // which can be decoded by using:
-//   var result string // This need to be same type as the one passed to RecordHeartbeat
-//   NewValue(data).Get(&result)
+//
+//	var result string // This need to be same type as the one passed to RecordHeartbeat
+//	NewValue(data).Get(&result)
 func NewValue(data *commonpb.Payloads) converter.EncodedValue {
 	return internal.NewValue(data)
 }
@@ -621,9 +632,10 @@ func NewValue(data *commonpb.Payloads) converter.EncodedValue {
 // User had Activity.RecordHeartbeat(ctx, "my-heartbeat", 123) and then got response from calling Client.DescribeWorkflowExecution.
 // The response contains binary field PendingActivityInfo.HeartbeatDetails,
 // which can be decoded by using:
-//   var result1 string
-//   var result2 int // These need to be same type as those arguments passed to RecordHeartbeat
-//   NewValues(data).Get(&result1, &result2)
+//
+//	var result1 string
+//	var result2 int // These need to be same type as those arguments passed to RecordHeartbeat
+//	NewValues(data).Get(&result1, &result2)
 func NewValues(data *commonpb.Payloads) converter.EncodedValues {
 	return internal.NewValues(data)
 }

--- a/internal/client.go
+++ b/internal/client.go
@@ -340,6 +340,11 @@ type (
 		// API. If the check fails, an error is returned.
 		CheckHealth(ctx context.Context, request *CheckHealthRequest) (*CheckHealthResponse, error)
 
+		// UpdateWorkflowExecution issues an update request to the specified
+		// workflow execution and returns the result synchronously.
+		// NOTE: Experimental
+		UpdateWorkflowExecution(ctx context.Context, workflowID string, updateName string, args []interface{}, opts UpdateWorkflowExecutionOptions) (converter.EncodedValue, error)
+
 		// WorkflowService provides access to the underlying gRPC service. This should only be used for advanced use cases
 		// that cannot be accomplished via other Client methods. Unlike calls to other Client methods, calls directly to the
 		// service are not configured with internal semantics such as automatic retries.
@@ -439,6 +444,15 @@ type (
 	// the error will be propagated back through the interceptor chain.
 	TrafficController interface {
 		CheckCallAllowed(ctx context.Context, method string, req, reply interface{}) error
+	}
+
+	// UpdateWorkflowExecutionOptions encapsulates the optional parameters for
+	// sending an update to a workflow execution.
+	// NOTE: Experimental
+	UpdateWorkflowExecutionOptions struct {
+		FirstExecutionRunID string
+		RunID               string
+		Header              *commonpb.Header
 	}
 
 	// ConnectionOptions is provided by SDK consumers to control optional connection params.
@@ -829,8 +843,9 @@ func newNamespaceServiceClient(workflowServiceClient workflowservice.WorkflowSer
 // User had Activity.RecordHeartbeat(ctx, "my-heartbeat") and then got response from calling Client.DescribeWorkflowExecution.
 // The response contains binary field PendingActivityInfo.HeartbeatDetails,
 // which can be decoded by using:
-//   var result string // This need to be same type as the one passed to RecordHeartbeat
-//   NewValue(data).Get(&result)
+//
+//	var result string // This need to be same type as the one passed to RecordHeartbeat
+//	NewValue(data).Get(&result)
 func NewValue(data *commonpb.Payloads) converter.EncodedValue {
 	return newEncodedValue(data, nil)
 }
@@ -839,9 +854,10 @@ func NewValue(data *commonpb.Payloads) converter.EncodedValue {
 // User had Activity.RecordHeartbeat(ctx, "my-heartbeat", 123) and then got response from calling Client.DescribeWorkflowExecution.
 // The response contains binary field PendingActivityInfo.HeartbeatDetails,
 // which can be decoded by using:
-//   var result1 string
-//   var result2 int // These need to be same type as those arguments passed to RecordHeartbeat
-//   NewValues(data).Get(&result1, &result2)
+//
+//	var result1 string
+//	var result2 int // These need to be same type as those arguments passed to RecordHeartbeat
+//	NewValues(data).Get(&result1, &result2)
 func NewValues(data *commonpb.Payloads) converter.EncodedValues {
 	return newEncodedValues(data, nil)
 }

--- a/internal/interceptor.go
+++ b/internal/interceptor.go
@@ -239,7 +239,8 @@ type WorkflowOutboundInterceptor interface {
 	// SetQueryHandler intercepts workflow.SetQueryHandler.
 	SetQueryHandler(ctx Context, queryType string, handler interface{}) error
 
-	SetUpdateHandler(ctx Context, updateName string, handler interface{}, opts UpdateOptions) error
+	// SetUpdateHandler intercepts workflow.SetUpdateHandler.
+	SetUpdateHandler(ctx Context, updateName string, handler interface{}, opts UpdateHandlerOptions) error
 
 	// IsReplaying intercepts workflow.IsReplaying.
 	IsReplaying(ctx Context) bool
@@ -299,7 +300,21 @@ type ClientOutboundInterceptor interface {
 	// interceptor.Header will return a non-nil map for this context.
 	QueryWorkflow(context.Context, *ClientQueryWorkflowInput) (converter.EncodedValue, error)
 
+	// UpdateWorkflowExecution intercepts client.Client.UpdateWorkflowExecution.
+	// interceptor.Header will return a non-nil map for this context.
+	UpdateWorkflowExecution(context.Context, *ClientUpdateWorkflowInput) (converter.EncodedValue, error)
+
 	mustEmbedClientOutboundInterceptorBase()
+}
+
+// ClientUpdateWorkflowInput is the input to
+// ClientOutboundInterceptor.UpdateWorkflowExecution.
+type ClientUpdateWorkflowInput struct {
+	WorkflowID          string
+	UpdateName          string
+	Args                []interface{}
+	RunID               string
+	FirstExecutionRunID string
 }
 
 // ScheduleClientCreateInput is the input to

--- a/internal/interceptor_base.go
+++ b/internal/interceptor_base.go
@@ -327,7 +327,7 @@ func (w *WorkflowOutboundInterceptorBase) SetQueryHandler(ctx Context, queryType
 }
 
 // SetUpdateHandler implements WorkflowOutboundInterceptor.SetUpdateHandler.
-func (w *WorkflowOutboundInterceptorBase) SetUpdateHandler(ctx Context, updateName string, handler interface{}, opts UpdateOptions) error {
+func (w *WorkflowOutboundInterceptorBase) SetUpdateHandler(ctx Context, updateName string, handler interface{}, opts UpdateHandlerOptions) error {
 	return w.Next.SetUpdateHandler(ctx, updateName, handler, opts)
 }
 
@@ -388,6 +388,13 @@ type ClientOutboundInterceptorBase struct {
 }
 
 var _ ClientOutboundInterceptor = &ClientOutboundInterceptorBase{}
+
+func (c *ClientOutboundInterceptorBase) UpdateWorkflowExecution(
+	ctx context.Context,
+	in *ClientUpdateWorkflowInput,
+) (converter.EncodedValue, error) {
+	return c.Next.UpdateWorkflowExecution(ctx, in)
+}
 
 // ExecuteWorkflow implements ClientOutboundInterceptor.ExecuteWorkflow.
 func (c *ClientOutboundInterceptorBase) ExecuteWorkflow(

--- a/internal/internal_event_handlers.go
+++ b/internal/internal_event_handlers.go
@@ -1060,7 +1060,6 @@ func (weh *workflowExecutionEventHandlerImpl) ProcessInteraction(
 			commands: weh.commandsHelper,
 		},
 	)
-	weh.workflowDefinition.OnWorkflowTaskStarted(weh.deadlockDetectionTimeout)
 	return nil
 }
 

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -1183,9 +1183,6 @@ func skipDeterministicCheckForCommand(d *commandpb.Command) bool {
 		if markerName == versionMarkerName || markerName == mutableSideEffectMarkerName {
 			return true
 		}
-	case enumspb.COMMAND_TYPE_ACCEPT_WORKFLOW_UPDATE,
-		enumspb.COMMAND_TYPE_COMPLETE_WORKFLOW_EXECUTION:
-		return true
 	}
 	return false
 }
@@ -1197,8 +1194,6 @@ func skipDeterministicCheckForEvent(e *historypb.HistoryEvent) bool {
 		if markerName == versionMarkerName || markerName == mutableSideEffectMarkerName {
 			return true
 		}
-		// case enumspb.EVENT_TYPE_WORKFLOW_TASK_STARTED:
-		//	return true
 	}
 	return false
 }

--- a/internal/internal_workflow.go
+++ b/internal/internal_workflow.go
@@ -1474,7 +1474,7 @@ func setQueryHandler(ctx Context, queryType string, handler interface{}) error {
 }
 
 // setUpdateHandler sets update handler for a given update name.
-func setUpdateHandler(ctx Context, updateName string, handler interface{}, opts UpdateOptions) error {
+func setUpdateHandler(ctx Context, updateName string, handler interface{}, opts UpdateHandlerOptions) error {
 	if err := validateUpdateHandlerFn(handler); err != nil {
 		return err
 	}
@@ -1483,7 +1483,7 @@ func setUpdateHandler(ctx Context, updateName string, handler interface{}, opts 
 		if err := validateValidatorFn(opts.Validator); err != nil {
 			return err
 		}
-		if err := validateSameParams(handler, opts.Validator); err != nil {
+		if err := validateEquivalentParams(handler, opts.Validator); err != nil {
 			return err
 		}
 		validateFn = opts.Validator
@@ -1497,7 +1497,11 @@ func setUpdateHandler(ctx Context, updateName string, handler interface{}, opts 
 	return nil
 }
 
-func validateSameParams(fn1, fn2 interface{}) error {
+// validateEquivalentParams verifies that both arguments are functions and that
+// said functions take the exact same parameter types in the same order but not
+// considering the presence or absence of a workflow.Context parameter in the
+// zeroth position.
+func validateEquivalentParams(fn1, fn2 interface{}) error {
 	fn1Type := reflect.TypeOf(fn1)
 	fn2Type := reflect.TypeOf(fn2)
 
@@ -1509,13 +1513,30 @@ func validateSameParams(fn1, fn2 interface{}) error {
 		return fmt.Errorf("type must be function but was %s", fn1Type.Kind())
 	}
 
-	if fn1Type.NumIn() != fn2Type.NumIn() {
+	ctxType := reflect.TypeOf(new(Context)).Elem()
+	extractRelevantParamTypes := func(t reflect.Type) []reflect.Type {
+		out := make([]reflect.Type, 0, t.NumIn())
+		for i := 0; i < t.NumIn(); i++ {
+			paramType := t.In(i)
+			if i == 0 && paramType.Implements(ctxType) {
+				// ignore the presence of a workflow.Context as a first param
+				continue
+			}
+			out = append(out, paramType)
+		}
+		return out
+	}
+
+	fn1ParamTypes := extractRelevantParamTypes(fn1Type)
+	fn2ParamTypes := extractRelevantParamTypes(fn2Type)
+
+	if len(fn1ParamTypes) != len(fn2ParamTypes) {
 		return errors.New("functions have different numbers of parameters")
 	}
 
-	for i := 0; i < fn1Type.NumIn(); i++ {
-		fn1ParamType := fn1Type.In(i)
-		fn2ParamType := fn2Type.In(i)
+	for i := 0; i < len(fn1ParamTypes); i++ {
+		fn1ParamType := fn1ParamTypes[i]
+		fn2ParamType := fn2ParamTypes[i]
 		if fn1ParamType != fn2ParamType {
 			return fmt.Errorf("functions differ at parameter %v; %v != %v", i, fn1ParamType, fn2ParamType)
 		}

--- a/internal/internal_workflow_test.go
+++ b/internal/internal_workflow_test.go
@@ -1395,7 +1395,7 @@ func MustSetUpdateHandler(
 	ctx Context,
 	name string,
 	handler interface{},
-	opts UpdateOptions,
+	opts UpdateHandlerOptions,
 ) {
 	t.Helper()
 	require.NoError(t, SetUpdateHandler(ctx, name, handler, opts))
@@ -1415,7 +1415,7 @@ func TestUpdateHandlerPanicSafety(t *testing.T) {
 	require.NoError(t, err)
 
 	panicFunc := func() error { panic("intentional") }
-	MustSetUpdateHandler(t, ctx, t.Name(), panicFunc, UpdateOptions{Validator: panicFunc})
+	MustSetUpdateHandler(t, ctx, t.Name(), panicFunc, UpdateHandlerOptions{Validator: panicFunc})
 	in := UpdateInput{Name: t.Name(), Args: []interface{}{}}
 
 	t.Run("ValidateUpdate", func(t *testing.T) {
@@ -1463,7 +1463,7 @@ func TestDefaultUpdateHandler(t *testing.T) {
 	runOnCallingThread := func(ctx Context, _ string, f func(Context)) Context { f(ctx); return ctx }
 
 	t.Run("no handler registered", func(t *testing.T) {
-		MustSetUpdateHandler(t, ctx, "unused_handler", func() error { panic("not called") }, UpdateOptions{})
+		MustSetUpdateHandler(t, ctx, "unused_handler", func() error { panic("not called") }, UpdateHandlerOptions{})
 		var rejectErr error
 		defaultUpdateHandler(ctx, "will_not_be_found", args, hdr, &testUpdateCallbacks{
 			RejectImpl: func(err error) { rejectErr = err },
@@ -1474,7 +1474,7 @@ func TestDefaultUpdateHandler(t *testing.T) {
 	})
 
 	t.Run("malformed serialized input", func(t *testing.T) {
-		MustSetUpdateHandler(t, ctx, t.Name(), func(Context, int) error { return nil }, UpdateOptions{})
+		MustSetUpdateHandler(t, ctx, t.Name(), func(Context, int) error { return nil }, UpdateHandlerOptions{})
 		junkArgs := &commonpb.Payloads{Payloads: []*commonpb.Payload{&commonpb.Payload{}}}
 		var rejectErr error
 		defaultUpdateHandler(ctx, t.Name(), junkArgs, hdr, &testUpdateCallbacks{
@@ -1486,7 +1486,7 @@ func TestDefaultUpdateHandler(t *testing.T) {
 	t.Run("reject from validator", func(t *testing.T) {
 		updateFunc := func(Context, string) error { panic("should not get called") }
 		validatorFunc := func(Context, string) error { return errors.New("expected") }
-		MustSetUpdateHandler(t, ctx, t.Name(), updateFunc, UpdateOptions{Validator: validatorFunc})
+		MustSetUpdateHandler(t, ctx, t.Name(), updateFunc, UpdateHandlerOptions{Validator: validatorFunc})
 		var rejectErr error
 		defaultUpdateHandler(ctx, t.Name(), args, hdr, &testUpdateCallbacks{
 			RejectImpl: func(err error) { rejectErr = err },
@@ -1496,7 +1496,7 @@ func TestDefaultUpdateHandler(t *testing.T) {
 
 	t.Run("error from update func", func(t *testing.T) {
 		updateFunc := func(Context, string) error { return errors.New("expected") }
-		MustSetUpdateHandler(t, ctx, t.Name(), updateFunc, UpdateOptions{})
+		MustSetUpdateHandler(t, ctx, t.Name(), updateFunc, UpdateHandlerOptions{})
 		var (
 			resultErr error
 			accepted  bool
@@ -1516,7 +1516,7 @@ func TestDefaultUpdateHandler(t *testing.T) {
 
 	t.Run("update success", func(t *testing.T) {
 		updateFunc := func(ctx Context, s string) (string, error) { return s + " success!", nil }
-		MustSetUpdateHandler(t, ctx, t.Name(), updateFunc, UpdateOptions{})
+		MustSetUpdateHandler(t, ctx, t.Name(), updateFunc, UpdateHandlerOptions{})
 		var (
 			resultErr error
 			accepted  bool
@@ -1616,6 +1616,16 @@ func TestParamValidator(t *testing.T) {
 			Check: require.NoError,
 		},
 		{
+			Fn0:   func(Context, int) {},
+			Fn1:   func(int) {},
+			Check: require.NoError,
+		},
+		{
+			Fn0:   func(int) {},
+			Fn1:   func(Context, int) {},
+			Check: require.NoError,
+		},
+		{
 			Fn0:   func(int) {},
 			Fn1:   func(int, ...struct{}) {},
 			Check: require.Error,
@@ -1657,7 +1667,7 @@ func TestParamValidator(t *testing.T) {
 		},
 	} {
 		t.Run(strconv.FormatInt(int64(i), 10), func(t *testing.T) {
-			tc.Check(t, validateSameParams(tc.Fn0, tc.Fn1))
+			tc.Check(t, validateEquivalentParams(tc.Fn0, tc.Fn1))
 		})
 	}
 }

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -317,8 +317,8 @@ type (
 		isMethod bool
 	}
 
-	// UpdateOptions consists of options for executing a named workflow update.
-	UpdateOptions struct {
+	// UpdateHandlerOptions consists of options for executing a named workflow update.
+	UpdateHandlerOptions struct {
 		// Validator is an optional (i.e. can be left nil) func with exactly the
 		// same type signature as the required update handler func but returning
 		// only a single value of type error. The implementation of this
@@ -513,16 +513,20 @@ func (wc *workflowEnvironmentInterceptor) Init(outbound WorkflowOutboundIntercep
 // Context can be used to pass the settings for this activity.
 // For example: task queue that this need to be routed, timeouts that need to be configured.
 // Use ActivityOptions to pass down the options.
-//  ao := ActivityOptions{
-// 	    TaskQueue: "exampleTaskQueue",
-// 	    ScheduleToStartTimeout: 10 * time.Second,
-// 	    StartToCloseTimeout: 5 * time.Second,
-// 	    ScheduleToCloseTimeout: 10 * time.Second,
-// 	    HeartbeatTimeout: 0,
-// 	}
-//	ctx := WithActivityOptions(ctx, ao)
+//
+//	ao := ActivityOptions{
+//		TaskQueue: "exampleTaskQueue",
+//		ScheduleToStartTimeout: 10 * time.Second,
+//		StartToCloseTimeout: 5 * time.Second,
+//		ScheduleToCloseTimeout: 10 * time.Second,
+//		HeartbeatTimeout: 0,
+//	}
+//		ctx := WithActivityOptions(ctx, ao)
+//
 // Or to override a single option
-//  ctx := WithTaskQueue(ctx, "exampleTaskQueue")
+//
+//	ctx := WithTaskQueue(ctx, "exampleTaskQueue")
+//
 // Input activity is either an activity name (string) or a function representing an activity that is getting scheduled.
 // Input args are the arguments that need to be passed to the scheduled activity.
 //
@@ -630,10 +634,12 @@ func (wc *workflowEnvironmentInterceptor) ExecuteActivity(ctx Context, typeName 
 //
 // Context can be used to pass the settings for this local activity.
 // For now there is only one setting for timeout to be set:
-//  lao := LocalActivityOptions{
-// 	    ScheduleToCloseTimeout: 5 * time.Second,
-// 	}
+//
+//	lao := LocalActivityOptions{
+//		ScheduleToCloseTimeout: 5 * time.Second,
+//	}
 //	ctx := WithLocalActivityOptions(ctx, lao)
+//
 // The timeout here should be relative shorter than the WorkflowTaskTimeout of the workflow. If you need a
 // longer timeout, you probably should not use local activity and instead should use regular activity. Local activity is
 // designed to be used for short living activities (usually finishes within seconds).
@@ -822,11 +828,13 @@ func (wc *workflowEnvironmentInterceptor) scheduleLocalActivity(ctx Context, par
 // Context can be used to pass the settings for the child workflow.
 // For example: task queue that this child workflow should be routed, timeouts that need to be configured.
 // Use ChildWorkflowOptions to pass down the options.
-//  cwo := ChildWorkflowOptions{
-// 	    WorkflowExecutionTimeout: 10 * time.Minute,
-// 	    WorkflowTaskTimeout: time.Minute,
-// 	}
-//  ctx := WithChildWorkflowOptions(ctx, cwo)
+//
+//	 cwo := ChildWorkflowOptions{
+//		WorkflowExecutionTimeout: 10 * time.Minute,
+//		WorkflowTaskTimeout: time.Minute,
+//	 }
+//	 ctx := WithChildWorkflowOptions(ctx, cwo)
+//
 // Input childWorkflow is either a workflow name or a workflow function that is getting scheduled.
 // Input args are the arguments that need to be passed to the child workflow function represented by childWorkflow.
 //
@@ -1078,7 +1086,9 @@ func (wc *workflowEnvironmentInterceptor) Sleep(ctx Context, d time.Duration) (e
 // then the currently running instance of that workflowID will be used.
 // By default, the current workflow's namespace will be used as target namespace. However, you can specify a different namespace
 // of the target workflow using the context like:
+//
 //	ctx := WithWorkflowNamespace(ctx, "namespace")
+//
 // RequestCancelExternalWorkflow return Future with failure or empty success result.
 func RequestCancelExternalWorkflow(ctx Context, workflowID, runID string) Future {
 	i := getWorkflowOutboundInterceptor(ctx)
@@ -1115,7 +1125,9 @@ func (wc *workflowEnvironmentInterceptor) RequestCancelExternalWorkflow(ctx Cont
 // then the currently running instance of that workflowID will be used.
 // By default, the current workflow's namespace will be used as target namespace. However, you can specify a different namespace
 // of the target workflow using the context like:
+//
 //	ctx := WithWorkflowNamespace(ctx, "namespace")
+//
 // SignalExternalWorkflow return Future with failure or empty success result.
 func SignalExternalWorkflow(ctx Context, workflowID, runID, signalName string, arg interface{}) Future {
 	i := getWorkflowOutboundInterceptor(ctx)
@@ -1184,25 +1196,29 @@ func signalExternalWorkflow(ctx Context, workflowID, runID, signalName string, a
 // The value has to deterministic when replay;
 // The value has to be Json serializable.
 // UpsertSearchAttributes will merge attributes to existing map in workflow, for example workflow code:
-//   func MyWorkflow(ctx workflow.Context, input string) error {
-//	   attr1 := map[string]interface{}{
-//		   "CustomIntField": 1,
-//		   "CustomBoolField": true,
-//	   }
-//	   workflow.UpsertSearchAttributes(ctx, attr1)
 //
-//	   attr2 := map[string]interface{}{
-//		   "CustomIntField": 2,
-//		   "CustomKeywordField": "seattle",
-//	   }
-//	   workflow.UpsertSearchAttributes(ctx, attr2)
-//   }
+//	func MyWorkflow(ctx workflow.Context, input string) error {
+//		attr1 := map[string]interface{}{
+//			"CustomIntField": 1,
+//			"CustomBoolField": true,
+//		}
+//		workflow.UpsertSearchAttributes(ctx, attr1)
+//
+//		attr2 := map[string]interface{}{
+//			"CustomIntField": 2,
+//			"CustomKeywordField": "seattle",
+//		}
+//		workflow.UpsertSearchAttributes(ctx, attr2)
+//	}
+//
 // will eventually have search attributes:
-//   map[string]interface{}{
-//   	"CustomIntField": 2,
-//   	"CustomBoolField": true,
-//   	"CustomKeywordField": "seattle",
-//   }
+//
+//	map[string]interface{}{
+//		"CustomIntField": 2,
+//		"CustomBoolField": true,
+//		"CustomKeywordField": "seattle",
+//	}
+//
 // This is only supported when using ElasticSearch.
 func UpsertSearchAttributes(ctx Context, attributes map[string]interface{}) error {
 	i := getWorkflowOutboundInterceptor(ctx)
@@ -1399,33 +1415,36 @@ func (b EncodedValue) HasValue() bool {
 //
 // Caution: do not use SideEffect to modify closures. Always retrieve result from SideEffect's encoded return value.
 // For example this code is BROKEN:
-//  // Bad example:
-//  var random int
-//  workflow.SideEffect(func(ctx workflow.Context) interface{} {
-//         random = rand.Intn(100)
-//         return nil
-//  })
-//  // random will always be 0 in replay, thus this code is non-deterministic
-//  if random < 50 {
-//         ....
-//  } else {
-//         ....
-//  }
+//
+//	// Bad example:
+//	var random int
+//	workflow.SideEffect(func(ctx workflow.Context) interface{} {
+//		random = rand.Intn(100)
+//		return nil
+//	})
+//	// random will always be 0 in replay, thus this code is non-deterministic
+//	if random < 50 {
+//		....
+//	} else {
+//		....
+//	}
+//
 // On replay the provided function is not executed, the random will always be 0, and the workflow could takes a
 // different path breaking the determinism.
 //
 // Here is the correct way to use SideEffect:
-//  // Good example:
-//  encodedRandom := SideEffect(func(ctx workflow.Context) interface{} {
-//        return rand.Intn(100)
-//  })
-//  var random int
-//  encodedRandom.Get(&random)
-//  if random < 50 {
-//         ....
-//  } else {
-//         ....
-//  }
+//
+//	// Good example:
+//	encodedRandom := SideEffect(func(ctx workflow.Context) interface{} {
+//		return rand.Intn(100)
+//	})
+//	var random int
+//	encodedRandom.Get(&random)
+//	if random < 50 {
+//		....
+//	} else {
+//		....
+//	}
 func SideEffect(ctx Context, f func(ctx Context) interface{}) converter.EncodedValue {
 	i := getWorkflowOutboundInterceptor(ctx)
 	return i.SideEffect(ctx, f)
@@ -1490,38 +1509,46 @@ const TemporalChangeVersion = "TemporalChangeVersion"
 // workflow history as a marker event. Even if maxSupported version is changed the version that was recorded is
 // returned on replay. DefaultVersion constant contains version of code that wasn't versioned before.
 // For example initially workflow has the following code:
-//  err = workflow.ExecuteActivity(ctx, foo).Get(ctx, nil)
+//
+//	err = workflow.ExecuteActivity(ctx, foo).Get(ctx, nil)
+//
 // it should be updated to
-//  err = workflow.ExecuteActivity(ctx, bar).Get(ctx, nil)
+//
+//	err = workflow.ExecuteActivity(ctx, bar).Get(ctx, nil)
+//
 // The backwards compatible way to execute the update is
-//  v :=  GetVersion(ctx, "fooChange", DefaultVersion, 1)
-//  if v  == DefaultVersion {
-//      err = workflow.ExecuteActivity(ctx, foo).Get(ctx, nil)
-//  } else {
-//      err = workflow.ExecuteActivity(ctx, bar).Get(ctx, nil)
-//  }
+//
+//	v :=  GetVersion(ctx, "fooChange", DefaultVersion, 1)
+//	if v  == DefaultVersion {
+//	    err = workflow.ExecuteActivity(ctx, foo).Get(ctx, nil)
+//	} else {
+//	    err = workflow.ExecuteActivity(ctx, bar).Get(ctx, nil)
+//	}
 //
 // Then bar has to be changed to baz:
-//  v :=  GetVersion(ctx, "fooChange", DefaultVersion, 2)
-//  if v  == DefaultVersion {
-//      err = workflow.ExecuteActivity(ctx, foo).Get(ctx, nil)
-//  } else if v == 1 {
-//      err = workflow.ExecuteActivity(ctx, bar).Get(ctx, nil)
-//  } else {
-//      err = workflow.ExecuteActivity(ctx, baz).Get(ctx, nil)
-//  }
+//
+//	v :=  GetVersion(ctx, "fooChange", DefaultVersion, 2)
+//	if v  == DefaultVersion {
+//	    err = workflow.ExecuteActivity(ctx, foo).Get(ctx, nil)
+//	} else if v == 1 {
+//	    err = workflow.ExecuteActivity(ctx, bar).Get(ctx, nil)
+//	} else {
+//	    err = workflow.ExecuteActivity(ctx, baz).Get(ctx, nil)
+//	}
 //
 // Later when there are no workflow executions running DefaultVersion the correspondent branch can be removed:
-//  v :=  GetVersion(ctx, "fooChange", 1, 2)
-//  if v == 1 {
-//      err = workflow.ExecuteActivity(ctx, bar).Get(ctx, nil)
-//  } else {
-//      err = workflow.ExecuteActivity(ctx, baz).Get(ctx, nil)
-//  }
+//
+//	v :=  GetVersion(ctx, "fooChange", 1, 2)
+//	if v == 1 {
+//	    err = workflow.ExecuteActivity(ctx, bar).Get(ctx, nil)
+//	} else {
+//	    err = workflow.ExecuteActivity(ctx, baz).Get(ctx, nil)
+//	}
 //
 // It is recommended to keep the GetVersion() call even if single branch is left:
-//  GetVersion(ctx, "fooChange", 2, 2)
-//  err = workflow.ExecuteActivity(ctx, baz).Get(ctx, nil)
+//
+//	GetVersion(ctx, "fooChange", 2, 2)
+//	err = workflow.ExecuteActivity(ctx, baz).Get(ctx, nil)
 //
 // The reason to keep it is: 1) it ensures that if there is older version execution still running, it will fail here
 // and not proceed; 2) if you ever need to make more changes for “fooChange”, for example change activity from baz to qux,
@@ -1533,12 +1560,12 @@ const TemporalChangeVersion = "TemporalChangeVersion"
 // as changeID. If you ever need to make changes to that same part like change from baz to qux, you would need to use a
 // different changeID like “fooChange-fix2”, and start minVersion from DefaultVersion again. The code would looks like:
 //
-//  v := workflow.GetVersion(ctx, "fooChange-fix2", workflow.DefaultVersion, 1)
-//  if v == workflow.DefaultVersion {
-//    err = workflow.ExecuteActivity(ctx, baz, data).Get(ctx, nil)
-//  } else {
-//    err = workflow.ExecuteActivity(ctx, qux, data).Get(ctx, nil)
-//  }
+//	v := workflow.GetVersion(ctx, "fooChange-fix2", workflow.DefaultVersion, 1)
+//	if v == workflow.DefaultVersion {
+//		err = workflow.ExecuteActivity(ctx, baz, data).Get(ctx, nil)
+//	} else {
+//		err = workflow.ExecuteActivity(ctx, qux, data).Get(ctx, nil)
+//	}
 func GetVersion(ctx Context, changeID string, minSupported, maxSupported Version) Version {
 	i := getWorkflowOutboundInterceptor(ctx)
 	return i.GetVersion(ctx, changeID, minSupported, maxSupported)
@@ -1559,33 +1586,34 @@ func (wc *workflowEnvironmentInterceptor) GetVersion(ctx Context, changeID strin
 // Channel.Get() or Future.Get(). Trying to do so in query handler code will fail the query and client will receive
 // QueryFailedError.
 // Example of workflow code that support query type "current_state":
-//  func MyWorkflow(ctx workflow.Context, input string) error {
-//    currentState := "started" // this could be any serializable struct
-//    err := workflow.SetQueryHandler(ctx, "current_state", func() (string, error) {
-//      return currentState, nil
-//    })
-//    if err != nil {
-//      currentState = "failed to register query handler"
-//      return err
-//    }
-//    // your normal workflow code begins here, and you update the currentState as the code makes progress.
-//    currentState = "waiting timer"
-//    err = NewTimer(ctx, time.Hour).Get(ctx, nil)
-//    if err != nil {
-//      currentState = "timer failed"
-//      return err
-//    }
 //
-//    currentState = "waiting activity"
-//    ctx = WithActivityOptions(ctx, myActivityOptions)
-//    err = ExecuteActivity(ctx, MyActivity, "my_input").Get(ctx, nil)
-//    if err != nil {
-//      currentState = "activity failed"
-//      return err
-//    }
-//    currentState = "done"
-//    return nil
-//  }
+//	func MyWorkflow(ctx workflow.Context, input string) error {
+//		currentState := "started" // this could be any serializable struct
+//		err := workflow.SetQueryHandler(ctx, "current_state", func() (string, error) {
+//			return currentState, nil
+//		})
+//		if err != nil {
+//			currentState = "failed to register query handler"
+//			return err
+//		}
+//		// your normal workflow code begins here, and you update the currentState as the code makes progress.
+//		currentState = "waiting timer"
+//		err = NewTimer(ctx, time.Hour).Get(ctx, nil)
+//		if err != nil {
+//			currentState = "timer failed"
+//			return err
+//		}
+//
+//		currentState = "waiting activity"
+//		ctx = WithActivityOptions(ctx, myActivityOptions)
+//		err = ExecuteActivity(ctx, MyActivity, "my_input").Get(ctx, nil)
+//		if err != nil {
+//			currentState = "activity failed"
+//			return err
+//		}
+//		currentState = "done"
+//		return nil
+//	}
 func SetQueryHandler(ctx Context, queryType string, handler interface{}) error {
 	i := getWorkflowOutboundInterceptor(ctx)
 	return i.SetQueryHandler(ctx, queryType, handler)
@@ -1600,7 +1628,7 @@ func SetQueryHandler(ctx Context, queryType string, handler interface{}) error {
 // parameter. The validator function MUST NOT mutate workflow state in any way,
 // much like a query handler function. The update handler function however is
 // free to do anything that normal workflow code would do.
-func SetUpdateHandler(ctx Context, updateName string, handler interface{}, opts UpdateOptions) error {
+func SetUpdateHandler(ctx Context, updateName string, handler interface{}, opts UpdateHandlerOptions) error {
 	i := getWorkflowOutboundInterceptor(ctx)
 	return i.SetUpdateHandler(ctx, updateName, handler, opts)
 }
@@ -1612,7 +1640,7 @@ func (wc *workflowEnvironmentInterceptor) SetQueryHandler(ctx Context, queryType
 	return setQueryHandler(ctx, queryType, handler)
 }
 
-func (wc *workflowEnvironmentInterceptor) SetUpdateHandler(ctx Context, name string, handler interface{}, opts UpdateOptions) error {
+func (wc *workflowEnvironmentInterceptor) SetUpdateHandler(ctx Context, name string, handler interface{}, opts UpdateHandlerOptions) error {
 	if strings.HasPrefix(name, "__") {
 		return errors.New("update names starting with '__' are reserved for internal use")
 	}

--- a/mocks/Client.go
+++ b/mocks/Client.go
@@ -542,6 +542,28 @@ func (_m *Client) CheckHealth(ctx context.Context, request *client.CheckHealthRe
 	return r0, r1
 }
 
+func (_m *Client) UpdateWorkflowExecution(ctx context.Context, workflowID string, updateName string, args []interface{}, opts client.UpdateWorkflowExecutionOptions) (converter.EncodedValue, error) {
+	ret := _m.Called(ctx, workflowID, updateName, args, opts)
+
+	var r0 converter.EncodedValue
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, []interface{}, client.UpdateWorkflowExecutionOptions) converter.EncodedValue); ok {
+		r0 = rf(ctx, workflowID, updateName, args, opts)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(converter.EncodedValue)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, []interface{}, client.UpdateWorkflowExecutionOptions) error); ok {
+		r1 = rf(ctx, workflowID, updateName, args, opts)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // WorkflowService provides a mock function with given fields:
 func (_m *Client) WorkflowService() workflowservice.WorkflowServiceClient {
 	ret := _m.Called()


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
- Adds UpdateWorkflowExecution to the client API and relevant interceptors
- Adopts expectation that interaction invocations will be attached to a PollWorkflowTaskQueueResponse (had previously been attached to the WFT Started event).
- Comment formatting for Go 1.19+

## Why?
<!-- Tell your future self why have you made these changes -->
Part of sync update project. Note that most of the relevant APIs are still in /internal/. Client api is made public only because there is an assertion that client.Client and internal.Client are compatible interfaces.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Unit tests & sdk-features

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
