### PR TITLE
Pin staticcheck to v0.3.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,12 @@ vet: $(ALL_SRC)
 	done;
 
 staticcheck: $(ALL_SRC)
-	go install honnef.co/go/tools/cmd/staticcheck@latest
+	# The latest version of staticcheck (0.4.0 as of 3 Feb 2023) scans
+	# dependencies (?) and incorrectly detects that the
+	# proxy.WorkflowServiceProxyOptions.Client field is unused in api-go. We
+	# will pin to the previous version for now but be advised this version is
+	# known not to work with go1.20.
+	go install honnef.co/go/tools/cmd/staticcheck@v0.3.3
 	@for dir in $(MOD_DIRS); do \
 		(cd "$$dir" && echo "In $$dir" && staticcheck ./...) || exit 1; \
 	done;


### PR DESCRIPTION

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Pin staticcheck to v0.3.3

## Why?
<!-- Tell your future self why have you made these changes -->
The latest version of staticcheck (0.4.0 as of 3 Feb 2023) scans dependencies (?) and incorrectly detects that the
proxy.WorkflowServiceProxyOptions.Client field is unused in api-go. We will pin to the previous version for now but be advised this version is known not to work with go1.20.


## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
