### PR TITLE
contrib/tally: improve godoc with links

### DIFF
--- a/contrib/tally/handler.go
+++ b/contrib/tally/handler.go
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-// Package tally implements a MetricsHandler backed by github.com/uber-go/tally.
+// Package tally implements a MetricsHandler backed by [github.com/uber-go/tally].
 package tally
 
 import (
@@ -30,36 +30,38 @@ import (
 
 type metricsHandler struct{ scope tally.Scope }
 
-// NewMetricsHandler returns a MetricsHandler that is backed by the given Tally
+// NewMetricsHandler returns a [client.MetricsHandler] that is backed by the given Tally
 // scope.
 //
 // Default metrics are Prometheus compatible, but they should be sanitized and
 // use the Prometheus naming scope so they are cross-SDK compatible with
 // OpenMetrics naming conventions:
-// 	opts := tally.ScopeOptions{
-// 		SanitizeOptions: &contribtally.PrometheusSanitizeOptions,
-// 		Separator: "_",
-// 	}
-// 	scope, _ := tally.NewRootScope(opts, time.Second)
-// 	scope = contribtally.NewPrometheusNamingScope(scope)
+//
+//	opts := tally.ScopeOptions{
+//		SanitizeOptions: &contribtally.PrometheusSanitizeOptions,
+//		Separator: "_",
+//	}
+//	scope, _ := tally.NewRootScope(opts, time.Second)
+//	scope = contribtally.NewPrometheusNamingScope(scope)
 func NewMetricsHandler(scope tally.Scope) client.MetricsHandler {
 	return metricsHandler{scope}
 }
 
 // ScopeFromHandler returns the underlying scope of the handler. Callers may
 // need to check workflow.IsReplaying(ctx) to avoid recording metrics during
-// replay. If this handler was not created via this package, tally.NoopScope is
+// replay. If this handler was not created via this package, [github.com/uber-go/tally.NoopScope] is
 // returned.
 //
 // Raw use of the scope is discouraged but may be used for Histograms or other
 // advanced features. This scope does not skip metrics during replay like the
 // metrics handler does. Therefore the caller should check replay state, for
 // example:
-// 	scope := tally.NoopScope
-// 	if !workflow.IsReplaying(ctx) {
-// 		scope = ScopeFromHandler(workflow.GetMetricsHandler(ctx))
-// 	}
-// 	scope.Histogram("my_histogram", nil).RecordDuration(5 * time.Second)
+//
+//	scope := tally.NoopScope
+//	if !workflow.IsReplaying(ctx) {
+//		scope = ScopeFromHandler(workflow.GetMetricsHandler(ctx))
+//	}
+//	scope.Histogram("my_histogram", nil).RecordDuration(5 * time.Second)
 func ScopeFromHandler(handler client.MetricsHandler) tally.Scope {
 	// Continually unwrap until we find an instance of our own handler
 	for {


### PR DESCRIPTION
Add doc links in package `contrib/tally` following godoc improvements in Go 1.19. See https://go.dev/doc/comment

## What was changed

Improve godoc for package contrib/tally by adding doc links.
See https://go.dev/doc/comment.

## Why?

Link to upstream tally package from this package documentation.
