### PR TITLE
Write sdk flags directly during replay

### DIFF
--- a/internal/internal_flags.go
+++ b/internal/internal_flags.go
@@ -94,6 +94,16 @@ func (sf *sdkFlags) tryUse(flag sdkFlag, record bool) bool {
 	}
 }
 
+// set marks a flag as in current use regardless of replay status.
+func (sf *sdkFlags) set(flags ...sdkFlag) {
+	if !sf.capabilities.GetSdkMetadata() {
+		return
+	}
+	for _, flag := range flags {
+		sf.currentFlags[flag] = true
+	}
+}
+
 // markSDKFlagsSent marks all sdk flags as sent to the server.
 func (sf *sdkFlags) markSDKFlagsSent() {
 	for flag := range sf.newFlags {

--- a/internal/internal_flags_test.go
+++ b/internal/internal_flags_test.go
@@ -1,0 +1,61 @@
+// The MIT License
+//
+// Copyright (c) 2023 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package internal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/api/workflowservice/v1"
+)
+
+var (
+	metadataDisabled = workflowservice.GetSystemInfoResponse_Capabilities{}
+	metadataEnabled  = workflowservice.GetSystemInfoResponse_Capabilities{
+		SdkMetadata: true,
+	}
+)
+
+const testFlag = SDKFlagChildWorkflowErrorExecution
+
+func TestSet(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no server sdk metadata support", func(t *testing.T) {
+		flags := newSDKFlags(&metadataDisabled)
+		flags.set(testFlag)
+		require.Empty(t, flags.gatherNewSDKFlags(),
+			"flags assigned when servier does not support metadata are dropped")
+		require.False(t, flags.tryUse(testFlag, false),
+			"flags assigned when servier does not support metadata are dropped")
+	})
+
+	t.Run("with server sdk metadata support", func(t *testing.T) {
+		flags := newSDKFlags(&metadataEnabled)
+		flags.set(testFlag)
+		require.Empty(t, flags.gatherNewSDKFlags(),
+			"flag set via sdkFlags.set is not 'new'")
+		require.True(t, flags.tryUse(testFlag, false),
+			"flag set via sdkFlags.set should be immediately visible")
+	})
+}

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -890,7 +890,6 @@ func (w *workflowExecutionContextImpl) ProcessWorkflowTask(workflowTask *workflo
 	eventHandler.ResetLAWFTAttemptCounts()
 	eventHandler.sdkFlags.markSDKFlagsSent()
 
-	// Process events
 ProcessEvents:
 	for {
 		reorderedEvents, markers, binaryChecksum, flags, err := reorderedHistory.NextCommandEvents()
@@ -898,6 +897,7 @@ ProcessEvents:
 			return nil, err
 		}
 
+		eventHandler.sdkFlags.set(flags...)
 		if len(reorderedEvents) == 0 {
 			break ProcessEvents
 		}


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->
Write sdk flags directly during replay

## Why?
<!-- Tell your future self why have you made these changes -->
If flags are found for a task via lookahead we want those flags to be written directly into the current flagset and not the new/pending flagset as residence in the latter is not visible to subsequent callers of sdkFlags.tryUse.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
This is needed for a subsequent PR that enables CommandProtocolMessages for Update and uses SDKFlags to check for whether or not the command should be sent.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
