### PR TITLE
Fix history replayer

### DIFF
--- a/internal/internal_event_handlers.go
+++ b/internal/internal_event_handlers.go
@@ -33,7 +33,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	commandpb "go.temporal.io/api/command/v1"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
@@ -331,7 +330,6 @@ func (wc *workflowEnvironmentImpl) SignalExternalWorkflow(
 	childWorkflowOnly bool,
 	callback ResultHandler,
 ) {
-
 	signalID := wc.GenerateSequenceID()
 	command := wc.commandsHelper.signalExternalWorkflowExecution(namespace, workflowID, runID, signalName, input,
 		header, signalID, childWorkflowOnly)
@@ -444,7 +442,8 @@ func (wc *workflowEnvironmentImpl) RegisterCancelHandler(handler func()) {
 }
 
 func (wc *workflowEnvironmentImpl) ExecuteChildWorkflow(
-	params ExecuteWorkflowParams, callback ResultHandler, startedHandler func(r WorkflowExecution, e error)) {
+	params ExecuteWorkflowParams, callback ResultHandler, startedHandler func(r WorkflowExecution, e error),
+) {
 	if params.WorkflowID == "" {
 		params.WorkflowID = wc.workflowInfo.WorkflowExecution.RunID + "_" + wc.GenerateSequenceID()
 	}
@@ -796,12 +795,6 @@ func (wc *workflowEnvironmentImpl) MutableSideEffect(id string, f func() interfa
 }
 
 func (wc *workflowEnvironmentImpl) isEqualValue(newValue interface{}, encodedOldValue *commonpb.Payloads, equals func(a, b interface{}) bool) bool {
-	if newValue == nil {
-		// new value is nil
-		newEncodedValue := wc.encodeValue(nil)
-		return proto.Equal(newEncodedValue, encodedOldValue)
-	}
-
 	oldValue := decodeValue(newEncodedValue(encodedOldValue, wc.GetDataConverter()), newValue)
 	return equals(newValue, oldValue)
 }
@@ -1103,7 +1096,8 @@ func (weh *workflowExecutionEventHandlerImpl) Close() {
 }
 
 func (weh *workflowExecutionEventHandlerImpl) handleWorkflowExecutionStarted(
-	attributes *historypb.WorkflowExecutionStartedEventAttributes) (err error) {
+	attributes *historypb.WorkflowExecutionStartedEventAttributes,
+) (err error) {
 	weh.workflowDefinition, err = weh.registry.getWorkflowDefinition(
 		weh.workflowInfo.WorkflowType,
 	)
@@ -1381,7 +1375,8 @@ func (weh *workflowExecutionEventHandlerImpl) ProcessLocalActivityResult(lar *lo
 }
 
 func (weh *workflowExecutionEventHandlerImpl) handleWorkflowExecutionSignaled(
-	attributes *historypb.WorkflowExecutionSignaledEventAttributes) error {
+	attributes *historypb.WorkflowExecutionSignaledEventAttributes,
+) error {
 	return weh.signalHandler(attributes.GetSignalName(), attributes.Input, attributes.Header)
 }
 

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -36,7 +36,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/status"
 	commandpb "go.temporal.io/api/command/v1"
 	commonpb "go.temporal.io/api/common/v1"
@@ -845,6 +844,13 @@ func (w *workflowExecutionContextImpl) ProcessWorkflowTask(workflowTask *workflo
 	invocations := indexInvocations(workflowTask)
 
 	skipReplayCheck := w.skipReplayCheck()
+	shouldForceReplayCheck := func() bool {
+		isInReplayer := IsReplayNamespace(w.wth.namespace)
+		// If we are in the replayer we should always check the history replay, even if the workflow is completed
+		// Skip if the workflow paniced to avoid potentially breaking old histories
+		_, wfPanicked := w.err.(*workflowPanicError)
+		return !wfPanicked && isInReplayer
+	}
 
 	metricsHandler := w.wth.metricsHandler.WithTags(metrics.WorkflowTags(task.WorkflowType.GetName()))
 	start := time.Now()
@@ -877,7 +883,7 @@ ProcessEvents:
 				if err != nil {
 					return nil, err
 				}
-				if w.isWorkflowCompleted {
+				if w.isWorkflowCompleted && !shouldForceReplayCheck() {
 					break ProcessEvents
 				}
 			}
@@ -918,7 +924,7 @@ ProcessEvents:
 				}
 			}
 
-			if w.isWorkflowCompleted {
+			if w.isWorkflowCompleted && !shouldForceReplayCheck() {
 				break ProcessEvents
 			}
 		}
@@ -930,7 +936,7 @@ ProcessEvents:
 				if err != nil {
 					return nil, err
 				}
-				if w.isWorkflowCompleted {
+				if w.isWorkflowCompleted && !shouldForceReplayCheck() {
 					break ProcessEvents
 				}
 			}
@@ -957,7 +963,7 @@ ProcessEvents:
 	// the replay of that event will panic on the command state machine and the workflow will be marked as completed
 	// with the panic error.
 	var workflowError error
-	if !skipReplayCheck && !w.isWorkflowCompleted {
+	if !skipReplayCheck && (!w.isWorkflowCompleted || shouldForceReplayCheck()) {
 		// check if commands from reply matches to the history events
 		if err := matchReplayWithHistory(replayCommands, respondEvents); err != nil {
 			workflowError = err
@@ -1197,8 +1203,10 @@ func skipDeterministicCheckForEvent(e *historypb.HistoryEvent) bool {
 		if markerName == versionMarkerName || markerName == mutableSideEffectMarkerName {
 			return true
 		}
-		// case enumspb.EVENT_TYPE_WORKFLOW_TASK_STARTED:
-		//	return true
+	case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED:
+		return true
+	case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_CONTINUED_AS_NEW:
+		return true
 	}
 	return false
 }
@@ -1254,7 +1262,7 @@ matchLoop:
 			return historyMismatchErrorf("nondeterministic workflow: extra replay command for %s", util.CommandToString(d))
 		}
 
-		if !isCommandMatchEvent(d, e, false) {
+		if !isCommandMatchEvent(d, e) {
 			return historyMismatchErrorf("nondeterministic workflow: history event is %s, replay command is %s",
 				util.HistoryEventToString(e), util.CommandToString(d))
 		}
@@ -1273,7 +1281,7 @@ func lastPartOfName(name string) string {
 	return name[lastDotIdx+1:]
 }
 
-func isCommandMatchEvent(d *commandpb.Command, e *historypb.HistoryEvent, strictMode bool) bool {
+func isCommandMatchEvent(d *commandpb.Command, e *historypb.HistoryEvent) bool {
 	switch d.GetCommandType() {
 	case enumspb.COMMAND_TYPE_SCHEDULE_ACTIVITY_TASK:
 		if e.GetEventType() != enumspb.EVENT_TYPE_ACTIVITY_TASK_SCHEDULED {
@@ -1283,9 +1291,7 @@ func isCommandMatchEvent(d *commandpb.Command, e *historypb.HistoryEvent, strict
 		commandAttributes := d.GetScheduleActivityTaskCommandAttributes()
 
 		if eventAttributes.GetActivityId() != commandAttributes.GetActivityId() ||
-			lastPartOfName(eventAttributes.ActivityType.GetName()) != lastPartOfName(commandAttributes.ActivityType.GetName()) ||
-			(strictMode && eventAttributes.TaskQueue.GetName() != commandAttributes.TaskQueue.GetName()) ||
-			(strictMode && !proto.Equal(eventAttributes.GetInput(), commandAttributes.GetInput())) {
+			lastPartOfName(eventAttributes.ActivityType.GetName()) != lastPartOfName(commandAttributes.ActivityType.GetName()) {
 			return false
 		}
 
@@ -1310,8 +1316,7 @@ func isCommandMatchEvent(d *commandpb.Command, e *historypb.HistoryEvent, strict
 		eventAttributes := e.GetTimerStartedEventAttributes()
 		commandAttributes := d.GetStartTimerCommandAttributes()
 
-		if eventAttributes.GetTimerId() != commandAttributes.GetTimerId() ||
-			(strictMode && common.DurationValue(eventAttributes.GetStartToFireTimeout()) != common.DurationValue(commandAttributes.GetStartToFireTimeout())) {
+		if eventAttributes.GetTimerId() != commandAttributes.GetTimerId() {
 			return false
 		}
 
@@ -1335,28 +1340,12 @@ func isCommandMatchEvent(d *commandpb.Command, e *historypb.HistoryEvent, strict
 		if e.GetEventType() != enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED {
 			return false
 		}
-		if strictMode {
-			eventAttributes := e.GetWorkflowExecutionCompletedEventAttributes()
-			commandAttributes := d.GetCompleteWorkflowExecutionCommandAttributes()
-
-			if !proto.Equal(eventAttributes.GetResult(), commandAttributes.GetResult()) {
-				return false
-			}
-		}
 
 		return true
 
 	case enumspb.COMMAND_TYPE_FAIL_WORKFLOW_EXECUTION:
 		if e.GetEventType() != enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_FAILED {
 			return false
-		}
-		if strictMode {
-			eventAttributes := e.GetWorkflowExecutionFailedEventAttributes()
-			commandAttributes := d.GetFailWorkflowExecutionCommandAttributes()
-
-			if !proto.Equal(eventAttributes.GetFailure(), commandAttributes.GetFailure()) {
-				return false
-			}
 		}
 
 		return true
@@ -1404,13 +1393,6 @@ func isCommandMatchEvent(d *commandpb.Command, e *historypb.HistoryEvent, strict
 		if e.GetEventType() != enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_CANCELED {
 			return false
 		}
-		if strictMode {
-			eventAttributes := e.GetWorkflowExecutionCanceledEventAttributes()
-			commandAttributes := d.GetCancelWorkflowExecutionCommandAttributes()
-			if !proto.Equal(eventAttributes.GetDetails(), commandAttributes.GetDetails()) {
-				return false
-			}
-		}
 		return true
 
 	case enumspb.COMMAND_TYPE_CONTINUE_AS_NEW_WORKFLOW_EXECUTION:
@@ -1426,9 +1408,7 @@ func isCommandMatchEvent(d *commandpb.Command, e *historypb.HistoryEvent, strict
 		}
 		eventAttributes := e.GetStartChildWorkflowExecutionInitiatedEventAttributes()
 		commandAttributes := d.GetStartChildWorkflowExecutionCommandAttributes()
-		if lastPartOfName(eventAttributes.WorkflowType.GetName()) != lastPartOfName(commandAttributes.WorkflowType.GetName()) ||
-			(strictMode && checkNamespacesInCommandAndEvent(eventAttributes.GetNamespace(), commandAttributes.GetNamespace())) ||
-			(strictMode && eventAttributes.TaskQueue.GetName() != commandAttributes.TaskQueue.GetName()) {
+		if lastPartOfName(eventAttributes.WorkflowType.GetName()) != lastPartOfName(commandAttributes.WorkflowType.GetName()) {
 			return false
 		}
 
@@ -1436,11 +1416,6 @@ func isCommandMatchEvent(d *commandpb.Command, e *historypb.HistoryEvent, strict
 
 	case enumspb.COMMAND_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES:
 		if e.GetEventType() != enumspb.EVENT_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES {
-			return false
-		}
-		eventAttributes := e.GetUpsertWorkflowSearchAttributesEventAttributes()
-		commandAttributes := d.GetUpsertWorkflowSearchAttributesCommandAttributes()
-		if strictMode && !isSearchAttributesMatched(eventAttributes.SearchAttributes, commandAttributes.SearchAttributes) {
 			return false
 		}
 		return true
@@ -1456,24 +1431,10 @@ func isCommandMatchEvent(d *commandpb.Command, e *historypb.HistoryEvent, strict
 			return false
 		}
 
-		if strictMode {
-			eventAttributes := e.GetWorkflowUpdateCompletedEventAttributes()
-			commandAttributes := d.GetCompleteWorkflowUpdateCommandAttributes()
-
-			if !proto.Equal(eventAttributes.GetOutput().GetSuccess(), commandAttributes.GetOutput().GetSuccess()) ||
-				!proto.Equal(eventAttributes.GetOutput().GetFailure(), commandAttributes.GetOutput().GetFailure()) {
-				return false
-			}
-		}
 		return true
 
 	case enumspb.COMMAND_TYPE_MODIFY_WORKFLOW_PROPERTIES:
 		if e.GetEventType() != enumspb.EVENT_TYPE_WORKFLOW_PROPERTIES_MODIFIED {
-			return false
-		}
-		eventAttributes := e.GetWorkflowPropertiesModifiedEventAttributes()
-		commandAttributes := d.GetModifyWorkflowPropertiesCommandAttributes()
-		if strictMode && !isMemoMatched(eventAttributes.UpsertedMemo, commandAttributes.UpsertedMemo) {
 			return false
 		}
 		return true

--- a/internal/internal_task_handlers_test.go
+++ b/internal/internal_task_handlers_test.go
@@ -146,69 +146,79 @@ func createTestEventWorkflowExecutionCompleted(eventID int64, attr *historypb.Wo
 	return &historypb.HistoryEvent{
 		EventId:    eventID,
 		EventType:  enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED,
-		Attributes: &historypb.HistoryEvent_WorkflowExecutionCompletedEventAttributes{WorkflowExecutionCompletedEventAttributes: attr}}
+		Attributes: &historypb.HistoryEvent_WorkflowExecutionCompletedEventAttributes{WorkflowExecutionCompletedEventAttributes: attr},
+	}
 }
 
 func createTestEventWorkflowExecutionStarted(eventID int64, attr *historypb.WorkflowExecutionStartedEventAttributes) *historypb.HistoryEvent {
 	return &historypb.HistoryEvent{
 		EventId:    eventID,
 		EventType:  enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED,
-		Attributes: &historypb.HistoryEvent_WorkflowExecutionStartedEventAttributes{WorkflowExecutionStartedEventAttributes: attr}}
+		Attributes: &historypb.HistoryEvent_WorkflowExecutionStartedEventAttributes{WorkflowExecutionStartedEventAttributes: attr},
+	}
 }
 
 func createTestEventMarkerRecorded(eventID int64, attr *historypb.MarkerRecordedEventAttributes) *historypb.HistoryEvent {
 	return &historypb.HistoryEvent{
 		EventId:    eventID,
 		EventType:  enumspb.EVENT_TYPE_MARKER_RECORDED,
-		Attributes: &historypb.HistoryEvent_MarkerRecordedEventAttributes{MarkerRecordedEventAttributes: attr}}
+		Attributes: &historypb.HistoryEvent_MarkerRecordedEventAttributes{MarkerRecordedEventAttributes: attr},
+	}
 }
 
 func createTestEventActivityTaskScheduled(eventID int64, attr *historypb.ActivityTaskScheduledEventAttributes) *historypb.HistoryEvent {
 	return &historypb.HistoryEvent{
 		EventId:    eventID,
 		EventType:  enumspb.EVENT_TYPE_ACTIVITY_TASK_SCHEDULED,
-		Attributes: &historypb.HistoryEvent_ActivityTaskScheduledEventAttributes{ActivityTaskScheduledEventAttributes: attr}}
+		Attributes: &historypb.HistoryEvent_ActivityTaskScheduledEventAttributes{ActivityTaskScheduledEventAttributes: attr},
+	}
 }
 
 func createTestEventActivityTaskCancelRequested(eventID int64, attr *historypb.ActivityTaskCancelRequestedEventAttributes) *historypb.HistoryEvent {
 	return &historypb.HistoryEvent{
 		EventId:    eventID,
 		EventType:  enumspb.EVENT_TYPE_ACTIVITY_TASK_CANCEL_REQUESTED,
-		Attributes: &historypb.HistoryEvent_ActivityTaskCancelRequestedEventAttributes{ActivityTaskCancelRequestedEventAttributes: attr}}
+		Attributes: &historypb.HistoryEvent_ActivityTaskCancelRequestedEventAttributes{ActivityTaskCancelRequestedEventAttributes: attr},
+	}
 }
 
 func createTestEventActivityTaskStarted(eventID int64, attr *historypb.ActivityTaskStartedEventAttributes) *historypb.HistoryEvent {
 	return &historypb.HistoryEvent{
 		EventId:    eventID,
 		EventType:  enumspb.EVENT_TYPE_ACTIVITY_TASK_STARTED,
-		Attributes: &historypb.HistoryEvent_ActivityTaskStartedEventAttributes{ActivityTaskStartedEventAttributes: attr}}
+		Attributes: &historypb.HistoryEvent_ActivityTaskStartedEventAttributes{ActivityTaskStartedEventAttributes: attr},
+	}
 }
 
 func createTestEventActivityTaskCompleted(eventID int64, attr *historypb.ActivityTaskCompletedEventAttributes) *historypb.HistoryEvent {
 	return &historypb.HistoryEvent{
 		EventId:    eventID,
 		EventType:  enumspb.EVENT_TYPE_ACTIVITY_TASK_COMPLETED,
-		Attributes: &historypb.HistoryEvent_ActivityTaskCompletedEventAttributes{ActivityTaskCompletedEventAttributes: attr}}
+		Attributes: &historypb.HistoryEvent_ActivityTaskCompletedEventAttributes{ActivityTaskCompletedEventAttributes: attr},
+	}
 }
 
 func createTestEventActivityTaskTimedOut(eventID int64, attr *historypb.ActivityTaskTimedOutEventAttributes) *historypb.HistoryEvent {
 	return &historypb.HistoryEvent{
 		EventId:    eventID,
 		EventType:  enumspb.EVENT_TYPE_ACTIVITY_TASK_TIMED_OUT,
-		Attributes: &historypb.HistoryEvent_ActivityTaskTimedOutEventAttributes{ActivityTaskTimedOutEventAttributes: attr}}
+		Attributes: &historypb.HistoryEvent_ActivityTaskTimedOutEventAttributes{ActivityTaskTimedOutEventAttributes: attr},
+	}
 }
 
 func createTestEventWorkflowTaskScheduled(eventID int64, attr *historypb.WorkflowTaskScheduledEventAttributes) *historypb.HistoryEvent {
 	return &historypb.HistoryEvent{
 		EventId:    eventID,
 		EventType:  enumspb.EVENT_TYPE_WORKFLOW_TASK_SCHEDULED,
-		Attributes: &historypb.HistoryEvent_WorkflowTaskScheduledEventAttributes{WorkflowTaskScheduledEventAttributes: attr}}
+		Attributes: &historypb.HistoryEvent_WorkflowTaskScheduledEventAttributes{WorkflowTaskScheduledEventAttributes: attr},
+	}
 }
 
 func createTestEventWorkflowTaskStarted(eventID int64) *historypb.HistoryEvent {
 	return &historypb.HistoryEvent{
 		EventId:   eventID,
-		EventType: enumspb.EVENT_TYPE_WORKFLOW_TASK_STARTED}
+		EventType: enumspb.EVENT_TYPE_WORKFLOW_TASK_STARTED,
+	}
 }
 
 func createTestEventWorkflowExecutionSignaled(eventID int64, signalName string) *historypb.HistoryEvent {
@@ -231,77 +241,88 @@ func createTestEventWorkflowTaskCompleted(eventID int64, attr *historypb.Workflo
 	return &historypb.HistoryEvent{
 		EventId:    eventID,
 		EventType:  enumspb.EVENT_TYPE_WORKFLOW_TASK_COMPLETED,
-		Attributes: &historypb.HistoryEvent_WorkflowTaskCompletedEventAttributes{WorkflowTaskCompletedEventAttributes: attr}}
+		Attributes: &historypb.HistoryEvent_WorkflowTaskCompletedEventAttributes{WorkflowTaskCompletedEventAttributes: attr},
+	}
 }
 
 func createTestEventWorkflowTaskFailed(eventID int64, attr *historypb.WorkflowTaskFailedEventAttributes) *historypb.HistoryEvent {
 	return &historypb.HistoryEvent{
 		EventId:    eventID,
 		EventType:  enumspb.EVENT_TYPE_WORKFLOW_TASK_FAILED,
-		Attributes: &historypb.HistoryEvent_WorkflowTaskFailedEventAttributes{WorkflowTaskFailedEventAttributes: attr}}
+		Attributes: &historypb.HistoryEvent_WorkflowTaskFailedEventAttributes{WorkflowTaskFailedEventAttributes: attr},
+	}
 }
 
 func createTestEventWorkflowTaskTimedOut(eventID int64, attr *historypb.WorkflowTaskTimedOutEventAttributes) *historypb.HistoryEvent {
 	return &historypb.HistoryEvent{
 		EventId:    eventID,
 		EventType:  enumspb.EVENT_TYPE_WORKFLOW_TASK_TIMED_OUT,
-		Attributes: &historypb.HistoryEvent_WorkflowTaskTimedOutEventAttributes{WorkflowTaskTimedOutEventAttributes: attr}}
+		Attributes: &historypb.HistoryEvent_WorkflowTaskTimedOutEventAttributes{WorkflowTaskTimedOutEventAttributes: attr},
+	}
 }
 
 func createTestEventSignalExternalWorkflowExecutionFailed(eventID int64, attr *historypb.SignalExternalWorkflowExecutionFailedEventAttributes) *historypb.HistoryEvent {
 	return &historypb.HistoryEvent{
 		EventId:    eventID,
 		EventType:  enumspb.EVENT_TYPE_SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_FAILED,
-		Attributes: &historypb.HistoryEvent_SignalExternalWorkflowExecutionFailedEventAttributes{SignalExternalWorkflowExecutionFailedEventAttributes: attr}}
+		Attributes: &historypb.HistoryEvent_SignalExternalWorkflowExecutionFailedEventAttributes{SignalExternalWorkflowExecutionFailedEventAttributes: attr},
+	}
 }
 
 func createTestEventStartChildWorkflowExecutionInitiated(eventID int64, attr *historypb.StartChildWorkflowExecutionInitiatedEventAttributes) *historypb.HistoryEvent {
 	return &historypb.HistoryEvent{
 		EventId:    eventID,
 		EventType:  enumspb.EVENT_TYPE_START_CHILD_WORKFLOW_EXECUTION_INITIATED,
-		Attributes: &historypb.HistoryEvent_StartChildWorkflowExecutionInitiatedEventAttributes{StartChildWorkflowExecutionInitiatedEventAttributes: attr}}
+		Attributes: &historypb.HistoryEvent_StartChildWorkflowExecutionInitiatedEventAttributes{StartChildWorkflowExecutionInitiatedEventAttributes: attr},
+	}
 }
 
 func createTestEventChildWorkflowExecutionStarted(eventID int64, attr *historypb.ChildWorkflowExecutionStartedEventAttributes) *historypb.HistoryEvent {
 	return &historypb.HistoryEvent{
 		EventId:    eventID,
 		EventType:  enumspb.EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_STARTED,
-		Attributes: &historypb.HistoryEvent_ChildWorkflowExecutionStartedEventAttributes{ChildWorkflowExecutionStartedEventAttributes: attr}}
+		Attributes: &historypb.HistoryEvent_ChildWorkflowExecutionStartedEventAttributes{ChildWorkflowExecutionStartedEventAttributes: attr},
+	}
 }
 
 func createTestEventStartChildWorkflowExecutionFailed(eventID int64, attr *historypb.StartChildWorkflowExecutionFailedEventAttributes) *historypb.HistoryEvent {
 	return &historypb.HistoryEvent{
 		EventId:    eventID,
 		EventType:  enumspb.EVENT_TYPE_START_CHILD_WORKFLOW_EXECUTION_FAILED,
-		Attributes: &historypb.HistoryEvent_StartChildWorkflowExecutionFailedEventAttributes{StartChildWorkflowExecutionFailedEventAttributes: attr}}
+		Attributes: &historypb.HistoryEvent_StartChildWorkflowExecutionFailedEventAttributes{StartChildWorkflowExecutionFailedEventAttributes: attr},
+	}
 }
 
 func createTestEventRequestCancelExternalWorkflowExecutionInitiated(eventID int64, attr *historypb.RequestCancelExternalWorkflowExecutionInitiatedEventAttributes) *historypb.HistoryEvent {
 	return &historypb.HistoryEvent{
 		EventId:    eventID,
 		EventType:  enumspb.EVENT_TYPE_REQUEST_CANCEL_EXTERNAL_WORKFLOW_EXECUTION_INITIATED,
-		Attributes: &historypb.HistoryEvent_RequestCancelExternalWorkflowExecutionInitiatedEventAttributes{RequestCancelExternalWorkflowExecutionInitiatedEventAttributes: attr}}
+		Attributes: &historypb.HistoryEvent_RequestCancelExternalWorkflowExecutionInitiatedEventAttributes{RequestCancelExternalWorkflowExecutionInitiatedEventAttributes: attr},
+	}
 }
 
 func createTestEventWorkflowExecutionCancelRequested(eventID int64, attr *historypb.WorkflowExecutionCancelRequestedEventAttributes) *historypb.HistoryEvent {
 	return &historypb.HistoryEvent{
 		EventId:    eventID,
 		EventType:  enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_CANCEL_REQUESTED,
-		Attributes: &historypb.HistoryEvent_WorkflowExecutionCancelRequestedEventAttributes{WorkflowExecutionCancelRequestedEventAttributes: attr}}
+		Attributes: &historypb.HistoryEvent_WorkflowExecutionCancelRequestedEventAttributes{WorkflowExecutionCancelRequestedEventAttributes: attr},
+	}
 }
 
 func createTestEventExternalWorkflowExecutionCancelRequested(eventID int64, attr *historypb.ExternalWorkflowExecutionCancelRequestedEventAttributes) *historypb.HistoryEvent {
 	return &historypb.HistoryEvent{
 		EventId:    eventID,
 		EventType:  enumspb.EVENT_TYPE_EXTERNAL_WORKFLOW_EXECUTION_CANCEL_REQUESTED,
-		Attributes: &historypb.HistoryEvent_ExternalWorkflowExecutionCancelRequestedEventAttributes{ExternalWorkflowExecutionCancelRequestedEventAttributes: attr}}
+		Attributes: &historypb.HistoryEvent_ExternalWorkflowExecutionCancelRequestedEventAttributes{ExternalWorkflowExecutionCancelRequestedEventAttributes: attr},
+	}
 }
 
 func createTestEventChildWorkflowExecutionCanceled(eventID int64, attr *historypb.ChildWorkflowExecutionCanceledEventAttributes) *historypb.HistoryEvent {
 	return &historypb.HistoryEvent{
 		EventId:    eventID,
 		EventType:  enumspb.EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_CANCELED,
-		Attributes: &historypb.HistoryEvent_ChildWorkflowExecutionCanceledEventAttributes{ChildWorkflowExecutionCanceledEventAttributes: attr}}
+		Attributes: &historypb.HistoryEvent_ChildWorkflowExecutionCanceledEventAttributes{ChildWorkflowExecutionCanceledEventAttributes: attr},
+	}
 }
 
 func createTestEventVersionMarker(eventID int64, workflowTaskCompletedID int64, changeID string, version Version) *historypb.HistoryEvent {
@@ -431,7 +452,8 @@ func createTestEventTimerStarted(eventID int64, id int) *historypb.HistoryEvent 
 	return &historypb.HistoryEvent{
 		EventId:    eventID,
 		EventType:  enumspb.EVENT_TYPE_TIMER_STARTED,
-		Attributes: &historypb.HistoryEvent_TimerStartedEventAttributes{TimerStartedEventAttributes: attr}}
+		Attributes: &historypb.HistoryEvent_TimerStartedEventAttributes{TimerStartedEventAttributes: attr},
+	}
 }
 
 func createTestEventTimerFired(eventID int64, id int) *historypb.HistoryEvent {
@@ -443,7 +465,8 @@ func createTestEventTimerFired(eventID int64, id int) *historypb.HistoryEvent {
 	return &historypb.HistoryEvent{
 		EventId:    eventID,
 		EventType:  enumspb.EVENT_TYPE_TIMER_FIRED,
-		Attributes: &historypb.HistoryEvent_TimerFiredEventAttributes{TimerFiredEventAttributes: attr}}
+		Attributes: &historypb.HistoryEvent_TimerFiredEventAttributes{TimerFiredEventAttributes: attr},
+	}
 }
 
 func createTestEventTimerCanceled(eventID int64, id int) *historypb.HistoryEvent {
@@ -455,7 +478,8 @@ func createTestEventTimerCanceled(eventID int64, id int) *historypb.HistoryEvent
 	return &historypb.HistoryEvent{
 		EventId:    eventID,
 		EventType:  enumspb.EVENT_TYPE_TIMER_CANCELED,
-		Attributes: &historypb.HistoryEvent_TimerCanceledEventAttributes{TimerCanceledEventAttributes: attr}}
+		Attributes: &historypb.HistoryEvent_TimerCanceledEventAttributes{TimerCanceledEventAttributes: attr},
+	}
 }
 
 var testWorkflowTaskTaskqueue = "tq1"
