### PR TITLE
Expose session state

### DIFF
--- a/internal/session_test.go
+++ b/internal/session_test.go
@@ -72,14 +72,14 @@ func (s *SessionTestSuite) TestCreationCompletion() {
 			return err
 		}
 		info := GetSessionInfo(sessionCtx)
-		if info == nil || info.sessionState != sessionStateOpen {
+		if info == nil || info.SessionState != SessionStateOpen {
 			return errors.New("session state should be open after creation")
 		}
 
 		CompleteSession(sessionCtx)
 
 		info = GetSessionInfo(sessionCtx)
-		if info == nil || info.sessionState != sessionStateClosed {
+		if info == nil || info.SessionState != SessionStateClosed {
 			return errors.New("session state should be closed after completion")
 		}
 		return nil
@@ -102,7 +102,7 @@ func (s *SessionTestSuite) TestCreationWithOpenSessionContext() {
 		sessionCtx := setSessionInfo(ctx, &SessionInfo{
 			SessionID:    "some random sessionID",
 			taskqueue:    "some random taskqueue",
-			sessionState: sessionStateOpen,
+			SessionState: SessionStateOpen,
 		})
 		_, err := CreateSession(sessionCtx, s.sessionOptions)
 		return err
@@ -137,7 +137,7 @@ func (s *SessionTestSuite) TestCreationWithClosedSessionContext() {
 		sessionCtx := setSessionInfo(ctx, &SessionInfo{
 			SessionID:    "some random sessionID",
 			taskqueue:    "some random taskqueue",
-			sessionState: sessionStateClosed,
+			SessionState: SessionStateClosed,
 		})
 
 		sessionCtx, err := CreateSession(sessionCtx, s.sessionOptions)
@@ -171,7 +171,7 @@ func (s *SessionTestSuite) TestCreationWithFailedSessionContext() {
 		sessionCtx := setSessionInfo(ctx, &SessionInfo{
 			SessionID:    "some random sessionID",
 			taskqueue:    "some random taskqueue",
-			sessionState: sessionStateFailed,
+			SessionState: SessionStateFailed,
 		})
 
 		sessionCtx, err := CreateSession(sessionCtx, s.sessionOptions)
@@ -199,7 +199,7 @@ func (s *SessionTestSuite) TestCompletionWithClosedSessionContext() {
 		sessionCtx := setSessionInfo(ctx, &SessionInfo{
 			SessionID:    "some random sessionID",
 			taskqueue:    "some random taskqueue",
-			sessionState: sessionStateClosed,
+			SessionState: SessionStateClosed,
 		})
 		CompleteSession(sessionCtx)
 		return nil
@@ -219,7 +219,7 @@ func (s *SessionTestSuite) TestCompletionWithFailedSessionContext() {
 		sessionCtx := setSessionInfo(ctx, &SessionInfo{
 			SessionID:    "some random sessionID",
 			taskqueue:    "some random taskqueue",
-			sessionState: sessionStateFailed,
+			SessionState: SessionStateFailed,
 		})
 		CompleteSession(sessionCtx)
 		return nil
@@ -244,7 +244,7 @@ func (s *SessionTestSuite) TestGetSessionInfo() {
 		sessionCtx := setSessionInfo(ctx, &SessionInfo{
 			SessionID:    "some random sessionID",
 			taskqueue:    "some random taskqueue",
-			sessionState: sessionStateFailed,
+			SessionState: SessionStateFailed,
 		})
 		info = GetSessionInfo(sessionCtx)
 		if info == nil {
@@ -254,7 +254,7 @@ func (s *SessionTestSuite) TestGetSessionInfo() {
 		newSessionInfo := &SessionInfo{
 			SessionID:    "another sessionID",
 			taskqueue:    "another taskqueue",
-			sessionState: sessionStateClosed,
+			SessionState: SessionStateClosed,
 		}
 		sessionCtx = setSessionInfo(ctx, newSessionInfo)
 		info = GetSessionInfo(sessionCtx)
@@ -286,7 +286,7 @@ func (s *SessionTestSuite) TestRecreation() {
 		sessionInfo := &SessionInfo{
 			SessionID:    "some random sessionID",
 			taskqueue:    "some random taskqueue",
-			sessionState: sessionStateFailed,
+			SessionState: SessionStateFailed,
 		}
 
 		sessionCtx, err := RecreateSession(ctx, sessionInfo.GetRecreateToken(), s.sessionOptions)
@@ -461,7 +461,7 @@ func (s *SessionTestSuite) TestSessionRecreationTaskQueue() {
 		sessionInfo := &SessionInfo{
 			SessionID:    "testSessionID",
 			taskqueue:    resourceSpecificTaskQueue,
-			sessionState: sessionStateClosed,
+			SessionState: SessionStateClosed,
 		}
 		sessionCtx, err := RecreateSession(ctx, sessionInfo.GetRecreateToken(), s.sessionOptions)
 		if err != nil {
@@ -509,7 +509,7 @@ func (s *SessionTestSuite) TestExecuteActivityInFailedSession() {
 		sessionCtx := setSessionInfo(ctx, &SessionInfo{
 			SessionID:    "random sessionID",
 			taskqueue:    "random taskqueue",
-			sessionState: sessionStateFailed,
+			SessionState: SessionStateFailed,
 		})
 
 		return ExecuteActivity(sessionCtx, testSessionActivity, "a random name").Get(sessionCtx, nil)
@@ -543,7 +543,7 @@ func (s *SessionTestSuite) TestExecuteActivityInClosedSession() {
 		sessionCtx := setSessionInfo(ctx, &SessionInfo{
 			SessionID:    "random sessionID",
 			taskqueue:    "random taskqueue",
-			sessionState: sessionStateClosed,
+			SessionState: SessionStateClosed,
 		})
 
 		return ExecuteActivity(sessionCtx, testSessionActivity, "some random message").Get(sessionCtx, nil)
@@ -569,7 +569,7 @@ func (s *SessionTestSuite) TestSessionRecreateToken() {
 	sessionInfo := &SessionInfo{
 		SessionID:    "testSessionID",
 		taskqueue:    taskqueue,
-		sessionState: sessionStateClosed,
+		SessionState: SessionStateClosed,
 	}
 	token := sessionInfo.GetRecreateToken()
 	params, err := deserializeRecreateToken(token)
@@ -600,7 +600,7 @@ func (s *SessionTestSuite) TestCompletionFailed() {
 		CompleteSession(sessionCtx)
 
 		info := GetSessionInfo(sessionCtx)
-		if info == nil || info.sessionState != sessionStateClosed {
+		if info == nil || info.SessionState != SessionStateClosed {
 			return errors.New("session state should be closed after completion even when completion activity failed")
 		}
 		return nil

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -566,11 +566,11 @@ func (wc *workflowEnvironmentInterceptor) ExecuteActivity(ctx Context, typeName 
 	// Validate session state.
 	if sessionInfo := getSessionInfo(ctx); sessionInfo != nil {
 		isCreationActivity := isSessionCreationActivity(typeName)
-		if sessionInfo.sessionState == sessionStateFailed && !isCreationActivity {
+		if sessionInfo.SessionState == SessionStateFailed && !isCreationActivity {
 			settable.Set(nil, ErrSessionFailed)
 			return future
 		}
-		if sessionInfo.sessionState == sessionStateOpen && !isCreationActivity {
+		if sessionInfo.SessionState == SessionStateOpen && !isCreationActivity {
 			// Use session taskqueue
 			oldTaskQueueName := options.TaskQueueName
 			options.TaskQueueName = sessionInfo.taskqueue

--- a/workflow/session.go
+++ b/workflow/session.go
@@ -47,9 +47,20 @@ type (
 	SessionOptions = internal.SessionOptions
 )
 
-// ErrSessionFailed is the error returned when user tries to execute an activity but the
-// session it belongs to has already failed
-var ErrSessionFailed = internal.ErrSessionFailed
+var (
+	// ErrSessionFailed is the error returned when user tries to execute an activity but the
+	// session it belongs to has already failed
+	ErrSessionFailed = internal.ErrSessionFailed
+
+	// SessionStateOpen means the session worker is heartbeating and new activities will be schedule on the session host.
+	SessionStateOpen = internal.SessionStateOpen
+
+	// SessionStateClosed means the session was closed by the workflow and new activities will not be scheduled on the session host.
+	SessionStateClosed = internal.SessionStateClosed
+
+	// SessionStateFailed means the session worker was detected to be down and the session cannot be used to schedule new activities.
+	SessionStateFailed = internal.SessionStateFailed
+)
 
 // Note: Worker should be configured to process session. To do this, set the following
 // fields in WorkerOptions:
@@ -62,11 +73,11 @@ var ErrSessionFailed = internal.ErrSessionFailed
 // ActivityOptions. If none is specified, the default one will be used.
 //
 // CreationSession will fail in the following situations:
-//     1. The context passed in already contains a session which is still open
-//        (not closed and failed).
-//     2. All the workers are busy (number of sessions currently running on all the workers have reached
-//        MaxConcurrentSessionExecutionSize, which is specified when starting the workers) and session
-//        cannot be created within a specified timeout.
+//  1. The context passed in already contains a session which is still open
+//     (not closed and failed).
+//  2. All the workers are busy (number of sessions currently running on all the workers have reached
+//     MaxConcurrentSessionExecutionSize, which is specified when starting the workers) and session
+//     cannot be created within a specified timeout.
 //
 // If an activity is executed using the returned context, it's regarded as part of the
 // session. All activities within the same session will be executed by the same worker.
@@ -83,22 +94,23 @@ var ErrSessionFailed = internal.ErrSessionFailed
 // New session can be created if necessary to retry the whole session.
 //
 // Example:
-//    so := &SessionOptions{
-// 	      ExecutionTimeout: time.Minute,
-// 	      CreationTimeout:  time.Minute,
-//    }
-//    sessionCtx, err := CreateSession(ctx, so)
-//    if err != nil {
-//		    // Creation failed. Wrong ctx or too many outstanding sessions.
-//    }
-//    defer CompleteSession(sessionCtx)
-//    err = ExecuteActivity(sessionCtx, someActivityFunc, activityInput).Get(sessionCtx, nil)
-//    if err == ErrSessionFailed {
-//        // Session has failed
-//    } else {
-//        // Handle activity error
-//    }
-//    ... // execute more activities using sessionCtx
+//
+//	   so := &SessionOptions{
+//		      ExecutionTimeout: time.Minute,
+//		      CreationTimeout:  time.Minute,
+//	   }
+//	   sessionCtx, err := CreateSession(ctx, so)
+//	   if err != nil {
+//			    // Creation failed. Wrong ctx or too many outstanding sessions.
+//	   }
+//	   defer CompleteSession(sessionCtx)
+//	   err = ExecuteActivity(sessionCtx, someActivityFunc, activityInput).Get(sessionCtx, nil)
+//	   if err == ErrSessionFailed {
+//	       // Session has failed
+//	   } else {
+//	       // Handle activity error
+//	   }
+//	   ... // execute more activities using sessionCtx
 //
 // NOTE: Session recreation via RecreateSession may not work properly across worker fail/crash before Temporal server
 // version v1.15.1.

--- a/workflow/session.go
+++ b/workflow/session.go
@@ -31,9 +31,17 @@ import (
 type (
 	// SessionInfo contains information of a created session. For now, exported
 	// fields are SessionID and HostName.
+	//
 	// SessionID is a uuid generated when CreateSession() or RecreateSession()
 	// is called and can be used to uniquely identify a session.
+	//
 	// HostName specifies which host is executing the session
+	//
+	// SessionState specifies the current know state of the session.
+	//
+	// Note: Sessions have an inherently stale view of the worker they are running on. Session
+	// state may be stale up the the SessionOptions.HeartbeatTimeout. SessionOptions.HeartbeatTimeout
+	// should be less than half the activity timeout for the state to be accurate when checking after activity failure.
 	SessionInfo = internal.SessionInfo
 
 	// SessionOptions specifies metadata for a session.
@@ -45,6 +53,9 @@ type (
 	//     Specifies the heartbeat timeout. If heartbeat is not received by server
 	//     within the timeout, the session will be declared as failed
 	SessionOptions = internal.SessionOptions
+
+	// SessionState specifies the state of the session.
+	SessionState = internal.SessionState
 )
 
 var (


### PR DESCRIPTION
Expose session state to users so they can understand if their activity failed because the session worker failed.

resolves:https://github.com/temporalio/sdk-go/issues/1021