### PR TITLE
Track mutable side effect calls

### DIFF
--- a/internal/internal_event_handlers.go
+++ b/internal/internal_event_handlers.go
@@ -30,6 +30,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"sort"
 	"sync"
 	"time"
 
@@ -109,7 +110,7 @@ type (
 		changeVersions             map[string]Version
 		pendingLaTasks             map[string]*localActivityTask
 		completedLaAttemptsThisWFT uint32
-		mutableSideEffect          map[string]*commonpb.Payloads
+		mutableSideEffect          map[string]map[int]*commonpb.Payloads
 		unstartedLaTasks           map[string]struct{}
 		openSessions               map[string]*SessionInfo
 
@@ -117,6 +118,10 @@ type (
 		// during replay to determine whether a command should be created. The keys
 		// are the user-provided IDs + "_" + the command counter.
 		mutableSideEffectsRecorded map[string]bool
+		// Records the number of times a mutable side effect was called per ID over the
+		// life of the workflow. Used to help distinguish multiple calls to MutableSideEffect in the same
+		// WorkflowTask.
+		mutableSideEffectCallCounter map[string]int
 
 		// LocalActivities have a separate, individual counter instead of relying on actual commandEventIDs.
 		// This is because command IDs are only incremented on activity completion, which breaks
@@ -196,22 +201,23 @@ func newWorkflowExecutionEventHandler(
 	deadlockDetectionTimeout time.Duration,
 ) workflowExecutionEventHandler {
 	context := &workflowEnvironmentImpl{
-		workflowInfo:             workflowInfo,
-		commandsHelper:           newCommandsHelper(),
-		sideEffectResult:         make(map[int64]*commonpb.Payloads),
-		mutableSideEffect:        make(map[string]*commonpb.Payloads),
-		changeVersions:           make(map[string]Version),
-		pendingLaTasks:           make(map[string]*localActivityTask),
-		unstartedLaTasks:         make(map[string]struct{}),
-		openSessions:             make(map[string]*SessionInfo),
-		completeHandler:          completeHandler,
-		enableLoggingInReplay:    enableLoggingInReplay,
-		registry:                 registry,
-		dataConverter:            dataConverter,
-		failureConverter:         failureConverter,
-		contextPropagators:       contextPropagators,
-		deadlockDetectionTimeout: deadlockDetectionTimeout,
-		protocols:                protocol.NewRegistry(),
+		workflowInfo:                 workflowInfo,
+		commandsHelper:               newCommandsHelper(),
+		sideEffectResult:             make(map[int64]*commonpb.Payloads),
+		mutableSideEffect:            make(map[string]map[int]*commonpb.Payloads),
+		changeVersions:               make(map[string]Version),
+		pendingLaTasks:               make(map[string]*localActivityTask),
+		unstartedLaTasks:             make(map[string]struct{}),
+		openSessions:                 make(map[string]*SessionInfo),
+		completeHandler:              completeHandler,
+		enableLoggingInReplay:        enableLoggingInReplay,
+		registry:                     registry,
+		dataConverter:                dataConverter,
+		failureConverter:             failureConverter,
+		contextPropagators:           contextPropagators,
+		deadlockDetectionTimeout:     deadlockDetectionTimeout,
+		protocols:                    protocol.NewRegistry(),
+		mutableSideEffectCallCounter: make(map[string]int),
 	}
 	context.logger = ilog.NewReplayLogger(
 		log.With(logger,
@@ -782,15 +788,51 @@ func (wc *workflowEnvironmentImpl) SideEffect(f func() (*commonpb.Payloads, erro
 	wc.logger.Debug("SideEffect Marker added", tagSideEffectID, sideEffectID)
 }
 
+func (wc *workflowEnvironmentImpl) lookupMutableSideEffect(id string) (*commonpb.Payloads, bool) {
+	if payloadAtCallCount, ok := wc.mutableSideEffect[id]; ok {
+		currentCallCount := wc.mutableSideEffectCallCounter[id]
+		// Sort the calls
+		calls := make([]int, 0)
+		for k := range payloadAtCallCount {
+			calls = append(calls, k)
+		}
+		sort.Ints(calls)
+		// Find the most recent call at/before the current call count
+		var payload *commonpb.Payloads
+		var foundIndex int
+		for i := len(calls) - 1; i >= 0; i-- {
+			if calls[i] <= currentCallCount {
+				payload = payloadAtCallCount[calls[i]]
+				foundIndex = i
+				break
+			}
+		}
+		if payload == nil {
+			return nil, false
+		}
+		// Garbage collect old entries
+		// TODO(quinn) unclear if this should be done aggressively at WFT boundry
+		for i := 0; i < foundIndex; i++ {
+			delete(payloadAtCallCount, calls[i])
+		}
+
+		return payload, true
+	}
+	return nil, false
+}
+
 func (wc *workflowEnvironmentImpl) MutableSideEffect(id string, f func() interface{}, equals func(a, b interface{}) bool) converter.EncodedValue {
-	if result, ok := wc.mutableSideEffect[id]; ok {
+	wc.mutableSideEffectCallCounter[id]++
+	callCount := wc.mutableSideEffectCallCounter[id]
+
+	if result, ok := wc.lookupMutableSideEffect(id); ok {
 		encodedResult := newEncodedValue(result, wc.GetDataConverter())
 		if wc.isReplay {
 			// During replay, we only generate a command if there was a known marker
 			// recorded on the next task. We have to append the current command
 			// counter to the user-provided ID to avoid duplicates.
 			if wc.mutableSideEffectsRecorded[fmt.Sprintf("%v_%v", id, wc.commandsHelper.nextCommandEventID)] {
-				return wc.recordMutableSideEffect(id, result)
+				return wc.recordMutableSideEffect(id, callCount, result)
 			}
 			return encodedResult
 		}
@@ -800,7 +842,7 @@ func (wc *workflowEnvironmentImpl) MutableSideEffect(id string, f func() interfa
 			return encodedResult
 		}
 
-		return wc.recordMutableSideEffect(id, wc.encodeValue(newValue))
+		return wc.recordMutableSideEffect(id, callCount, wc.encodeValue(newValue))
 	}
 
 	if wc.isReplay {
@@ -808,7 +850,7 @@ func (wc *workflowEnvironmentImpl) MutableSideEffect(id string, f func() interfa
 		panic(fmt.Sprintf("Non deterministic workflow code change detected. MutableSideEffect API call doesn't have a correspondent event in the workflow history. MutableSideEffect ID: %s", id))
 	}
 
-	return wc.recordMutableSideEffect(id, wc.encodeValue(f()))
+	return wc.recordMutableSideEffect(id, callCount, wc.encodeValue(f()))
 }
 
 func (wc *workflowEnvironmentImpl) isEqualValue(newValue interface{}, encodedOldValue *commonpb.Payloads, equals func(a, b interface{}) bool) bool {
@@ -844,13 +886,16 @@ func (wc *workflowEnvironmentImpl) encodeArg(arg interface{}) (*commonpb.Payload
 	return wc.GetDataConverter().ToPayloads(arg)
 }
 
-func (wc *workflowEnvironmentImpl) recordMutableSideEffect(id string, data *commonpb.Payloads) converter.EncodedValue {
+func (wc *workflowEnvironmentImpl) recordMutableSideEffect(id string, callCountHint int, data *commonpb.Payloads) converter.EncodedValue {
 	details, err := encodeArgs(wc.GetDataConverter(), []interface{}{id, data})
 	if err != nil {
 		panic(err)
 	}
-	wc.commandsHelper.recordMutableSideEffectMarker(id, details, wc.dataConverter)
-	wc.mutableSideEffect[id] = data
+	wc.commandsHelper.recordMutableSideEffectMarker(id, callCountHint, details, wc.dataConverter)
+	if wc.mutableSideEffect[id] == nil {
+		wc.mutableSideEffect[id] = make(map[int]*commonpb.Payloads)
+	}
+	wc.mutableSideEffect[id][callCountHint] = data
 	return newEncodedValue(data, wc.GetDataConverter())
 }
 
@@ -1311,7 +1356,20 @@ func (weh *workflowExecutionEventHandlerImpl) handleMarkerRecorded(
 				err = weh.dataConverter.FromPayloads(sideEffectDataPayload, &sideEffectDataID, &sideEffectDataContents)
 			}
 			if err == nil {
-				weh.mutableSideEffect[sideEffectDataID] = &sideEffectDataContents
+				counterHintPayload, ok := attributes.GetDetails()[mutableSideEffectCallCounterName]
+				var counterHint int
+				if ok {
+					err = weh.dataConverter.FromPayloads(counterHintPayload, &counterHint)
+				} else {
+					// An old version of the SDK did not write the counter hint so we have to assume.
+					// If multiple mutable side effects on the same ID are in a WFT only the last value is used.
+					counterHint = weh.mutableSideEffectCallCounter[sideEffectDataID]
+				}
+
+				if weh.mutableSideEffect[sideEffectDataID] == nil {
+					weh.mutableSideEffect[sideEffectDataID] = make(map[int]*commonpb.Payloads)
+				}
+				weh.mutableSideEffect[sideEffectDataID][counterHint] = &sideEffectDataContents
 				// We must mark that it is recorded so we can know whether a command
 				// needs to be generated during replay
 				if weh.mutableSideEffectsRecorded == nil {

--- a/test/replaytests/mutable-side-effect-legacy.json
+++ b/test/replaytests/mutable-side-effect-legacy.json
@@ -1,0 +1,436 @@
+{
+ "events": [
+  {
+   "eventId": "1",
+   "eventTime": "2023-02-27T15:49:36.778294674Z",
+   "eventType": "WorkflowExecutionStarted",
+   "taskId": "2097525",
+   "workflowExecutionStartedEventAttributes": {
+    "workflowType": {
+     "name": "MutableSideEffectWorkflow"
+    },
+    "taskQueue": {
+     "name": "replay-test",
+     "kind": "Normal"
+    },
+    "workflowExecutionTimeout": "0s",
+    "workflowRunTimeout": "0s",
+    "workflowTaskTimeout": "10s",
+    "originalExecutionRunId": "7361aca8-5876-43cb-b5a2-a626f7ce80ac",
+    "identity": "63909@Quinn-Klassens-MacBook-Pro.local@",
+    "firstExecutionRunId": "7361aca8-5876-43cb-b5a2-a626f7ce80ac",
+    "attempt": 1,
+    "firstWorkflowTaskBackoff": "0s",
+    "header": {
+
+    }
+   }
+  },
+  {
+   "eventId": "2",
+   "eventTime": "2023-02-27T15:49:36.778309174Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "2097526",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "replay-test",
+     "kind": "Normal"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "3",
+   "eventTime": "2023-02-27T15:49:36.786177299Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "2097533",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "2",
+    "identity": "63909@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "ba56ad01-21e2-4bd6-b45b-1470c8a04237"
+   }
+  },
+  {
+   "eventId": "4",
+   "eventTime": "2023-02-27T15:49:36.791056799Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "2097537",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "2",
+    "startedEventId": "3",
+    "identity": "63909@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "56a1bbb2bf8bca5865d3fdc89bb9d0e9"
+   }
+  },
+  {
+   "eventId": "5",
+   "eventTime": "2023-02-27T15:49:36.791069757Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "2097538",
+   "markerRecordedEventAttributes": {
+    "markerName": "MutableSideEffect",
+    "details": {
+     "data": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InNpZGUtZWZmZWN0LTEi"
+       },
+       {
+        "metadata": {
+         "encoding": "anNvbi9wcm90b2J1Zg==",
+         "messageType": "dGVtcG9yYWwuYXBpLmNvbW1vbi52MS5QYXlsb2Fkcw=="
+        },
+        "data": "eyJwYXlsb2FkcyI6W3sibWV0YWRhdGEiOnsiZW5jb2RpbmciOiJhbk52Ymk5d2JHRnBiZz09In0sImRhdGEiOiJNQT09In1dfQ=="
+       }
+      ]
+     },
+     "side-effect-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InNpZGUtZWZmZWN0LTFfNSI="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "4"
+   }
+  },
+  {
+   "eventId": "6",
+   "eventTime": "2023-02-27T15:49:36.791070341Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "2097539",
+   "markerRecordedEventAttributes": {
+    "markerName": "MutableSideEffect",
+    "details": {
+     "data": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InNpZGUtZWZmZWN0LTEi"
+       },
+       {
+        "metadata": {
+         "encoding": "anNvbi9wcm90b2J1Zg==",
+         "messageType": "dGVtcG9yYWwuYXBpLmNvbW1vbi52MS5QYXlsb2Fkcw=="
+        },
+        "data": "eyJwYXlsb2FkcyI6W3sibWV0YWRhdGEiOnsiZW5jb2RpbmciOiJhbk52Ymk5d2JHRnBiZz09In0sImRhdGEiOiJNUT09In1dfQ=="
+       }
+      ]
+     },
+     "side-effect-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InNpZGUtZWZmZWN0LTFfNiI="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "4"
+   }
+  },
+  {
+   "eventId": "7",
+   "eventTime": "2023-02-27T15:49:36.791070882Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "2097540",
+   "markerRecordedEventAttributes": {
+    "markerName": "MutableSideEffect",
+    "details": {
+     "data": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InNpZGUtZWZmZWN0LTEi"
+       },
+       {
+        "metadata": {
+         "encoding": "anNvbi9wcm90b2J1Zg==",
+         "messageType": "dGVtcG9yYWwuYXBpLmNvbW1vbi52MS5QYXlsb2Fkcw=="
+        },
+        "data": "eyJwYXlsb2FkcyI6W3sibWV0YWRhdGEiOnsiZW5jb2RpbmciOiJhbk52Ymk5d2JHRnBiZz09In0sImRhdGEiOiJNZz09In1dfQ=="
+       }
+      ]
+     },
+     "side-effect-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InNpZGUtZWZmZWN0LTFfNyI="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "4"
+   }
+  },
+  {
+   "eventId": "8",
+   "eventTime": "2023-02-27T15:49:36.791071841Z",
+   "eventType": "TimerStarted",
+   "taskId": "2097541",
+   "timerStartedEventAttributes": {
+    "timerId": "8",
+    "startToFireTimeout": "1s",
+    "workflowTaskCompletedEventId": "4"
+   }
+  },
+  {
+   "eventId": "9",
+   "eventTime": "2023-02-27T15:49:37.812912175Z",
+   "eventType": "TimerFired",
+   "taskId": "2097545",
+   "timerFiredEventAttributes": {
+    "timerId": "8",
+    "startedEventId": "8"
+   }
+  },
+  {
+   "eventId": "10",
+   "eventTime": "2023-02-27T15:49:37.812926675Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "2097546",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:827b909a-fe69-406f-bef5-e626b6786cb7",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "11",
+   "eventTime": "2023-02-27T15:49:37.822084758Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "2097550",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "10",
+    "identity": "63909@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "5d9f45d3-5ce0-4715-b29f-224aeb2b8a42"
+   }
+  },
+  {
+   "eventId": "12",
+   "eventTime": "2023-02-27T15:49:37.830171633Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "2097554",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "10",
+    "startedEventId": "11",
+    "identity": "63909@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "56a1bbb2bf8bca5865d3fdc89bb9d0e9"
+   }
+  },
+  {
+   "eventId": "13",
+   "eventTime": "2023-02-27T15:49:37.830182883Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "2097555",
+   "markerRecordedEventAttributes": {
+    "markerName": "MutableSideEffect",
+    "details": {
+     "data": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InNpZGUtZWZmZWN0LTEi"
+       },
+       {
+        "metadata": {
+         "encoding": "anNvbi9wcm90b2J1Zg==",
+         "messageType": "dGVtcG9yYWwuYXBpLmNvbW1vbi52MS5QYXlsb2Fkcw=="
+        },
+        "data": "eyJwYXlsb2FkcyI6W3sibWV0YWRhdGEiOnsiZW5jb2RpbmciOiJhbk52Ymk5d2JHRnBiZz09In0sImRhdGEiOiJNdz09In1dfQ=="
+       }
+      ]
+     },
+     "side-effect-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InNpZGUtZWZmZWN0LTFfMTMi"
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "12"
+   }
+  },
+  {
+   "eventId": "14",
+   "eventTime": "2023-02-27T15:49:37.830183966Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "2097556",
+   "markerRecordedEventAttributes": {
+    "markerName": "MutableSideEffect",
+    "details": {
+     "data": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InNpZGUtZWZmZWN0LTEi"
+       },
+       {
+        "metadata": {
+         "encoding": "anNvbi9wcm90b2J1Zg==",
+         "messageType": "dGVtcG9yYWwuYXBpLmNvbW1vbi52MS5QYXlsb2Fkcw=="
+        },
+        "data": "eyJwYXlsb2FkcyI6W3sibWV0YWRhdGEiOnsiZW5jb2RpbmciOiJhbk52Ymk5d2JHRnBiZz09In0sImRhdGEiOiJOQT09In1dfQ=="
+       }
+      ]
+     },
+     "side-effect-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InNpZGUtZWZmZWN0LTFfMTQi"
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "12"
+   }
+  },
+  {
+   "eventId": "15",
+   "eventTime": "2023-02-27T15:49:37.830185341Z",
+   "eventType": "TimerStarted",
+   "taskId": "2097557",
+   "timerStartedEventAttributes": {
+    "timerId": "15",
+    "startToFireTimeout": "1s",
+    "workflowTaskCompletedEventId": "12"
+   }
+  },
+  {
+   "eventId": "16",
+   "eventTime": "2023-02-27T15:49:38.844678675Z",
+   "eventType": "TimerFired",
+   "taskId": "2097560",
+   "timerFiredEventAttributes": {
+    "timerId": "15",
+    "startedEventId": "15"
+   }
+  },
+  {
+   "eventId": "17",
+   "eventTime": "2023-02-27T15:49:38.844703383Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "2097561",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:827b909a-fe69-406f-bef5-e626b6786cb7",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "18",
+   "eventTime": "2023-02-27T15:49:38.865545133Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "2097565",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "17",
+    "identity": "63909@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "2b438072-fd19-44a0-b81a-8f58e1aa4137"
+   }
+  },
+  {
+   "eventId": "19",
+   "eventTime": "2023-02-27T15:49:38.880684883Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "2097569",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "17",
+    "startedEventId": "18",
+    "identity": "63909@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "56a1bbb2bf8bca5865d3fdc89bb9d0e9"
+   }
+  },
+  {
+   "eventId": "20",
+   "eventTime": "2023-02-27T15:49:38.880702717Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "2097570",
+   "markerRecordedEventAttributes": {
+    "markerName": "MutableSideEffect",
+    "details": {
+     "data": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InNpZGUtZWZmZWN0LTEi"
+       },
+       {
+        "metadata": {
+         "encoding": "anNvbi9wcm90b2J1Zg==",
+         "messageType": "dGVtcG9yYWwuYXBpLmNvbW1vbi52MS5QYXlsb2Fkcw=="
+        },
+        "data": "eyJwYXlsb2FkcyI6W3sibWV0YWRhdGEiOnsiZW5jb2RpbmciOiJhbk52Ymk5d2JHRnBiZz09In0sImRhdGEiOiJOUT09In1dfQ=="
+       }
+      ]
+     },
+     "side-effect-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InNpZGUtZWZmZWN0LTFfMjAi"
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "19"
+   }
+  },
+  {
+   "eventId": "21",
+   "eventTime": "2023-02-27T15:49:38.880707342Z",
+   "eventType": "WorkflowExecutionCompleted",
+   "taskId": "2097571",
+   "workflowExecutionCompletedEventAttributes": {
+    "result": {
+     "payloads": [
+      {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg=="
+       },
+       "data": "WzAsMCwwLDEsMSwyLDMsMyw0LDQsNV0="
+      }
+     ]
+    },
+    "workflowTaskCompletedEventId": "19"
+   }
+  }
+ ]
+}

