### PR TITLE
Fix panic on starting child workflows with duplicate IDs

### DIFF
--- a/internal/internal_command_state_machine_test.go
+++ b/internal/internal_command_state_machine_test.go
@@ -353,7 +353,8 @@ func Test_ChildWorkflowStateMachine_Basic(t *testing.T) {
 	h := newCommandsHelper()
 
 	// start child workflow
-	d := h.startChildWorkflowExecution(attributes)
+	d, err := h.startChildWorkflowExecution(attributes)
+	require.NoError(t, err)
 	require.Equal(t, commandStateCreated, d.getState())
 
 	// send command
@@ -391,7 +392,8 @@ func Test_ChildWorkflowStateMachine_CancelSucceed(t *testing.T) {
 	h := newCommandsHelper()
 
 	// start child workflow
-	d := h.startChildWorkflowExecution(attributes)
+	d, err := h.startChildWorkflowExecution(attributes)
+	require.NoError(t, err)
 	// send command
 	_ = h.getCommands(true)
 	// child workflow initiated
@@ -435,11 +437,12 @@ func Test_ChildWorkflowStateMachine_InvalidStates(t *testing.T) {
 	h := newCommandsHelper()
 
 	// start child workflow
-	d := h.startChildWorkflowExecution(attributes)
+	d, err := h.startChildWorkflowExecution(attributes)
+	require.NoError(t, err)
 	require.Equal(t, commandStateCreated, d.getState())
 
 	// invalid: start child workflow failed before command was sent
-	err := runAndCatchPanic(func() {
+	err = runAndCatchPanic(func() {
 		h.handleStartChildWorkflowExecutionFailed(workflowID)
 	})
 	require.NotNil(t, err)
@@ -511,7 +514,8 @@ func Test_ChildWorkflow_UnusualCancelationOrdering(t *testing.T) {
 	h := newCommandsHelper()
 
 	// start child workflow
-	h.startChildWorkflowExecution(attributes)
+	_, err := h.startChildWorkflowExecution(attributes)
+	require.NoError(t, err)
 	// send command
 	h.getCommands(true)
 	// child workflow initiated
@@ -525,7 +529,7 @@ func Test_ChildWorkflow_UnusualCancelationOrdering(t *testing.T) {
 	// Now, the unusual part. The cancellation happens before we get the external cancel request
 	h.handleChildWorkflowExecutionCanceled(workflowID)
 	// Oh no, server took a bit.
-	err := runAndCatchPanic(func() {
+	err = runAndCatchPanic(func() {
 		h.handleExternalWorkflowExecutionCancelRequested(initiatedEventID, workflowID)
 	})
 	require.Nil(t, err)
@@ -544,7 +548,8 @@ func Test_ChildWorkflowStateMachine_CancelFailed(t *testing.T) {
 	h := newCommandsHelper()
 
 	// start child workflow
-	d := h.startChildWorkflowExecution(attributes)
+	d, err := h.startChildWorkflowExecution(attributes)
+	require.NoError(t, err)
 	// send command
 	h.getCommands(true)
 	// child workflow initiated

--- a/internal/internal_event_handlers.go
+++ b/internal/internal_event_handlers.go
@@ -479,7 +479,11 @@ func (wc *workflowEnvironmentImpl) ExecuteChildWorkflow(
 		attributes.CronSchedule = params.CronSchedule
 	}
 
-	command := wc.commandsHelper.startChildWorkflowExecution(attributes)
+	command, err := wc.commandsHelper.startChildWorkflowExecution(attributes)
+	if _, ok := err.(*childWorkflowExistsWithId); ok {
+		callback(nil, &ChildWorkflowExecutionAlreadyStartedError{})
+		return
+	}
 	command.setData(&scheduledChildWorkflow{
 		resultCallback:      callback,
 		startedCallback:     startedHandler,

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -999,9 +999,16 @@ func (ts *IntegrationTestSuite) TestCancelChildWorkflowUnusualTransitions() {
 	)
 	ts.NoError(err)
 
-	// Synchronously wait for the workflow completion. Behind the scenes the SDK performs a long poll operation.
-	// If you need to wait for the workflow completion from another process use
-	// Client.GetWorkflow API to get an instance of a WorkflowRun.
+	err = run.Get(context.Background(), nil)
+	ts.NoError(err)
+}
+
+func (ts *IntegrationTestSuite) TestChildWorkflowDuplicatePanic_Regression() {
+	wfid := "test-child-workflow-duplicate-panic-regression"
+	run, err := ts.client.ExecuteWorkflow(context.Background(),
+		ts.startWorkflowOptions(wfid),
+		ts.workflows.ChildWorkflowDuplicatePanicRepro)
+	ts.NoError(err)
 	err = run.Get(context.Background(), nil)
 	ts.NoError(err)
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Fix this panic. See the added docstring in the PR for more.

## Why?
Panic bad, yo.

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-go/issues/947

2. How was this tested:
Added integ test, existing tests.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
