### PR TITLE
Fix history paging on looking for WFT Fail

### DIFF
--- a/internal/internal_task_handlers_interfaces_test.go
+++ b/internal/internal_task_handlers_interfaces_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	enumspb "go.temporal.io/api/enums/v1"
 	historypb "go.temporal.io/api/history/v1"
+	"go.temporal.io/api/protocol/v1"
 	"go.temporal.io/api/sdk/v1"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	updatepb "go.temporal.io/api/update/v1"
@@ -307,4 +308,122 @@ func (s *PollLayerInterfacesTestSuite) TestMessageCommands() {
 	s.Equal(enumspb.EVENT_TYPE_WORKFLOW_TASK_STARTED, events[2].GetEventType())
 
 	s.Equal(0, len(msgs))
+}
+
+func (s *PollLayerInterfacesTestSuite) TestEmptyPages() {
+	// Schedule an activity and see if we complete workflow.
+	taskQueue := "tq1"
+	testEvents := []*historypb.HistoryEvent{
+		createTestEventWorkflowExecutionStarted(1, &historypb.WorkflowExecutionStartedEventAttributes{TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue}}),
+		createTestEventWorkflowTaskScheduled(2, &historypb.WorkflowTaskScheduledEventAttributes{TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue}}),
+		createTestEventWorkflowTaskStarted(3),
+		{
+			EventId:   4,
+			EventType: enumspb.EVENT_TYPE_WORKFLOW_TASK_TIMED_OUT,
+		},
+		createTestEventWorkflowTaskScheduled(5, &historypb.WorkflowTaskScheduledEventAttributes{TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue}}),
+		createTestEventWorkflowTaskStarted(6),
+		createTestEventWorkflowTaskCompleted(7, &historypb.WorkflowTaskCompletedEventAttributes{
+			ScheduledEventId: 5,
+			StartedEventId:   6,
+		}),
+		{
+			EventId:   8,
+			EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_ACCEPTED,
+			Attributes: &historypb.HistoryEvent_WorkflowExecutionUpdateAcceptedEventAttributes{
+				WorkflowExecutionUpdateAcceptedEventAttributes: &historypb.WorkflowExecutionUpdateAcceptedEventAttributes{
+					ProtocolInstanceId: "test",
+					AcceptedRequest:    &updatepb.Request{},
+				},
+			},
+		},
+		createTestEventWorkflowTaskScheduled(9, &historypb.WorkflowTaskScheduledEventAttributes{TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue}}),
+		createTestEventWorkflowTaskStarted(10),
+	}
+	task := createWorkflowTaskWithQueries(testEvents[0:2], 0, "HelloWorld_Workflow", nil, false)
+
+	returnEmptyPage := true
+	eventID := 2
+	historyIterator := MockHistoryIterator{
+		GetNextPageImpl: func() (*historypb.History, error) {
+			if returnEmptyPage {
+				returnEmptyPage = false
+				return &historypb.History{
+					Events: []*historypb.HistoryEvent{},
+				}, nil
+			}
+			returnEmptyPage = true
+			eventID += 1
+			return &historypb.History{
+				Events: testEvents[eventID-1 : eventID],
+			}, nil
+		},
+		HasNextPageImpl: func() bool {
+			return !(eventID >= len(testEvents) && returnEmptyPage == false)
+		},
+	}
+
+	workflowTask := &workflowTask{task: task, historyIterator: historyIterator}
+	eh := newHistory(workflowTask, nil)
+
+	type result struct {
+		events   []*historypb.HistoryEvent
+		messages []*protocol.Message
+	}
+
+	expectedResults := []result{
+		{
+			events: []*historypb.HistoryEvent{
+				{
+					EventId:   1,
+					EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED,
+				},
+				{
+					EventId:   6,
+					EventType: enumspb.EVENT_TYPE_WORKFLOW_TASK_STARTED,
+				},
+			},
+			messages: []*protocol.Message{
+				{
+					ProtocolInstanceId: "test",
+				},
+			},
+		},
+		{
+			events: []*historypb.HistoryEvent{
+				{
+					EventId:   7,
+					EventType: enumspb.EVENT_TYPE_WORKFLOW_TASK_COMPLETED,
+				},
+				{
+					EventId:   8,
+					EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_ACCEPTED,
+				},
+				{
+					EventId:   10,
+					EventType: enumspb.EVENT_TYPE_WORKFLOW_TASK_STARTED,
+				},
+			},
+			messages: []*protocol.Message{},
+		},
+		{
+			events:   []*historypb.HistoryEvent{},
+			messages: []*protocol.Message{},
+		},
+	}
+
+	for _, expected := range expectedResults {
+		result, _, _, _, msgs, err := eh.NextCommandEvents()
+		s.NoError(err)
+		s.Equal(len(expected.events), len(result))
+		for i, event := range result {
+			s.Equal(expected.events[i].EventId, event.EventId)
+			s.Equal(expected.events[i].EventType, event.EventType)
+		}
+
+		s.Equal(len(expected.messages), len(msgs))
+		for i, msg := range msgs {
+			s.Equal(expected.messages[i].ProtocolInstanceId, msg.ProtocolInstanceId)
+		}
+	}
 }


### PR DESCRIPTION
Make the Go SDK more robust to empty pages from the server when running `IsNextWorkflowTaskFailed`.

 I saw without the change to `IsNextWorkflowTaskFailed` the unit test `TestEmptyPages` would return different events and messages if I used the `MockHistoryIterator` to return empty pages every other request or not.