--- a/test/replaytests/mutable-side-effect.json
+++ b/test/replaytests/mutable-side-effect.json
@@ -1,0 +1,496 @@
+{
+ "events": [
+  {
+   "eventId": "1",
+   "eventTime": "2023-02-27T17:38:18.406830375Z",
+   "eventType": "WorkflowExecutionStarted",
+   "taskId": "2097952",
+   "workflowExecutionStartedEventAttributes": {
+    "workflowType": {
+     "name": "MutableSideEffectWorkflow"
+    },
+    "taskQueue": {
+     "name": "replay-test",
+     "kind": "Normal"
+    },
+    "workflowExecutionTimeout": "0s",
+    "workflowRunTimeout": "0s",
+    "workflowTaskTimeout": "10s",
+    "originalExecutionRunId": "945b4924-4af9-4ef6-886a-d78647fbd032",
+    "identity": "74340@Quinn-Klassens-MacBook-Pro.local@",
+    "firstExecutionRunId": "945b4924-4af9-4ef6-886a-d78647fbd032",
+    "attempt": 1,
+    "firstWorkflowTaskBackoff": "0s",
+    "header": {
+
+    }
+   }
+  },
+  {
+   "eventId": "2",
+   "eventTime": "2023-02-27T17:38:18.406847666Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "2097953",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "replay-test",
+     "kind": "Normal"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "3",
+   "eventTime": "2023-02-27T17:38:18.416057500Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "2097960",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "2",
+    "identity": "74340@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "dd08e552-5559-4b0c-9bf9-ee6359e08795"
+   }
+  },
+  {
+   "eventId": "4",
+   "eventTime": "2023-02-27T17:38:18.420992791Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "2097964",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "2",
+    "startedEventId": "3",
+    "identity": "74340@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "87a5052442d22c6648e7160baa96a782"
+   }
+  },
+  {
+   "eventId": "5",
+   "eventTime": "2023-02-27T17:38:18.421006916Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "2097965",
+   "markerRecordedEventAttributes": {
+    "markerName": "MutableSideEffect",
+    "details": {
+     "data": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InNpZGUtZWZmZWN0LTEi"
+       },
+       {
+        "metadata": {
+         "encoding": "anNvbi9wcm90b2J1Zg==",
+         "messageType": "dGVtcG9yYWwuYXBpLmNvbW1vbi52MS5QYXlsb2Fkcw=="
+        },
+        "data": "eyJwYXlsb2FkcyI6W3sibWV0YWRhdGEiOnsiZW5jb2RpbmciOiJhbk52Ymk5d2JHRnBiZz09In0sImRhdGEiOiJNQT09In1dfQ=="
+       }
+      ]
+     },
+     "mutable-side-effect-call-counter": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MQ=="
+       }
+      ]
+     },
+     "side-effect-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InNpZGUtZWZmZWN0LTFfNSI="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "4"
+   }
+  },
+  {
+   "eventId": "6",
+   "eventTime": "2023-02-27T17:38:18.421007666Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "2097966",
+   "markerRecordedEventAttributes": {
+    "markerName": "MutableSideEffect",
+    "details": {
+     "data": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InNpZGUtZWZmZWN0LTEi"
+       },
+       {
+        "metadata": {
+         "encoding": "anNvbi9wcm90b2J1Zg==",
+         "messageType": "dGVtcG9yYWwuYXBpLmNvbW1vbi52MS5QYXlsb2Fkcw=="
+        },
+        "data": "eyJwYXlsb2FkcyI6W3sibWV0YWRhdGEiOnsiZW5jb2RpbmciOiJhbk52Ymk5d2JHRnBiZz09In0sImRhdGEiOiJNUT09In1dfQ=="
+       }
+      ]
+     },
+     "mutable-side-effect-call-counter": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "NA=="
+       }
+      ]
+     },
+     "side-effect-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InNpZGUtZWZmZWN0LTFfNiI="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "4"
+   }
+  },
+  {
+   "eventId": "7",
+   "eventTime": "2023-02-27T17:38:18.421008208Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "2097967",
+   "markerRecordedEventAttributes": {
+    "markerName": "MutableSideEffect",
+    "details": {
+     "data": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InNpZGUtZWZmZWN0LTEi"
+       },
+       {
+        "metadata": {
+         "encoding": "anNvbi9wcm90b2J1Zg==",
+         "messageType": "dGVtcG9yYWwuYXBpLmNvbW1vbi52MS5QYXlsb2Fkcw=="
+        },
+        "data": "eyJwYXlsb2FkcyI6W3sibWV0YWRhdGEiOnsiZW5jb2RpbmciOiJhbk52Ymk5d2JHRnBiZz09In0sImRhdGEiOiJNZz09In1dfQ=="
+       }
+      ]
+     },
+     "mutable-side-effect-call-counter": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "Ng=="
+       }
+      ]
+     },
+     "side-effect-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InNpZGUtZWZmZWN0LTFfNyI="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "4"
+   }
+  },
+  {
+   "eventId": "8",
+   "eventTime": "2023-02-27T17:38:18.421009041Z",
+   "eventType": "TimerStarted",
+   "taskId": "2097968",
+   "timerStartedEventAttributes": {
+    "timerId": "8",
+    "startToFireTimeout": "1s",
+    "workflowTaskCompletedEventId": "4"
+   }
+  },
+  {
+   "eventId": "9",
+   "eventTime": "2023-02-27T17:38:19.422434292Z",
+   "eventType": "TimerFired",
+   "taskId": "2097972",
+   "timerFiredEventAttributes": {
+    "timerId": "8",
+    "startedEventId": "8"
+   }
+  },
+  {
+   "eventId": "10",
+   "eventTime": "2023-02-27T17:38:19.422439709Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "2097973",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:44a981a2-7655-4caa-ad9d-50ace79ef3f0",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "11",
+   "eventTime": "2023-02-27T17:38:19.430524Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "2097977",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "10",
+    "identity": "74340@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "d071f05f-e2b0-4692-877b-385d71d6273d"
+   }
+  },
+  {
+   "eventId": "12",
+   "eventTime": "2023-02-27T17:38:19.440257292Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "2097981",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "10",
+    "startedEventId": "11",
+    "identity": "74340@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "87a5052442d22c6648e7160baa96a782"
+   }
+  },
+  {
+   "eventId": "13",
+   "eventTime": "2023-02-27T17:38:19.440266709Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "2097982",
+   "markerRecordedEventAttributes": {
+    "markerName": "MutableSideEffect",
+    "details": {
+     "data": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InNpZGUtZWZmZWN0LTEi"
+       },
+       {
+        "metadata": {
+         "encoding": "anNvbi9wcm90b2J1Zg==",
+         "messageType": "dGVtcG9yYWwuYXBpLmNvbW1vbi52MS5QYXlsb2Fkcw=="
+        },
+        "data": "eyJwYXlsb2FkcyI6W3sibWV0YWRhdGEiOnsiZW5jb2RpbmciOiJhbk52Ymk5d2JHRnBiZz09In0sImRhdGEiOiJNdz09In1dfQ=="
+       }
+      ]
+     },
+     "mutable-side-effect-call-counter": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "Nw=="
+       }
+      ]
+     },
+     "side-effect-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InNpZGUtZWZmZWN0LTFfMTMi"
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "12"
+   }
+  },
+  {
+   "eventId": "14",
+   "eventTime": "2023-02-27T17:38:19.440267625Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "2097983",
+   "markerRecordedEventAttributes": {
+    "markerName": "MutableSideEffect",
+    "details": {
+     "data": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InNpZGUtZWZmZWN0LTEi"
+       },
+       {
+        "metadata": {
+         "encoding": "anNvbi9wcm90b2J1Zg==",
+         "messageType": "dGVtcG9yYWwuYXBpLmNvbW1vbi52MS5QYXlsb2Fkcw=="
+        },
+        "data": "eyJwYXlsb2FkcyI6W3sibWV0YWRhdGEiOnsiZW5jb2RpbmciOiJhbk52Ymk5d2JHRnBiZz09In0sImRhdGEiOiJOQT09In1dfQ=="
+       }
+      ]
+     },
+     "mutable-side-effect-call-counter": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "OQ=="
+       }
+      ]
+     },
+     "side-effect-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InNpZGUtZWZmZWN0LTFfMTQi"
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "12"
+   }
+  },
+  {
+   "eventId": "15",
+   "eventTime": "2023-02-27T17:38:19.440268917Z",
+   "eventType": "TimerStarted",
+   "taskId": "2097984",
+   "timerStartedEventAttributes": {
+    "timerId": "15",
+    "startToFireTimeout": "1s",
+    "workflowTaskCompletedEventId": "12"
+   }
+  },
+  {
+   "eventId": "16",
+   "eventTime": "2023-02-27T17:38:20.461986584Z",
+   "eventType": "TimerFired",
+   "taskId": "2097987",
+   "timerFiredEventAttributes": {
+    "timerId": "15",
+    "startedEventId": "15"
+   }
+  },
+  {
+   "eventId": "17",
+   "eventTime": "2023-02-27T17:38:20.461992876Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "2097988",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:44a981a2-7655-4caa-ad9d-50ace79ef3f0",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "18",
+   "eventTime": "2023-02-27T17:38:20.469852459Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "2097992",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "17",
+    "identity": "74340@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "fa94b5bf-b939-4061-bd4d-c0fca9f1b8f3"
+   }
+  },
+  {
+   "eventId": "19",
+   "eventTime": "2023-02-27T17:38:20.479404542Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "2097996",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "17",
+    "startedEventId": "18",
+    "identity": "74340@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "87a5052442d22c6648e7160baa96a782"
+   }
+  },
+  {
+   "eventId": "20",
+   "eventTime": "2023-02-27T17:38:20.479416167Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "2097997",
+   "markerRecordedEventAttributes": {
+    "markerName": "MutableSideEffect",
+    "details": {
+     "data": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InNpZGUtZWZmZWN0LTEi"
+       },
+       {
+        "metadata": {
+         "encoding": "anNvbi9wcm90b2J1Zg==",
+         "messageType": "dGVtcG9yYWwuYXBpLmNvbW1vbi52MS5QYXlsb2Fkcw=="
+        },
+        "data": "eyJwYXlsb2FkcyI6W3sibWV0YWRhdGEiOnsiZW5jb2RpbmciOiJhbk52Ymk5d2JHRnBiZz09In0sImRhdGEiOiJOUT09In1dfQ=="
+       }
+      ]
+     },
+     "mutable-side-effect-call-counter": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MTE="
+       }
+      ]
+     },
+     "side-effect-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InNpZGUtZWZmZWN0LTFfMjAi"
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "19"
+   }
+  },
+  {
+   "eventId": "21",
+   "eventTime": "2023-02-27T17:38:20.479418459Z",
+   "eventType": "WorkflowExecutionCompleted",
+   "taskId": "2097998",
+   "workflowExecutionCompletedEventAttributes": {
+    "result": {
+     "payloads": [
+      {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg=="
+       },
+       "data": "WzAsMCwwLDEsMSwyLDMsMyw0LDQsNV0="
+      }
+     ]
+    },
+    "workflowTaskCompletedEventId": "19"
+   }
+  }
+ ]
+}

