### PR TITLE
Change message look ahead

### DIFF
--- a/internal/internal_task_handlers_interfaces_test.go
+++ b/internal/internal_task_handlers_interfaces_test.go
@@ -252,16 +252,16 @@ func (s *PollLayerInterfacesTestSuite) TestMessageCommands() {
 		createTestEventWorkflowExecutionStarted(1, &historypb.WorkflowExecutionStartedEventAttributes{TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue}}),
 		createTestEventWorkflowTaskScheduled(2, &historypb.WorkflowTaskScheduledEventAttributes{TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue}}),
 		createTestEventWorkflowTaskStarted(3),
-		createTestEventWorkflowTaskCompleted(4, &historypb.WorkflowTaskCompletedEventAttributes{
-			ScheduledEventId: 2,
-			StartedEventId:   3,
-		}),
-		createTestEventWorkflowTaskScheduled(5, &historypb.WorkflowTaskScheduledEventAttributes{TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue}}),
-		createTestEventWorkflowTaskStarted(6),
 		{
-			EventId:   7,
+			EventId:   4,
 			EventType: enumspb.EVENT_TYPE_WORKFLOW_TASK_FAILED,
 		},
+		createTestEventWorkflowTaskScheduled(5, &historypb.WorkflowTaskScheduledEventAttributes{TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue}}),
+		createTestEventWorkflowTaskStarted(6),
+		createTestEventWorkflowTaskCompleted(7, &historypb.WorkflowTaskCompletedEventAttributes{
+			ScheduledEventId: 5,
+			StartedEventId:   6,
+		}),
 		{
 			EventId:   8,
 			EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_ACCEPTED,


### PR DESCRIPTION
Draft solution to fix the issue seen during load testing update.

```
process event for temporal-bench [panic]:
go.temporal.io/sdk/internal.panicIllegalState(...)
	/Users/quinnklassen/go/pkg/mod/go.temporal.io/sdk@v1.23.0/internal/internal_command_state_machine.go:456
go.temporal.io/sdk/internal.(*commandsHelper).handleActivityTaskScheduled(0x14000cb7a40, {0x1400077a32a, 0x3}, 0x0?)
	/Users/quinnklassen/go/pkg/mod/go.temporal.io/sdk@v1.23.0/internal/internal_command_state_machine.go:1039 +0xec
go.temporal.io/sdk/internal.(*workflowExecutionEventHandlerImpl).ProcessEvent(0x1400102b8d8, 0x14000c9e740, 0x3?, 0x0)
	/Users/quinnklassen/go/pkg/mod/go.temporal.io/sdk@v1.23.0/internal/internal_event_handlers.go:1068 +0x210
go.temporal.io/sdk/internal.(*workflowExecutionContextImpl).ProcessWorkflowTask(0x1400102f290, 0x140011367b0)
	/Users/quinnklassen/go/pkg/mod/go.temporal.io/sdk@v1.23.0/internal/internal_task_handlers.go:967 +0xf04
go.temporal.io/sdk/internal.(*workflowTaskHandlerImpl).ProcessWorkflowTask(0x14000437450, 0x140011367b0, 0x1400127aa80)
	/Users/quinnklassen/go/pkg/mod/go.temporal.io/sdk@v1.23.0/internal/internal_task_handlers.go:788 +0x34c
go.temporal.io/sdk/internal.(*workflowTaskPoller).processWorkflowTask(0x1400047c6c0, 0x140011367b0)
	/Users/quinnklassen/go/pkg/mod/go.temporal.io/sdk@v1.23.0/internal/internal_task_pollers.go:342 +0x2bc
go.temporal.io/sdk/internal.(*workflowTaskPoller).ProcessTask(0x1400047c6c0, {0x101394c20?, 0x140011367b0})
	/Users/quinnklassen/go/pkg/mod/go.temporal.io/sdk@v1.23.0/internal/internal_task_pollers.go:315 +0x74
go.temporal.io/sdk/internal.(*baseWorker).processTask(0x140004483c0, {0x1013947a0, 0x14000ca61d0})
	/Users/quinnklassen/go/pkg/mod/go.temporal.io/sdk@v1.23.0/internal/internal_worker_base.go:440 +0x154
created by go.temporal.io/sdk/internal.(*baseWorker).runTaskDispatcher
	/Users/quinnklassen/go/pkg/mod/go.temporal.io/sdk@v1.23.0/internal/internal_worker_base.go:334 +0x98
```

Current theory is the previous implementation of look ahead was only looking one "page" of history ahead on certain replay scenarios. On multiple page histories with update accepted not on the original page this could cause non determinism as the state machine would not be aware of them. This PR fixes this by doing the look ahead the same way we look ahead for `markers`

Marking as draft because this deserves a unit test and integration test. Also some minor refactoring
