### PR TITLE
Add FrontendHostPort method to DevServer

### DIFF
--- a/testsuite/devserver.go
+++ b/testsuite/devserver.go
@@ -82,8 +82,9 @@ type DevServerOptions struct {
 
 // Temporal CLI based DevServer
 type DevServer struct {
-	cmd    *exec.Cmd
-	client client.Client
+	cmd              *exec.Cmd
+	client           client.Client
+	frontendHostPort string
 }
 
 // StartDevServer starts a Temporal CLI dev server process. This may download the server if not already downloaded.
@@ -121,7 +122,11 @@ func StartDevServer(ctx context.Context, options DevServerOptions) (*DevServer, 
 		return nil, err
 	}
 	clientOptions.Logger.Info("DevServer ready")
-	return &DevServer{client: returnedClient, cmd: cmd}, nil
+	return &DevServer{
+		client:           returnedClient,
+		cmd:              cmd,
+		frontendHostPort: clientOptions.HostPort,
+	}, nil
 }
 
 func prepareCommand(options *DevServerOptions, host, port, namespace string) []string {
@@ -365,4 +370,9 @@ func (s *DevServer) Stop() error {
 // Get a connected client, configured to work with the dev server.
 func (s *DevServer) Client() client.Client {
 	return s.client
+}
+
+// FrontendHostPort returns the host:port for this server.
+func (s *DevServer) FrontendHostPort() string {
+	return s.frontendHostPort
 }

--- a/testsuite/devserver_test.go
+++ b/testsuite/devserver_test.go
@@ -58,3 +58,15 @@ func TestStartDevServer_CustomNamespace(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "testing", info.NamespaceInfo.Name)
 }
+
+func TestStartDevServer_FrontendHostPort(t *testing.T) {
+	server, err := testsuite.StartDevServer(context.Background(), testsuite.DevServerOptions{})
+	require.NoError(t, err)
+	defer func() { _ = server.Stop() }()
+	hostPort := server.FrontendHostPort()
+	client, err := client.Dial(client.Options{HostPort: hostPort})
+	require.NoError(t, err)
+	info, err := client.WorkflowService().GetSystemInfo(context.Background(), &workflowservice.GetSystemInfoRequest{})
+	require.NoError(t, err)
+	require.NotNil(t, info.Capabilities)
+}


### PR DESCRIPTION
## What was changed

Added a new `FrontendHostPort` method to `testsuite.DevServer` that returns the `host:port` to the dev server, similar to Temporalite ([here](https://github.com/temporalio/temporalite/blob/2df426ad3426fb6ecc91d3b2e03274018bf14721/server.go#L158-L164)).

## Why?

This would be useful when the client.Client can't be shared with the unit being tested, e.g. a Command struct that only accepts os.Args, environment strings or other form of configuration.