### PR TITLE
Allow ignoring function ref issues

### DIFF
--- a/contrib/tools/workflowcheck/determinism/checker.go
+++ b/contrib/tools/workflowcheck/determinism/checker.go
@@ -125,7 +125,7 @@ func (c *Checker) Run(pass *analysis.Pass) (PackageNonDeterminisms, error) {
 		}
 
 		// Update ignore map
-		updateIgnoreMap(pass.Fset, file, coll.ignoreMap)
+		UpdateIgnoreMap(pass.Fset, file, coll.ignoreMap)
 
 		// Collect the decls to check and check vars/iface patterns
 		for _, decl := range file.Decls {
@@ -199,7 +199,7 @@ func (c *Checker) Run(pass *analysis.Pass) (PackageNonDeterminisms, error) {
 	return coll.applyFacts(), nil
 }
 
-func updateIgnoreMap(fset *token.FileSet, f *ast.File, m map[ast.Node]struct{}) {
+func UpdateIgnoreMap(fset *token.FileSet, f *ast.File, m map[ast.Node]struct{}) {
 	// Collect only the ignore comments
 	var comments []*ast.CommentGroup
 	for _, group := range f.Comments {

--- a/contrib/tools/workflowcheck/workflow/checker.go
+++ b/contrib/tools/workflowcheck/workflow/checker.go
@@ -157,9 +157,16 @@ func (c *Checker) Run(pass *analysis.Pass) error {
 		determinism.UpdateIgnoreMap(pass.Fset, file, ignoreMap)
 
 		ast.Inspect(file, func(n ast.Node) bool {
-			// Only handle calls
+			// Only handle calls with followable function pointers
+			_, isIgnored := ignoreMap[n]
+			for k := range ignoreMap {
+				asExprStmt, _ := k.(*ast.ExprStmt)
+				if asExprStmt != nil && asExprStmt.X == n {
+					isIgnored = true
+				}
+			}
 			callExpr, _ := n.(*ast.CallExpr)
-			if callExpr == nil {
+			if callExpr == nil || isIgnored {
 				return true
 			}
 			// Callee needs to be workflow registry
@@ -180,17 +187,8 @@ func (c *Checker) Run(pass *analysis.Pass) error {
 			}
 			// Report if couldn't get type
 			if fn == nil {
-				_, isIgnored := ignoreMap[n]
-				for k := range ignoreMap {
-					asExprStmt, _ := k.(*ast.ExprStmt)
-					if asExprStmt != nil && asExprStmt.X == n {
-						isIgnored = true
-					}
-				}
-				if !isIgnored {
-					pass.Reportf(callExpr.Args[0].Pos(),
-						"unrecognized function reference format. We cannot follow this function reference to check for non-determinism.")
-				}
+				pass.Reportf(callExpr.Args[0].Pos(),
+					"unrecognized function reference format. We cannot follow this function reference to check for non-determinism.")
 				return true
 			}
 			c.debugf("Checking workflow function %v", fn.FullName())

--- a/contrib/tools/workflowcheck/workflow/testdata/src/a/workflow.go
+++ b/contrib/tools/workflowcheck/workflow/testdata/src/a/workflow.go
@@ -16,6 +16,7 @@ func PrepWorkflow() {
 	wrk.RegisterWorkflow(WorkflowIterateMap)           // want "a.WorkflowIterateMap is non-deterministic, reason: iterates over map"
 	wrk.RegisterWorkflow(WorkflowWithTemplate)         // want "a.WorkflowWithTemplate is non-deterministic, reason: calls non-deterministic function \\(\\*text/template\\.Template\\)\\.Execute.*"
 	wrk.RegisterWorkflow(WorkflowWithAwait)
+	HigherOrderWorkflowCallIgnorable(wrk, WorkflowNop)
 }
 
 func WorkflowNop(ctx workflow.Context) error {
@@ -51,4 +52,9 @@ func WorkflowWithAwait(ctx workflow.Context) error {
 	// We do not expect this to fail
 	_, err := workflow.AwaitWithTimeout(ctx, 5*time.Second, func() bool { return true })
 	return err
+}
+
+func HigherOrderWorkflowCallIgnorable(w worker.Worker, wfunc func(workflow.Context) error) {
+	//workflowcheck:ignore
+	w.RegisterWorkflow(wfunc)
 }


### PR DESCRIPTION
Allows `//workflowcheck:ignore` to work on workflow function registration sites