@@ -814,7 +838,7 @@ func (t *TaskHandlersTestSuite) testSideEffectDeferHelper(cacheSize int) {
 	value := "should not be modified"
 	expectedValue := value
 	doneCh := make(chan struct{})
-	var myWorkerCachePtr = &sharedWorkerCache{}
+	myWorkerCachePtr := &sharedWorkerCache{}
 	var myWorkerCacheLock sync.Mutex
 
 	workflowFunc := func(ctx Context) error {
@@ -1061,7 +1085,8 @@ func (t *TaskHandlersTestSuite) TestConsistentQuery_Success() {
 		createTestEventWorkflowTaskScheduled(2, &historypb.WorkflowTaskScheduledEventAttributes{}),
 		createTestEventWorkflowTaskStarted(3),
 		createTestEventWorkflowTaskCompleted(4, &historypb.WorkflowTaskCompletedEventAttributes{
-			ScheduledEventId: 2, BinaryChecksum: checksum1}),
+			ScheduledEventId: 2, BinaryChecksum: checksum1,
+		}),
 		createTestEventWorkflowExecutionSignaledWithPayload(5, signalCh, signal),
 		createTestEventWorkflowTaskScheduled(6, &historypb.WorkflowTaskScheduledEventAttributes{}),
 		createTestEventWorkflowTaskStarted(7),
@@ -1214,7 +1239,8 @@ func (t *TaskHandlersTestSuite) TestLocalActivityRetry_Workflow() {
 	testEvents := []*historypb.HistoryEvent{
 		createTestEventWorkflowExecutionStarted(1, &historypb.WorkflowExecutionStartedEventAttributes{
 			WorkflowTaskTimeout: &onesec,
-			TaskQueue:           &taskqueuepb.TaskQueue{Name: testWorkflowTaskTaskqueue}},
+			TaskQueue:           &taskqueuepb.TaskQueue{Name: testWorkflowTaskTaskqueue},
+		},
 		),
 		createTestEventWorkflowTaskScheduled(2, &historypb.WorkflowTaskScheduledEventAttributes{}),
 		workflowTaskStartedEvent,
@@ -1296,7 +1322,8 @@ func (t *TaskHandlersTestSuite) TestLocalActivityRetry_WorkflowTaskHeartbeatFail
 		createTestEventWorkflowExecutionStarted(1, &historypb.WorkflowExecutionStartedEventAttributes{
 			// make sure the timeout is same as the backoff interval
 			WorkflowTaskTimeout: &wftTimeout,
-			TaskQueue:           &taskqueuepb.TaskQueue{Name: testWorkflowTaskTaskqueue}},
+			TaskQueue:           &taskqueuepb.TaskQueue{Name: testWorkflowTaskTaskqueue},
+		},
 		),
 		createTestEventWorkflowTaskScheduled(2, &historypb.WorkflowTaskScheduledEventAttributes{}),
 		workflowTaskStartedEvent,
@@ -1491,7 +1518,8 @@ func (t *TaskHandlersTestSuite) TestActivityExecutionDeadline() {
 			TaskToken: []byte("token"),
 			WorkflowExecution: &commonpb.WorkflowExecution{
 				WorkflowId: "wID",
-				RunId:      "rID"},
+				RunId:      "rID",
+			},
 			ActivityType:           &commonpb.ActivityType{Name: d.ActivityType},
 			ActivityId:             uuid.New(),
 			ScheduledTime:          &d.ScheduleTS,
@@ -1548,7 +1576,8 @@ func (t *TaskHandlersTestSuite) TestActivityExecutionWorkerStop() {
 		TaskToken: []byte("token"),
 		WorkflowExecution: &commonpb.WorkflowExecution{
 			WorkflowId: "wID",
-			RunId:      "rID"},
+			RunId:      "rID",
+		},
 		ActivityType:           &commonpb.ActivityType{Name: "test"},
 		ActivityId:             uuid.New(),
 		ScheduledTime:          &now,
@@ -1588,7 +1617,6 @@ func Test_NonDeterministicCheck(t *testing.T) {
 func Test_IsCommandMatchEvent_UpsertWorkflowSearchAttributes(t *testing.T) {
 	diType := enumspb.COMMAND_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES
 	eType := enumspb.EVENT_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES
-	strictMode := false
 
 	testCases := []struct {
 		name     string
@@ -1617,7 +1645,8 @@ func Test_IsCommandMatchEvent_UpsertWorkflowSearchAttributes(t *testing.T) {
 			},
 			event: &historypb.HistoryEvent{
 				EventType:  eType,
-				Attributes: &historypb.HistoryEvent_UpsertWorkflowSearchAttributesEventAttributes{UpsertWorkflowSearchAttributesEventAttributes: &historypb.UpsertWorkflowSearchAttributesEventAttributes{}}},
+				Attributes: &historypb.HistoryEvent_UpsertWorkflowSearchAttributesEventAttributes{UpsertWorkflowSearchAttributesEventAttributes: &historypb.UpsertWorkflowSearchAttributesEventAttributes{}},
+			},
 			expected: true,
 		},
 		{
@@ -1640,11 +1669,9 @@ func Test_IsCommandMatchEvent_UpsertWorkflowSearchAttributes(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			require.Equal(t, testCase.expected, isCommandMatchEvent(testCase.command, testCase.event, strictMode))
+			require.Equal(t, testCase.expected, isCommandMatchEvent(testCase.command, testCase.event))
 		})
 	}
-
-	strictMode = true
 
 	testCases = []struct {
 		name     string
@@ -1662,14 +1689,15 @@ func Test_IsCommandMatchEvent_UpsertWorkflowSearchAttributes(t *testing.T) {
 			},
 			event: &historypb.HistoryEvent{
 				EventType:  eType,
-				Attributes: &historypb.HistoryEvent_UpsertWorkflowSearchAttributesEventAttributes{UpsertWorkflowSearchAttributesEventAttributes: &historypb.UpsertWorkflowSearchAttributesEventAttributes{}}},
+				Attributes: &historypb.HistoryEvent_UpsertWorkflowSearchAttributesEventAttributes{UpsertWorkflowSearchAttributesEventAttributes: &historypb.UpsertWorkflowSearchAttributesEventAttributes{}},
+			},
 			expected: false,
 		},
 	}
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			require.Equal(t, testCase.expected, isCommandMatchEvent(testCase.command, testCase.event, strictMode))
+			require.Equal(t, testCase.expected, isCommandMatchEvent(testCase.command, testCase.event))
 		})
 	}
 }