--- a/test/replaytests/replay_test.go
+++ b/test/replaytests/replay_test.go
@@ -36,6 +36,7 @@ import (
 	"go.temporal.io/api/workflowservicemock/v1"
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/converter"
+	"go.temporal.io/sdk/internal"
 	ilog "go.temporal.io/sdk/internal/log"
 	"go.temporal.io/sdk/worker"
 )
@@ -253,7 +254,7 @@ func (s *replayTestSuite) TestMutableSideEffectLegacyWorkflow() {
 	err := replayer.ReplayWorkflowHistoryFromJSONFile(ilog.NewDefaultLogger(), "mutable-side-effect-legacy.json")
 	require.NoError(s.T(), err)
 	var result []int
-	require.NoError(s.T(), replayer.GetWorkflowResult("ReplayId", &result))
+	require.NoError(s.T(), replayer.(*internal.WorkflowReplayer).GetWorkflowResult("ReplayId", &result))
 	require.Equal(s.T(), []int{2, 2, 2, 2, 2, 2, 4, 4, 4, 5, 5}, result)
 }
 
@@ -264,7 +265,7 @@ func (s *replayTestSuite) TestMutableSideEffectWorkflow() {
 	err := replayer.ReplayWorkflowHistoryFromJSONFile(ilog.NewDefaultLogger(), "mutable-side-effect.json")
 	require.NoError(s.T(), err)
 	var result []int
-	require.NoError(s.T(), replayer.GetWorkflowResult("ReplayId", &result))
+	require.NoError(s.T(), replayer.(*internal.WorkflowReplayer).GetWorkflowResult("ReplayId", &result))
 	require.Equal(s.T(), []int{0, 0, 0, 1, 1, 2, 3, 3, 4, 4, 5}, result)
 }
 

