### PR TITLE
Prevent cache eviction race

### DIFF
--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -1166,6 +1166,8 @@ func (w *workflowExecutionContextImpl) SetCurrentTask(task *workflowservice.Poll
 }
 
 func (w *workflowExecutionContextImpl) SetPreviousStartedEventID(eventID int64) {
+	w.mutex.Lock() // This call can race against the cache eviction thread - see clearState
+	defer w.mutex.Unlock()
 	w.previousStartedEventID = eventID
 }
 


### PR DESCRIPTION


<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
In some server tests the race detector noticed that SetPreviousStartedEventID can race with cache removal which happens on the cache eviction thread.

## Why?
<!-- Tell your future self why have you made these changes -->
Data races bad

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