@@ -1743,7 +1771,6 @@ func Test_IsSearchAttributesMatched(t *testing.T) {
 func Test_IsCommandMatchEvent_ModifyWorkflowProperties(t *testing.T) {
 	diType := enumspb.COMMAND_TYPE_MODIFY_WORKFLOW_PROPERTIES
 	eType := enumspb.EVENT_TYPE_WORKFLOW_PROPERTIES_MODIFIED
-	strictMode := false
 
 	testCases := []struct {
 		name     string
@@ -1811,13 +1838,11 @@ func Test_IsCommandMatchEvent_ModifyWorkflowProperties(t *testing.T) {
 				require.Equal(
 					t,
 					testCase.expected,
-					isCommandMatchEvent(testCase.command, testCase.event, strictMode),
+					isCommandMatchEvent(testCase.command, testCase.event),
 				)
 			},
 		)
 	}
-
-	strictMode = true
 
 	testCases = []struct {
 		name     string
@@ -1852,7 +1877,7 @@ func Test_IsCommandMatchEvent_ModifyWorkflowProperties(t *testing.T) {
 				require.Equal(
 					t,
 					testCase.expected,
-					isCommandMatchEvent(testCase.command, testCase.event, strictMode),
+					isCommandMatchEvent(testCase.command, testCase.event),
 				)
 			},
 		)
@@ -1932,13 +1957,13 @@ func TestInvocationIndexing(t *testing.T) {
 	wft := &workflowTask{
 		task: &workflowservice.PollWorkflowTaskQueueResponse{
 			Interactions: []*interactionpb.Invocation{
-				&interactionpb.Invocation{
+				{
 					Meta: &interactionpb.Meta{Id: "ID.1", EventId: 3},
 				},
-				&interactionpb.Invocation{
+				{
 					Meta: &interactionpb.Meta{Id: "ID.2", EventId: 5},
 				},
-				&interactionpb.Invocation{
+				{
 					Meta: &interactionpb.Meta{Id: "ID.3", EventId: 3},
 				},
 			},

--- a/test/fixtures/activity.cancel.sm.repro.json
+++ b/test/fixtures/activity.cancel.sm.repro.json
@@ -1,199 +1,323 @@
 {
-  "events": [
-    {
-      "eventId": 1,
-      "eventTime": "2020-07-30T00:30:02.971655189Z",
-      "eventType": "WorkflowExecutionStarted",
-      "version": -24,
-      "workflowExecutionStartedEventAttributes": {
-        "workflowType": {
-          "name": "ActivityCancelRepro"
-        },
-        "taskQueue": {
-          "name": "tq-1"
-        },
-        "workflowRunTimeout": "10s",
-        "workflowTaskTimeout": "1s",
-        "identity": "97228@samar-C02XG22GJGH6@"
-      }
+ "events": [
+  {
+   "eventId": "1",
+   "eventTime": "2022-12-29T18:15:28.878550094Z",
+   "eventType": "WorkflowExecutionStarted",
+   "taskId": "8425426",
+   "workflowExecutionStartedEventAttributes": {
+    "workflowType": {
+     "name": "ActivityCancelRepro"
     },
-    {
-      "eventId": 2,
-      "eventTime": "2020-07-30T00:30:02.971655189Z",
-      "eventType": "WorkflowTaskScheduled",
-      "version": -24,
-      "workflowTaskScheduledEventAttributes": {
-        "taskQueue": {
-          "name": "tq-1"
-        },
-        "startToCloseTimeout": "1s",
-        "attempt": 1
-      }
+    "taskQueue": {
+     "name": "tq-7d749b97-85a2-4d8d-85a9-2efa207ee859-TestIntegrationSuite/TestActivityCancelRepro",
+     "kind": "Normal"
     },
-    {
-      "eventId": 3,
-      "eventTime": "2020-07-30T00:30:02.971655189Z",
-      "eventType": "WorkflowTaskStarted",
-      "version": -24,
-      "workflowTaskStartedEventAttributes": {
-        "scheduledEventId": 2,
-        "identity": "97228@samar-C02XG22GJGH6@tl-1",
-        "requestId": "9c612c81-6cd9-402d-866f-e5652e9c4823"
-      }
-    },
-    {
-      "eventId": 4,
-      "eventTime": "2020-07-30T00:30:02.971655189Z",
-      "eventType": "WorkflowTaskCompleted",
-      "version": -24,
-      "workflowTaskCompletedEventAttributes": {
-        "scheduledEventId": 2,
-        "startedEventId": 3,
-        "identity": "97228@samar-C02XG22GJGH6@tl-1"
-      }
-    },
-    {
-      "eventId": 5,
-      "eventTime": "2020-07-30T00:30:02.971655189Z",
-      "eventType": "TimerStarted",
-      "version": -24,
-      "timerStartedEventAttributes": {
-        "timerId": "5",
-        "startToFireTimeout": "10s",
-        "workflowTaskCompletedEventId": 4
-      }
-    },
-    {
-      "eventId": 6,
-      "eventTime": "2020-07-30T00:30:02.971655189Z",
-      "eventType": "ActivityTaskScheduled",
-      "version": -24,
-      "activityTaskScheduledEventAttributes": {
-        "activityId": "6",
-        "activityType": {
-          "name": "toUpperWithDelay"
-        },
-        "taskQueue": {
-          "name": "tq-1"
-        },
-        "input": null,
-        "scheduleToCloseTimeout": "10s",
-        "scheduleToStartTimeout": "10s",
-        "startToCloseTimeout": "9s",
-        "heartbeatTimeout": "0s",
-        "workflowTaskCompletedEventId": 4
-      }
-    },
-    {
-      "eventId": 7,
-      "eventTime": "2020-07-30T00:30:02.971655189Z",
-      "eventType": "ActivityTaskScheduled",
-      "version": -24,
-      "activityTaskScheduledEventAttributes": {
-        "activityId": "7",
-        "activityType": {
-          "name": "toUpper"
-        },
-        "taskQueue": {
-          "name": "bad_tq"
-        },
-        "input": null,
-        "scheduleToCloseTimeout": "10s",
-        "scheduleToStartTimeout": "10s",
-        "startToCloseTimeout": "9s",
-        "heartbeatTimeout": "0s",
-        "workflowTaskCompletedEventId": 4
-      }
-    },
-    {
-      "eventId": 8,
-      "eventTime": "2020-07-30T00:30:02.971655189Z",
-      "eventType": "ActivityTaskScheduled",
-      "version": -24,
-      "activityTaskScheduledEventAttributes": {
-        "activityId": "8",
-        "activityType": {
-          "name": "toUpper"
-        },
-        "taskQueue": {
-          "name": "bad_tq"
-        },
-        "input": null,
-        "scheduleToCloseTimeout": "10s",
-        "scheduleToStartTimeout": "10s",
-        "startToCloseTimeout": "9s",
-        "heartbeatTimeout": "0s",
-        "workflowTaskCompletedEventId": 4
-      }
-    },
-    {
-      "eventId": 9,
-      "eventTime": "2020-07-30T00:30:02.971655189Z",
-      "eventType": "ActivityTaskStarted",
-      "version": -24,
-      "activityTaskStartedEventAttributes": {
-        "scheduledEventId": 6,
-        "identity": "97228@samar-C02XG22GJGH6@tl-1",
-        "requestId": "8b1ab5fd-5f15-4867-af33-97a7b00da341",
-        "attempt": 1
-      }
-    },
-    {
-      "eventId": 10,
-      "eventTime": "2020-07-30T00:30:02.971655189Z",
-      "eventType": "ActivityTaskCompleted",
-      "version": -24,
-      "activityTaskCompletedEventAttributes": {
-        "result": null,
-        "scheduledEventId": 6,
-        "startedEventId": 9,
-        "identity": "97228@samar-C02XG22GJGH6@tl-1"
-      }
-    },
-    {
-      "eventId": 11,
-      "eventTime": "2020-07-30T00:30:02.971655189Z",
-      "eventType": "WorkflowTaskScheduled",
-      "version": -24,
-      "workflowTaskScheduledEventAttributes": {
-        "taskQueue": {
-          "name": "tq-1"
-        },
-        "startToCloseTimeout": "1s",
-        "attempt": 1
-      }
-    },
-    {
-      "eventId": 12,
-      "eventTime": "2020-07-30T00:30:02.971655189Z",
-      "eventType": "WorkflowTaskStarted",
-      "version": -24,
-      "workflowTaskStartedEventAttributes": {
-        "scheduledEventId": 11,
-        "identity": "97228@samar-C02XG22GJGH6@tl-1",
-        "requestId": "89f09b7a-2f34-497f-b3c4-99ede5efaf30"
-      }
-    },
-    {
-      "eventId": 13,
-      "eventTime": "2020-07-30T00:30:02.971655189Z",
-      "eventType": "WorkflowTaskFailed",
-      "version": -24,
-      "workflowTaskFailedEventAttributes": {
-        "scheduledEventId": 11,
-        "startedEventId": 12,
-        "cause": "WorkflowWorkerUnhandledFailure",
-        "failure": null,
-        "identity": "97228@samar-C02XG22GJGH6@tl-1"
-      }
-    },
-    {
-      "eventId": 14,
-      "eventTime": "2020-07-30T00:30:02.971655189Z",
-      "eventType": "WorkflowExecutionTimedOut",
-      "version": -24,
-      "workflowExecutionTimedOutEventAttributes": {
-      }
+    "workflowExecutionTimeout": "15s",
+    "workflowRunTimeout": "15s",
+    "workflowTaskTimeout": "1s",
+    "originalExecutionRunId": "6d1c5f55-2164-44d8-9071-523fe47fef54",
+    "identity": "78495@Quinn-Klassens-MacBook-Pro.local@",
+    "firstExecutionRunId": "6d1c5f55-2164-44d8-9071-523fe47fef54",
+    "attempt": 1,
+    "workflowExecutionExpirationTime": "2022-12-29T18:15:43.878Z",
+    "firstWorkflowTaskBackoff": "0s",
+    "header": {
+
     }
-  ]
+   }
+  },
+  {
+   "eventId": "2",
+   "eventTime": "2022-12-29T18:15:28.878578594Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "8425427",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "tq-7d749b97-85a2-4d8d-85a9-2efa207ee859-TestIntegrationSuite/TestActivityCancelRepro",
+     "kind": "Normal"
+    },
+    "startToCloseTimeout": "1s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "3",
+   "eventTime": "2022-12-29T18:15:28.892896136Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "8425436",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "2",
+    "identity": "78495@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "42868ace-5ac8-474e-a1df-cd00df675c04"
+   }
+  },
+  {
+   "eventId": "4",
+   "eventTime": "2022-12-29T18:15:28.899246844Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "8425440",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "2",
+    "startedEventId": "3",
+    "identity": "78495@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "6c79979b82c427f78bbe93dc93735607"
+   }
+  },
+  {
+   "eventId": "5",
+   "eventTime": "2022-12-29T18:15:28.899262344Z",
+   "eventType": "TimerStarted",
+   "taskId": "8425441",
+   "timerStartedEventAttributes": {
+    "timerId": "5",
+    "startToFireTimeout": "10s",
+    "workflowTaskCompletedEventId": "4"
+   }
+  },
+  {
+   "eventId": "6",
+   "eventTime": "2022-12-29T18:15:28.899269094Z",
+   "eventType": "ActivityTaskScheduled",
+   "taskId": "8425442",
+   "activityTaskScheduledEventAttributes": {
+    "activityId": "6",
+    "activityType": {
+     "name": "Prefix_ToUpperWithDelay"
+    },
+    "taskQueue": {
+     "name": "tq-7d749b97-85a2-4d8d-85a9-2efa207ee859-TestIntegrationSuite/TestActivityCancelRepro",
+     "kind": "Normal"
+    },
+    "header": {
+
+    },
+    "input": {
+     "payloads": [
+      {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg=="
+       },
+       "data": "ImhlbGxvIg=="
+      },
+      {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg=="
+       },
+       "data": "MTAwMDAwMDAwMA=="
+      }
+     ]
+    },
+    "scheduleToCloseTimeout": "10s",
+    "scheduleToStartTimeout": "10s",
+    "startToCloseTimeout": "9s",
+    "heartbeatTimeout": "0s",
+    "workflowTaskCompletedEventId": "4",
+    "retryPolicy": {
+     "initialInterval": "1s",
+     "backoffCoefficient": 2,
+     "maximumInterval": "100s"
+    }
+   }
+  },
+  {
+   "eventId": "7",
+   "eventTime": "2022-12-29T18:15:28.899276178Z",
+   "eventType": "ActivityTaskScheduled",
+   "taskId": "8425443",
+   "activityTaskScheduledEventAttributes": {
+    "activityId": "7",
+    "activityType": {
+     "name": "Prefix_ToUpper"
+    },
+    "taskQueue": {
+     "name": "bad_tq",
+     "kind": "Normal"
+    },
+    "header": {
+
+    },
+    "input": {
+     "payloads": [
+      {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg=="
+       },
+       "data": "ImhlbGxvIg=="
+      }
+     ]
+    },
+    "scheduleToCloseTimeout": "10s",
+    "scheduleToStartTimeout": "10s",
+    "startToCloseTimeout": "1s",
+    "heartbeatTimeout": "0s",
+    "workflowTaskCompletedEventId": "4",
+    "retryPolicy": {
+     "initialInterval": "1s",
+     "backoffCoefficient": 2,
+     "maximumInterval": "100s"
+    }
+   }
+  },
+  {
+   "eventId": "8",
+   "eventTime": "2022-12-29T18:15:28.899279469Z",
+   "eventType": "ActivityTaskScheduled",
+   "taskId": "8425444",
+   "activityTaskScheduledEventAttributes": {
+    "activityId": "8",
+    "activityType": {
+     "name": "Prefix_ToUpper"
+    },
+    "taskQueue": {
+     "name": "bad_tq",
+     "kind": "Normal"
+    },
+    "header": {
+
+    },
+    "input": {
+     "payloads": [
+      {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg=="
+       },
+       "data": "ImhlbGxvIg=="
+      }
+     ]
+    },
+    "scheduleToCloseTimeout": "10s",
+    "scheduleToStartTimeout": "10s",
+    "startToCloseTimeout": "1s",
+    "heartbeatTimeout": "0s",
+    "workflowTaskCompletedEventId": "4",
+    "retryPolicy": {
+     "initialInterval": "1s",
+     "backoffCoefficient": 2,
+     "maximumInterval": "100s"
+    }
+   }
+  },
+  {
+   "eventId": "9",
+   "eventTime": "2022-12-29T18:15:28.908553261Z",
+   "eventType": "ActivityTaskStarted",
+   "taskId": "8425454",
+   "activityTaskStartedEventAttributes": {
+    "scheduledEventId": "6",
+    "identity": "78495@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "c061178a-488d-4e51-b54d-8bc589023a96",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "10",
+   "eventTime": "2022-12-29T18:15:29.922392553Z",
+   "eventType": "ActivityTaskCompleted",
+   "taskId": "8425455",
+   "activityTaskCompletedEventAttributes": {
+    "result": {
+     "payloads": [
+      {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg=="
+       },
+       "data": "IkhFTExPIg=="
+      }
+     ]
+    },
+    "scheduledEventId": "6",
+    "startedEventId": "9",
+    "identity": "78495@Quinn-Klassens-MacBook-Pro.local@"
+   }
+  },
+  {
+   "eventId": "11",
+   "eventTime": "2022-12-29T18:15:29.922422011Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "8425456",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:4a55a3d3-295c-4a2c-bfe8-4602902c2d8e",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "1s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "12",
+   "eventTime": "2022-12-29T18:15:29.952487136Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "8425461",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "11",
+    "identity": "78495@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "21400c1a-83c2-4230-89a6-b7551f94e80d"
+   }
+  },
+  {
+   "eventId": "13",
+   "eventTime": "2022-12-29T18:15:29.967085345Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "8425465",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "11",
+    "startedEventId": "12",
+    "identity": "78495@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "6c79979b82c427f78bbe93dc93735607"
+   }
+  },
+  {
+   "eventId": "14",
+   "eventTime": "2022-12-29T18:15:29.967097428Z",
+   "eventType": "TimerCanceled",
+   "taskId": "8425466",
+   "timerCanceledEventAttributes": {
+    "timerId": "5",
+    "startedEventId": "5",
+    "workflowTaskCompletedEventId": "13",
+    "identity": "78495@Quinn-Klassens-MacBook-Pro.local@"
+   }
+  },
+  {
+   "eventId": "15",
+   "eventTime": "2022-12-29T18:15:29.967104720Z",
+   "eventType": "ActivityTaskCancelRequested",
+   "taskId": "8425467",
+   "activityTaskCancelRequestedEventAttributes": {
+    "scheduledEventId": "7",
+    "workflowTaskCompletedEventId": "13"
+   }
+  },
+  {
+   "eventId": "16",
+   "eventTime": "2022-12-29T18:15:29.967132011Z",
+   "eventType": "ActivityTaskCancelRequested",
+   "taskId": "8425468",
+   "activityTaskCancelRequestedEventAttributes": {
+    "scheduledEventId": "8",
+    "workflowTaskCompletedEventId": "13"
+   }
+  },
+  {
+   "eventId": "17",
+   "eventTime": "2022-12-29T18:15:29.967141053Z",
+   "eventType": "WorkflowExecutionCompleted",
+   "taskId": "8425469",
+   "workflowExecutionCompletedEventAttributes": {
+    "result": {
+     "payloads": [
+      {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg=="
+       },
+       "data": "WyJ0b1VwcGVyV2l0aERlbGF5Il0="
+      }
+     ]
+    },
+    "workflowTaskCompletedEventId": "13"
+   }
+  }
+ ]
 }

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -895,7 +895,7 @@ func (ts *IntegrationTestSuite) TestChildWFWithParentClosePolicyAbandon() {
 func (ts *IntegrationTestSuite) TestActivityCancelUsingReplay() {
 	replayer := worker.NewWorkflowReplayer()
 	replayer.RegisterWorkflowWithOptions(ts.workflows.ActivityCancelRepro, workflow.RegisterOptions{DisableAlreadyRegisteredCheck: true})
-	err := replayer.ReplayPartialWorkflowHistoryFromJSONFile(ilog.NewDefaultLogger(), "fixtures/activity.cancel.sm.repro.json", 12)
+	err := replayer.ReplayWorkflowHistoryFromJSONFile(ilog.NewDefaultLogger(), "fixtures/activity.cancel.sm.repro.json")
 	ts.NoError(err)
 }
 

--- a/test/replaytests/bad-continue-as-new-2.json
+++ b/test/replaytests/bad-continue-as-new-2.json
@@ -1,0 +1,86 @@
+{
+ "events": [
+  {
+   "eventId": "1",
+   "eventTime": "2022-12-14T19:45:55.862915835Z",
+   "eventType": "WorkflowExecutionStarted",
+   "taskId": "7344364",
+   "workflowExecutionStartedEventAttributes": {
+    "workflowType": {
+     "name": "ContinueAsNewWorkflow"
+    },
+    "taskQueue": {
+     "name": "replay-test",
+     "kind": "Normal"
+    },
+    "input": {
+     "payloads": [
+      {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg=="
+       },
+       "data": "dHJ1ZQ=="
+      }
+     ]
+    },
+    "workflowExecutionTimeout": "0s",
+    "workflowRunTimeout": "0s",
+    "workflowTaskTimeout": "10s",
+    "originalExecutionRunId": "d4517dc9-5a5b-4f00-84b2-3af8b6bec753",
+    "identity": "32656@Quinn-Klassens-MacBook-Pro.local@",
+    "firstExecutionRunId": "d4517dc9-5a5b-4f00-84b2-3af8b6bec753",
+    "attempt": 1,
+    "firstWorkflowTaskBackoff": "0s",
+    "header": {
+
+    }
+   }
+  },
+  {
+   "eventId": "2",
+   "eventTime": "2022-12-14T19:45:55.862935294Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "7344365",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "replay-test",
+     "kind": "Normal"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "3",
+   "eventTime": "2022-12-14T19:45:55.871394877Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "7344372",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "2",
+    "identity": "32656@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "5bda1026-1ff7-4027-b5d3-da6b5a4147bf"
+   }
+  },
+  {
+   "eventId": "4",
+   "eventTime": "2022-12-14T19:45:55.875993835Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "7344376",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "2",
+    "startedEventId": "3",
+    "identity": "32656@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "0c23de87770f076626dd550d6d25850c"
+   }
+  },
+  {
+   "eventId": "5",
+   "eventTime": "2022-12-14T19:45:55.876011960Z",
+   "eventType": "WorkflowExecutionCompleted",
+   "taskId": "7344377",
+   "workflowExecutionCompletedEventAttributes": {
+    "workflowTaskCompletedEventId": "4"
+   }
+  }
+ ]
+}

