### PR TITLE
Allow update panics to bubble up

### DIFF
--- a/internal/internal_update.go
+++ b/internal/internal_update.go
@@ -317,28 +317,14 @@ func newUpdateHandler(
 	}, nil
 }
 
-// validate invokes the update's validation function and maps panics to errors.
+// validate invokes the update's validation function.
 func (h *updateHandler) validate(ctx Context, input []interface{}) (err error) {
-	defer func() {
-		if p := recover(); p != nil {
-			st := getStackTraceRaw("update validator [panic]:", 7, 0)
-			err = newPanicError(fmt.Sprintf("update validator panic: %v", p), st)
-		}
-	}()
 	_, err = executeFunctionWithWorkflowContext(ctx, h.validateFn, input)
 	return err
 }
 
-// execute executes the update itself and maps panics to errors.
+// execute executes the update itself.
 func (h *updateHandler) execute(ctx Context, input []interface{}) (result interface{}, err error) {
-	defer func() {
-		if p := recover(); p != nil {
-			result = nil
-			st := getStackTraceRaw("update handler [panic]:", 7, 0)
-			err = newPanicError(fmt.Sprintf("update handler panic: %v", p), st)
-		}
-	}()
-
 	return executeFunctionWithWorkflowContext(ctx, h.fn, input)
 }
 

--- a/internal/internal_update_test.go
+++ b/internal/internal_update_test.go
@@ -81,7 +81,7 @@ var runOnCallingThread = &testUpdateScheduler{
 	YieldImpl: func(Context, string) {},
 }
 
-func TestUpdateHandlerPanicSafety(t *testing.T) {
+func TestUpdateHandlerPanicsPropagate(t *testing.T) {
 	t.Parallel()
 
 	env := &workflowEnvironmentImpl{
@@ -99,14 +99,12 @@ func TestUpdateHandlerPanicSafety(t *testing.T) {
 	in := UpdateInput{Name: t.Name(), Args: []interface{}{}}
 
 	t.Run("ValidateUpdate", func(t *testing.T) {
-		err := interceptor.inboundInterceptor.ValidateUpdate(ctx, &in)
-		var panicErr *PanicError
-		require.ErrorAs(t, err, &panicErr)
+		defer func() { require.NotNil(t, recover(), "expected a panic") }()
+		_ = interceptor.inboundInterceptor.ValidateUpdate(ctx, &in)
 	})
 	t.Run("ExecuteUpdate", func(t *testing.T) {
-		_, err := interceptor.inboundInterceptor.ExecuteUpdate(ctx, &in)
-		var panicErr *PanicError
-		require.ErrorAs(t, err, &panicErr)
+		defer func() { require.NotNil(t, recover(), "expected a panic") }()
+		_, _ = interceptor.inboundInterceptor.ExecuteUpdate(ctx, &in)
 	})
 }
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Remove panic recovery guards around invoking user update code. These panics will now escape the handler and bubble up, eventually being processed by the workflow's panic handling policy. 

## Why?
<!-- Tell your future self why have you made these changes -->
This makes update execution consistent with other workflow code.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Features tests to be landed after this PR

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
No