--- a/test/workflow_test.go
+++ b/test/workflow_test.go
@@ -2015,6 +2015,9 @@ func (w *Workflows) MutableSideEffect(ctx workflow.Context, startVal int) (currV
 			func(ctx workflow.Context) interface{} { return retVal },
 			func(a, b interface{}) bool { return a.(int) == b.(int) },
 		).Get(&newVal)
+		if retVal != newVal {
+			log.Panicf("MutableSideEffect did not return expected value %d == %d", retVal, newVal)
+		}
 		return
 	}
 	// Make several mutable side effect calls, some that change the data, some

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -199,6 +199,12 @@ type (
 		// The logger is the only optional parameter. Defaults to the noop logger. The Run ID and Workflow ID used during replay are derived
 		// from execution.
 		ReplayWorkflowExecution(ctx context.Context, service workflowservice.WorkflowServiceClient, logger log.Logger, namespace string, execution workflow.Execution) error
+
+		// GetWorkflowResult gets the result from a succesfully replayed workflow that finished with WorkflowExecutionCompleted.
+		// WorkflowID is optional and defaults to ReplayId.
+		//
+		// Note: For all replay functions if no WorkflowID is given for replay the default is ReplayId.
+		GetWorkflowResult(workflowID string, valuePtr interface{}) error
 	}
 
 	// Options is used to configure a worker instance.

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -199,12 +199,6 @@ type (
 		// The logger is the only optional parameter. Defaults to the noop logger. The Run ID and Workflow ID used during replay are derived
 		// from execution.
 		ReplayWorkflowExecution(ctx context.Context, service workflowservice.WorkflowServiceClient, logger log.Logger, namespace string, execution workflow.Execution) error
-
-		// GetWorkflowResult gets the result from a succesfully replayed workflow that finished with WorkflowExecutionCompleted.
-		// WorkflowID is optional and defaults to ReplayId.
-		//
-		// Note: For all replay functions if no WorkflowID is given for replay the default is ReplayId.
-		GetWorkflowResult(workflowID string, valuePtr interface{}) error
 	}
 
 	// Options is used to configure a worker instance.


### PR DESCRIPTION
Track how many times a mutable side effect is called to distinguish multiple `MutableSIdeEffect` calls in the same WFT.

I'll note this PR wont help existing histories that executed multiple `MutableSIdeEffect` in the same WFT. If we also use the `CommandID` to help distinguish multiple calls. The could help certain histories replay correctly. The trade off is an even more complex implementation. There will always be some histories that we cannot save because the SDK did not write enough information to history

Resolves: https://github.com/temporalio/sdk-go/issues/1014