### PR TITLE
Clarify description of With function

### DIFF
--- a/log/with_logger.go
+++ b/log/with_logger.go
@@ -29,7 +29,8 @@ type WithLogger interface {
 	With(keyvals ...interface{}) Logger
 }
 
-// With returns Logger instance that prepend every log entry with keyvals. If logger implements WithLogger it is used, otherwise every log call will be intercepted.
+// With creates a child Logger that includes the supplied key-value pairs in each log entry. It does this by
+// using the supplied logger if it implements WithLogger; otherwise, it does so by intercepting every log call.
 func With(logger Logger, keyvals ...interface{}) Logger {
 	if wl, ok := logger.(WithLogger); ok {
 		return wl.With(keyvals...)


### PR DESCRIPTION
I found the previous wording confusing, as the use of "prepend" suggests a position of the key-value pairs that was different than what I observed in the output.

## What was changed
I reworded a comment that appears in the generated documentation. 

## Why?
The comment previously said, "With returns Logger instance that prepend every log entry with keyvals. If logger implements WithLogger it is used, otherwise every log call will be intercepted."

I interpret the use of "prepend" to mean that the key-value pairs I supply will appear first in the output. However, I found that they are the last things to appear. After further experimentation, I found that the KV pairs supplied to `With` appear after both the KV pairs in the parent logger and the string that I provided in the log statement, although they do appear before any KV pairs included in a specific log statement. 

Chad Retz from the SDK team agreed that prepend was not the correct verb to use here, so I have reworded to remove it. As a result, it no longer makes any guarantee about the position of these  key-value pairs, but that seemed like an implementation detail, and I find it to be more clear now because I'm no longer misguided about where within the output line I should be looking.

## Checklist
1. Closes N/A

2. How was this tested:
I ran `go doc --all` in the `log` subdirectory of my `sdk-go` clone and verified that the comment appeared as I had intended.

3. Any docs updates needed?

This change updates the only documentation about `log.With` of which I am aware.