### PR TITLE
Correct updateHandle.Get when passed nil pointer

### DIFF
--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -1663,11 +1663,7 @@ func (w *workflowClientInterceptor) UpdateWorkflow(
 			},
 		},
 	})
-	handle := &updateHandle{
-		ref: &updatepb.UpdateRef{
-			WorkflowExecution: wfexec,
-			UpdateId:          in.UpdateID,
-		}}
+	handle := &updateHandle{ref: resp.UpdateRef}
 	if err != nil {
 		handle.err = err
 		return handle, nil
@@ -1699,7 +1695,12 @@ func (uh *updateHandle) UpdateID() string {
 }
 
 func (uh *updateHandle) Get(ctx context.Context, valuePtr interface{}) error {
-	if uh.err != nil {
+	// implementation note: this is a broken implementation that assumes the
+	// update has already completed by the time Get is called. This is true for
+	// the current implementation of synchronous updates but will not be true in
+	// the future with async update.
+
+	if uh.err != nil || valuePtr == nil {
 		return uh.err
 	}
 	return uh.value.Get(valuePtr)

--- a/internal/internal_workflow_client_test.go
+++ b/internal/internal_workflow_client_test.go
@@ -1481,8 +1481,8 @@ func TestUpdateHandle(t *testing.T) {
 		require.Equal(t, t.Name(), out)
 	})
 
-	t.Run("invalid state", func(t *testing.T) {
+	t.Run("nil does not panic", func(t *testing.T) {
 		uh := updateHandle{}
-		require.Panics(t, func() { _ = uh.Get(context.TODO(), nil) })
+		require.NotPanics(t, func() { _ = uh.Get(context.TODO(), nil) })
 	})
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Match the behavior of Future, which is to return the error value (which
is likely nil) in such cases and not to try to assign to nil.

## Why?
<!-- Tell your future self why have you made these changes -->
Consistent with Future and allows for updates that do not return a value. 

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Unit test and features test

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
No