--- a/test/replaytests/bad-continue-as-new.json
+++ b/test/replaytests/bad-continue-as-new.json
@@ -1,0 +1,109 @@
+{
+ "events": [
+  {
+   "eventId": "1",
+   "eventTime": "2022-12-13T23:18:31.822878008Z",
+   "eventType": "WorkflowExecutionStarted",
+   "taskId": "7343430",
+   "workflowExecutionStartedEventAttributes": {
+    "workflowType": {
+     "name": "ContinueAsNewWorkflow"
+    },
+    "taskQueue": {
+     "name": "replay-test",
+     "kind": "Normal"
+    },
+    "input": {
+     "payloads": [
+      {
+        "metadata": {
+            "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "ZmFsc2U="
+      }
+     ]
+    },
+    "workflowExecutionTimeout": "0s",
+    "workflowRunTimeout": "0s",
+    "workflowTaskTimeout": "10s",
+    "originalExecutionRunId": "bdb5a608-0880-421d-90fb-f85e748d12b4",
+    "identity": "14127@Quinn-Klassens-MacBook-Pro.local@",
+    "firstExecutionRunId": "bdb5a608-0880-421d-90fb-f85e748d12b4",
+    "attempt": 1,
+    "firstWorkflowTaskBackoff": "0s",
+    "header": {
+
+    }
+   }
+  },
+  {
+   "eventId": "2",
+   "eventTime": "2022-12-13T23:18:31.822898091Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "7343431",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "replay-test",
+     "kind": "Normal"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "3",
+   "eventTime": "2022-12-13T23:18:31.830787008Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "7343438",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "2",
+    "identity": "14127@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "c55e1ca9-08f1-4409-ab41-20080efe48f1"
+   }
+  },
+  {
+   "eventId": "4",
+   "eventTime": "2022-12-13T23:18:31.835409800Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "7343442",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "2",
+    "startedEventId": "3",
+    "identity": "14127@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "88517a4f638baf593f75e0214a4ebf92"
+   }
+  },
+  {
+   "eventId": "5",
+   "eventTime": "2022-12-13T23:18:31.835425591Z",
+   "eventType": "WorkflowExecutionContinuedAsNew",
+   "taskId": "7343443",
+   "workflowExecutionContinuedAsNewEventAttributes": {
+    "newExecutionRunId": "74f38af0-7c7d-4aae-bc10-6c34ba946693",
+    "workflowType": {
+     "name": "BadWorkflow"
+    },
+    "taskQueue": {
+     "name": "replay-test",
+     "kind": "Normal"
+    },
+    "input": {
+     "payloads": [
+      {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg=="
+       },
+       "data": "ZmFsc2U="
+      }
+     ]
+    },
+    "workflowRunTimeout": "0s",
+    "workflowTaskTimeout": "10s",
+    "workflowTaskCompletedEventId": "4",
+    "header": {
+
+    }
+   }
+  }
+ ]
+}

--- a/test/replaytests/bad-empty-workflow.json
+++ b/test/replaytests/bad-empty-workflow.json
@@ -1,0 +1,483 @@
+{
+  "events": [
+    {
+      "eventId": "1",
+      "eventTime": "2020-07-30T00:30:02.971655189Z",
+      "eventType": "WorkflowExecutionStarted",
+      "version": "-24",
+      "taskId": "1048576",
+      "workflowExecutionStartedEventAttributes": {
+        "workflowType": {
+          "name": "EmptyWorkflow"
+        },
+        "taskQueue": {
+          "name": "replay-test",
+          "kind": "Normal"
+        },
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "IldvcmtmbG93MSI="
+            }
+          ]
+        },
+        "workflowExecutionTimeout": "315360000s",
+        "workflowRunTimeout": "315360000s",
+        "workflowTaskTimeout": "10s",
+        "initiator": "Workflow",
+        "originalExecutionRunId": "32c62bbb-dfa3-4558-8bab-11cd5b4e17b7",
+        "identity": "22866@ShtinUbuntu2@",
+        "firstExecutionRunId": "32c62bbb-dfa3-4558-8bab-11cd5b4e17b7",
+        "attempt": 1,
+        "workflowExecutionExpirationTime": "0001-01-01T00:00:00Z",
+        "firstWorkflowTaskBackoff": "0s",
+        "header": {}
+      }
+    },
+    {
+      "eventId": "2",
+      "eventTime": "2020-07-30T00:30:02.971668264Z",
+      "eventType": "WorkflowTaskScheduled",
+      "version": "-24",
+      "taskId": "1048577",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "replay-test",
+          "kind": "Normal"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": "1"
+      }
+    },
+    {
+      "eventId": "3",
+      "eventTime": "2020-07-30T00:30:02.981403193Z",
+      "eventType": "WorkflowTaskStarted",
+      "version": "-24",
+      "taskId": "1048582",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "2",
+        "identity": "22866@ShtinUbuntu2@",
+        "requestId": "43107987-202a-44ca-b718-4aecc6cd6f3b"
+      }
+    },
+    {
+      "eventId": "4",
+      "eventTime": "2020-07-30T00:30:02.992586820Z",
+      "eventType": "WorkflowTaskCompleted",
+      "version": "-24",
+      "taskId": "1048585",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "2",
+        "startedEventId": "3",
+        "identity": "22866@ShtinUbuntu2@",
+        "binaryChecksum": "01c85c2da1ff4eb3ef3641a5746edef0"
+      }
+    },
+    {
+      "eventId": "5",
+      "eventTime": "2020-07-30T00:30:02.992740076Z",
+      "eventType": "MarkerRecorded",
+      "version": "-24",
+      "taskId": "1048586",
+      "markerRecordedEventAttributes": {
+        "markerName": "Version",
+        "details": {
+          "change-id": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg=="
+                },
+                "data": "InRlc3QtY2hhbmdlIg=="
+              }
+            ]
+          },
+          "version": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg=="
+                },
+                "data": "MQ=="
+              }
+            ]
+          }
+        },
+        "workflowTaskCompletedEventId": "4"
+      }
+    },
+    {
+      "eventId": "6",
+      "eventTime": "2020-07-30T00:30:02.992943898Z",
+      "eventType": "UpsertWorkflowSearchAttributes",
+      "version": "-24",
+      "taskId": "1048587",
+      "upsertWorkflowSearchAttributesEventAttributes": {
+        "workflowTaskCompletedEventId": "4",
+        "searchAttributes": {
+          "indexedFields": {
+            "TemporalChangeVersion": {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "WyJ0ZXN0LWNoYW5nZS0xIl0="
+            }
+          }
+        }
+      }
+    },
+    {
+      "eventId": "7",
+      "eventTime": "2020-07-30T00:30:02.992959657Z",
+      "eventType": "ActivityTaskScheduled",
+      "version": "-24",
+      "taskId": "1048588",
+      "activityTaskScheduledEventAttributes": {
+        "activityId": "7",
+        "activityType": {
+          "name": "helloworldActivity"
+        },
+        "taskQueue": {
+          "name": "replay-test",
+          "kind": "Normal"
+        },
+        "header": {},
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "IldvcmtmbG93MSI="
+            }
+          ]
+        },
+        "scheduleToCloseTimeout": "315360000s",
+        "scheduleToStartTimeout": "60s",
+        "startToCloseTimeout": "60s",
+        "heartbeatTimeout": "20s",
+        "workflowTaskCompletedEventId": "4",
+        "retryPolicy": {
+          "initialInterval": "1s",
+          "backoffCoefficient": 2,
+          "maximumInterval": "120s"
+        }
+      }
+    },
+    {
+      "eventId": "8",
+      "eventTime": "2020-07-30T00:30:03.000176849Z",
+      "eventType": "ActivityTaskStarted",
+      "version": "-24",
+      "taskId": "1048594",
+      "activityTaskStartedEventAttributes": {
+        "scheduledEventId": "7",
+        "identity": "22866@ShtinUbuntu2@",
+        "requestId": "115ee611-7746-43b6-9966-afa6d78f33a0",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "9",
+      "eventTime": "2020-07-30T00:30:03.004500861Z",
+      "eventType": "ActivityTaskCompleted",
+      "version": "-24",
+      "taskId": "1048595",
+      "activityTaskCompletedEventAttributes": {
+        "result": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "IkhlbGxvIFdvcmtmbG93MSEi"
+            }
+          ]
+        },
+        "scheduledEventId": "7",
+        "startedEventId": "8",
+        "identity": "22866@ShtinUbuntu2@"
+      }
+    },
+    {
+      "eventId": "10",
+      "eventTime": "2020-07-30T00:30:03.004546840Z",
+      "eventType": "WorkflowTaskScheduled",
+      "version": "-24",
+      "taskId": "1048598",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "ShtinUbuntu2:558d9b07-a236-4b7a-9866-ac678c7d4248",
+          "kind": "Sticky"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": "1"
+      }
+    },
+    {
+      "eventId": "11",
+      "eventTime": "2020-07-30T00:30:03.011253288Z",
+      "eventType": "WorkflowTaskStarted",
+      "version": "-24",
+      "taskId": "1048602",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "10",
+        "identity": "22866@ShtinUbuntu2@",
+        "requestId": "05a54015-aa0c-49e9-afcf-89fc297f794f"
+      }
+    },
+    {
+      "eventId": "12",
+      "eventTime": "2020-07-30T00:30:03.017420164Z",
+      "eventType": "WorkflowTaskCompleted",
+      "version": "-24",
+      "taskId": "1048605",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "10",
+        "startedEventId": "11",
+        "identity": "22866@ShtinUbuntu2@",
+        "binaryChecksum": "01c85c2da1ff4eb3ef3641a5746edef0"
+      }
+    },
+    {
+      "eventId": "13",
+      "eventTime": "2020-07-30T00:30:03.017446790Z",
+      "eventType": "ActivityTaskScheduled",
+      "version": "-24",
+      "taskId": "1048606",
+      "activityTaskScheduledEventAttributes": {
+        "activityId": "13",
+        "activityType": {
+          "name": "helloworldActivity"
+        },
+        "taskQueue": {
+          "name": "replay-test",
+          "kind": "Normal"
+        },
+        "header": {},
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "IldvcmtmbG93MSI="
+            }
+          ]
+        },
+        "scheduleToCloseTimeout": "315360000s",
+        "scheduleToStartTimeout": "60s",
+        "startToCloseTimeout": "60s",
+        "heartbeatTimeout": "20s",
+        "workflowTaskCompletedEventId": "12",
+        "retryPolicy": {
+          "initialInterval": "1s",
+          "backoffCoefficient": 2,
+          "maximumInterval": "120s"
+        }
+      }
+    },
+    {
+      "eventId": "14",
+      "eventTime": "2020-07-30T00:30:03.022531293Z",
+      "eventType": "ActivityTaskStarted",
+      "version": "-24",
+      "taskId": "1048611",
+      "activityTaskStartedEventAttributes": {
+        "scheduledEventId": "13",
+        "identity": "22866@ShtinUbuntu2@",
+        "requestId": "d5ab2e59-e910-439b-aa6a-826f5a70a4a0",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "15",
+      "eventTime": "2020-07-30T00:30:03.026839379Z",
+      "eventType": "ActivityTaskCompleted",
+      "version": "-24",
+      "taskId": "1048612",
+      "activityTaskCompletedEventAttributes": {
+        "result": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "IkhlbGxvIFdvcmtmbG93MSEi"
+            }
+          ]
+        },
+        "scheduledEventId": "13",
+        "startedEventId": "14",
+        "identity": "22866@ShtinUbuntu2@"
+      }
+    },
+    {
+      "eventId": "16",
+      "eventTime": "2020-07-30T00:30:03.026848476Z",
+      "eventType": "WorkflowTaskScheduled",
+      "version": "-24",
+      "taskId": "1048615",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "ShtinUbuntu2:558d9b07-a236-4b7a-9866-ac678c7d4248",
+          "kind": "Sticky"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": "1"
+      }
+    },
+    {
+      "eventId": "17",
+      "eventTime": "2020-07-30T00:30:03.031989958Z",
+      "eventType": "WorkflowTaskStarted",
+      "version": "-24",
+      "taskId": "1048619",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "16",
+        "identity": "22866@ShtinUbuntu2@",
+        "requestId": "fc9e0d16-4df1-476e-9b6c-d310f4fb3d98"
+      }
+    },
+    {
+      "eventId": "18",
+      "eventTime": "2020-07-30T00:30:03.038368790Z",
+      "eventType": "WorkflowTaskCompleted",
+      "version": "-24",
+      "taskId": "1048622",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "16",
+        "startedEventId": "17",
+        "identity": "22866@ShtinUbuntu2@",
+        "binaryChecksum": "01c85c2da1ff4eb3ef3641a5746edef0"
+      }
+    },
+    {
+      "eventId": "19",
+      "eventTime": "2020-07-30T00:30:03.038399041Z",
+      "eventType": "ActivityTaskScheduled",
+      "version": "-24",
+      "taskId": "1048623",
+      "activityTaskScheduledEventAttributes": {
+        "activityId": "19",
+        "activityType": {
+          "name": "helloworldActivity"
+        },
+        "taskQueue": {
+          "name": "replay-test",
+          "kind": "Normal"
+        },
+        "header": {},
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "IldvcmtmbG93MSI="
+            }
+          ]
+        },
+        "scheduleToCloseTimeout": "315360000s",
+        "scheduleToStartTimeout": "60s",
+        "startToCloseTimeout": "60s",
+        "heartbeatTimeout": "20s",
+        "workflowTaskCompletedEventId": "18",
+        "retryPolicy": {
+          "initialInterval": "1s",
+          "backoffCoefficient": 2,
+          "maximumInterval": "120s"
+        }
+      }
+    },
+    {
+      "eventId": "20",
+      "eventTime": "2020-07-30T00:30:03.043777440Z",
+      "eventType": "ActivityTaskStarted",
+      "version": "-24",
+      "taskId": "1048628",
+      "activityTaskStartedEventAttributes": {
+        "scheduledEventId": "19",
+        "identity": "22866@ShtinUbuntu2@",
+        "requestId": "e177df9e-29e7-4f31-927d-bfa0f9e8e639",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "21",
+      "eventTime": "2020-07-30T00:30:03.048056395Z",
+      "eventType": "ActivityTaskCompleted",
+      "version": "-24",
+      "taskId": "1048629",
+      "activityTaskCompletedEventAttributes": {
+        "result": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "IkhlbGxvIFdvcmtmbG93MSEi"
+            }
+          ]
+        },
+        "scheduledEventId": "19",
+        "startedEventId": "20",
+        "identity": "22866@ShtinUbuntu2@"
+      }
+    },
+    {
+      "eventId": "22",
+      "eventTime": "2020-07-30T00:30:03.048065496Z",
+      "eventType": "WorkflowTaskScheduled",
+      "version": "-24",
+      "taskId": "1048632",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "ShtinUbuntu2:558d9b07-a236-4b7a-9866-ac678c7d4248",
+          "kind": "Sticky"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": "1"
+      }
+    },
+    {
+      "eventId": "23",
+      "eventTime": "2020-07-30T00:30:03.062716538Z",
+      "eventType": "WorkflowTaskStarted",
+      "version": "-24",
+      "taskId": "1048636",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "22",
+        "identity": "22866@ShtinUbuntu2@",
+        "requestId": "cbd16b72-040e-41c8-a754-4a9d72e4b69b"
+      }
+    },
+    {
+      "eventId": "24",
+      "eventTime": "2020-07-30T00:30:03.070392239Z",
+      "eventType": "WorkflowTaskCompleted",
+      "version": "-24",
+      "taskId": "1048639",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "22",
+        "startedEventId": "23",
+        "identity": "22866@ShtinUbuntu2@",
+        "binaryChecksum": "01c85c2da1ff4eb3ef3641a5746edef0"
+      }
+    },
+    {
+      "eventId": "25",
+      "eventTime": "2020-07-30T00:30:03.070438610Z",
+      "eventType": "WorkflowExecutionCompleted",
+      "version": "-24",
+      "taskId": "1048640",
+      "workflowExecutionCompletedEventAttributes": {
+        "workflowTaskCompletedEventId": "24"
+      }
+    }
+  ]
+}

