### PR TITLE
Fix DevServer tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ BUILD := .build
 TEST_TIMEOUT := 5m
 TEST_ARG ?= -race -v -timeout $(TEST_TIMEOUT)
 
-INTEG_TEST_ROOT := ./test
+INTEG_TEST_ROOT := ./test/
 COVER_ROOT := $(abspath $(BUILD)/coverage)
 UT_COVER_FILE := $(COVER_ROOT)/unit_test_cover.out
 INTEG_ZERO_CACHE_COVER_FILE := $(COVER_ROOT)/integ_test_zero_cache_cover.out

--- a/testsuite/devserver_test.go
+++ b/testsuite/devserver_test.go
@@ -35,7 +35,7 @@ import (
 func TestStartDevServer_Defaults(t *testing.T) {
 	server, err := testsuite.StartDevServer(context.Background(), testsuite.DevServerOptions{})
 	require.NoError(t, err)
-	defer require.NoError(t, server.Stop())
+	defer func() { _ = server.Stop() }()
 	info, err := server.Client().WorkflowService().GetSystemInfo(context.Background(), &workflowservice.GetSystemInfoRequest{})
 	require.NoError(t, err)
 	require.NotNil(t, info.Capabilities)
@@ -44,7 +44,7 @@ func TestStartDevServer_Defaults(t *testing.T) {
 func TestStartDevServer_SpecificVersion(t *testing.T) {
 	server, err := testsuite.StartDevServer(context.Background(), testsuite.DevServerOptions{CachedDownload: testsuite.CachedDownload{Version: "v0.3.0"}})
 	require.NoError(t, err)
-	defer require.NoError(t, server.Stop())
+	defer func() { _ = server.Stop() }()
 	info, err := server.Client().WorkflowService().GetSystemInfo(context.Background(), &workflowservice.GetSystemInfoRequest{})
 	require.NoError(t, err)
 	require.NotNil(t, info.Capabilities)
@@ -53,7 +53,7 @@ func TestStartDevServer_SpecificVersion(t *testing.T) {
 func TestStartDevServer_CustomNamespace(t *testing.T) {
 	server, err := testsuite.StartDevServer(context.Background(), testsuite.DevServerOptions{ClientOptions: &client.Options{Namespace: "testing"}})
 	require.NoError(t, err)
-	defer require.NoError(t, server.Stop())
+	defer func() { _ = server.Stop() }()
 	info, err := server.Client().WorkflowService().DescribeNamespace(context.Background(), &workflowservice.DescribeNamespaceRequest{Namespace: "testing"})
 	require.NoError(t, err)
 	require.Equal(t, "testing", info.NamespaceInfo.Name)


### PR DESCRIPTION
## What was changed
- Included testsuite/*_test.go in UT_DIRS (`make unit-test`), and
- Ignored error returned by Stop() until https://github.com/temporalio/cli/issues/175 is addressed.