### PR TITLE
Update CI to test golang 1.20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.17"
+          go-version: "1.20"
       - name: Check and unit test
         run: make check unit-test
       - name: Clone Temporal Docker compose
@@ -54,7 +54,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.17"
+          go-version: "1.20"
       - name: Single integration test against cloud
         run: 'go test -v --count 1 -p 1 . -run "TestIntegrationSuite/TestBasic$"'
         working-directory: test

--- a/Makefile
+++ b/Makefile
@@ -76,12 +76,7 @@ vet: $(ALL_SRC)
 	done;
 
 staticcheck: $(ALL_SRC)
-	# The latest version of staticcheck (0.4.0 as of 3 Feb 2023) scans
-	# dependencies (?) and incorrectly detects that the
-	# proxy.WorkflowServiceProxyOptions.Client field is unused in api-go. We
-	# will pin to the previous version for now but be advised this version is
-	# known not to work with go1.20.
-	go install honnef.co/go/tools/cmd/staticcheck@v0.3.3
+	go install honnef.co/go/tools/cmd/staticcheck@v0.4.1
 	@for dir in $(MOD_DIRS); do \
 		(cd "$$dir" && echo "In $$dir" && staticcheck ./...) || exit 1; \
 	done;

--- a/internal/common/backoff/retry.go
+++ b/internal/common/backoff/retry.go
@@ -186,7 +186,7 @@ func Retry(ctx context.Context, operation Operation, policy RetryPolicy, isRetry
 func IgnoreErrors(errorsToExclude []error) func(error) bool {
 	return func(err error) bool {
 		for _, errorToExclude := range errorsToExclude {
-			if err == errorToExclude {
+			if errors.Is(err, errorToExclude) {
 				return false
 			}
 		}


### PR DESCRIPTION
Currently CI tests 1.17 that has been EOL for 6 months.  I would also be OK with adding a test for 1.19 as well, but seems slightly unnecessary. 