--- a/test/replaytests/bad-history-2.json
+++ b/test/replaytests/bad-history-2.json
@@ -1,0 +1,465 @@
+{
+ "events": [
+  {
+   "eventId": "1",
+   "eventTime": "2022-12-13T21:58:41.516345129Z",
+   "eventType": "WorkflowExecutionStarted",
+   "taskId": "7342880",
+   "workflowExecutionStartedEventAttributes": {
+    "workflowType": {
+     "name": "Workflow1"
+    },
+    "taskQueue": {
+     "name": "replay-test",
+     "kind": "Normal"
+    },
+    "input": {
+     "payloads": [
+      {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg=="
+       },
+       "data": "IldvcmtmbG93MSI="
+      }
+     ]
+    },
+    "workflowExecutionTimeout": "0s",
+    "workflowRunTimeout": "0s",
+    "workflowTaskTimeout": "10s",
+    "originalExecutionRunId": "4b662bbb-8cca-4bb7-85f1-9cd36d0d940d",
+    "identity": "9438@Quinn-Klassens-MacBook-Pro.local@",
+    "firstExecutionRunId": "4b662bbb-8cca-4bb7-85f1-9cd36d0d940d",
+    "attempt": 1,
+    "firstWorkflowTaskBackoff": "0s",
+    "header": {
+
+    }
+   }
+  },
+  {
+   "eventId": "2",
+   "eventTime": "2022-12-13T21:58:41.516371796Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "7342881",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "replay-test",
+     "kind": "Normal"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "3",
+   "eventTime": "2022-12-13T21:58:41.531107754Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "7342886",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "2",
+    "identity": "9438@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "f9caff60-811a-4175-bcbd-2962b2dffca6"
+   }
+  },
+  {
+   "eventId": "4",
+   "eventTime": "2022-12-13T21:58:41.537984212Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "7342890",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "2",
+    "startedEventId": "3",
+    "identity": "9438@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "1109e9ceafb5bc2729eae35f8965f409"
+   }
+  },
+  {
+   "eventId": "5",
+   "eventTime": "2022-12-13T21:58:41.537999296Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "7342891",
+   "markerRecordedEventAttributes": {
+    "markerName": "Version",
+    "details": {
+     "change-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InRlc3QtY2hhbmdlIg=="
+       }
+      ]
+     },
+     "version": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MQ=="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "4"
+   }
+  },
+  {
+   "eventId": "6",
+   "eventTime": "2022-12-13T21:58:41.538396546Z",
+   "eventType": "UpsertWorkflowSearchAttributes",
+   "taskId": "7342892",
+   "upsertWorkflowSearchAttributesEventAttributes": {
+    "workflowTaskCompletedEventId": "4",
+    "searchAttributes": {
+     "indexedFields": {
+      "TemporalChangeVersion": {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg==",
+        "type": "S2V5d29yZA=="
+       },
+       "data": "WyJ0ZXN0LWNoYW5nZS0xIl0="
+      }
+     }
+    }
+   }
+  },
+  {
+   "eventId": "7",
+   "eventTime": "2022-12-13T21:58:41.538403254Z",
+   "eventType": "ActivityTaskScheduled",
+   "taskId": "7342893",
+   "activityTaskScheduledEventAttributes": {
+    "activityId": "7",
+    "activityType": {
+     "name": "helloworldActivity"
+    },
+    "taskQueue": {
+     "name": "replay-test",
+     "kind": "Normal"
+    },
+    "header": {
+
+    },
+    "input": {
+     "payloads": [
+      {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg=="
+       },
+       "data": "IldvcmtmbG93MSI="
+      }
+     ]
+    },
+    "scheduleToCloseTimeout": "0s",
+    "scheduleToStartTimeout": "60s",
+    "startToCloseTimeout": "60s",
+    "heartbeatTimeout": "20s",
+    "workflowTaskCompletedEventId": "4",
+    "retryPolicy": {
+     "initialInterval": "1s",
+     "backoffCoefficient": 2,
+     "maximumInterval": "100s"
+    }
+   }
+  },
+  {
+   "eventId": "8",
+   "eventTime": "2022-12-13T21:58:41.545653837Z",
+   "eventType": "ActivityTaskStarted",
+   "taskId": "7342901",
+   "activityTaskStartedEventAttributes": {
+    "scheduledEventId": "7",
+    "identity": "9438@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "f50d782d-a128-4aaf-8649-47bb9be74000",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "9",
+   "eventTime": "2022-12-13T21:58:41.549750379Z",
+   "eventType": "ActivityTaskCompleted",
+   "taskId": "7342902",
+   "activityTaskCompletedEventAttributes": {
+    "result": {
+     "payloads": [
+      {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg=="
+       },
+       "data": "IkhlbGxvIFdvcmtmbG93MSEi"
+      }
+     ]
+    },
+    "scheduledEventId": "7",
+    "startedEventId": "8",
+    "identity": "9438@Quinn-Klassens-MacBook-Pro.local@"
+   }
+  },
+  {
+   "eventId": "10",
+   "eventTime": "2022-12-13T21:58:41.549753837Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "7342903",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:ac9944c6-d633-4216-b537-58d2890ce6e6",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "11",
+   "eventTime": "2022-12-13T21:58:41.553736587Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "7342907",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "10",
+    "identity": "9438@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "7e929a72-8ac4-4cae-9d15-95af3c10f526"
+   }
+  },
+  {
+   "eventId": "12",
+   "eventTime": "2022-12-13T21:58:41.558344546Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "7342911",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "10",
+    "startedEventId": "11",
+    "identity": "9438@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "1109e9ceafb5bc2729eae35f8965f409"
+   }
+  },
+  {
+   "eventId": "13",
+   "eventTime": "2022-12-13T21:58:41.558352629Z",
+   "eventType": "ActivityTaskScheduled",
+   "taskId": "7342912",
+   "activityTaskScheduledEventAttributes": {
+    "activityId": "13",
+    "activityType": {
+     "name": "helloworldActivity"
+    },
+    "taskQueue": {
+     "name": "replay-test",
+     "kind": "Normal"
+    },
+    "header": {
+
+    },
+    "input": {
+     "payloads": [
+      {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg=="
+       },
+       "data": "IldvcmtmbG93MSI="
+      }
+     ]
+    },
+    "scheduleToCloseTimeout": "0s",
+    "scheduleToStartTimeout": "60s",
+    "startToCloseTimeout": "60s",
+    "heartbeatTimeout": "20s",
+    "workflowTaskCompletedEventId": "12",
+    "retryPolicy": {
+     "initialInterval": "1s",
+     "backoffCoefficient": 2,
+     "maximumInterval": "100s"
+    }
+   }
+  },
+  {
+   "eventId": "14",
+   "eventTime": "2022-12-13T21:58:41.562576587Z",
+   "eventType": "ActivityTaskStarted",
+   "taskId": "7342918",
+   "activityTaskStartedEventAttributes": {
+    "scheduledEventId": "13",
+    "identity": "9438@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "6ff01959-2001-41fc-9595-5eee2d10c8cb",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "15",
+   "eventTime": "2022-12-13T21:58:41.565936629Z",
+   "eventType": "ActivityTaskCompleted",
+   "taskId": "7342919",
+   "activityTaskCompletedEventAttributes": {
+    "result": {
+     "payloads": [
+      {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg=="
+       },
+       "data": "IkhlbGxvIFdvcmtmbG93MSEi"
+      }
+     ]
+    },
+    "scheduledEventId": "13",
+    "startedEventId": "14",
+    "identity": "9438@Quinn-Klassens-MacBook-Pro.local@"
+   }
+  },
+  {
+   "eventId": "16",
+   "eventTime": "2022-12-13T21:58:41.565939421Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "7342920",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:ac9944c6-d633-4216-b537-58d2890ce6e6",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "17",
+   "eventTime": "2022-12-13T21:58:41.570524254Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "7342924",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "16",
+    "identity": "9438@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "4b2726a7-0889-446b-b469-d5e2049255f4"
+   }
+  },
+  {
+   "eventId": "18",
+   "eventTime": "2022-12-13T21:58:41.575192921Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "7342928",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "16",
+    "startedEventId": "17",
+    "identity": "9438@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "1109e9ceafb5bc2729eae35f8965f409"
+   }
+  },
+  {
+   "eventId": "19",
+   "eventTime": "2022-12-13T21:58:41.575200046Z",
+   "eventType": "ActivityTaskScheduled",
+   "taskId": "7342929",
+   "activityTaskScheduledEventAttributes": {
+    "activityId": "19",
+    "activityType": {
+     "name": "BAD ACTIVITY"
+    },
+    "taskQueue": {
+     "name": "replay-test",
+     "kind": "Normal"
+    },
+    "header": {
+
+    },
+    "input": {
+     "payloads": [
+      {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg=="
+       },
+       "data": "IldvcmtmbG93MSI="
+      }
+     ]
+    },
+    "scheduleToCloseTimeout": "0s",
+    "scheduleToStartTimeout": "60s",
+    "startToCloseTimeout": "60s",
+    "heartbeatTimeout": "20s",
+    "workflowTaskCompletedEventId": "18",
+    "retryPolicy": {
+     "initialInterval": "1s",
+     "backoffCoefficient": 2,
+     "maximumInterval": "100s"
+    }
+   }
+  },
+  {
+   "eventId": "20",
+   "eventTime": "2022-12-13T21:58:41.579631337Z",
+   "eventType": "ActivityTaskStarted",
+   "taskId": "7342935",
+   "activityTaskStartedEventAttributes": {
+    "scheduledEventId": "19",
+    "identity": "9438@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "8e5b4851-6a55-46e4-8942-de10758f3ef8",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "21",
+   "eventTime": "2022-12-13T21:58:41.583529504Z",
+   "eventType": "ActivityTaskCompleted",
+   "taskId": "7342936",
+   "activityTaskCompletedEventAttributes": {
+    "result": {
+     "payloads": [
+      {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg=="
+       },
+       "data": "IkhlbGxvIFdvcmtmbG93MSEi"
+      }
+     ]
+    },
+    "scheduledEventId": "19",
+    "startedEventId": "20",
+    "identity": "9438@Quinn-Klassens-MacBook-Pro.local@"
+   }
+  },
+  {
+   "eventId": "22",
+   "eventTime": "2022-12-13T21:58:41.583532212Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "7342937",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:ac9944c6-d633-4216-b537-58d2890ce6e6",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "23",
+   "eventTime": "2022-12-13T21:58:41.587173879Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "7342941",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "22",
+    "identity": "9438@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "69bc1b2e-235c-42b1-97e3-6e35fedecae3"
+   }
+  },
+  {
+   "eventId": "24",
+   "eventTime": "2022-12-13T21:58:41.591964796Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "7342945",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "22",
+    "startedEventId": "23",
+    "identity": "9438@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "1109e9ceafb5bc2729eae35f8965f409"
+   }
+  },
+  {
+   "eventId": "25",
+   "eventTime": "2022-12-13T21:58:41.591970129Z",
+   "eventType": "WorkflowExecutionCompleted",
+   "taskId": "7342946",
+   "workflowExecutionCompletedEventAttributes": {
+    "workflowTaskCompletedEventId": "24"
+   }
+  }
+ ]
+}

--- a/test/replaytests/bad-local-activity-2.json
+++ b/test/replaytests/bad-local-activity-2.json
@@ -1,0 +1,150 @@
+{
+ "events": [
+  {
+   "eventId": "1",
+   "eventTime": "2022-12-14T18:54:44.616158840Z",
+   "eventType": "WorkflowExecutionStarted",
+   "taskId": "7344270",
+   "workflowExecutionStartedEventAttributes": {
+    "workflowType": {
+     "name": "LocalActivityWorkflow"
+    },
+    "taskQueue": {
+     "name": "replay-test",
+     "kind": "Normal"
+    },
+    "input": {
+     "payloads": [
+      {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg=="
+       },
+       "data": "InRlc3QgbWVtbyI="
+      }
+     ]
+    },
+    "workflowExecutionTimeout": "0s",
+    "workflowRunTimeout": "0s",
+    "workflowTaskTimeout": "10s",
+    "originalExecutionRunId": "77c5c64b-cf74-426d-8030-c49bf94c8ed2",
+    "identity": "30468@Quinn-Klassens-MacBook-Pro.local@",
+    "firstExecutionRunId": "77c5c64b-cf74-426d-8030-c49bf94c8ed2",
+    "attempt": 1,
+    "firstWorkflowTaskBackoff": "0s",
+    "header": {
+
+    }
+   }
+  },
+  {
+   "eventId": "2",
+   "eventTime": "2022-12-14T18:54:44.616221173Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "7344271",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "replay-test",
+     "kind": "Normal"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "3",
+   "eventTime": "2022-12-14T18:54:44.625892423Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "7344278",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "2",
+    "identity": "30468@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "0f489578-cdbb-44e7-934a-d6480f041e4e"
+   }
+  },
+  {
+   "eventId": "4",
+   "eventTime": "2022-12-14T18:54:44.631229131Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "7344282",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "2",
+    "startedEventId": "3",
+    "identity": "30468@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "a0533a79c778e211b9af0d20a271948a"
+   }
+  },
+  {
+   "eventId": "5",
+   "eventTime": "2022-12-14T18:54:44.631356548Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "7344283",
+   "markerRecordedEventAttributes": {
+    "markerName": "LocalActivity",
+    "details": {
+     "data": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "eyJBY3Rpdml0eUlEIjoiMSIsIkFjdGl2aXR5VHlwZSI6ImhlbGxvd29ybGRBY3Rpdml0eSIsIlJlcGxheVRpbWUiOiIyMDIyLTEyLTE0VDE4OjU0OjQ0LjYyNTk5ODYzMVoiLCJBdHRlbXB0IjoxLCJCYWNrb2ZmIjowfQ=="
+       }
+      ]
+     },
+     "result": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "IkhlbGxvIHRlc3QgbWVtbyEi"
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "4"
+   }
+  },
+  {
+   "eventId": "6",
+   "eventTime": "2022-12-14T18:54:44.631357965Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "7344284",
+   "markerRecordedEventAttributes": {
+    "markerName": "LocalActivity",
+    "details": {
+     "data": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "eyJBY3Rpdml0eUlEIjoiMiIsIkFjdGl2aXR5VHlwZSI6ImhlbGxvd29ybGRBY3Rpdml0eSIsIlJlcGxheVRpbWUiOiIyMDIyLTEyLTE0VDE4OjU0OjQ0LjYyNjAzNjIxNFoiLCJBdHRlbXB0IjoxLCJCYWNrb2ZmIjowfQ=="
+       }
+      ]
+     },
+     "result": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "IkhlbGxvIHRlc3QgbWVtbyEi"
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "4"
+   }
+  },
+  {
+   "eventId": "7",
+   "eventTime": "2022-12-14T18:54:44.631359298Z",
+   "eventType": "WorkflowExecutionCompleted",
+   "taskId": "7344285",
+   "workflowExecutionCompletedEventAttributes": {
+    "workflowTaskCompletedEventId": "4"
+   }
+  }
+ ]
+}

