### PR TITLE
Workaround for updates delivered in first WFT

### DIFF
--- a/internal/internal_update.go
+++ b/internal/internal_update.go
@@ -232,7 +232,7 @@ func defaultUpdateHandler(
 		// because this update is part of the first workflow task and is being
 		// delivered before the workflow function itself has run and had a
 		// chance to register update handlers) then we yield control back to the
-		// scheduler to allow handler registration to occur. The sceduler will
+		// scheduler to allow handler registration to occur. The scheduler will
 		// resume this coroutine after others have run to a blocking point.
 		if len(eo.updateHandlers) == 0 {
 			scheduler.Yield(ctx, "yielding for initial handler registration")


### PR DESCRIPTION


<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Adds a conditional yield point during update processing to allow the scheduler to do other things like registering update handlers.

## Why?
<!-- Tell your future self why have you made these changes -->
If the first WFT includes an update we can have a problem because the workflow function itself hasn't run yet to register update handlers and the update will be rejected. Adding this yield allows the scheduler to execute the workflow function up to the first blocking point, at which point the handler(s) will be registered by user code.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Unit test here and I was able to remove all the time.Sleep(1*time.Second) from the features tests.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
No
