### PR TITLE
Disable encoding of built in queries by default

### DIFF
--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -120,20 +120,21 @@ type (
 
 	// workflowTaskHandlerImpl is the implementation of WorkflowTaskHandler
 	workflowTaskHandlerImpl struct {
-		namespace                string
-		metricsHandler           metrics.Handler
-		ppMgr                    pressurePointMgr
-		logger                   log.Logger
-		identity                 string
-		enableLoggingInReplay    bool
-		registry                 *registry
-		laTunnel                 *localActivityTunnel
-		workflowPanicPolicy      WorkflowPanicPolicy
-		dataConverter            converter.DataConverter
-		failureConverter         converter.FailureConverter
-		contextPropagators       []ContextPropagator
-		cache                    *WorkerCache
-		deadlockDetectionTimeout time.Duration
+		namespace                  string
+		metricsHandler             metrics.Handler
+		ppMgr                      pressurePointMgr
+		logger                     log.Logger
+		identity                   string
+		enableLoggingInReplay      bool
+		registry                   *registry
+		laTunnel                   *localActivityTunnel
+		workflowPanicPolicy        WorkflowPanicPolicy
+		dataConverter              converter.DataConverter
+		failureConverter           converter.FailureConverter
+		contextPropagators         []ContextPropagator
+		cache                      *WorkerCache
+		deadlockDetectionTimeout   time.Duration
+		enableEncodeBuiltInQueries bool
 	}
 
 	activityProvider func(name string) activity
@@ -399,19 +400,20 @@ func isPreloadMarkerEvent(event *historypb.HistoryEvent) bool {
 func newWorkflowTaskHandler(params workerExecutionParameters, ppMgr pressurePointMgr, registry *registry) WorkflowTaskHandler {
 	ensureRequiredParams(&params)
 	return &workflowTaskHandlerImpl{
-		namespace:                params.Namespace,
-		logger:                   params.Logger,
-		ppMgr:                    ppMgr,
-		metricsHandler:           params.MetricsHandler,
-		identity:                 params.Identity,
-		enableLoggingInReplay:    params.EnableLoggingInReplay,
-		registry:                 registry,
-		workflowPanicPolicy:      params.WorkflowPanicPolicy,
-		dataConverter:            params.DataConverter,
-		failureConverter:         params.FailureConverter,
-		contextPropagators:       params.ContextPropagators,
-		cache:                    params.cache,
-		deadlockDetectionTimeout: params.DeadlockDetectionTimeout,
+		namespace:                  params.Namespace,
+		logger:                     params.Logger,
+		ppMgr:                      ppMgr,
+		metricsHandler:             params.MetricsHandler,
+		identity:                   params.Identity,
+		enableLoggingInReplay:      params.EnableLoggingInReplay,
+		registry:                   registry,
+		workflowPanicPolicy:        params.WorkflowPanicPolicy,
+		dataConverter:              params.DataConverter,
+		failureConverter:           params.FailureConverter,
+		contextPropagators:         params.ContextPropagators,
+		cache:                      params.cache,
+		deadlockDetectionTimeout:   params.DeadlockDetectionTimeout,
+		enableEncodeBuiltInQueries: params.EnableEncodeBuiltInQueries,
 	}
 }
 
@@ -516,6 +518,7 @@ func (w *workflowExecutionContextImpl) createEventHandler() {
 		w.wth.failureConverter,
 		w.wth.contextPropagators,
 		w.wth.deadlockDetectionTimeout,
+		w.wth.enableEncodeBuiltInQueries,
 	)
 
 	w.eventHandler = &eventHandler

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -215,6 +215,9 @@ type (
 		cache *WorkerCache
 
 		eagerActivityExecutor *eagerActivityExecutor
+
+		// Enable using the provided data converter for built in queries like stack trace queries.
+		EnableEncodeBuiltInQueries bool
 	}
 )
 
@@ -1443,6 +1446,7 @@ func NewAggregatedWorker(client *WorkflowClient, taskQueue string, options Worke
 		MetricsHandler:                        client.metricsHandler.WithTags(metrics.TaskQueueTags(taskQueue)),
 		Logger:                                client.logger,
 		EnableLoggingInReplay:                 options.EnableLoggingInReplay,
+		EnableEncodeBuiltInQueries:            options.EnableEncodeBuiltInQueries,
 		UserContext:                           backgroundActivityContext,
 		UserContextCancel:                     backgroundActivityContextCancel,
 		StickyScheduleToStartTimeout:          options.StickyScheduleToStartTimeout,

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -2634,6 +2634,7 @@ func assertWorkerExecutionParamsEqual(t *testing.T, paramsA workerExecutionParam
 	require.Equal(t, paramsA.MaxConcurrentActivityTaskQueuePollers, paramsB.MaxConcurrentActivityTaskQueuePollers)
 	require.Equal(t, paramsA.WorkflowPanicPolicy, paramsB.WorkflowPanicPolicy)
 	require.Equal(t, paramsA.EnableLoggingInReplay, paramsB.EnableLoggingInReplay)
+	require.Equal(t, paramsA.EnableEncodeBuiltInQueries, paramsB.EnableEncodeBuiltInQueries)
 }
 
 // Encode function args

--- a/internal/worker.go
+++ b/internal/worker.go
@@ -227,6 +227,12 @@ type (
 		// and aliased names when not using string names when executing child
 		// workflow or activities.
 		DisableRegistrationAliasing bool
+
+		// Optional: Enable encoding built in query handles like stack trace.
+		// if enabled built in queries will use the provided data converter.
+		// if disabled they will use the default data converter.
+		// default: false
+		EnableEncodeBuiltInQueries bool
 	}
 )
 


### PR DESCRIPTION
Disable encoding of built in queries by default like java. Since go sdk also has the open sessions built in query I generalized the parameter and applied it to that as well since I couldn't see a reason to treat it any different.

Note: this is a breaking change as before stack traces always uses the user provided data converter.

resolves: https://github.com/temporalio/sdk-go/issues/996