--- a/test/replaytests/bad-local-activity.json
+++ b/test/replaytests/bad-local-activity.json
@@ -1,0 +1,86 @@
+{
+ "events": [
+  {
+   "eventId": "1",
+   "eventTime": "2022-12-13T22:57:21.969826881Z",
+   "eventType": "WorkflowExecutionStarted",
+   "taskId": "7343136",
+   "workflowExecutionStartedEventAttributes": {
+    "workflowType": {
+     "name": "LocalActivityWorkflow"
+    },
+    "taskQueue": {
+     "name": "replay-test",
+     "kind": "Normal"
+    },
+    "input": {
+     "payloads": [
+      {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg=="
+       },
+       "data": "IldvcmtmbG93MyI="
+      }
+     ]
+    },
+    "workflowExecutionTimeout": "0s",
+    "workflowRunTimeout": "0s",
+    "workflowTaskTimeout": "10s",
+    "originalExecutionRunId": "10b9318f-ffb3-4a8d-94cf-895576b912db",
+    "identity": "11971@Quinn-Klassens-MacBook-Pro.local@",
+    "firstExecutionRunId": "10b9318f-ffb3-4a8d-94cf-895576b912db",
+    "attempt": 1,
+    "firstWorkflowTaskBackoff": "0s",
+    "header": {
+
+    }
+   }
+  },
+  {
+   "eventId": "2",
+   "eventTime": "2022-12-13T22:57:21.969933173Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "7343137",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "replay-test",
+     "kind": "Normal"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "3",
+   "eventTime": "2022-12-13T22:57:21.977729881Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "7343144",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "2",
+    "identity": "11971@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "2a5348eb-5042-4f17-8094-623028c96f55"
+   }
+  },
+  {
+   "eventId": "4",
+   "eventTime": "2022-12-13T22:57:21.982317048Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "7343148",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "2",
+    "startedEventId": "3",
+    "identity": "11971@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "fae814e72b62981201eb2e6561c37ca1"
+   }
+  },
+  {
+   "eventId": "5",
+   "eventTime": "2022-12-13T22:57:21.982330423Z",
+   "eventType": "WorkflowExecutionCompleted",
+   "taskId": "7343149",
+   "workflowExecutionCompletedEventAttributes": {
+    "workflowTaskCompletedEventId": "4"
+   }
+  }
+ ]
+}

--- a/test/replaytests/bad-search-attribute-2.json
+++ b/test/replaytests/bad-search-attribute-2.json
@@ -1,0 +1,215 @@
+{
+ "events": [
+  {
+   "eventId": "1",
+   "eventTime": "2022-12-15T18:42:03.048523840Z",
+   "eventType": "WorkflowExecutionStarted",
+   "taskId": "7345875",
+   "workflowExecutionStartedEventAttributes": {
+    "workflowType": {
+     "name": "UpsertSearchAttributesWorkflow"
+    },
+    "taskQueue": {
+     "name": "replay-test",
+     "kind": "Normal"
+    },
+    "input": {
+     "payloads": [
+      {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg=="
+       },
+       "data": "InRlc3Qi"
+      }
+     ]
+    },
+    "workflowExecutionTimeout": "0s",
+    "workflowRunTimeout": "0s",
+    "workflowTaskTimeout": "10s",
+    "originalExecutionRunId": "f42f23e7-b7b4-4649-84a6-ba2f4156b7bd",
+    "identity": "43772@Quinn-Klassens-MacBook-Pro.local@",
+    "firstExecutionRunId": "f42f23e7-b7b4-4649-84a6-ba2f4156b7bd",
+    "attempt": 1,
+    "firstWorkflowTaskBackoff": "0s",
+    "header": {
+
+    }
+   }
+  },
+  {
+   "eventId": "2",
+   "eventTime": "2022-12-15T18:42:03.048554715Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "7345876",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "replay-test",
+     "kind": "Normal"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "3",
+   "eventTime": "2022-12-15T18:42:03.056548173Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "7345883",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "2",
+    "identity": "43772@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "e56526c1-c037-4ed9-b3bc-948a63473296"
+   }
+  },
+  {
+   "eventId": "4",
+   "eventTime": "2022-12-15T18:42:03.061462590Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "7345887",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "2",
+    "startedEventId": "3",
+    "identity": "43772@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "9239e08852dc5dd438c66ae6d3e260fd"
+   }
+  },
+  {
+   "eventId": "5",
+   "eventTime": "2022-12-15T18:42:03.061478215Z",
+   "eventType": "ActivityTaskScheduled",
+   "taskId": "7345888",
+   "activityTaskScheduledEventAttributes": {
+    "activityId": "5",
+    "activityType": {
+     "name": "helloworldActivity"
+    },
+    "taskQueue": {
+     "name": "replay-test",
+     "kind": "Normal"
+    },
+    "header": {
+
+    },
+    "input": {
+     "payloads": [
+      {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg=="
+       },
+       "data": "InRlc3Qi"
+      }
+     ]
+    },
+    "scheduleToCloseTimeout": "0s",
+    "scheduleToStartTimeout": "60s",
+    "startToCloseTimeout": "60s",
+    "heartbeatTimeout": "20s",
+    "workflowTaskCompletedEventId": "4",
+    "retryPolicy": {
+     "initialInterval": "1s",
+     "backoffCoefficient": 2,
+     "maximumInterval": "100s"
+    }
+   }
+  },
+  {
+   "eventId": "6",
+   "eventTime": "2022-12-15T18:42:03.065987298Z",
+   "eventType": "ActivityTaskStarted",
+   "taskId": "7345895",
+   "activityTaskStartedEventAttributes": {
+    "scheduledEventId": "5",
+    "identity": "43772@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "f88f2bcf-7e77-4c4c-a797-cdd11f30cf6b",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "7",
+   "eventTime": "2022-12-15T18:42:03.070920298Z",
+   "eventType": "ActivityTaskCompleted",
+   "taskId": "7345896",
+   "activityTaskCompletedEventAttributes": {
+    "result": {
+     "payloads": [
+      {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg=="
+       },
+       "data": "IkhlbGxvIHRlc3QhIg=="
+      }
+     ]
+    },
+    "scheduledEventId": "5",
+    "startedEventId": "6",
+    "identity": "43772@Quinn-Klassens-MacBook-Pro.local@"
+   }
+  },
+  {
+   "eventId": "8",
+   "eventTime": "2022-12-15T18:42:03.070923673Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "7345897",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:1d4c19cf-908a-4ece-bb6d-e2536d3256e5",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "9",
+   "eventTime": "2022-12-15T18:42:03.075586006Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "7345901",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "8",
+    "identity": "43772@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "359da4bf-1117-46f8-bc07-bffda3bbd95f"
+   }
+  },
+  {
+   "eventId": "10",
+   "eventTime": "2022-12-15T18:42:03.080536256Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "7345905",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "8",
+    "startedEventId": "9",
+    "identity": "43772@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "9239e08852dc5dd438c66ae6d3e260fd"
+   }
+  },
+  {
+   "eventId": "11",
+   "eventTime": "2022-12-15T18:42:03.080688923Z",
+   "eventType": "UpsertWorkflowSearchAttributes",
+   "taskId": "7345906",
+   "upsertWorkflowSearchAttributesEventAttributes": {
+    "workflowTaskCompletedEventId": "10",
+    "searchAttributes": {
+     "indexedFields": {
+      "CustomStringField": {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg==",
+        "type": "VGV4dA=="
+       },
+       "data": "IkhlbGxvIHRlc3QhIg=="
+      }
+     }
+    }
+   }
+  },
+  {
+   "eventId": "12",
+   "eventTime": "2022-12-15T18:42:03.080693340Z",
+   "eventType": "WorkflowExecutionCompleted",
+   "taskId": "7345907",
+   "workflowExecutionCompletedEventAttributes": {
+    "workflowTaskCompletedEventId": "10"
+   }
+  }
+ ]
+}

--- a/test/replaytests/bad-search-attribute.json
+++ b/test/replaytests/bad-search-attribute.json
@@ -1,0 +1,215 @@
+{
+ "events": [
+  {
+   "eventId": "1",
+   "eventTime": "2022-12-15T18:41:42.448003261Z",
+   "eventType": "WorkflowExecutionStarted",
+   "taskId": "7345764",
+   "workflowExecutionStartedEventAttributes": {
+    "workflowType": {
+     "name": "UpsertSearchAttributesWorkflow"
+    },
+    "taskQueue": {
+     "name": "replay-test",
+     "kind": "Normal"
+    },
+    "input": {
+     "payloads": [
+      {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg=="
+       },
+       "data": "InRlc3Qi"
+      }
+     ]
+    },
+    "workflowExecutionTimeout": "0s",
+    "workflowRunTimeout": "0s",
+    "workflowTaskTimeout": "10s",
+    "originalExecutionRunId": "b0f6548a-258b-4b50-899d-64d1c269c383",
+    "identity": "43649@Quinn-Klassens-MacBook-Pro.local@",
+    "firstExecutionRunId": "b0f6548a-258b-4b50-899d-64d1c269c383",
+    "attempt": 1,
+    "firstWorkflowTaskBackoff": "0s",
+    "header": {
+
+    }
+   }
+  },
+  {
+   "eventId": "2",
+   "eventTime": "2022-12-15T18:41:42.448035094Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "7345765",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "replay-test",
+     "kind": "Normal"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "3",
+   "eventTime": "2022-12-15T18:41:42.456083886Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "7345772",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "2",
+    "identity": "43649@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "b278a531-4097-4dd4-84af-7a8e3805b453"
+   }
+  },
+  {
+   "eventId": "4",
+   "eventTime": "2022-12-15T18:41:42.464223761Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "7345776",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "2",
+    "startedEventId": "3",
+    "identity": "43649@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "1c0f5dea574644f15634e9cc5e7d5cbc"
+   }
+  },
+  {
+   "eventId": "5",
+   "eventTime": "2022-12-15T18:41:42.464684886Z",
+   "eventType": "UpsertWorkflowSearchAttributes",
+   "taskId": "7345777",
+   "upsertWorkflowSearchAttributesEventAttributes": {
+    "workflowTaskCompletedEventId": "4",
+    "searchAttributes": {
+     "indexedFields": {
+      "CustomStringField": {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg==",
+        "type": "VGV4dA=="
+       },
+       "data": "InRlc3Qi"
+      }
+     }
+    }
+   }
+  },
+  {
+   "eventId": "6",
+   "eventTime": "2022-12-15T18:41:42.464691511Z",
+   "eventType": "ActivityTaskScheduled",
+   "taskId": "7345778",
+   "activityTaskScheduledEventAttributes": {
+    "activityId": "6",
+    "activityType": {
+     "name": "helloworldActivity"
+    },
+    "taskQueue": {
+     "name": "replay-test",
+     "kind": "Normal"
+    },
+    "header": {
+
+    },
+    "input": {
+     "payloads": [
+      {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg=="
+       },
+       "data": "InRlc3Qi"
+      }
+     ]
+    },
+    "scheduleToCloseTimeout": "0s",
+    "scheduleToStartTimeout": "60s",
+    "startToCloseTimeout": "60s",
+    "heartbeatTimeout": "20s",
+    "workflowTaskCompletedEventId": "4",
+    "retryPolicy": {
+     "initialInterval": "1s",
+     "backoffCoefficient": 2,
+     "maximumInterval": "100s"
+    }
+   }
+  },
+  {
+   "eventId": "7",
+   "eventTime": "2022-12-15T18:41:42.469144803Z",
+   "eventType": "ActivityTaskStarted",
+   "taskId": "7345786",
+   "activityTaskStartedEventAttributes": {
+    "scheduledEventId": "6",
+    "identity": "43649@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "99fe31ce-0f1d-48b9-9fb1-eaa203525ddd",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "8",
+   "eventTime": "2022-12-15T18:41:42.472563261Z",
+   "eventType": "ActivityTaskCompleted",
+   "taskId": "7345787",
+   "activityTaskCompletedEventAttributes": {
+    "result": {
+     "payloads": [
+      {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg=="
+       },
+       "data": "IkhlbGxvIHRlc3QhIg=="
+      }
+     ]
+    },
+    "scheduledEventId": "6",
+    "startedEventId": "7",
+    "identity": "43649@Quinn-Klassens-MacBook-Pro.local@"
+   }
+  },
+  {
+   "eventId": "9",
+   "eventTime": "2022-12-15T18:41:42.472566636Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "7345788",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:d72cfada-4d91-41fe-8a1d-400e5d31fb09",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "10",
+   "eventTime": "2022-12-15T18:41:42.477350678Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "7345792",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "9",
+    "identity": "43649@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "16467d06-9765-4a42-8a32-a05aecad77e2"
+   }
+  },
+  {
+   "eventId": "11",
+   "eventTime": "2022-12-15T18:41:42.481956094Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "7345796",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "9",
+    "startedEventId": "10",
+    "identity": "43649@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "1c0f5dea574644f15634e9cc5e7d5cbc"
+   }
+  },
+  {
+   "eventId": "12",
+   "eventTime": "2022-12-15T18:41:42.481961761Z",
+   "eventType": "WorkflowExecutionCompleted",
+   "taskId": "7345797",
+   "workflowExecutionCompletedEventAttributes": {
+    "workflowTaskCompletedEventId": "11"
+   }
+  }
+ ]
+}

--- a/test/replaytests/bad-upsert-memo-workflow-2.json
+++ b/test/replaytests/bad-upsert-memo-workflow-2.json
@@ -1,0 +1,214 @@
+{
+ "events": [
+  {
+   "eventId": "1",
+   "eventTime": "2022-12-20T22:37:52.172348461Z",
+   "eventType": "WorkflowExecutionStarted",
+   "taskId": "8389854",
+   "workflowExecutionStartedEventAttributes": {
+    "workflowType": {
+     "name": "UpsertMemoWorkflow"
+    },
+    "taskQueue": {
+     "name": "replay-test",
+     "kind": "Normal"
+    },
+    "input": {
+     "payloads": [
+      {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg=="
+       },
+       "data": "InRlc3Qi"
+      }
+     ]
+    },
+    "workflowExecutionTimeout": "0s",
+    "workflowRunTimeout": "0s",
+    "workflowTaskTimeout": "10s",
+    "originalExecutionRunId": "db9bc92d-526a-4301-9923-a5e707c89ed9",
+    "identity": "3206@Quinn-Klassens-MacBook-Pro.local@",
+    "firstExecutionRunId": "db9bc92d-526a-4301-9923-a5e707c89ed9",
+    "attempt": 1,
+    "firstWorkflowTaskBackoff": "0s",
+    "header": {
+
+    }
+   }
+  },
+  {
+   "eventId": "2",
+   "eventTime": "2022-12-20T22:37:52.172369253Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "8389855",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "replay-test",
+     "kind": "Normal"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "3",
+   "eventTime": "2022-12-20T22:37:52.181577586Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "8389862",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "2",
+    "identity": "3206@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "a6cf1581-3220-4339-8acf-174a23060d9b"
+   }
+  },
+  {
+   "eventId": "4",
+   "eventTime": "2022-12-20T22:37:52.186361128Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "8389866",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "2",
+    "startedEventId": "3",
+    "identity": "3206@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "d584a7f4e7d6d259e8facd1ec1e8bfb5"
+   }
+  },
+  {
+   "eventId": "5",
+   "eventTime": "2022-12-20T22:37:52.186380044Z",
+   "eventType": "ActivityTaskScheduled",
+   "taskId": "8389867",
+   "activityTaskScheduledEventAttributes": {
+    "activityId": "5",
+    "activityType": {
+     "name": "helloworldActivity"
+    },
+    "taskQueue": {
+     "name": "replay-test",
+     "kind": "Normal"
+    },
+    "header": {
+
+    },
+    "input": {
+     "payloads": [
+      {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg=="
+       },
+       "data": "InRlc3Qi"
+      }
+     ]
+    },
+    "scheduleToCloseTimeout": "0s",
+    "scheduleToStartTimeout": "60s",
+    "startToCloseTimeout": "60s",
+    "heartbeatTimeout": "20s",
+    "workflowTaskCompletedEventId": "4",
+    "retryPolicy": {
+     "initialInterval": "1s",
+     "backoffCoefficient": 2,
+     "maximumInterval": "100s"
+    }
+   }
+  },
+  {
+   "eventId": "6",
+   "eventTime": "2022-12-20T22:37:52.191016794Z",
+   "eventType": "ActivityTaskStarted",
+   "taskId": "8389874",
+   "activityTaskStartedEventAttributes": {
+    "scheduledEventId": "5",
+    "identity": "3206@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "e351e514-0887-4aca-89a2-2856abdecddb",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "7",
+   "eventTime": "2022-12-20T22:37:52.195148503Z",
+   "eventType": "ActivityTaskCompleted",
+   "taskId": "8389875",
+   "activityTaskCompletedEventAttributes": {
+    "result": {
+     "payloads": [
+      {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg=="
+       },
+       "data": "IkhlbGxvIHRlc3QhIg=="
+      }
+     ]
+    },
+    "scheduledEventId": "5",
+    "startedEventId": "6",
+    "identity": "3206@Quinn-Klassens-MacBook-Pro.local@"
+   }
+  },
+  {
+   "eventId": "8",
+   "eventTime": "2022-12-20T22:37:52.195154669Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "8389876",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:727336b7-6905-4be8-8af4-cebae36eb11d",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "9",
+   "eventTime": "2022-12-20T22:37:52.199443503Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "8389880",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "8",
+    "identity": "3206@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "2f947102-7018-4401-8cda-dcd40a5cae8b"
+   }
+  },
+  {
+   "eventId": "10",
+   "eventTime": "2022-12-20T22:37:52.204886294Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "8389884",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "8",
+    "startedEventId": "9",
+    "identity": "3206@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "d584a7f4e7d6d259e8facd1ec1e8bfb5"
+   }
+  },
+  {
+   "eventId": "11",
+   "eventTime": "2022-12-20T22:37:52.204897919Z",
+   "eventType": "WorkflowPropertiesModified",
+   "taskId": "8389885",
+   "workflowPropertiesModifiedEventAttributes": {
+    "workflowTaskCompletedEventId": "10",
+    "upsertedMemo": {
+     "fields": {
+      "Test key": {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg=="
+       },
+       "data": "IkhlbGxvIHRlc3QhIg=="
+      }
+     }
+    }
+   }
+  },
+  {
+   "eventId": "12",
+   "eventTime": "2022-12-20T22:37:52.204902086Z",
+   "eventType": "WorkflowExecutionCompleted",
+   "taskId": "8389886",
+   "workflowExecutionCompletedEventAttributes": {
+    "workflowTaskCompletedEventId": "10"
+   }
+  }
+ ]
+}

