### PR TITLE
Async Update Polling

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -172,10 +172,10 @@ type (
 	// NOTE: Experimental
 	WorkflowUpdateHandle = internal.WorkflowUpdateHandle
 
-	// WorkflowUpdateRef encapsulates the parameters needed to unambiguously
+	// GetWorkflowUpdateHandleOptions encapsulates the parameters needed to unambiguously
 	// refer to a Workflow Update
 	// NOTE: Experimental
-	WorkflowUpdateRef = internal.WorkflowUpdateRef
+	GetWorkflowUpdateHandleOptions = internal.GetWorkflowUpdateHandleOptions
 
 	// UpdateWorkerBuildIdCompatibilityOptions is the input to Client.UpdateWorkerBuildIdCompatibility.
 	// NOTE: Experimental
@@ -512,7 +512,7 @@ type (
 		// which can be polled for an outcome. Note that runID is optional and
 		// if not specified the most recent runID will be used.
 		// NOTE: Experimental
-		GetWorkflowUpdateHandle(ref WorkflowUpdateRef) WorkflowUpdateHandle
+		GetWorkflowUpdateHandle(ref GetWorkflowUpdateHandleOptions) WorkflowUpdateHandle
 
 		// WorkflowService provides access to the underlying gRPC service. This should only be used for advanced use cases
 		// that cannot be accomplished via other Client methods. Unlike calls to other Client methods, calls directly to the

--- a/client/client.go
+++ b/client/client.go
@@ -23,7 +23,6 @@
 // THE SOFTWARE.
 
 //go:generate mockgen -copyright_file ../LICENSE -package client -source client.go -destination client_mock.go
-//go:generate go run ../internal/cmd/generateproxy/main.go
 
 // Package client is used by external programs to communicate with Temporal service.
 // NOTE: DO NOT USE THIS API INSIDE OF ANY WORKFLOW CODE!!!

--- a/client/client.go
+++ b/client/client.go
@@ -172,8 +172,8 @@ type (
 	// NOTE: Experimental
 	WorkflowUpdateHandle = internal.WorkflowUpdateHandle
 
-	// WorkflowUpdateRef reflects the fields needed to refer to a workflow
-	// update.
+	// WorkflowUpdateRef encapsulates the parameters needed to unambiguously
+	// refer to a Workflow Update
 	// NOTE: Experimental
 	WorkflowUpdateRef = internal.WorkflowUpdateRef
 
@@ -508,10 +508,11 @@ type (
 		// NOTE: Experimental
 		UpdateWorkflowWithOptions(ctx context.Context, request *UpdateWorkflowWithOptionsRequest) (WorkflowUpdateHandle, error)
 
-		// WorkflowUpdateHandleFromRef creates a handle to the referenced update
-		// which can be polled for an outcome.
+		// GetWorkflowUpdateHandle creates a handle to the referenced update
+		// which can be polled for an outcome. Note that runID is optional and
+		// if not specified the most recent runID will be used.
 		// NOTE: Experimental
-		WorkflowUpdateHandleFromRef(ref WorkflowUpdateRef) WorkflowUpdateHandle
+		GetWorkflowUpdateHandle(ref WorkflowUpdateRef) WorkflowUpdateHandle
 
 		// WorkflowService provides access to the underlying gRPC service. This should only be used for advanced use cases
 		// that cannot be accomplished via other Client methods. Unlike calls to other Client methods, calls directly to the

--- a/client/client.go
+++ b/client/client.go
@@ -172,6 +172,11 @@ type (
 	// NOTE: Experimental
 	WorkflowUpdateHandle = internal.WorkflowUpdateHandle
 
+	// WorkflowUpdateRef reflects the fields needed to refer to a workflow
+	// update.
+	// NOTE: Experimental
+	WorkflowUpdateRef = internal.WorkflowUpdateRef
+
 	// UpdateWorkerBuildIdCompatibilityOptions is the input to Client.UpdateWorkerBuildIdCompatibility.
 	// NOTE: Experimental
 	UpdateWorkerBuildIdCompatibilityOptions = internal.UpdateWorkerBuildIdCompatibilityOptions
@@ -502,6 +507,11 @@ type (
 		// directly from this function call.
 		// NOTE: Experimental
 		UpdateWorkflowWithOptions(ctx context.Context, request *UpdateWorkflowWithOptionsRequest) (WorkflowUpdateHandle, error)
+
+		// WorkflowUpdateHandleFromRef creates a handle to the referenced update
+		// which can be polled for an outcome.
+		// NOTE: Experimental
+		WorkflowUpdateHandleFromRef(ref WorkflowUpdateRef) WorkflowUpdateHandle
 
 		// WorkflowService provides access to the underlying gRPC service. This should only be used for advanced use cases
 		// that cannot be accomplished via other Client methods. Unlike calls to other Client methods, calls directly to the

--- a/converter/codec.go
+++ b/converter/codec.go
@@ -20,8 +20,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-//go:generate go run ../internal/cmd/generateinterceptor/main.go
-
 package converter
 
 import (

--- a/internal/client.go
+++ b/internal/client.go
@@ -367,6 +367,11 @@ type (
 		// NOTE: Experimental
 		UpdateWorkflowWithOptions(ctx context.Context, request *UpdateWorkflowWithOptionsRequest) (WorkflowUpdateHandle, error)
 
+		// WorkflowUpdateHandleFromRef creates a handle to the referenced update
+		// which can be polled for an outcome.
+		// NOTE: Experimental
+		WorkflowUpdateHandleFromRef(ref WorkflowUpdateRef) WorkflowUpdateHandle
+
 		// WorkflowService provides access to the underlying gRPC service. This should only be used for advanced use cases
 		// that cannot be accomplished via other Client methods. Unlike calls to other Client methods, calls directly to the
 		// service are not configured with internal semantics such as automatic retries.

--- a/internal/client.go
+++ b/internal/client.go
@@ -371,7 +371,7 @@ type (
 		// which can be polled for an outcome. Note that runID is optional and
 		// if not specified the most recent runID will be used.
 		// NOTE: Experimental
-		GetWorkflowUpdateHandle(WorkflowUpdateRef) WorkflowUpdateHandle
+		GetWorkflowUpdateHandle(GetWorkflowUpdateHandleOptions) WorkflowUpdateHandle
 
 		// WorkflowService provides access to the underlying gRPC service. This should only be used for advanced use cases
 		// that cannot be accomplished via other Client methods. Unlike calls to other Client methods, calls directly to the

--- a/internal/client.go
+++ b/internal/client.go
@@ -367,10 +367,11 @@ type (
 		// NOTE: Experimental
 		UpdateWorkflowWithOptions(ctx context.Context, request *UpdateWorkflowWithOptionsRequest) (WorkflowUpdateHandle, error)
 
-		// WorkflowUpdateHandleFromRef creates a handle to the referenced update
-		// which can be polled for an outcome.
+		// GetWorkflowUpdateHandle creates a handle to the referenced update
+		// which can be polled for an outcome. Note that runID is optional and
+		// if not specified the most recent runID will be used.
 		// NOTE: Experimental
-		WorkflowUpdateHandleFromRef(ref WorkflowUpdateRef) WorkflowUpdateHandle
+		GetWorkflowUpdateHandle(WorkflowUpdateRef) WorkflowUpdateHandle
 
 		// WorkflowService provides access to the underlying gRPC service. This should only be used for advanced use cases
 		// that cannot be accomplished via other Client methods. Unlike calls to other Client methods, calls directly to the

--- a/internal/interceptor.go
+++ b/internal/interceptor.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	commonpb "go.temporal.io/api/common/v1"
+	updatepb "go.temporal.io/api/update/v1"
 	"go.temporal.io/sdk/converter"
 	"go.temporal.io/sdk/internal/common/metrics"
 	"go.temporal.io/sdk/log"
@@ -308,6 +309,12 @@ type ClientOutboundInterceptor interface {
 	// NOTE: Experimental
 	UpdateWorkflow(context.Context, *ClientUpdateWorkflowInput) (WorkflowUpdateHandle, error)
 
+	// PollWorkflowUpdate requests the outcome of a specific update from the
+	// server.
+	//
+	// NOTE: Experimental
+	PollWorkflowUpdate(context.Context, *ClientPollWorkflowUpdateInput) (converter.EncodedValue, error)
+
 	mustEmbedClientOutboundInterceptorBase()
 }
 
@@ -322,9 +329,13 @@ type ClientUpdateWorkflowInput struct {
 	Args                []interface{}
 	RunID               string
 	FirstExecutionRunID string
+	WaitPolicy          *updatepb.WaitPolicy
+}
 
-	// this isn't upstream in API yet
-	// WaitFor enumspb.WorkflowExecutionUpdateWaitEvent
+// ClientPollWorkflowUpdateInput is the input to
+// ClientOutboundInterceptor.PollWorkflowUpdate.
+type ClientPollWorkflowUpdateInput struct {
+	UpdateRef *updatepb.UpdateRef
 }
 
 // ScheduleClientCreateInput is the input to

--- a/internal/interceptor_base.go
+++ b/internal/interceptor_base.go
@@ -396,6 +396,13 @@ func (c *ClientOutboundInterceptorBase) UpdateWorkflow(
 	return c.Next.UpdateWorkflow(ctx, in)
 }
 
+func (c *ClientOutboundInterceptorBase) PollWorkflowUpdate(
+	ctx context.Context,
+	in *ClientPollWorkflowUpdateInput,
+) (converter.EncodedValue, error) {
+	return c.Next.PollWorkflowUpdate(ctx, in)
+}
+
 // ExecuteWorkflow implements ClientOutboundInterceptor.ExecuteWorkflow.
 func (c *ClientOutboundInterceptorBase) ExecuteWorkflow(
 	ctx context.Context,

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -792,10 +792,10 @@ type WorkflowUpdateHandle interface {
 	Get(ctx context.Context, valuePtr interface{}) error
 }
 
-// WorkflowUpdateRef encapsulates the parameters needed to unambiguously
+// GetWorkflowUpdateHandleOptions encapsulates the parameters needed to unambiguously
 // refer to a Workflow Update.
 // NOTE: Experimental
-type WorkflowUpdateRef struct {
+type GetWorkflowUpdateHandleOptions struct {
 	// WorkflowID of the target update
 	WorkflowID string
 
@@ -1035,7 +1035,7 @@ func (wc *WorkflowClient) UpdateWorkflowWithOptions(
 	})
 }
 
-func (wc *WorkflowClient) GetWorkflowUpdateHandle(ref WorkflowUpdateRef) WorkflowUpdateHandle {
+func (wc *WorkflowClient) GetWorkflowUpdateHandle(ref GetWorkflowUpdateHandleOptions) WorkflowUpdateHandle {
 	return &lazyUpdateHandle{
 		client: wc,
 		baseUpdateHandle: baseUpdateHandle{

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -1816,7 +1816,9 @@ func (w *workflowClientInterceptor) PollWorkflowUpdate(
 		)
 		resp, err := w.client.workflowService.PollWorkflowExecutionUpdate(ctx, &pollReq)
 		cancel()
-		if err == context.DeadlineExceeded || status.Code(err) == codes.DeadlineExceeded {
+		if err == context.DeadlineExceeded ||
+			status.Code(err) == codes.DeadlineExceeded ||
+			(err == nil && resp.GetOutcome() == nil) {
 			continue
 		}
 		if err != nil {

--- a/mocks/Client.go
+++ b/mocks/Client.go
@@ -623,6 +623,19 @@ func (_m *Client) UpdateWorkflowWithOptions(ctx context.Context, req *client.Upd
 	return r0, r1
 }
 
+func (_m *Client) WorkflowUpdateHandleFromRef(ref client.WorkflowUpdateRef) client.WorkflowUpdateHandle {
+	ret := _m.Called(ref)
+
+	if rf, ok := ret.Get(0).(func(client.WorkflowUpdateRef) client.WorkflowUpdateHandle); ok {
+		return rf(ref)
+	} else {
+		if ret.Get(0) != nil {
+			return ret.Get(0).(client.WorkflowUpdateHandle)
+		}
+	}
+	return nil
+}
+
 // WorkflowService provides a mock function with given fields:
 func (_m *Client) WorkflowService() workflowservice.WorkflowServiceClient {
 	ret := _m.Called()

--- a/mocks/Client.go
+++ b/mocks/Client.go
@@ -623,7 +623,7 @@ func (_m *Client) UpdateWorkflowWithOptions(ctx context.Context, req *client.Upd
 	return r0, r1
 }
 
-func (_m *Client) WorkflowUpdateHandleFromRef(ref client.WorkflowUpdateRef) client.WorkflowUpdateHandle {
+func (_m *Client) GetWorkflowUpdateHandle(ref client.WorkflowUpdateRef) client.WorkflowUpdateHandle {
 	ret := _m.Called(ref)
 
 	if rf, ok := ret.Get(0).(func(client.WorkflowUpdateRef) client.WorkflowUpdateHandle); ok {

--- a/mocks/Client.go
+++ b/mocks/Client.go
@@ -623,10 +623,10 @@ func (_m *Client) UpdateWorkflowWithOptions(ctx context.Context, req *client.Upd
 	return r0, r1
 }
 
-func (_m *Client) GetWorkflowUpdateHandle(ref client.WorkflowUpdateRef) client.WorkflowUpdateHandle {
+func (_m *Client) GetWorkflowUpdateHandle(ref client.GetWorkflowUpdateHandleOptions) client.WorkflowUpdateHandle {
 	ret := _m.Called(ref)
 
-	if rf, ok := ret.Get(0).(func(client.WorkflowUpdateRef) client.WorkflowUpdateHandle); ok {
+	if rf, ok := ret.Get(0).(func(client.GetWorkflowUpdateHandleOptions) client.WorkflowUpdateHandle); ok {
 		return rf(ref)
 	} else {
 		if ret.Get(0) != nil {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Adds support for async updates
- A WorkflowUpdateHandle implementation that runs a poll RPC as part of the call to Get
- Add PollWorkflowUpdate to the client and the interceptor layers
- The ability to "rehydrate" an update reference into a handle 

## Why?
<!-- Tell your future self why have you made these changes -->
Planned feature

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Unit tests here and a succeeding feature test that is waiting on this PR and an server PR

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
