### PR TITLE
On replayer use task queue from history

### DIFF
--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -1289,6 +1289,10 @@ func (aw *WorkflowReplayer) replayWorkflowHistory(logger log.Logger, service wor
 		execution.RunId = first.GetWorkflowExecutionStartedEventAttributes().GetOriginalExecutionRunId()
 	}
 
+	if first.GetWorkflowExecutionStartedEventAttributes().GetTaskQueue().GetName() != "" {
+		taskQueue = first.GetWorkflowExecutionStartedEventAttributes().GetTaskQueue().GetName()
+	}
+
 	task := &workflowservice.PollWorkflowTaskQueueResponse{
 		Attempt:                1,
 		TaskToken:              []byte("ReplayTaskToken"),


### PR DESCRIPTION
Use the task queue if it is available in the history rather than "ReplayTaskQueue" so replay is closer to real execution.

See also: https://github.com/temporalio/features/issues/114
