### PR TITLE
Remove coveralls link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Temporal Go SDK [![Build Status](https://badge.buildkite.com/ce6df3b1a8b375270261ae70fb2d2756af298fef3a0dac4d20.svg?theme=github&branch=master)](https://buildkite.com/temporal/temporal-go-client) [![Coverage Status](https://coveralls.io/repos/github/temporalio/temporal-go-sdk/badge.svg?branch=master)](https://coveralls.io/github/temporalio/temporal-go-sdk?branch=master) [![PkgGoDev](https://pkg.go.dev/badge/go.temporal.io/sdk)](https://pkg.go.dev/go.temporal.io/sdk)
+# Temporal Go SDK [![Build Status](https://badge.buildkite.com/ce6df3b1a8b375270261ae70fb2d2756af298fef3a0dac4d20.svg?theme=github&branch=master)](https://buildkite.com/temporal/temporal-go-client) [![PkgGoDev](https://pkg.go.dev/badge/go.temporal.io/sdk)](https://pkg.go.dev/go.temporal.io/sdk)
 
 [Temporal](https://github.com/temporalio/temporal) is a distributed, scalable, durable, and highly available orchestration engine used to execute asynchronous long-running business logic in a scalable and resilient way.
 


### PR DESCRIPTION
Last update was 2020. 

<img width="370" alt="image" src="https://github.com/temporalio/sdk-go/assets/251288/fe3646c1-c559-43d6-aa5a-5ce7d807d9ee">

https://coveralls.io/github/temporalio/temporal-go-sdk?branch=master

Alternatively, we could keep it if we can get it updated, and preferably if it shows 80+% (yellow) or 90+% (green).