--- a/test/replaytests/bad-upsert-memo-workflow.json
+++ b/test/replaytests/bad-upsert-memo-workflow.json
@@ -1,0 +1,214 @@
+{
+ "events": [
+  {
+   "eventId": "1",
+   "eventTime": "2022-12-20T22:26:52.976354045Z",
+   "eventType": "WorkflowExecutionStarted",
+   "taskId": "8389306",
+   "workflowExecutionStartedEventAttributes": {
+    "workflowType": {
+     "name": "UpsertMemoWorkflow"
+    },
+    "taskQueue": {
+     "name": "replay-test",
+     "kind": "Normal"
+    },
+    "input": {
+     "payloads": [
+      {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg=="
+       },
+       "data": "InRlc3Qi"
+      }
+     ]
+    },
+    "workflowExecutionTimeout": "0s",
+    "workflowRunTimeout": "0s",
+    "workflowTaskTimeout": "10s",
+    "originalExecutionRunId": "8d855db7-59e5-4e30-b475-d9a78f8231e9",
+    "identity": "794@Quinn-Klassens-MacBook-Pro.local@",
+    "firstExecutionRunId": "8d855db7-59e5-4e30-b475-d9a78f8231e9",
+    "attempt": 1,
+    "firstWorkflowTaskBackoff": "0s",
+    "header": {
+
+    }
+   }
+  },
+  {
+   "eventId": "2",
+   "eventTime": "2022-12-20T22:26:52.976379170Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "8389307",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "replay-test",
+     "kind": "Normal"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "3",
+   "eventTime": "2022-12-20T22:26:52.985661461Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "8389314",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "2",
+    "identity": "794@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "b0f2e145-6889-4548-8ac0-c45135f536e8"
+   }
+  },
+  {
+   "eventId": "4",
+   "eventTime": "2022-12-20T22:26:52.990238836Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "8389318",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "2",
+    "startedEventId": "3",
+    "identity": "794@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "6456ac6dd7f8e99b28eda6281af26545"
+   }
+  },
+  {
+   "eventId": "5",
+   "eventTime": "2022-12-20T22:26:52.990256045Z",
+   "eventType": "WorkflowPropertiesModified",
+   "taskId": "8389319",
+   "workflowPropertiesModifiedEventAttributes": {
+    "workflowTaskCompletedEventId": "4",
+    "upsertedMemo": {
+     "fields": {
+      "Test key": {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg=="
+       },
+       "data": "InRlc3Qi"
+      }
+     }
+    }
+   }
+  },
+  {
+   "eventId": "6",
+   "eventTime": "2022-12-20T22:26:52.990261170Z",
+   "eventType": "ActivityTaskScheduled",
+   "taskId": "8389320",
+   "activityTaskScheduledEventAttributes": {
+    "activityId": "6",
+    "activityType": {
+     "name": "helloworldActivity"
+    },
+    "taskQueue": {
+     "name": "replay-test",
+     "kind": "Normal"
+    },
+    "header": {
+
+    },
+    "input": {
+     "payloads": [
+      {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg=="
+       },
+       "data": "InRlc3Qi"
+      }
+     ]
+    },
+    "scheduleToCloseTimeout": "0s",
+    "scheduleToStartTimeout": "60s",
+    "startToCloseTimeout": "60s",
+    "heartbeatTimeout": "20s",
+    "workflowTaskCompletedEventId": "4",
+    "retryPolicy": {
+     "initialInterval": "1s",
+     "backoffCoefficient": 2,
+     "maximumInterval": "100s"
+    }
+   }
+  },
+  {
+   "eventId": "7",
+   "eventTime": "2022-12-20T22:26:52.994759003Z",
+   "eventType": "ActivityTaskStarted",
+   "taskId": "8389328",
+   "activityTaskStartedEventAttributes": {
+    "scheduledEventId": "6",
+    "identity": "794@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "9c402c9b-b853-41bb-b849-e3314f5bb68a",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "8",
+   "eventTime": "2022-12-20T22:26:52.998543295Z",
+   "eventType": "ActivityTaskCompleted",
+   "taskId": "8389329",
+   "activityTaskCompletedEventAttributes": {
+    "result": {
+     "payloads": [
+      {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg=="
+       },
+       "data": "IkhlbGxvIHRlc3QhIg=="
+      }
+     ]
+    },
+    "scheduledEventId": "6",
+    "startedEventId": "7",
+    "identity": "794@Quinn-Klassens-MacBook-Pro.local@"
+   }
+  },
+  {
+   "eventId": "9",
+   "eventTime": "2022-12-20T22:26:52.998546170Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "8389330",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:e99f5507-cb8e-4c03-be1c-8104ce82df52",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "10",
+   "eventTime": "2022-12-20T22:26:53.002450295Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "8389334",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "9",
+    "identity": "794@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "b0618c9f-784e-4b04-9602-fdf48698cd9c"
+   }
+  },
+  {
+   "eventId": "11",
+   "eventTime": "2022-12-20T22:26:53.007126212Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "8389338",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "9",
+    "startedEventId": "10",
+    "identity": "794@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "6456ac6dd7f8e99b28eda6281af26545"
+   }
+  },
+  {
+   "eventId": "12",
+   "eventTime": "2022-12-20T22:26:53.007130795Z",
+   "eventType": "WorkflowExecutionCompleted",
+   "taskId": "8389339",
+   "workflowExecutionCompletedEventAttributes": {
+    "workflowTaskCompletedEventId": "11"
+   }
+  }
+ ]
+}

--- a/test/replaytests/continue-as-new.json
+++ b/test/replaytests/continue-as-new.json
@@ -1,0 +1,109 @@
+{
+ "events": [
+  {
+   "eventId": "1",
+   "eventTime": "2022-12-13T23:18:31.822878008Z",
+   "eventType": "WorkflowExecutionStarted",
+   "taskId": "7343430",
+   "workflowExecutionStartedEventAttributes": {
+    "workflowType": {
+     "name": "ContinueAsNewWorkflow"
+    },
+    "taskQueue": {
+     "name": "replay-test",
+     "kind": "Normal"
+    },
+    "input": {
+     "payloads": [
+      {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg=="
+       },
+       "data": "dHJ1ZQ=="
+      }
+     ]
+    },
+    "workflowExecutionTimeout": "0s",
+    "workflowRunTimeout": "0s",
+    "workflowTaskTimeout": "10s",
+    "originalExecutionRunId": "bdb5a608-0880-421d-90fb-f85e748d12b4",
+    "identity": "14127@Quinn-Klassens-MacBook-Pro.local@",
+    "firstExecutionRunId": "bdb5a608-0880-421d-90fb-f85e748d12b4",
+    "attempt": 1,
+    "firstWorkflowTaskBackoff": "0s",
+    "header": {
+
+    }
+   }
+  },
+  {
+   "eventId": "2",
+   "eventTime": "2022-12-13T23:18:31.822898091Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "7343431",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "replay-test",
+     "kind": "Normal"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "3",
+   "eventTime": "2022-12-13T23:18:31.830787008Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "7343438",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "2",
+    "identity": "14127@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "c55e1ca9-08f1-4409-ab41-20080efe48f1"
+   }
+  },
+  {
+   "eventId": "4",
+   "eventTime": "2022-12-13T23:18:31.835409800Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "7343442",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "2",
+    "startedEventId": "3",
+    "identity": "14127@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "88517a4f638baf593f75e0214a4ebf92"
+   }
+  },
+  {
+   "eventId": "5",
+   "eventTime": "2022-12-13T23:18:31.835425591Z",
+   "eventType": "WorkflowExecutionContinuedAsNew",
+   "taskId": "7343443",
+   "workflowExecutionContinuedAsNewEventAttributes": {
+    "newExecutionRunId": "74f38af0-7c7d-4aae-bc10-6c34ba946693",
+    "workflowType": {
+     "name": "ContinueAsNewWorkflow"
+    },
+    "taskQueue": {
+     "name": "replay-test",
+     "kind": "Normal"
+    },
+    "input": {
+     "payloads": [
+      {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg=="
+       },
+       "data": "ZmFsc2U="
+      }
+     ]
+    },
+    "workflowRunTimeout": "0s",
+    "workflowTaskTimeout": "10s",
+    "workflowTaskCompletedEventId": "4",
+    "header": {
+
+    }
+   }
+  }
+ ]
+}

--- a/test/replaytests/local-activity.json
+++ b/test/replaytests/local-activity.json
@@ -1,0 +1,118 @@
+{
+ "events": [
+  {
+   "eventId": "1",
+   "eventTime": "2022-12-13T22:51:53.636542965Z",
+   "eventType": "WorkflowExecutionStarted",
+   "taskId": "7343043",
+   "workflowExecutionStartedEventAttributes": {
+    "workflowType": {
+     "name": "LocalActivityWorkflow"
+    },
+    "taskQueue": {
+     "name": "replay-test",
+     "kind": "Normal"
+    },
+    "input": {
+     "payloads": [
+      {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg=="
+       },
+       "data": "IldvcmtmbG93MyI="
+      }
+     ]
+    },
+    "workflowExecutionTimeout": "0s",
+    "workflowRunTimeout": "0s",
+    "workflowTaskTimeout": "10s",
+    "originalExecutionRunId": "9068faf2-5070-4e3f-95cf-6172644cfa24",
+    "identity": "11111@Quinn-Klassens-MacBook-Pro.local@",
+    "firstExecutionRunId": "9068faf2-5070-4e3f-95cf-6172644cfa24",
+    "attempt": 1,
+    "firstWorkflowTaskBackoff": "0s",
+    "header": {
+
+    }
+   }
+  },
+  {
+   "eventId": "2",
+   "eventTime": "2022-12-13T22:51:53.636593965Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "7343044",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "replay-test",
+     "kind": "Normal"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "3",
+   "eventTime": "2022-12-13T22:51:53.643692507Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "7343051",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "2",
+    "identity": "11111@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "2c9dfc74-8477-45f7-9bd7-710054bf870c"
+   }
+  },
+  {
+   "eventId": "4",
+   "eventTime": "2022-12-13T22:51:53.648255882Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "7343055",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "2",
+    "startedEventId": "3",
+    "identity": "11111@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "48a264a4d5038290773fdab470dbf90b"
+   }
+  },
+  {
+   "eventId": "5",
+   "eventTime": "2022-12-13T22:51:53.648280423Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "7343056",
+   "markerRecordedEventAttributes": {
+    "markerName": "LocalActivity",
+    "details": {
+     "data": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "eyJBY3Rpdml0eUlEIjoiMSIsIkFjdGl2aXR5VHlwZSI6ImhlbGxvd29ybGRBY3Rpdml0eSIsIlJlcGxheVRpbWUiOiIyMDIyLTEyLTEzVDIyOjUxOjUzLjY0MzgyMjA0OVoiLCJBdHRlbXB0IjoxLCJCYWNrb2ZmIjowfQ=="
+       }
+      ]
+     },
+     "result": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "IkhlbGxvIFdvcmtmbG93MyEi"
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "4"
+   }
+  },
+  {
+   "eventId": "6",
+   "eventTime": "2022-12-13T22:51:53.648281840Z",
+   "eventType": "WorkflowExecutionCompleted",
+   "taskId": "7343057",
+   "workflowExecutionCompletedEventAttributes": {
+    "workflowTaskCompletedEventId": "4"
+   }
+  }
+ ]
+}

--- a/test/replaytests/search-attribute.json
+++ b/test/replaytests/search-attribute.json
@@ -1,0 +1,235 @@
+{
+ "events": [
+  {
+   "eventId": "1",
+   "eventTime": "2022-12-15T18:35:12.455426261Z",
+   "eventType": "WorkflowExecutionStarted",
+   "taskId": "7345651",
+   "workflowExecutionStartedEventAttributes": {
+    "workflowType": {
+     "name": "UpsertSearchAttributesWorkflow"
+    },
+    "taskQueue": {
+     "name": "replay-test",
+     "kind": "Normal"
+    },
+    "input": {
+     "payloads": [
+      {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg=="
+       },
+       "data": "InRlc3Qi"
+      }
+     ]
+    },
+    "workflowExecutionTimeout": "0s",
+    "workflowRunTimeout": "0s",
+    "workflowTaskTimeout": "10s",
+    "originalExecutionRunId": "73b5e04b-9608-4052-a508-36b9d4fc1a7d",
+    "identity": "42735@Quinn-Klassens-MacBook-Pro.local@",
+    "firstExecutionRunId": "73b5e04b-9608-4052-a508-36b9d4fc1a7d",
+    "attempt": 1,
+    "firstWorkflowTaskBackoff": "0s",
+    "header": {
+
+    }
+   }
+  },
+  {
+   "eventId": "2",
+   "eventTime": "2022-12-15T18:35:12.455441136Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "7345652",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "replay-test",
+     "kind": "Normal"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "3",
+   "eventTime": "2022-12-15T18:35:12.464017844Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "7345659",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "2",
+    "identity": "42735@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "05d08650-161e-4074-ad0c-7bde331ce24c"
+   }
+  },
+  {
+   "eventId": "4",
+   "eventTime": "2022-12-15T18:35:12.468484136Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "7345663",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "2",
+    "startedEventId": "3",
+    "identity": "42735@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "f00489cb3e60e218143d7f7ef585a06d"
+   }
+  },
+  {
+   "eventId": "5",
+   "eventTime": "2022-12-15T18:35:12.468866344Z",
+   "eventType": "UpsertWorkflowSearchAttributes",
+   "taskId": "7345664",
+   "upsertWorkflowSearchAttributesEventAttributes": {
+    "workflowTaskCompletedEventId": "4",
+    "searchAttributes": {
+     "indexedFields": {
+      "CustomStringField": {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg==",
+        "type": "VGV4dA=="
+       },
+       "data": "InRlc3Qi"
+      }
+     }
+    }
+   }
+  },
+  {
+   "eventId": "6",
+   "eventTime": "2022-12-15T18:35:12.468872803Z",
+   "eventType": "ActivityTaskScheduled",
+   "taskId": "7345665",
+   "activityTaskScheduledEventAttributes": {
+    "activityId": "6",
+    "activityType": {
+     "name": "helloworldActivity"
+    },
+    "taskQueue": {
+     "name": "replay-test",
+     "kind": "Normal"
+    },
+    "header": {
+
+    },
+    "input": {
+     "payloads": [
+      {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg=="
+       },
+       "data": "InRlc3Qi"
+      }
+     ]
+    },
+    "scheduleToCloseTimeout": "0s",
+    "scheduleToStartTimeout": "60s",
+    "startToCloseTimeout": "60s",
+    "heartbeatTimeout": "20s",
+    "workflowTaskCompletedEventId": "4",
+    "retryPolicy": {
+     "initialInterval": "1s",
+     "backoffCoefficient": 2,
+     "maximumInterval": "100s"
+    }
+   }
+  },
+  {
+   "eventId": "7",
+   "eventTime": "2022-12-15T18:35:12.472889636Z",
+   "eventType": "ActivityTaskStarted",
+   "taskId": "7345673",
+   "activityTaskStartedEventAttributes": {
+    "scheduledEventId": "6",
+    "identity": "42735@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "8ce40646-bb85-4e27-b2c4-7788706adf8b",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "8",
+   "eventTime": "2022-12-15T18:35:12.476664011Z",
+   "eventType": "ActivityTaskCompleted",
+   "taskId": "7345674",
+   "activityTaskCompletedEventAttributes": {
+    "result": {
+     "payloads": [
+      {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg=="
+       },
+       "data": "IkhlbGxvIHRlc3QhIg=="
+      }
+     ]
+    },
+    "scheduledEventId": "6",
+    "startedEventId": "7",
+    "identity": "42735@Quinn-Klassens-MacBook-Pro.local@"
+   }
+  },
+  {
+   "eventId": "9",
+   "eventTime": "2022-12-15T18:35:12.476667053Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "7345675",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:e9a4aaad-4256-43bc-aa50-44530bb273fd",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "10",
+   "eventTime": "2022-12-15T18:35:12.480592178Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "7345679",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "9",
+    "identity": "42735@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "c2874e7b-ad19-4fe0-867d-3cf86140f08d"
+   }
+  },
+  {
+   "eventId": "11",
+   "eventTime": "2022-12-15T18:35:12.485195303Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "7345683",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "9",
+    "startedEventId": "10",
+    "identity": "42735@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "f00489cb3e60e218143d7f7ef585a06d"
+   }
+  },
+  {
+   "eventId": "12",
+   "eventTime": "2022-12-15T18:35:12.485763511Z",
+   "eventType": "UpsertWorkflowSearchAttributes",
+   "taskId": "7345684",
+   "upsertWorkflowSearchAttributesEventAttributes": {
+    "workflowTaskCompletedEventId": "11",
+    "searchAttributes": {
+     "indexedFields": {
+      "CustomStringField": {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg==",
+        "type": "VGV4dA=="
+       },
+       "data": "IkhlbGxvIHRlc3QhIg=="
+      }
+     }
+    }
+   }
+  },
+  {
+   "eventId": "13",
+   "eventTime": "2022-12-15T18:35:12.485767761Z",
+   "eventType": "WorkflowExecutionCompleted",
+   "taskId": "7345685",
+   "workflowExecutionCompletedEventAttributes": {
+    "workflowTaskCompletedEventId": "11"
+   }
+  }
+ ]
+}

