### PR TITLE
Switch to the official coveralls uploader

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,53 +6,103 @@ on:
       - master
 
 jobs:
-  build-and-test:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Print build information
         run: "echo head_ref: ${{ github.head_ref }}, ref: ${{ github.ref }}"
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v4
         with:
           go-version: "1.20"
-      - name: Check and unit test
-        run: make check unit-test
+      - name: Build
+        run: make check # includes full compilation
+
+  test:
+    runs-on: ubuntu-latest
+    needs: build
+    strategy:
+      matrix:
+        include:
+          - label: Integration tests cache disabled
+            target: integration-test-zero-cache
+            coverage_file: .build/coverage/integ_test_zero_cache_cover.out
+            needs_server: true
+          - label: Integration tests
+            target: integration-test-normal-cache
+            coverage_file: .build/coverage/integ_test_normal_cache_cover.out
+            needs_server: true
+          - label: Unit tests
+            target: unit-test
+            coverage_file: .build/coverage/unit_test_cover.out
+            needs_server: false
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - uses: actions/setup-go@v4
+        with:
+          go-version: "1.20"
       - name: Clone Temporal Docker compose
-        uses: actions/checkout@v2
+        if: ${{ matrix.needs_server }}
+        uses: actions/checkout@v3
         with:
           repository: temporalio/docker-compose
           path: ./docker-compose
       - name: Start Temporal server
+        if: ${{ matrix.needs_server }}
         run: |
           cp ./.github/workflows/docker/docker-compose.override.yaml ./docker-compose/docker-compose.override.yaml
           cp ./.github/workflows/docker/dynamic-config-custom.yaml ./docker-compose/dynamicconfig/dynamic-config-custom.yaml
           docker-compose --project-directory ./docker-compose up &
           go run ./.github/workflows/wait_for_server.go
-      - name: Integration tests (without cache)
-        run: make integration-test-zero-cache
-      - name: Integration tests (with cache)
-        run: make integration-test-normal-cache
+      - name: ${{ matrix.label }}
+        run: make ${{ matrix.target }}
       - name: Upload coverage
-        env:
-          COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: make cover_ci
+        continue-on-error: true
+        uses: coverallsapp/github-action@v2
+        with:
+          parallel: true
+          file: ${{ matrix.coverage_file }}
+          flag-name: ${{ matrix.target }}
+          format: golang
+
+  finish-test:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Finish Coveralls Upload
+        uses: coverallsapp/github-action@v2
+        with:
+          parallel-finished: true
+
+  # This is temporary - once this workflow lands on sdk-go@master we can change
+  # that branch's protection rule to reference the "test" job rather than
+  # "build-and-test"
+  build-and-test:
+    runs-on: ubuntu-latest
+    needs: [build, test]
+    steps:
+      - name: Complete
+        run: echo "Complete"
 
   cloud-test:
     # Only supported in non-fork runs, since secrets are not available in forks.
     if: ${{ github.event.pull_request.head.repo.full_name == '' || github.event.pull_request.head.repo.full_name == 'temporalio/sdk-go' }}
     runs-on: ubuntu-latest
+    needs: build
     env:
       SERVICE_ADDR: tinycicd.sdk.tmprl.cloud:7233
       TEMPORAL_NAMESPACE: tinycicd.sdk
       TEMPORAL_CLIENT_CERT: ${{ secrets.TEMPORAL_CLIENT_CERT }}
       TEMPORAL_CLIENT_KEY: ${{ secrets.TEMPORAL_CLIENT_KEY }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v4
         with:
           go-version: "1.20"
       - name: Single integration test against cloud
@@ -61,7 +111,9 @@ jobs:
 
   features-test:
     uses: temporalio/features/.github/workflows/go.yaml@main
+    needs: build
     with:
       go-repo-path: ${{github.event.pull_request.head.repo.full_name}}
       version: ${{github.event.pull_request.head.ref}}
       version-is-repo-ref: true
+

--- a/Makefile
+++ b/Makefile
@@ -57,19 +57,6 @@ integration-test-normal-cache: $(BUILD)/dummy
 
 test: unit-test integration-test-zero-cache integration-test-normal-cache
 
-$(COVER_ROOT)/cover.out: $(UT_COVER_FILE) $(INTEG_ZERO_CACHE_COVER_FILE) $(INTEG_NORMAL_CACHE_COVER_FILE)
-	@echo "mode: atomic" > $(COVER_ROOT)/cover.out
-	cat $(UT_COVER_FILE) | grep -v "^mode: \w\+" | grep -v ".gen" >> $(COVER_ROOT)/cover.out
-	cat $(INTEG_ZERO_CACHE_COVER_FILE) | grep -v "^mode: \w\+" | grep -v ".gen" >> $(COVER_ROOT)/cover.out
-	cat $(INTEG_NORMAL_CACHE_COVER_FILE) | grep -v "^mode: \w\+" | grep -v ".gen" >> $(COVER_ROOT)/cover.out
-
-cover: $(COVER_ROOT)/cover.out
-	go tool cover -html=$(COVER_ROOT)/cover.out;
-
-cover_ci: $(COVER_ROOT)/cover.out
-	go install github.com/mattn/goveralls@latest
-	goveralls -coverprofile=$(COVER_ROOT)/cover.out -service=github
-
 vet: $(ALL_SRC)
 	@for dir in $(MOD_DIRS); do \
 		(cd "$$dir" && echo "In $$dir" && go vet ./...) || exit 1; \


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Switch to the official coveralls uploader.

Secondarily
- parallelize integration tests
- tag coverage uploads (unit vs. integration)
- update actions/checkout and actions/setup-go dependencies

## Why?
<!-- Tell your future self why have you made these changes -->
goveralls has stopped working (gets a 500 from the server) and rather than debug someone's personal project we're switching to something official and more likely to remain supported.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Running ci workflow in my fork

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
No
