### PR TITLE
Add option to ignore unknown fields when protojson unmarshalling

### DIFF
--- a/converter/payload_converter_test.go
+++ b/converter/payload_converter_test.go
@@ -71,6 +71,21 @@ func TestProtoJsonPayloadConverter_Gogo(t *testing.T) {
 
 	s := pc.ToString(payload)
 	assert.Equal(t, `{"eventId":"1978","eventType":"WorkflowTaskTimedOut","workflowTaskTimedOutEventAttributes":{"scheduledEventId":"2","timeoutType":"ScheduleToStart"}}`, s)
+
+	// Add additional field to payload data
+	payload.Data = []byte(`{"eventId":"1978","eventType":"WorkflowTaskTimedOut","workflowTaskTimedOutEventAttributes":{"scheduledEventId":"2","timeoutType":"ScheduleToStart"},"newField":"newValue"}`)
+	// Should fail, unknown field
+	wt5 := &GoV2{}
+	err = pc.FromPayload(payload, &wt5)
+	require.Error(t, err)
+
+	// Shouldn't fail, unknown fields are allowed
+	pc = NewProtoJSONPayloadConverterWithOptions(ProtoJSONPayloadConverterOptions{
+		AllowUnknownFields: true,
+	})
+	wt6 := &GoV2{}
+	err = pc.FromPayload(payload, &wt6)
+	require.NoError(t, err)
 }
 
 func TestProtoJsonPayloadConverter_Google(t *testing.T) {
@@ -104,6 +119,21 @@ func TestProtoJsonPayloadConverter_Google(t *testing.T) {
 
 	s := pc.ToString(payload)
 	assert.Equal(t, `{"name":"qwe","birthDay":"12","type":"TYPEV2_R","valueS":"asd"}`, strings.Replace(s, " ", "", -1))
+
+	// Add additional field to payload data
+	payload.Data = []byte(`{"name":"qwe","birthDay":"12","type":"TYPEV2_R","valueS":"asd","newField":"newValue"}`)
+	// Should fail, unknown field
+	wt5 := &GoV2{}
+	err = pc.FromPayload(payload, &wt5)
+	require.Error(t, err)
+
+	// Shouldn't fail, unknown fields are allowed
+	pc = NewProtoJSONPayloadConverterWithOptions(ProtoJSONPayloadConverterOptions{
+		AllowUnknownFields: true,
+	})
+	wt6 := &GoV2{}
+	err = pc.FromPayload(payload, &wt6)
+	require.NoError(t, err)
 }
 
 func TestProtoPayloadConverter_Gogo(t *testing.T) {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
We would like to use the temporal data converters for encoding/decoding payloads, but the proto JSON converter doesn't expose the unmarshalling option to ignore unknown fields. This adds that option, but maintains the current behaviour for anyone wanting it that way

## Why?
We don't want unknown fields in proto JSON to cause decode errors

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
