### PR TITLE
Fix inconsistent BuildID field name & empty TQ in intent check

### DIFF
--- a/internal/worker_version_sets.go
+++ b/internal/worker_version_sets.go
@@ -72,7 +72,7 @@ type (
 	}
 	BuildIDOpAddNewCompatibleVersion struct {
 		BuildID                   string
-		ExistingCompatibleBuildId string
+		ExistingCompatibleBuildID string
 		MakeSetDefault            bool
 	}
 	BuildIDOpPromoteSet struct {
@@ -102,13 +102,13 @@ func (uw *UpdateWorkerBuildIdCompatibilityOptions) validateAndConvertToProto() (
 		}
 
 	case *BuildIDOpAddNewCompatibleVersion:
-		if v.ExistingCompatibleBuildId == "" {
-			return nil, errors.New("missing ExistingCompatibleBuildId")
+		if v.ExistingCompatibleBuildID == "" {
+			return nil, errors.New("missing ExistingCompatibleBuildID")
 		}
 		req.Operation = &workflowservice.UpdateWorkerBuildIdCompatibilityRequest_AddNewCompatibleBuildId{
 			AddNewCompatibleBuildId: &workflowservice.UpdateWorkerBuildIdCompatibilityRequest_AddNewCompatibleVersion{
 				NewBuildId:                v.BuildID,
-				ExistingCompatibleBuildId: v.ExistingCompatibleBuildId,
+				ExistingCompatibleBuildId: v.ExistingCompatibleBuildID,
 				MakeSetDefault:            v.MakeSetDefault,
 			},
 		}
@@ -188,8 +188,9 @@ func determineUseCompatibleFlagForCommand(intent VersioningIntent, workerTq, Tar
 	if intent == VersioningIntentDefault {
 		useCompat = false
 	} else if intent == VersioningIntentUnspecified {
-		// If the target task queue doesn't match ours, use the default version
-		if workerTq != TargetTq {
+		// If the target task queue doesn't match ours, use the default version. Empty target counts
+		// as matching.
+		if TargetTq != "" && workerTq != TargetTq {
 			useCompat = false
 		}
 	}

--- a/internal/worker_version_sets_test.go
+++ b/internal/worker_version_sets_test.go
@@ -120,3 +120,7 @@ func Test_VersioningIntent(t *testing.T) {
 		})
 	}
 }
+
+func Test_VersioningIntent_EmptyTargetTQ(t *testing.T) {
+	assert.Equal(t, true, determineUseCompatibleFlagForCommand(VersioningIntentUnspecified, "something", ""))
+}

--- a/test/worker_versioning_test.go
+++ b/test/worker_versioning_test.go
@@ -81,7 +81,7 @@ func (ts *WorkerVersioningTestSuite) TestManipulateVersionSets() {
 		TaskQueue: ts.taskQueueName,
 		Operation: &client.BuildIDOpAddNewCompatibleVersion{
 			BuildID:                   "1.1",
-			ExistingCompatibleBuildId: "1.0",
+			ExistingCompatibleBuildID: "1.0",
 		},
 	})
 	ts.NoError(err)


### PR DESCRIPTION
Two minor fixes before release