### PR TITLE
Handle CanceledAfterStarted in CanceledEvent

### DIFF
--- a/internal/internal_command_state_machine.go
+++ b/internal/internal_command_state_machine.go
@@ -534,7 +534,7 @@ func (d *commandStateMachineBase) handleCancelFailedEvent() {
 
 func (d *commandStateMachineBase) handleCanceledEvent() {
 	switch d.state {
-	case commandStateCancellationCommandSent, commandStateCanceledAfterInitiated, commandStateCancellationCommandAccepted:
+	case commandStateCancellationCommandSent, commandStateCanceledAfterInitiated, commandStateCanceledAfterStarted, commandStateCancellationCommandAccepted:
 		d.moveState(commandStateCompleted, eventCanceled)
 	default:
 		d.failStateTransition(eventCanceled)

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -1003,6 +1003,39 @@ func (ts *IntegrationTestSuite) TestCancelChildWorkflowUnusualTransitions() {
 	ts.NoError(err)
 }
 
+func (ts *IntegrationTestSuite) TestCancelChildWorkflowAndParentWorkflow() {
+	wfid := "test-cancel-child-workflow-and-parent-workflow"
+	run, err := ts.client.ExecuteWorkflow(context.Background(),
+		ts.startWorkflowOptions(wfid),
+		ts.workflows.ChildWorkflowAndParentCancel)
+	ts.NoError(err)
+
+	// Give it a sec to populate the query
+	<-time.After(1 * time.Second)
+
+	v, err := ts.client.QueryWorkflow(context.Background(), run.GetID(), "", "child-and-parent-cancel-child-workflow-id")
+	ts.NoError(err)
+
+	var childWorkflowID string
+	err = v.Get(&childWorkflowID)
+	ts.NoError(err)
+	ts.NotNil(childWorkflowID)
+	ts.NotEmpty(childWorkflowID)
+
+	err = ts.client.CancelWorkflow(context.Background(), childWorkflowID, "")
+	ts.NoError(err)
+
+	err = ts.client.CancelWorkflow(context.Background(), run.GetID(), "")
+	ts.NoError(err)
+
+	err = run.Get(context.Background(), nil)
+	ts.NoError(err)
+
+	err = ts.client.GetWorkflow(context.Background(), childWorkflowID, "").Get(context.Background(), nil)
+	var canceledError *temporal.CanceledError
+	ts.ErrorAs(err, &canceledError)
+}
+
 func (ts *IntegrationTestSuite) TestChildWorkflowDuplicatePanic_Regression() {
 	wfid := "test-child-workflow-duplicate-panic-regression"
 	run, err := ts.client.ExecuteWorkflow(context.Background(),


### PR DESCRIPTION
User reported this issue where I believe they tried to cancel a workflow that had a child workflow and it resulted in the parent workflow getting stuck panicing on invalid state transition on the `ChildWorkflowExecutionCanceled` because it didn't expect it to be in `CanceledAfterStarted`. I don't see why we would treat `CanceledAfterInitiated` differently than `CanceledAfterStarted` so I allowed the state transition.


Previously the SDK would consider this an invalid state transition and panic, now the SDK handles it as a canceled child workflow. 