### PR TITLE
Isolate Ctrl+Break to dev server instead of console

### DIFF
--- a/testsuite/devserver.go
+++ b/testsuite/devserver.go
@@ -109,8 +109,8 @@ func StartDevServer(ctx context.Context, options DevServerOptions) (*DevServer, 
 	}
 
 	args := prepareCommand(&options, host, port, clientOptions.Namespace)
-	cmd := exec.Command(exePath, args...)
-	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
+
+	cmd := newCmd(exePath, args...)
 	clientOptions.Logger.Info("Starting DevServer", "ExePath", exePath, "Args", args)
 	if err := cmd.Start(); err != nil {
 		return nil, fmt.Errorf("failed starting: %w", err)

--- a/testsuite/interrupt_windows.go
+++ b/testsuite/interrupt_windows.go
@@ -61,5 +61,17 @@ func sendInterrupt(process *os.Process) error {
 	if r1 == 0 {
 		return err
 	}
+
+	// Free the console after sending the interrupt
+	// To prevent sending the CTRL+BREAK signal to all processes sharing the console
+	f, err = dll.FindProc("FreeConsole")
+	if err != nil {
+		return err
+	}
+	r1, _, err = f.Call()
+	if r1 == 0 {
+		return err
+	}
+
 	return nil
 }

--- a/testsuite/process_nonwindows.go
+++ b/testsuite/process_nonwindows.go
@@ -26,8 +26,16 @@ package testsuite
 
 import (
 	"os"
+	"os/exec"
 	"syscall"
 )
+
+// newCmd creates a new command with the given executable path and arguments.
+func newCmd(exePath string, args ...string) *exec.Cmd {
+	cmd := exec.Command(exePath, args...)
+	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
+	return cmd
+}
 
 // sendInterrupt sends an interrupt signal to the given process for graceful shutdown.
 func sendInterrupt(process *os.Process) error {

--- a/testsuite/process_windows.go
+++ b/testsuite/process_windows.go
@@ -34,7 +34,7 @@ import (
 func newCmd(exePath string, args ...string) *exec.Cmd {
 	cmd := exec.Command(exePath, args...)
 	cmd.SysProcAttr = &syscall.SysProcAttr{
-		// isolate the process from the current console so interrupt signals are not sent to it
+		// isolate the process and signals sent to it from the current console
 		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP,
 	}
 	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr

--- a/testsuite/process_windows.go
+++ b/testsuite/process_windows.go
@@ -24,9 +24,22 @@ package testsuite
 
 import (
 	"os"
+	"os/exec"
+	"syscall"
 
 	"golang.org/x/sys/windows"
 )
+
+// newCmd creates a new command with the given executable path and arguments.
+func newCmd(exePath string, args ...string) *exec.Cmd {
+	cmd := exec.Command(exePath, args...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		// isolate the process from the current console so interrupt signals are not sent to it
+		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP,
+	}
+	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
+	return cmd
+}
 
 // sendInterrupt calls the break event on the given process for graceful shutdown.
 func sendInterrupt(process *os.Process) error {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Isolated the Ctrl + break event to dev server

## Why?
<!-- Tell your future self why have you made these changes -->

Stopping dev server with `devserver.Stop()` would result in the origin process to be interrupted instead of just the devserver. Ex. Go tests with devserver preemptively exited with RC `1`

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

tested with e2e tests in https://github.com/temporalio/cli/pull/257

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
