### PR TITLE
Add ContextPropagators option for replay tests

### DIFF
--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -1085,6 +1085,7 @@ type WorkflowReplayer struct {
 	registry              *registry
 	dataConverter         converter.DataConverter
 	failureConverter      converter.FailureConverter
+	contextPropagators    []ContextPropagator
 	enableLoggingInReplay bool
 }
 
@@ -1095,6 +1096,10 @@ type WorkflowReplayerOptions struct {
 	DataConverter converter.DataConverter
 
 	FailureConverter converter.FailureConverter
+
+	// Optional: Sets ContextPropagators that allows users to control the context information passed through a workflow
+	// default: nil
+	ContextPropagators []ContextPropagator
 
 	// Interceptors to apply to the worker. Earlier interceptors wrap later
 	// interceptors.
@@ -1128,6 +1133,7 @@ func NewWorkflowReplayer(options WorkflowReplayerOptions) (*WorkflowReplayer, er
 		registry:              registry,
 		dataConverter:         options.DataConverter,
 		failureConverter:      options.FailureConverter,
+		contextPropagators:    options.ContextPropagators,
 		enableLoggingInReplay: options.EnableLoggingInReplay,
 	}, nil
 }
@@ -1310,6 +1316,7 @@ func (aw *WorkflowReplayer) replayWorkflowHistory(logger log.Logger, service wor
 		cache:                 cache,
 		DataConverter:         aw.dataConverter,
 		FailureConverter:      aw.failureConverter,
+		ContextPropagators:    aw.contextPropagators,
 		EnableLoggingInReplay: aw.enableLoggingInReplay,
 	}
 	taskHandler := newWorkflowTaskHandler(params, nil, aw.registry)


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

This PR enables setting `ContextPropagators` on workflow replay options, which can currently only be set on `client.Options` passed to a worker.

## Why?
<!-- Tell your future self why have you made these changes -->

Context propagators can extract information from workflow headers and modify workflow contexts. This is important for workflow replay in some cases, because information in a `workflow.Context` may be used to modify workflow behavior, eg. workflow code that performs role based access control based on claims in workflow headers.

## Checklist
<!--- add/delete as needed --->

How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

This was tested in our internal environment where workflow replay was previously failing due to missing context propagators.