--- a/test/replaytests/side-effect.json
+++ b/test/replaytests/side-effect.json
@@ -1,0 +1,227 @@
+{
+ "events": [
+  {
+   "eventId": "1",
+   "eventTime": "2022-12-15T23:10:06.392288305Z",
+   "eventType": "WorkflowExecutionStarted",
+   "taskId": "7345992",
+   "workflowExecutionStartedEventAttributes": {
+    "workflowType": {
+     "name": "SideEffectWorkflow"
+    },
+    "taskQueue": {
+     "name": "replay-test",
+     "kind": "Normal"
+    },
+    "input": {
+     "payloads": [
+      {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg=="
+       },
+       "data": "InRlc3Qi"
+      }
+     ]
+    },
+    "workflowExecutionTimeout": "0s",
+    "workflowRunTimeout": "0s",
+    "workflowTaskTimeout": "10s",
+    "originalExecutionRunId": "c0fcaa0d-4f50-4ea7-8bfb-3f603a8fdd9f",
+    "identity": "47068@Quinn-Klassens-MacBook-Pro.local@",
+    "firstExecutionRunId": "c0fcaa0d-4f50-4ea7-8bfb-3f603a8fdd9f",
+    "attempt": 1,
+    "firstWorkflowTaskBackoff": "0s",
+    "header": {
+
+    }
+   }
+  },
+  {
+   "eventId": "2",
+   "eventTime": "2022-12-15T23:10:06.392307305Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "7345993",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "replay-test",
+     "kind": "Normal"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "3",
+   "eventTime": "2022-12-15T23:10:06.400594430Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "7346000",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "2",
+    "identity": "47068@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "0363ed78-484a-434c-a30d-9770d1a58684"
+   }
+  },
+  {
+   "eventId": "4",
+   "eventTime": "2022-12-15T23:10:06.405217888Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "7346004",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "2",
+    "startedEventId": "3",
+    "identity": "47068@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "fc88fffd8d7fb3abeb4c353fe1095db1"
+   }
+  },
+  {
+   "eventId": "5",
+   "eventTime": "2022-12-15T23:10:06.405231513Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "7346005",
+   "markerRecordedEventAttributes": {
+    "markerName": "SideEffect",
+    "details": {
+     "data": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "ODE="
+       }
+      ]
+     },
+     "side-effect-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MQ=="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "4"
+   }
+  },
+  {
+   "eventId": "6",
+   "eventTime": "2022-12-15T23:10:06.405235096Z",
+   "eventType": "ActivityTaskScheduled",
+   "taskId": "7346006",
+   "activityTaskScheduledEventAttributes": {
+    "activityId": "6",
+    "activityType": {
+     "name": "helloworldActivity"
+    },
+    "taskQueue": {
+     "name": "replay-test",
+     "kind": "Normal"
+    },
+    "header": {
+
+    },
+    "input": {
+     "payloads": [
+      {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg=="
+       },
+       "data": "InRlc3Qi"
+      }
+     ]
+    },
+    "scheduleToCloseTimeout": "0s",
+    "scheduleToStartTimeout": "60s",
+    "startToCloseTimeout": "60s",
+    "heartbeatTimeout": "20s",
+    "workflowTaskCompletedEventId": "4",
+    "retryPolicy": {
+     "initialInterval": "1s",
+     "backoffCoefficient": 2,
+     "maximumInterval": "100s"
+    }
+   }
+  },
+  {
+   "eventId": "7",
+   "eventTime": "2022-12-15T23:10:06.410084096Z",
+   "eventType": "ActivityTaskStarted",
+   "taskId": "7346013",
+   "activityTaskStartedEventAttributes": {
+    "scheduledEventId": "6",
+    "identity": "47068@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "6b0a3858-e2b7-4955-9ed1-00e013b46416",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "8",
+   "eventTime": "2022-12-15T23:10:06.413697430Z",
+   "eventType": "ActivityTaskCompleted",
+   "taskId": "7346014",
+   "activityTaskCompletedEventAttributes": {
+    "result": {
+     "payloads": [
+      {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg=="
+       },
+       "data": "IkhlbGxvIHRlc3QhIg=="
+      }
+     ]
+    },
+    "scheduledEventId": "6",
+    "startedEventId": "7",
+    "identity": "47068@Quinn-Klassens-MacBook-Pro.local@"
+   }
+  },
+  {
+   "eventId": "9",
+   "eventTime": "2022-12-15T23:10:06.413700430Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "7346015",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:9f3d265e-58d5-47bf-b18f-baba96019419",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "10",
+   "eventTime": "2022-12-15T23:10:06.418363930Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "7346019",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "9",
+    "identity": "47068@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "e0153d74-abe9-4d2d-bbc5-5f54fdbdde12"
+   }
+  },
+  {
+   "eventId": "11",
+   "eventTime": "2022-12-15T23:10:06.422869596Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "7346023",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "9",
+    "startedEventId": "10",
+    "identity": "47068@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "fc88fffd8d7fb3abeb4c353fe1095db1"
+   }
+  },
+  {
+   "eventId": "12",
+   "eventTime": "2022-12-15T23:10:06.422874263Z",
+   "eventType": "WorkflowExecutionCompleted",
+   "taskId": "7346024",
+   "workflowExecutionCompletedEventAttributes": {
+    "workflowTaskCompletedEventId": "11"
+   }
+  }
+ ]
+}

--- a/test/replaytests/test-workflow.json
+++ b/test/replaytests/test-workflow.json
@@ -1,0 +1,125 @@
+{
+ "events": [
+  {
+   "eventId": "1",
+   "eventTime": "2022-12-14T18:17:27.189644513Z",
+   "eventType": "WorkflowExecutionStarted",
+   "taskId": "7343830",
+   "workflowExecutionStartedEventAttributes": {
+    "workflowType": {
+     "name": "WorkflowTest"
+    },
+    "taskQueue": {
+     "name": "replay-test",
+     "kind": "Normal"
+    },
+    "input": {
+     "payloads": [
+      {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg=="
+       },
+       "data": "InRlc3QgbWVtbyI="
+      }
+     ]
+    },
+    "workflowExecutionTimeout": "0s",
+    "workflowRunTimeout": "0s",
+    "workflowTaskTimeout": "10s",
+    "originalExecutionRunId": "78b803c0-a0d2-4bf4-83b8-b6c773468986",
+    "identity": "26250@Quinn-Klassens-MacBook-Pro.local@",
+    "firstExecutionRunId": "78b803c0-a0d2-4bf4-83b8-b6c773468986",
+    "attempt": 1,
+    "firstWorkflowTaskBackoff": "0s",
+    "header": {
+
+    }
+   }
+  },
+  {
+   "eventId": "2",
+   "eventTime": "2022-12-14T18:17:27.189662013Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "7343831",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "replay-test",
+     "kind": "Normal"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "3",
+   "eventTime": "2022-12-14T18:17:27.196593346Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "7343838",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "2",
+    "identity": "26250@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "9b0757ec-115b-4779-a99c-691f29ceaeb0"
+   }
+  },
+  {
+   "eventId": "4",
+   "eventTime": "2022-12-14T18:17:27.201093679Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "7343842",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "2",
+    "startedEventId": "3",
+    "identity": "26250@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "cd0fe5bd921279b3b38205a57c4c5e78"
+   }
+  },
+  {
+   "eventId": "5",
+   "eventTime": "2022-12-14T18:17:27.201108846Z",
+   "eventType": "ActivityTaskScheduled",
+   "taskId": "7343843",
+   "activityTaskScheduledEventAttributes": {
+    "activityId": "5",
+    "activityType": {
+     "name": "helloworldActivity"
+    },
+    "taskQueue": {
+     "name": "replay-test",
+     "kind": "Normal"
+    },
+    "header": {
+
+    },
+    "input": {
+     "payloads": [
+      {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg=="
+       },
+       "data": "InRlc3QgbWVtbyI="
+      }
+     ]
+    },
+    "scheduleToCloseTimeout": "0s",
+    "scheduleToStartTimeout": "60s",
+    "startToCloseTimeout": "60s",
+    "heartbeatTimeout": "20s",
+    "workflowTaskCompletedEventId": "4",
+    "retryPolicy": {
+     "initialInterval": "1s",
+     "backoffCoefficient": 2,
+     "maximumInterval": "100s"
+    }
+   }
+  },
+  {
+   "eventId": "6",
+   "eventTime": "2022-12-14T18:17:27.201113721Z",
+   "eventType": "WorkflowExecutionCompleted",
+   "taskId": "7343844",
+   "workflowExecutionCompletedEventAttributes": {
+    "workflowTaskCompletedEventId": "4"
+   }
+  }
+ ]
+}

--- a/test/replaytests/upsert-memo-workflow.json
+++ b/test/replaytests/upsert-memo-workflow.json
@@ -1,0 +1,233 @@
+{
+ "events": [
+  {
+   "eventId": "1",
+   "eventTime": "2022-12-20T22:22:21.613764044Z",
+   "eventType": "WorkflowExecutionStarted",
+   "taskId": "8389116",
+   "workflowExecutionStartedEventAttributes": {
+    "workflowType": {
+     "name": "UpsertMemoWorkflow"
+    },
+    "taskQueue": {
+     "name": "replay-test",
+     "kind": "Normal"
+    },
+    "input": {
+     "payloads": [
+      {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg=="
+       },
+       "data": "InRlc3Qi"
+      }
+     ]
+    },
+    "workflowExecutionTimeout": "0s",
+    "workflowRunTimeout": "0s",
+    "workflowTaskTimeout": "10s",
+    "originalExecutionRunId": "1786f30e-10d5-4eb8-ab7b-22b1d4c8cdbb",
+    "identity": "99828@Quinn-Klassens-MacBook-Pro.local@",
+    "firstExecutionRunId": "1786f30e-10d5-4eb8-ab7b-22b1d4c8cdbb",
+    "attempt": 1,
+    "firstWorkflowTaskBackoff": "0s",
+    "header": {
+
+    }
+   }
+  },
+  {
+   "eventId": "2",
+   "eventTime": "2022-12-20T22:22:21.613784378Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "8389117",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "replay-test",
+     "kind": "Normal"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "3",
+   "eventTime": "2022-12-20T22:22:21.622169919Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "8389124",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "2",
+    "identity": "99828@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "f28a5f34-a33a-483e-9832-2720781dc911"
+   }
+  },
+  {
+   "eventId": "4",
+   "eventTime": "2022-12-20T22:22:21.627457128Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "8389128",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "2",
+    "startedEventId": "3",
+    "identity": "99828@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "5f4bad3ef2c4ae7a1f958ebe3bb6b563"
+   }
+  },
+  {
+   "eventId": "5",
+   "eventTime": "2022-12-20T22:22:21.627473586Z",
+   "eventType": "WorkflowPropertiesModified",
+   "taskId": "8389129",
+   "workflowPropertiesModifiedEventAttributes": {
+    "workflowTaskCompletedEventId": "4",
+    "upsertedMemo": {
+     "fields": {
+      "Test key": {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg=="
+       },
+       "data": "InRlc3Qi"
+      }
+     }
+    }
+   }
+  },
+  {
+   "eventId": "6",
+   "eventTime": "2022-12-20T22:22:21.627480419Z",
+   "eventType": "ActivityTaskScheduled",
+   "taskId": "8389130",
+   "activityTaskScheduledEventAttributes": {
+    "activityId": "6",
+    "activityType": {
+     "name": "helloworldActivity"
+    },
+    "taskQueue": {
+     "name": "replay-test",
+     "kind": "Normal"
+    },
+    "header": {
+
+    },
+    "input": {
+     "payloads": [
+      {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg=="
+       },
+       "data": "InRlc3Qi"
+      }
+     ]
+    },
+    "scheduleToCloseTimeout": "0s",
+    "scheduleToStartTimeout": "60s",
+    "startToCloseTimeout": "60s",
+    "heartbeatTimeout": "20s",
+    "workflowTaskCompletedEventId": "4",
+    "retryPolicy": {
+     "initialInterval": "1s",
+     "backoffCoefficient": 2,
+     "maximumInterval": "100s"
+    }
+   }
+  },
+  {
+   "eventId": "7",
+   "eventTime": "2022-12-20T22:22:21.632484919Z",
+   "eventType": "ActivityTaskStarted",
+   "taskId": "8389138",
+   "activityTaskStartedEventAttributes": {
+    "scheduledEventId": "6",
+    "identity": "99828@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "59615316-c6fe-4397-9cc3-eb6fd8387c72",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "8",
+   "eventTime": "2022-12-20T22:22:21.636429669Z",
+   "eventType": "ActivityTaskCompleted",
+   "taskId": "8389139",
+   "activityTaskCompletedEventAttributes": {
+    "result": {
+     "payloads": [
+      {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg=="
+       },
+       "data": "IkhlbGxvIHRlc3QhIg=="
+      }
+     ]
+    },
+    "scheduledEventId": "6",
+    "startedEventId": "7",
+    "identity": "99828@Quinn-Klassens-MacBook-Pro.local@"
+   }
+  },
+  {
+   "eventId": "9",
+   "eventTime": "2022-12-20T22:22:21.636433044Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "8389140",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:65943999-d4d5-497f-b9e1-79872ca29107",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "10",
+   "eventTime": "2022-12-20T22:22:21.640463961Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "8389144",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "9",
+    "identity": "99828@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "f1cda97d-8552-4727-9a71-ff33118b6d34"
+   }
+  },
+  {
+   "eventId": "11",
+   "eventTime": "2022-12-20T22:22:21.645284628Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "8389148",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "9",
+    "startedEventId": "10",
+    "identity": "99828@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "5f4bad3ef2c4ae7a1f958ebe3bb6b563"
+   }
+  },
+  {
+   "eventId": "12",
+   "eventTime": "2022-12-20T22:22:21.645333211Z",
+   "eventType": "WorkflowPropertiesModified",
+   "taskId": "8389149",
+   "workflowPropertiesModifiedEventAttributes": {
+    "workflowTaskCompletedEventId": "11",
+    "upsertedMemo": {
+     "fields": {
+      "Test key": {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg=="
+       },
+       "data": "IkhlbGxvIHRlc3QhIg=="
+      }
+     }
+    }
+   }
+  },
+  {
+   "eventId": "13",
+   "eventTime": "2022-12-20T22:22:21.645337586Z",
+   "eventType": "WorkflowExecutionCompleted",
+   "taskId": "8389150",
+   "workflowExecutionCompletedEventAttributes": {
+    "workflowTaskCompletedEventId": "11"
+   }
+  }
+ ]
+}


### PR DESCRIPTION
Fix a few issues with the replayer missing non deterministic changes in workflows described in the linked issues. These checks only apply in the replayer to avoid the risk of breaking any old workflow code.

Added a bunch more history tests with changes to them that should cause the replayer to fail.

Note on backwards compatibility: Any history that used to fail should still fail with the same error, but some histories that used to pass may now fail because the replayer was not properly checking before.

resolves: https://github.com/temporalio/sdk-go/issues/978, https://github.com/temporalio/sdk-go/issues/876 and https://github.com/temporalio/sdk-go/issues/983.


