### PR TITLE
Lookahead to infer messages on all replay paths

### DIFF
--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -665,6 +665,7 @@ func (w *workflowExecutionContextImpl) resetStateIfDestroyed(task *workflowservi
 				return err
 			}
 		}
+		task.Messages = inferMessages(task.GetHistory().GetEvents())
 		if w.workflowInfo != nil {
 			// Reset the search attributes and memos from the WorkflowExecutionStartedEvent.
 			// The search attributes and memo may have been modified by calls like UpsertMemo


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Include lookahead message inference on this path to workflow state rebuilding

## Why?
<!-- Tell your future self why have you made these changes -->
Without inference, updates are not replayed

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

#1044 

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

New unit test here.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
No