### PR TITLE
Fix stopping dev server on Windows 

### DIFF
--- a/testsuite/devserver.go
+++ b/testsuite/devserver.go
@@ -39,7 +39,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
-	"syscall"
 	"time"
 
 	"go.temporal.io/sdk/client"
@@ -361,12 +360,7 @@ func retryFor(maxAttempts int, interval time.Duration, cond func() error) error 
 
 // Stop the running server and wait for shutdown to complete. Error is propagated from server shutdown.
 func (s *DevServer) Stop() error {
-	if runtime.GOOS == "windows" {
-		// On Windows, we can't send SIGTERM to the process, so we just kill it.
-		return s.cmd.Process.Kill()
-	}
-
-	if err := s.cmd.Process.Signal(syscall.SIGTERM); err != nil {
+	if err := sendInterrupt(s.cmd.Process); err != nil {
 		return err
 	}
 	return s.cmd.Wait()

--- a/testsuite/devserver.go
+++ b/testsuite/devserver.go
@@ -361,6 +361,11 @@ func retryFor(maxAttempts int, interval time.Duration, cond func() error) error 
 
 // Stop the running server and wait for shutdown to complete. Error is propagated from server shutdown.
 func (s *DevServer) Stop() error {
+	if runtime.GOOS == "windows" {
+		// On Windows, we can't send SIGTERM to the process, so we just kill it.
+		return s.cmd.Process.Kill()
+	}
+
 	if err := s.cmd.Process.Signal(syscall.SIGTERM); err != nil {
 		return err
 	}

--- a/testsuite/devserver.go
+++ b/testsuite/devserver.go
@@ -360,7 +360,7 @@ func retryFor(maxAttempts int, interval time.Duration, cond func() error) error 
 
 // Stop the running server and wait for shutdown to complete. Error is propagated from server shutdown.
 func (s *DevServer) Stop() error {
-	if err := sendTerminate(s.cmd.Process); err != nil {
+	if err := sendInterrupt(s.cmd.Process); err != nil {
 		return err
 	}
 	return s.cmd.Wait()

--- a/testsuite/devserver.go
+++ b/testsuite/devserver.go
@@ -360,7 +360,7 @@ func retryFor(maxAttempts int, interval time.Duration, cond func() error) error 
 
 // Stop the running server and wait for shutdown to complete. Error is propagated from server shutdown.
 func (s *DevServer) Stop() error {
-	if err := sendInterrupt(s.cmd.Process); err != nil {
+	if err := sendTerminate(s.cmd.Process); err != nil {
 		return err
 	}
 	return s.cmd.Wait()

--- a/testsuite/interrupt_nonwindows.go
+++ b/testsuite/interrupt_nonwindows.go
@@ -29,7 +29,7 @@ import (
 	"syscall"
 )
 
-// sendTerminate sends a terminate signal to the given process for graceful shutdown.
-func sendTerminate(process *os.Process) error {
-	return process.Signal(syscall.SIGTERM)
+// sendInterrupt sends an interrupt signal to the given process for graceful shutdown.
+func sendInterrupt(process *os.Process) error {
+	return process.Signal(syscall.SIGINT)
 }

--- a/testsuite/interrupt_nonwindows.go
+++ b/testsuite/interrupt_nonwindows.go
@@ -7,6 +7,7 @@ import (
 	"syscall"
 )
 
-func sendInterrupt(process *os.Process) error {
-	return process.Signal(syscall.SIGINT)
+// sendTerminate sends a terminate signal to the given process for graceful shutdown.
+func sendTerminate(process *os.Process) error {
+	return process.Signal(syscall.SIGTERM)
 }

--- a/testsuite/interrupt_nonwindows.go
+++ b/testsuite/interrupt_nonwindows.go
@@ -1,5 +1,27 @@
 //go:build !windows
 
+// The MIT License
+//
+// Copyright (c) 2023 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package testsuite
 
 import (

--- a/testsuite/interrupt_nonwindows.go
+++ b/testsuite/interrupt_nonwindows.go
@@ -1,0 +1,12 @@
+//go:build !windows
+
+package testsuite
+
+import (
+	"os"
+	"syscall"
+)
+
+func sendInterrupt(process *os.Process) error {
+	return process.Signal(syscall.SIGINT)
+}

--- a/testsuite/interrupt_nonwindows.go
+++ b/testsuite/interrupt_nonwindows.go
@@ -1,5 +1,3 @@
-//go:build !windows
-
 // The MIT License
 //
 // Copyright (c) 2023 Temporal Technologies Inc.  All rights reserved.
@@ -21,6 +19,8 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
+
+//go:build !windows
 
 package testsuite
 

--- a/testsuite/interrupt_windows.go
+++ b/testsuite/interrupt_windows.go
@@ -1,3 +1,5 @@
+//go:build windows
+
 package testsuite
 
 import (
@@ -7,7 +9,8 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-func sendInterrupt(process *os.Process) error {
+// sendTerminate calls the break event on the given process for graceful shutdown.
+func sendTerminate(process *os.Process) error {
 	dll, err := windows.LoadDLL("kernel32.dll")
 	if err != nil {
 		return err

--- a/testsuite/interrupt_windows.go
+++ b/testsuite/interrupt_windows.go
@@ -1,0 +1,42 @@
+package testsuite
+
+import (
+	"os"
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+func sendInterrupt(process *os.Process) error {
+	dll, err := windows.LoadDLL("kernel32.dll")
+	if err != nil {
+		return err
+	}
+	defer dll.Release()
+	f, err := dll.FindProc("AttachConsole")
+	if err != nil {
+		return err
+	}
+	r1, _, err := f.Call(uintptr(process.Pid))
+	if r1 == 0 && err != syscall.ERROR_ACCESS_DENIED {
+		return err
+	}
+
+	f, err = dll.FindProc("SetConsoleCtrlHandler")
+	if err != nil {
+		return err
+	}
+	r1, _, err = f.Call(0, 1)
+	if r1 == 0 {
+		return err
+	}
+	f, err = dll.FindProc("GenerateConsoleCtrlEvent")
+	if err != nil {
+		return err
+	}
+	r1, _, err = f.Call(windows.CTRL_BREAK_EVENT, uintptr(process.Pid))
+	if r1 == 0 {
+		return err
+	}
+	return nil
+}

--- a/testsuite/interrupt_windows.go
+++ b/testsuite/interrupt_windows.go
@@ -1,5 +1,27 @@
 //go:build windows
 
+// The MIT License
+//
+// Copyright (c) 2023 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package testsuite
 
 import (

--- a/testsuite/interrupt_windows.go
+++ b/testsuite/interrupt_windows.go
@@ -1,5 +1,3 @@
-//go:build windows
-
 // The MIT License
 //
 // Copyright (c) 2023 Temporal Technologies Inc.  All rights reserved.
@@ -31,8 +29,8 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-// sendTerminate calls the break event on the given process for graceful shutdown.
-func sendTerminate(process *os.Process) error {
+// sendInterrupt calls the break event on the given process for graceful shutdown.
+func sendInterrupt(process *os.Process) error {
 	dll, err := windows.LoadDLL("kernel32.dll")
 	if err != nil {
 		return err


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Starting killing the dev server process on Windows since sending signals (and SIGTERM or os.Interrupt) is not supported 

## Why?
<!-- Tell your future self why have you made these changes -->

Ensuring the dev server is stopped and doesn't leave hanging

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

Added test

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
