### PR TITLE
Deliver messages even when events are skipped

### DIFF
--- a/internal/internal_message.go
+++ b/internal/internal_message.go
@@ -1,0 +1,63 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package internal
+
+import (
+	"sort"
+
+	protocolpb "go.temporal.io/api/protocol/v1"
+)
+
+type eventMsgIndex []*protocolpb.Message
+
+// indexMessagesByEventID creates an index over a set of input messages that allows for
+// fast access to messages with an event ID less than or equal to a specific
+// upper bound. The order of messages with the same event ID will be preserved.
+func indexMessagesByEventID(msgs []*protocolpb.Message) *eventMsgIndex {
+	// implementor note: the order preservation requirement is why we can't use
+	// the heap package from the Go SDK here.
+
+	sorted := make(eventMsgIndex, len(msgs))
+	copy(sorted, msgs)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		return sorted[i].GetEventId() < sorted[j].GetEventId()
+	})
+	return &sorted
+}
+
+// takeLTE removes and returns the messages in this index that have an event ID
+// less than or equal to the input argument.
+func (emi *eventMsgIndex) takeLTE(eventID int64) []*protocolpb.Message {
+	indexOfFirstGreater := len(*emi)
+	for i, msg := range *emi {
+		if msg.GetEventId() > eventID {
+			indexOfFirstGreater = i
+			break
+		}
+	}
+	var out []*protocolpb.Message
+	out, *emi = (*emi)[0:indexOfFirstGreater], (*emi)[indexOfFirstGreater:]
+	return out
+}

--- a/internal/internal_message_test.go
+++ b/internal/internal_message_test.go
@@ -1,0 +1,81 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package internal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	protocolpb "go.temporal.io/api/protocol/v1"
+)
+
+func TestEventMessageIndex(t *testing.T) {
+	newMsg := func(id string, eventID int64) *protocolpb.Message {
+		return &protocolpb.Message{
+			Id:           id,
+			SequencingId: &protocolpb.Message_EventId{EventId: eventID},
+		}
+	}
+	messages := []*protocolpb.Message{
+		newMsg("00", 0),
+		newMsg("01", 2),
+		newMsg("02", 2),
+		newMsg("03", 101),
+		newMsg("04", 100),
+		newMsg("05", 50),
+		newMsg("06", 3),
+		newMsg("07", 0),
+		newMsg("08", 100),
+	}
+
+	emi := indexMessagesByEventID(messages)
+
+	batch := emi.takeLTE(2)
+	require.Len(t, batch, 4)
+	for i := 0; i < len(batch)-1; i++ {
+		if batch[i].GetEventId() == batch[i+1].GetEventId() {
+			require.Less(t, batch[i].Id, batch[i+1].Id)
+		}
+	}
+
+	batch = emi.takeLTE(2)
+	require.Empty(t, batch)
+
+	batch = emi.takeLTE(3)
+	require.Len(t, batch, 1)
+
+	batch = emi.takeLTE(100)
+	require.Len(t, batch, 3)
+	for i := 0; i < len(batch)-1; i++ {
+		if batch[i].GetEventId() == batch[i+1].GetEventId() {
+			require.Less(t, batch[i].Id, batch[i+1].Id)
+		}
+	}
+
+	emi = indexMessagesByEventID(messages)
+	batch = emi.takeLTE(9000)
+	require.Len(t, batch, len(messages))
+	require.Empty(t, emi)
+}

--- a/internal/internal_task_handlers_test.go
+++ b/internal/internal_task_handlers_test.go
@@ -42,7 +42,6 @@ import (
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	historypb "go.temporal.io/api/history/v1"
-	protocolpb "go.temporal.io/api/protocol/v1"
 	querypb "go.temporal.io/api/query/v1"
 	"go.temporal.io/api/serviceerror"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
@@ -1890,40 +1889,6 @@ func Test_IsMemoMatched(t *testing.T) {
 			},
 		)
 	}
-}
-
-func TestMessageIndexing(t *testing.T) {
-	wft := &workflowTask{
-		task: &workflowservice.PollWorkflowTaskQueueResponse{
-			Messages: []*protocolpb.Message{
-				{
-					Id:           "ID.1",
-					SequencingId: &protocolpb.Message_EventId{EventId: 3},
-				},
-				{
-					Id:           "ID.2",
-					SequencingId: &protocolpb.Message_EventId{EventId: 5},
-				},
-				{
-					Id:           "ID.3",
-					SequencingId: &protocolpb.Message_EventId{EventId: 3},
-				},
-			},
-		},
-	}
-	index := indexMessages(wft)
-
-	event3Interactions := index[3]
-	event4Interactions := index[4]
-	event5Interactions := index[5]
-
-	require.Len(t, event3Interactions, 2)
-	require.Len(t, event4Interactions, 0)
-	require.Len(t, event5Interactions, 1)
-
-	require.Equal(t, event3Interactions[0].Id, "ID.1")
-	require.Equal(t, event3Interactions[1].Id, "ID.3")
-	require.Equal(t, event5Interactions[0].Id, "ID.2")
 }
 
 func TestHeartbeatThrottleInterval(t *testing.T) {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Here we switch to delivering all messages dependent on events IDs less than or equal to the current event ID.

## Why?
<!-- Tell your future self why have you made these changes -->
We don't run WFTScheduledEvent instances through standard event handling so we were missing messages dependent on events of that type

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Unit & features

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
