### PR TITLE
Some documentation fixes

### DIFF
--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -1390,6 +1390,14 @@ func NewAggregatedWorker(client *WorkflowClient, taskQueue string, options Worke
 		panic("cannot set MaxConcurrentWorkflowTaskPollers to 1")
 	}
 
+	// If max-concurrent workflow task execution size is 1, the worker will only do
+	// sticky-queue requests and never regular-queue requests. This is because we
+	// limit the number of running pollers to MaxConcurrentWorkflowTaskExecutionSize.
+	// 	We disallow the value of 1 here.
+	if options.MaxConcurrentWorkflowTaskExecutionSize == 1 {
+		panic("cannot set MaxConcurrentWorkflowTaskExecutionSize to 1")
+	}
+
 	// Need reference to result for fatal error handler
 	var aw *AggregatedWorker
 	fatalErrorCallback := func(err error) {

--- a/internal/schedule_client.go
+++ b/internal/schedule_client.go
@@ -551,12 +551,12 @@ type (
 		// describes what workflow is run.
 		WorkflowType WorkflowType
 
-		// RecentActions- Most recent 10 Actions started (including manual triggers).
+		// RecentActions- Most recent 5 Actions started (including manual triggers).
 		//
 		// Sorted from older start time to newer.
 		RecentActions []ScheduleActionResult
 
-		// NextActionTimes - Next 10 scheduled Action times.
+		// NextActionTimes - Next 5 scheduled Action times.
 		NextActionTimes []time.Time
 
 		// Memo - Non-indexed user supplied information.

--- a/internal/worker.go
+++ b/internal/worker.go
@@ -79,7 +79,9 @@ type (
 		MaxConcurrentActivityTaskPollers int
 
 		// Optional: To set the maximum concurrent workflow task executions this worker can have.
-		// The zero value of this uses the default value.
+		// The zero value of this uses the default value. Due to internal logic where pollers
+		// alternate between stick and non-sticky queues, this
+		// value cannot be 1 and will panic if set to that value.
 		// default: defaultMaxConcurrentTaskExecutionSize(1k)
 		MaxConcurrentWorkflowTaskExecutionSize int
 


### PR DESCRIPTION
Fix the count in `ScheduleListEntry`

Disallow setting `MaxConcurrentWorkflowTaskExecutionSize` to one because it doesn't work

>Looks like we limit the number of pollers to `MaxConcurrentWorkflowTaskExecutionSize ` so the worker will only be polling on the sticky queue, so it will never pick up work. So the root cause is the same reason we need 2 workflow task pollers
Note: Technically we do create `maxConcurrentWorkflowTaskPollers ` number of pollers , but only really start `MaxConcurrentWorkflowTaskExecutionSize `
`MaxConcurrentWorkflowTaskExecutionSize` should never be less than `MaxConcurrentWorkflowTaskPollers `
We call this out here https://docs.temporal.io/application-development/worker-performance#invariants but say it only applies to java which is not true it also applies to the go sdk from reading the code.
Basically we need to document this and probably force `MaxConcurrentWorkflowTaskExecutionSize` to be greater than `MaxConcurrentWorkflowTaskPollers `
 
 This change is technically a breaking change, but their workers were not able to process workflows anyway so seems reasonable.

 We could force `MaxConcurrentWorkflowTaskExecutionSize` to be greater than `MaxConcurrentWorkflowTaskPollers` theoretically could cause users working workers to panic so I held off on it. 

resolves https://github.com/temporalio/sdk-go/issues/1003