### PR TITLE
Use sensible defaults for ScheduleCalendarSpec

### DIFF
--- a/internal/internal_schedule_client.go
+++ b/internal/internal_schedule_client.go
@@ -719,9 +719,37 @@ func convertFromPBScheduleCalendarSpecList(calendarSpecPB []*schedulepb.Structur
 	return calendarSpec
 }
 
+func applyScheduleCalendarSpecDefault(calendarSpec *ScheduleCalendarSpec) {
+	if calendarSpec.Second == nil {
+		calendarSpec.Second = []ScheduleRange{{Start: 0}}
+	}
+
+	if calendarSpec.Minute == nil {
+		calendarSpec.Minute = []ScheduleRange{{Start: 0}}
+	}
+
+	if calendarSpec.Hour == nil {
+		calendarSpec.Hour = []ScheduleRange{{Start: 0}}
+	}
+
+	if calendarSpec.DayOfMonth == nil {
+		calendarSpec.DayOfMonth = []ScheduleRange{{Start: 1, End: 31}}
+	}
+
+	if calendarSpec.Month == nil {
+		calendarSpec.Month = []ScheduleRange{{Start: 1, End: 12}}
+	}
+
+	if calendarSpec.DayOfWeek == nil {
+		calendarSpec.DayOfWeek = []ScheduleRange{{Start: 0, End: 6}}
+	}
+}
+
 func convertToPBScheduleCalendarSpecList(calendarSpec []ScheduleCalendarSpec) []*schedulepb.StructuredCalendarSpec {
 	calendarSpecPB := make([]*schedulepb.StructuredCalendarSpec, len(calendarSpec))
 	for i, e := range calendarSpec {
+		applyScheduleCalendarSpecDefault(&e)
+
 		calendarSpecPB[i] = &schedulepb.StructuredCalendarSpec{
 			Second:     convertToPBRangeList(e.Second),
 			Minute:     convertToPBRangeList(e.Minute),

--- a/internal/schedule_client.go
+++ b/internal/schedule_client.go
@@ -54,25 +54,38 @@ type (
 	// that means all years match. For all fields besides year, at least one Range must be present to match anything.
 	ScheduleCalendarSpec struct {
 		// Second range to match (0-59).
+		//
+		// default: matches 0
 		Second []ScheduleRange
 
 		// Minute range to match (0-59).
+		//
+		// default: matches 0
 		Minute []ScheduleRange
 
 		// Hour range to match (0-23).
+		//
+		// default: matches 0
 		Hour []ScheduleRange
 
 		// DayOfMonth range to match (1-31)
+		//
+		// default: matches all days
 		DayOfMonth []ScheduleRange
 
 		// Month range to match (1-12)
+		//
+		// default: matches all months
 		Month []ScheduleRange
 
 		// Year range to match.
-		// Optional: Defaulted to "*"
+		//
+		// default: empty that matches all years
 		Year []ScheduleRange
 
 		// DayOfWeek range to match (0-6; 0 is Sunday)
+		//
+		// default: matches all days of the week
 		DayOfWeek []ScheduleRange
 
 		// Comment - Description of the intention of this schedule.


### PR DESCRIPTION
Align with python and typescript SDKs and use sensible defaults for ScheduleCalendarSpec to help users.

Defaults are taken from the python SDK.

Note: This is a breaking change because we are changing defaults, but schedules is marked as experimental and users have been asking for this