### PR TITLE
Error on Registering Activity with Workflow Context

### DIFF
--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -723,6 +723,15 @@ func validateFnFormat(fnType reflect.Type, isWorkflow bool) error {
 		if !isWorkflowContext(fnType.In(0)) {
 			return fmt.Errorf("expected first argument to be workflow.Context but found %s", fnType.In(0))
 		}
+	} else {
+		// For activities, check that workflow context is not accidentally provided
+		// Activities registered with structs will have their receiver as the first argument so confirm it is not
+		// in the first two arguments
+		for i := 0; i < fnType.NumIn() && i < 2; i++ {
+			if isWorkflowContext(fnType.In(i)) {
+				return fmt.Errorf("unexpected use of workflow context for an activity")
+			}
+		}
 	}
 
 	// Return values

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -2280,7 +2280,7 @@ func testRegisterStructWithInvalidActivityWithWorkflowContextFails() {
 }
 
 func TestRegisterStructWithInvalidActivityWithWorkflowContextFails(t *testing.T) {
-	assert.Panics(t, testRegisterStructWithInvalidWorkflowContextFnFails)
+	assert.Panics(t, testRegisterStructWithInvalidActivityWithWorkflowContextFails)
 }
 
 func TestVariousActivitySchedulingOption(t *testing.T) {

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -2252,6 +2252,37 @@ func TestRegisterStructWithInvalidFnsWithoutSkipFails(t *testing.T) {
 	assert.Panics(t, testRegisterStructWithInvalidFnsWithoutSkipFails)
 }
 
+type testActivityStructWithFnWithWorkflowContext struct{}
+
+func (t *testActivityStructWithFnWithWorkflowContext) InvalidActivity(Context) error {
+	return nil
+}
+
+func testRegisterStructWithInvalidWorkflowContextFnFails() {
+	registry := newRegistry()
+	registry.RegisterActivityWithOptions(&testActivityStructWithFnWithWorkflowContext{}, RegisterActivityOptions{
+		Name:                       "testActivityStructWithFnWithWorkflowContext_",
+		SkipInvalidStructFunctions: false,
+	})
+}
+
+func TestRegisterStructWithInvalidWorkflowContextFnFails(t *testing.T) {
+	assert.Panics(t, testRegisterStructWithInvalidWorkflowContextFnFails)
+}
+
+func InvalidActivityWithWorkflowContext(Context) error {
+	return nil
+}
+
+func testRegisterStructWithInvalidActivityWithWorkflowContextFails() {
+	registry := newRegistry()
+	registry.RegisterActivity(InvalidActivityWithWorkflowContext)
+}
+
+func TestRegisterStructWithInvalidActivityWithWorkflowContextFails(t *testing.T) {
+	assert.Panics(t, testRegisterStructWithInvalidWorkflowContextFnFails)
+}
+
 func TestVariousActivitySchedulingOption(t *testing.T) {
 	w := &activitiesCallingOptionsWorkflow{t: t}
 


### PR DESCRIPTION
## What was changed
Check for workflow context usage within activity arguments as this is usually developer error (accidental and misunderstanding). Note that this would likely fail later on anyways when executing the function.

## Why?
Prevent accidental errors.

## Checklist

1. Closes #1061 

2. How was this tested: Added unit tests for new behavior, existing tests should verify current behavior. 

3. Any docs updates needed? No as this is not stated as an allowed behavior (nor will it even work).