### PR TITLE
Exposing WorkflowExecution Started Event attributes on the Workflow Info

### DIFF
--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -573,11 +573,11 @@ func (wth *workflowTaskHandlerImpl) createWorkflowContext(task *workflowservice.
 	}
 	workflowInfo := &WorkflowInfo{
 		WorkflowExecution: WorkflowExecution{
-			ID:            workflowID,
-			RunID:         runID,
-			OriginalRunID: attributes.OriginalExecutionRunId,
-			FirstRunID:    attributes.FirstExecutionRunId,
+			ID:    workflowID,
+			RunID: runID,
 		},
+		OriginalRunID:            attributes.OriginalExecutionRunId,
+		FirstRunID:               attributes.FirstExecutionRunId,
 		WorkflowType:             WorkflowType{Name: task.WorkflowType.GetName()},
 		TaskQueueName:            taskQueue.GetName(),
 		WorkflowExecutionTimeout: common.DurationValue(attributes.GetWorkflowExecutionTimeout()),

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -573,8 +573,10 @@ func (wth *workflowTaskHandlerImpl) createWorkflowContext(task *workflowservice.
 	}
 	workflowInfo := &WorkflowInfo{
 		WorkflowExecution: WorkflowExecution{
-			ID:    workflowID,
-			RunID: runID,
+			ID:            workflowID,
+			RunID:         runID,
+			OriginalRunID: attributes.OriginalExecutionRunId,
+			FirstRunID:    attributes.FirstExecutionRunId,
 		},
 		WorkflowType:             WorkflowType{Name: task.WorkflowType.GetName()},
 		TaskQueueName:            taskQueue.GetName(),

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -944,9 +944,11 @@ func (wc *workflowEnvironmentInterceptor) ExecuteChildWorkflow(ctx Context, chil
 
 // WorkflowInfo information about currently executing workflow
 type WorkflowInfo struct {
-	WorkflowExecution        WorkflowExecution
-	OriginalRunID            string // The original runID before resetting. Using it instead of current runID can make workflow decision determinstic after reset. See also FirstRunId
-	FirstRunID               string // The very first original RunId of the current Workflow Execution preserved along the chain of ContinueAsNew, Retry, Cron and Reset. Identifies the whole Runs chain of Workflow Execution.
+	WorkflowExecution WorkflowExecution
+	// The original runID before resetting. Using it instead of current runID can make workflow decision deterministic after reset. See also FirstRunId
+	OriginalRunID string
+	// The very first original RunId of the current Workflow Execution preserved along the chain of ContinueAsNew, Retry, Cron and Reset. Identifies the whole Runs chain of Workflow Execution.
+	FirstRunID               string
 	WorkflowType             WorkflowType
 	TaskQueueName            string
 	WorkflowExecutionTimeout time.Duration

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -211,10 +211,8 @@ type (
 
 	// WorkflowExecution details.
 	WorkflowExecution struct {
-		ID            string
-		RunID         string
-		OriginalRunID string // The original runID before resetting. Using it instead of current runID can make workflow decision determinstic after reset. See also FirstRunId
-		FirstRunID    string // The very first original RunId of the current Workflow Execution preserved along the chain of ContinueAsNew, Retry, Cron and Reset. Identifies the whole Runs chain of Workflow Execution.
+		ID    string
+		RunID string
 	}
 
 	// EncodedValue is type used to encapsulate/extract encoded result from workflow/activity.
@@ -947,6 +945,8 @@ func (wc *workflowEnvironmentInterceptor) ExecuteChildWorkflow(ctx Context, chil
 // WorkflowInfo information about currently executing workflow
 type WorkflowInfo struct {
 	WorkflowExecution        WorkflowExecution
+	OriginalRunID            string // The original runID before resetting. Using it instead of current runID can make workflow decision determinstic after reset. See also FirstRunId
+	FirstRunID               string // The very first original RunId of the current Workflow Execution preserved along the chain of ContinueAsNew, Retry, Cron and Reset. Identifies the whole Runs chain of Workflow Execution.
 	WorkflowType             WorkflowType
 	TaskQueueName            string
 	WorkflowExecutionTimeout time.Duration

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -211,8 +211,10 @@ type (
 
 	// WorkflowExecution details.
 	WorkflowExecution struct {
-		ID    string
-		RunID string
+		ID            string
+		RunID         string
+		OriginalRunID string // The original runID before resetting. Using it instead of current runID can make workflow decision determinstic after reset. See also FirstRunId
+		FirstRunID    string // The very first original RunId of the current Workflow Execution preserved along the chain of ContinueAsNew, Retry, Cron and Reset. Identifies the whole Runs chain of Workflow Execution.
 	}
 
 	// EncodedValue is type used to encapsulate/extract encoded result from workflow/activity.


### PR DESCRIPTION
## What was changed

This pull requests address issue #1087 to expose additional fields from the WorkflowExecutionStartedEvent into the SDK
 
<!-- Describe what has changed in this PR -->

## Why?
It was a missing feature that the Java SDK already implemented, and that is implemented in Cadence.


## Checklist

- [] Add unit tests
<!--- add/delete as needed --->

1. Closes #1087 

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

Not tested

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

Comments describing the fields should be good