### PR TITLE
Prevent modifying workflow state in read only contexts

### DIFF
--- a/.github/workflows/docker/dynamic-config-custom.yaml
+++ b/.github/workflows/docker/dynamic-config-custom.yaml
@@ -3,3 +3,7 @@ system.forceSearchAttributesCacheRefreshOnRead:
     constraints: {}
 system.enableActivityEagerExecution:
   - value: true
+frontend.enableUpdateWorkflowExecution:
+  - value: true
+frontend.enableUpdateWorkflowExecutionAsyncAccepted:
+  - value: true

--- a/internal/internal_update.go
+++ b/internal/internal_update.go
@@ -66,7 +66,7 @@ type (
 		Complete(success interface{}, err error)
 	}
 
-	// UpdateScheduluer allows an update state machine to spawn coroutines and
+	// UpdateScheduler allows an update state machine to spawn coroutines and
 	// yield itself as necessary.
 	UpdateScheduler interface {
 		// Spawn starts a new named coroutine, executing the given function f.
@@ -231,7 +231,7 @@ func (up *updateProtocol) checkAcceptedEvent(e *historypb.HistoryEvent) bool {
 		attrs.AcceptedRequest != nil
 }
 
-// defaultHandler receives the initial invocation of an upate during WFT
+// defaultHandler receives the initial invocation of an update during WFT
 // processing. The implementation will verify that an updateHandler exists for
 // the supplied name (rejecting the update otherwise) and use the provided spawn
 // function to create a new coroutine that will execute in the workflow context.
@@ -253,6 +253,8 @@ func defaultUpdateHandler(
 		return
 	}
 	scheduler.Spawn(ctx, name, func(ctx Context) {
+		defer getState(ctx).dispatcher.setIsReadOnly(false)
+		getState(ctx).dispatcher.setIsReadOnly(true)
 		eo := getWorkflowEnvOptions(ctx)
 
 		// If we suspect that handler registration has not occurred (e.g.
@@ -295,6 +297,7 @@ func defaultUpdateHandler(
 			}
 		}
 		callbacks.Accept()
+		getState(ctx).dispatcher.setIsReadOnly(false)
 		success, err := envInterceptor.inboundInterceptor.ExecuteUpdate(ctx, &input)
 		callbacks.Complete(success, err)
 	})

--- a/internal/internal_update.go
+++ b/internal/internal_update.go
@@ -253,8 +253,6 @@ func defaultUpdateHandler(
 		return
 	}
 	scheduler.Spawn(ctx, name, func(ctx Context) {
-		defer getState(ctx).dispatcher.setIsReadOnly(false)
-		getState(ctx).dispatcher.setIsReadOnly(true)
 		eo := getWorkflowEnvOptions(ctx)
 
 		// If we suspect that handler registration has not occurred (e.g.
@@ -291,6 +289,8 @@ func defaultUpdateHandler(
 		if !IsReplaying(ctx) {
 			// we don't execute update validation during replay so that
 			// validation routines can change across versions
+			defer getState(ctx).dispatcher.setIsReadOnly(false)
+			getState(ctx).dispatcher.setIsReadOnly(true)
 			if err := envInterceptor.inboundInterceptor.ValidateUpdate(ctx, &input); err != nil {
 				callbacks.Reject(err)
 				return

--- a/internal/internal_update_test.go
+++ b/internal/internal_update_test.go
@@ -102,6 +102,11 @@ func TestUpdateHandlerPanicHandling(t *testing.T) {
 	}
 	interceptor, ctx, err := newWorkflowContext(env, nil)
 	require.NoError(t, err)
+	dispatcher, ctx := newDispatcher(
+		ctx,
+		interceptor,
+		func(ctx Context) {})
+	dispatcher.executing = true
 
 	panicFunc := func() error { panic("intentional") }
 	mustSetUpdateHandler(t, ctx, t.Name(), panicFunc, UpdateHandlerOptions{Validator: panicFunc})
@@ -176,8 +181,13 @@ func TestDefaultUpdateHandler(t *testing.T) {
 			TaskQueueName: "taskqueue:" + t.Name(),
 		},
 	}
-	_, ctx, err := newWorkflowContext(env, nil)
+	interceptor, ctx, err := newWorkflowContext(env, nil)
 	require.NoError(t, err)
+	dispatcher, ctx := newDispatcher(
+		ctx,
+		interceptor,
+		func(ctx Context) {})
+	dispatcher.executing = true
 
 	hdr := &commonpb.Header{Fields: map[string]*commonpb.Payload{}}
 	argStr := t.Name()
@@ -288,8 +298,13 @@ func TestDefaultUpdateHandler(t *testing.T) {
 		// don't reuse the context that has all the other update handlers
 		// registered because the code under test will think the handler
 		// registration at workflow start time has already occurred
-		_, ctx, err := newWorkflowContext(env, nil)
+		interceptor, ctx, err := newWorkflowContext(env, nil)
 		require.NoError(t, err)
+		dispatcher, ctx := newDispatcher(
+			ctx,
+			interceptor,
+			func(ctx Context) {})
+		dispatcher.executing = true
 
 		updateFunc := func(ctx Context, s string) (string, error) { return s + " success!", nil }
 		var (

--- a/internal/internal_workflow.go
+++ b/internal/internal_workflow.go
@@ -1449,7 +1449,6 @@ func newDecodeFuture(ctx Context, fn interface{}) (Future, Settable) {
 
 // setQueryHandler sets query handler for given queryType.
 func setQueryHandler(ctx Context, queryType string, handler interface{}) error {
-	assertNotInReadOnlyState(ctx)
 	qh := &queryHandler{fn: handler, queryType: queryType, dataConverter: getDataConverterFromWorkflowContext(ctx)}
 	err := validateQueryHandlerFn(qh.fn)
 	if err != nil {
@@ -1462,7 +1461,6 @@ func setQueryHandler(ctx Context, queryType string, handler interface{}) error {
 
 // setUpdateHandler sets update handler for a given update name.
 func setUpdateHandler(ctx Context, updateName string, handler interface{}, opts UpdateHandlerOptions) error {
-	assertNotInReadOnlyState(ctx)
 	uh, err := newUpdateHandler(updateName, handler, opts)
 	if err != nil {
 		return err

--- a/internal/internal_workflow.go
+++ b/internal/internal_workflow.go
@@ -316,6 +316,7 @@ func getWorkflowOutboundInterceptor(ctx Context) WorkflowOutboundInterceptor {
 }
 
 func (f *futureImpl) Get(ctx Context, valuePtr interface{}) error {
+	assertNotInReadOnlyState(ctx)
 	more := f.channel.Receive(ctx, nil)
 	if more {
 		panic("not closed")
@@ -1194,6 +1195,7 @@ func (s *selectorImpl) HasPending() bool {
 }
 
 func (s *selectorImpl) Select(ctx Context) {
+	assertNotInReadOnlyState(ctx)
 	state := getState(ctx)
 	var readyBranch func()
 	var cleanups []func()
@@ -1447,6 +1449,7 @@ func newDecodeFuture(ctx Context, fn interface{}) (Future, Settable) {
 
 // setQueryHandler sets query handler for given queryType.
 func setQueryHandler(ctx Context, queryType string, handler interface{}) error {
+	assertNotInReadOnlyState(ctx)
 	qh := &queryHandler{fn: handler, queryType: queryType, dataConverter: getDataConverterFromWorkflowContext(ctx)}
 	err := validateQueryHandlerFn(qh.fn)
 	if err != nil {
@@ -1459,6 +1462,7 @@ func setQueryHandler(ctx Context, queryType string, handler interface{}) error {
 
 // setUpdateHandler sets update handler for a given update name.
 func setUpdateHandler(ctx Context, updateName string, handler interface{}, opts UpdateHandlerOptions) error {
+	assertNotInReadOnlyState(ctx)
 	uh, err := newUpdateHandler(updateName, handler, opts)
 	if err != nil {
 		return err
@@ -1591,7 +1595,7 @@ func (wg *waitGroupImpl) Done() {
 	wg.Add(-1)
 }
 
-// Wait blocks and waits for specified number of couritines to
+// Wait blocks and waits for specified number of coroutines to
 // finish executing and then unblocks once the counter has reached 0.
 //
 // param ctx Context -> workflow context

--- a/internal/internal_workflow_test.go
+++ b/internal/internal_workflow_test.go
@@ -1348,6 +1348,72 @@ func (s *WorkflowUnitTest) Test_WaitGroupWorkflowTest() {
 	s.Equal(n, total)
 }
 
+func (s *WorkflowUnitTest) Test_MutatingFunctionsInQueries() {
+	env := s.NewTestWorkflowEnvironment()
+
+	wf := func(ctx Context) error {
+		currentState := "fail"
+		_ = SetQueryHandler(ctx, queryType, func() (string, error) {
+			_ = Sleep(ctx, time.Minute)
+			return currentState, nil
+		})
+		_ = Sleep(ctx, time.Minute)
+		return nil
+	}
+	env.RegisterWorkflow(wf)
+	env.RegisterDelayedCallback(func() {
+		_, err := env.QueryWorkflow(queryType, "test")
+		s.NoError(err)
+	}, time.Second)
+	env.ExecuteWorkflow(wf)
+	s.True(env.IsWorkflowCompleted())
+	s.NoError(env.GetWorkflowError())
+}
+
+type updateCallback struct {
+	accept   func()
+	reject   func(error)
+	complete func(interface{}, error)
+}
+
+func (uc *updateCallback) Accept() {
+	uc.accept()
+}
+
+func (uc *updateCallback) Reject(err error) {
+	uc.reject(err)
+}
+
+func (uc *updateCallback) Complete(success interface{}, err error) {
+	uc.complete(success, err)
+}
+
+func (s *WorkflowUnitTest) Test_MutatingFunctionsInUpdateValidator() {
+	env := s.NewTestWorkflowEnvironment()
+
+	wf := func(ctx Context) error {
+		currentState := "fail"
+		_ = setUpdateHandler(ctx, updateType, func(ctx Context) (string, error) {
+			_ = Sleep(ctx, time.Minute)
+			return currentState, nil
+		}, UpdateHandlerOptions{
+			Validator: func(ctx Context) error {
+				return Sleep(ctx, time.Minute)
+			},
+		})
+		_ = Sleep(ctx, time.Minute)
+		return nil
+	}
+	env.RegisterWorkflow(wf)
+	env.RegisterDelayedCallback(func() {
+		env.UpdateWorkflow(updateType, &updateCallback{})
+		//s.NoError(err)
+	}, time.Second)
+	env.ExecuteWorkflow(wf)
+	s.True(env.IsWorkflowCompleted())
+	s.NoError(env.GetWorkflowError())
+}
+
 func (s *WorkflowUnitTest) Test_StaleGoroutinesAreShutDown() {
 	env := s.NewTestWorkflowEnvironment()
 	deferred := make(chan struct{})

--- a/internal/internal_workflow_test.go
+++ b/internal/internal_workflow_test.go
@@ -1348,6 +1348,38 @@ func (s *WorkflowUnitTest) Test_WaitGroupWorkflowTest() {
 	s.Equal(n, total)
 }
 
+func (s *WorkflowUnitTest) Test_MutatingFunctionsInSideEffect() {
+	env := s.NewTestWorkflowEnvironment()
+
+	wf := func(ctx Context) error {
+		SideEffect(ctx, func(ctx Context) interface{} {
+			_ = Sleep(ctx, time.Minute)
+			return nil
+		})
+		return nil
+	}
+	env.RegisterWorkflow(wf)
+	env.ExecuteWorkflow(wf)
+	s.True(env.IsWorkflowCompleted())
+	s.Error(env.GetWorkflowError())
+}
+
+func (s *WorkflowUnitTest) Test_MutatingFunctionsInMutableSideEffect() {
+	env := s.NewTestWorkflowEnvironment()
+
+	wf := func(ctx Context) error {
+		MutableSideEffect(ctx, "test-side-effect", func(ctx Context) interface{} {
+			_ = Sleep(ctx, time.Minute)
+			return nil
+		}, func(a, b interface{}) bool { return false })
+		return nil
+	}
+	env.RegisterWorkflow(wf)
+	env.ExecuteWorkflow(wf)
+	s.True(env.IsWorkflowCompleted())
+	s.Error(env.GetWorkflowError())
+}
+
 func (s *WorkflowUnitTest) Test_MutatingFunctionsInQueries() {
 	env := s.NewTestWorkflowEnvironment()
 

--- a/internal/internal_workflow_test.go
+++ b/internal/internal_workflow_test.go
@@ -1425,7 +1425,7 @@ func (s *WorkflowUnitTest) Test_MutatingFunctionsInUpdateValidator() {
 
 	wf := func(ctx Context) error {
 		currentState := "fail"
-		_ = setUpdateHandler(ctx, updateType, func(ctx Context) (string, error) {
+		_ = SetUpdateHandler(ctx, updateType, func(ctx Context) (string, error) {
 			_ = Sleep(ctx, time.Minute)
 			return currentState, nil
 		}, UpdateHandlerOptions{

--- a/internal/internal_workflow_test.go
+++ b/internal/internal_workflow_test.go
@@ -1363,7 +1363,7 @@ func (s *WorkflowUnitTest) Test_MutatingFunctionsInQueries() {
 	env.RegisterWorkflow(wf)
 	env.RegisterDelayedCallback(func() {
 		_, err := env.QueryWorkflow(queryType, "test")
-		s.NoError(err)
+		s.Error(err)
 	}, time.Second)
 	env.ExecuteWorkflow(wf)
 	s.True(env.IsWorkflowCompleted())
@@ -1406,8 +1406,11 @@ func (s *WorkflowUnitTest) Test_MutatingFunctionsInUpdateValidator() {
 	}
 	env.RegisterWorkflow(wf)
 	env.RegisterDelayedCallback(func() {
-		env.UpdateWorkflow(updateType, &updateCallback{})
-		//s.NoError(err)
+		env.UpdateWorkflow(updateType, &updateCallback{
+			reject: func(err error) {
+				s.Error(err)
+			},
+		})
 	}, time.Second)
 	env.ExecuteWorkflow(wf)
 	s.True(env.IsWorkflowCompleted())

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -1422,6 +1422,7 @@ func withContextPropagators(ctx Context, contextPropagators []ContextPropagator)
 
 // GetSignalChannel returns channel corresponding to the signal name.
 func GetSignalChannel(ctx Context, signalName string) ReceiveChannel {
+	assertNotInReadOnlyState(ctx)
 	i := getWorkflowOutboundInterceptor(ctx)
 	return i.GetSignalChannel(ctx, signalName)
 }

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -343,6 +343,7 @@ type (
 // Await blocks the calling thread until condition() returns true
 // Returns CanceledError if the ctx is canceled.
 func Await(ctx Context, condition func() bool) error {
+	assertNotInReadOnlyState(ctx)
 	state := getState(ctx)
 	defer state.unblocked()
 
@@ -362,6 +363,7 @@ func Await(ctx Context, condition func() bool) error {
 // AwaitWithTimeout blocks the calling thread until condition() returns true
 // Returns ok equals to false if timed out and err equals to CanceledError if the ctx is canceled.
 func AwaitWithTimeout(ctx Context, timeout time.Duration, condition func() bool) (ok bool, err error) {
+	assertNotInReadOnlyState(ctx)
 	state := getState(ctx)
 	defer state.unblocked()
 	timer := NewTimer(ctx, timeout)
@@ -417,18 +419,21 @@ func NewSelector(ctx Context) Selector {
 
 // NewNamedSelector creates a new Selector instance with a given human readable name.
 // Name appears in stack traces that are blocked on this Selector.
-func NewNamedSelector(_ Context, name string) Selector {
+func NewNamedSelector(ctx Context, name string) Selector {
+	assertNotInReadOnlyState(ctx)
 	return &selectorImpl{name: name}
 }
 
 // NewWaitGroup creates a new WaitGroup instance.
 func NewWaitGroup(ctx Context) WaitGroup {
+	assertNotInReadOnlyState(ctx)
 	f, s := NewFuture(ctx)
 	return &waitGroupImpl{future: f, settable: s}
 }
 
 // Go creates a new coroutine. It has similar semantic to goroutine in a context of the workflow.
 func Go(ctx Context, f func(ctx Context)) {
+	assertNotInReadOnlyState(ctx)
 	state := getState(ctx)
 	state.dispatcher.interceptor.Go(ctx, "", f)
 }
@@ -437,12 +442,14 @@ func Go(ctx Context, f func(ctx Context)) {
 // It has similar semantic to goroutine in a context of the workflow.
 // Name appears in stack traces that are blocked on this Channel.
 func GoNamed(ctx Context, name string, f func(ctx Context)) {
+	assertNotInReadOnlyState(ctx)
 	state := getState(ctx)
 	state.dispatcher.interceptor.Go(ctx, name, f)
 }
 
 // NewFuture creates a new future as well as associated Settable that is used to set its value.
 func NewFuture(ctx Context) (Future, Settable) {
+	assertNotInReadOnlyState(ctx)
 	impl := &futureImpl{channel: NewChannel(ctx).(*channelImpl)}
 	return impl, impl
 }
@@ -547,6 +554,7 @@ func (wc *workflowEnvironmentInterceptor) Init(outbound WorkflowOutboundIntercep
 //
 // ExecuteActivity returns Future with activity result or failure.
 func ExecuteActivity(ctx Context, activity interface{}, args ...interface{}) Future {
+	assertNotInReadOnlyState(ctx)
 	i := getWorkflowOutboundInterceptor(ctx)
 	registry := getRegistryFromWorkflowContext(ctx)
 	activityType := getActivityFunctionName(registry, activity)
@@ -557,6 +565,7 @@ func ExecuteActivity(ctx Context, activity interface{}, args ...interface{}) Fut
 
 func (wc *workflowEnvironmentInterceptor) ExecuteActivity(ctx Context, typeName string, args ...interface{}) Future {
 	// Validate type and its arguments.
+	assertNotInReadOnlyState(ctx)
 	dataConverter := getDataConverterFromWorkflowContext(ctx)
 	registry := getRegistryFromWorkflowContext(ctx)
 	future, settable := newDecodeFuture(ctx, typeName)
@@ -667,6 +676,7 @@ func (wc *workflowEnvironmentInterceptor) ExecuteActivity(ctx Context, typeName 
 //
 // ExecuteLocalActivity returns Future with local activity result or failure.
 func ExecuteLocalActivity(ctx Context, activity interface{}, args ...interface{}) Future {
+	assertNotInReadOnlyState(ctx)
 	i := getWorkflowOutboundInterceptor(ctx)
 	env := getWorkflowEnvironment(ctx)
 	activityType, isMethod := getFunctionName(activity)
@@ -855,6 +865,7 @@ func (wc *workflowEnvironmentInterceptor) scheduleLocalActivity(ctx Context, par
 //
 // ExecuteChildWorkflow returns ChildWorkflowFuture.
 func ExecuteChildWorkflow(ctx Context, childWorkflow interface{}, args ...interface{}) ChildWorkflowFuture {
+	assertNotInReadOnlyState(ctx)
 	i := getWorkflowOutboundInterceptor(ctx)
 	env := getWorkflowEnvironment(ctx)
 	workflowType, err := getWorkflowFunctionName(env.GetRegistry(), childWorkflow)
@@ -1043,6 +1054,7 @@ func (wc *workflowEnvironmentInterceptor) Now(ctx Context) time.Time {
 // timer by cancel the Context (using context from workflow.WithCancel(ctx)) and that will cancel the timer. After timer
 // is canceled, the returned Future become ready, and Future.Get() will return *CanceledError.
 func NewTimer(ctx Context, d time.Duration) Future {
+	assertNotInReadOnlyState(ctx)
 	i := getWorkflowOutboundInterceptor(ctx)
 	return i.NewTimer(ctx, d)
 }
@@ -1086,6 +1098,7 @@ func (wc *workflowEnvironmentInterceptor) NewTimer(ctx Context, d time.Duration)
 // reasons the ctx could be canceled: 1) your workflow code cancel the ctx (with workflow.WithCancel(ctx));
 // 2) your workflow itself is canceled by external request.
 func Sleep(ctx Context, d time.Duration) (err error) {
+	assertNotInReadOnlyState(ctx)
 	i := getWorkflowOutboundInterceptor(ctx)
 	return i.Sleep(ctx, d)
 }
@@ -1107,6 +1120,7 @@ func (wc *workflowEnvironmentInterceptor) Sleep(ctx Context, d time.Duration) (e
 //
 // RequestCancelExternalWorkflow return Future with failure or empty success result.
 func RequestCancelExternalWorkflow(ctx Context, workflowID, runID string) Future {
+	assertNotInReadOnlyState(ctx)
 	i := getWorkflowOutboundInterceptor(ctx)
 	return i.RequestCancelExternalWorkflow(ctx, workflowID, runID)
 }
@@ -1146,6 +1160,7 @@ func (wc *workflowEnvironmentInterceptor) RequestCancelExternalWorkflow(ctx Cont
 //
 // SignalExternalWorkflow return Future with failure or empty success result.
 func SignalExternalWorkflow(ctx Context, workflowID, runID, signalName string, arg interface{}) Future {
+	assertNotInReadOnlyState(ctx)
 	i := getWorkflowOutboundInterceptor(ctx)
 	// Put header on context before executing
 	ctx = workflowContextWithNewHeader(ctx)
@@ -1237,6 +1252,7 @@ func signalExternalWorkflow(ctx Context, workflowID, runID, signalName string, a
 //
 // This is only supported when using ElasticSearch.
 func UpsertSearchAttributes(ctx Context, attributes map[string]interface{}) error {
+	assertNotInReadOnlyState(ctx)
 	i := getWorkflowOutboundInterceptor(ctx)
 	return i.UpsertSearchAttributes(ctx, attributes)
 }
@@ -1275,6 +1291,7 @@ func (wc *workflowEnvironmentInterceptor) UpsertSearchAttributes(ctx Context, at
 //
 // This is only supported with Temporal Server 1.18+
 func UpsertMemo(ctx Context, memo map[string]interface{}) error {
+	assertNotInReadOnlyState(ctx)
 	i := getWorkflowOutboundInterceptor(ctx)
 	return i.UpsertMemo(ctx, memo)
 }
@@ -1473,6 +1490,7 @@ func (b EncodedValue) HasValue() bool {
 //	       ....
 //	}
 func SideEffect(ctx Context, f func(ctx Context) interface{}) converter.EncodedValue {
+	assertNotInReadOnlyState(ctx)
 	i := getWorkflowOutboundInterceptor(ctx)
 	return i.SideEffect(ctx, f)
 }
@@ -1481,6 +1499,9 @@ func (wc *workflowEnvironmentInterceptor) SideEffect(ctx Context, f func(ctx Con
 	dc := getDataConverterFromWorkflowContext(ctx)
 	future, settable := NewFuture(ctx)
 	wrapperFunc := func() (*commonpb.Payloads, error) {
+		coroutineState := getState(ctx)
+		defer coroutineState.dispatcher.setIsReadOnly(false)
+		coroutineState.dispatcher.setIsReadOnly(true)
 		r := f(ctx)
 		return encodeArg(dc, r)
 	}
@@ -1498,7 +1519,7 @@ func (wc *workflowEnvironmentInterceptor) SideEffect(ctx Context, f func(ctx Con
 // MutableSideEffect executes the provided function once, then it looks up the history for the value with the given id.
 // If there is no existing value, then it records the function result as a value with the given id on history;
 // otherwise, it compares whether the existing value from history has changed from the new function result by calling
-// theprovided equals function. If they are equal, it returns the value without recording a new one in history;
+// the provided equals function. If they are equal, it returns the value without recording a new one in history;
 //
 //	otherwise, it records the new value with the same id on history.
 //
@@ -1512,12 +1533,16 @@ func (wc *workflowEnvironmentInterceptor) SideEffect(ctx Context, f func(ctx Con
 //
 // One good use case of MutableSideEffect() is to access dynamically changing config without breaking determinism.
 func MutableSideEffect(ctx Context, id string, f func(ctx Context) interface{}, equals func(a, b interface{}) bool) converter.EncodedValue {
+	assertNotInReadOnlyState(ctx)
 	i := getWorkflowOutboundInterceptor(ctx)
 	return i.MutableSideEffect(ctx, id, f, equals)
 }
 
 func (wc *workflowEnvironmentInterceptor) MutableSideEffect(ctx Context, id string, f func(ctx Context) interface{}, equals func(a, b interface{}) bool) converter.EncodedValue {
 	wrapperFunc := func() interface{} {
+		coroutineState := getState(ctx)
+		defer coroutineState.dispatcher.setIsReadOnly(false)
+		coroutineState.dispatcher.setIsReadOnly(true)
 		return f(ctx)
 	}
 	return wc.env.MutableSideEffect(id, wrapperFunc, equals)
@@ -1595,6 +1620,7 @@ const TemporalChangeVersion = "TemporalChangeVersion"
 //	  err = workflow.ExecuteActivity(ctx, qux, data).Get(ctx, nil)
 //	}
 func GetVersion(ctx Context, changeID string, minSupported, maxSupported Version) Version {
+	assertNotInReadOnlyState(ctx)
 	i := getWorkflowOutboundInterceptor(ctx)
 	return i.GetVersion(ctx, changeID, minSupported, maxSupported)
 }
@@ -1643,6 +1669,7 @@ func (wc *workflowEnvironmentInterceptor) GetVersion(ctx Context, changeID strin
 //	  return nil
 //	}
 func SetQueryHandler(ctx Context, queryType string, handler interface{}) error {
+	assertNotInReadOnlyState(ctx)
 	i := getWorkflowOutboundInterceptor(ctx)
 	return i.SetQueryHandler(ctx, queryType, handler)
 }
@@ -1672,6 +1699,7 @@ func SetQueryHandler(ctx Context, queryType string, handler interface{}) error {
 //
 // NOTE: Experimental
 func SetUpdateHandler(ctx Context, updateName string, handler interface{}, opts UpdateHandlerOptions) error {
+	assertNotInReadOnlyState(ctx)
 	i := getWorkflowOutboundInterceptor(ctx)
 	return i.SetUpdateHandler(ctx, updateName, handler, opts)
 }

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -565,7 +565,6 @@ func ExecuteActivity(ctx Context, activity interface{}, args ...interface{}) Fut
 
 func (wc *workflowEnvironmentInterceptor) ExecuteActivity(ctx Context, typeName string, args ...interface{}) Future {
 	// Validate type and its arguments.
-	assertNotInReadOnlyState(ctx)
 	dataConverter := getDataConverterFromWorkflowContext(ctx)
 	registry := getRegistryFromWorkflowContext(ctx)
 	future, settable := newDecodeFuture(ctx, typeName)

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -1174,7 +1174,7 @@ func (ts *IntegrationTestSuite) TestMutatingQuery() {
 	ts.Nil(err)
 	_, err = ts.client.QueryWorkflow(ctx, "test-mutating-query", run.GetRunID(), "mutating_query")
 	ts.Error(err)
-	ts.client.CancelWorkflow(ctx, "test-mutating-query", "")
+	ts.Nil(ts.client.CancelWorkflow(ctx, "test-mutating-query", ""))
 }
 
 func (ts *IntegrationTestSuite) TestMutatingUpdateValidator() {
@@ -1186,7 +1186,7 @@ func (ts *IntegrationTestSuite) TestMutatingUpdateValidator() {
 	ts.NoError(err)
 
 	ts.Error(handler.Get(ctx, nil))
-	ts.client.CancelWorkflow(ctx, "test-mutating-update-validator", "")
+	ts.Nil(ts.client.CancelWorkflow(ctx, "test-mutating-update-validator", ""))
 }
 
 func (ts *IntegrationTestSuite) TestMutatingSideEffect() {

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -1167,6 +1167,40 @@ func (ts *IntegrationTestSuite) TestLargeQueryResultError() {
 	ts.Nil(value)
 }
 
+func (ts *IntegrationTestSuite) TestMutatingQuery() {
+	ctx := context.Background()
+	run, err := ts.client.ExecuteWorkflow(ctx,
+		ts.startWorkflowOptions("test-mutating-query"), ts.workflows.MutatingQueryWorkflow)
+	ts.Nil(err)
+	_, err = ts.client.QueryWorkflow(ctx, "test-mutating-query", run.GetRunID(), "mutating_query")
+	ts.Error(err)
+	ts.client.CancelWorkflow(ctx, "test-mutating-query", "")
+}
+
+func (ts *IntegrationTestSuite) TestMutatingUpdateValidator() {
+	ctx := context.Background()
+	run, err := ts.client.ExecuteWorkflow(ctx,
+		ts.startWorkflowOptions("test-mutating-update-validator"), ts.workflows.MutatingUpdateValidatorWorkflow)
+	ts.Nil(err)
+	handler, err := ts.client.UpdateWorkflow(ctx, "test-mutating-update-validator", run.GetRunID(), "mutating_update")
+	ts.NoError(err)
+
+	ts.Error(handler.Get(ctx, nil))
+	ts.client.CancelWorkflow(ctx, "test-mutating-update-validator", "")
+}
+
+func (ts *IntegrationTestSuite) TestMutatingSideEffect() {
+	ctx := context.Background()
+	err := ts.executeWorkflowWithContextAndOption(ctx, ts.startWorkflowOptions("test-mutating-side-effect"), ts.workflows.MutatingSideEffectWorkflow, nil)
+	ts.Error(err)
+}
+
+func (ts *IntegrationTestSuite) TestMutatingMutableSideEffect() {
+	ctx := context.Background()
+	err := ts.executeWorkflowWithContextAndOption(ctx, ts.startWorkflowOptions("test-mutating-mutable-side-effect"), ts.workflows.MutatingMutableSideEffectWorkflow, nil)
+	ts.Error(err)
+}
+
 func (ts *IntegrationTestSuite) TestInspectActivityInfo() {
 	err := ts.executeWorkflow("test-activity-info", ts.workflows.InspectActivityInfo, nil)
 	ts.Nil(err)

--- a/test/workflow_test.go
+++ b/test/workflow_test.go
@@ -860,6 +860,56 @@ func (w *Workflows) LargeQueryResultWorkflow(ctx workflow.Context) (string, erro
 	return "hello", nil
 }
 
+func (w *Workflows) MutatingQueryWorkflow(ctx workflow.Context) (string, error) {
+	err := workflow.SetQueryHandler(ctx, "mutating_query", func() (string, error) {
+		workflow.Sleep(ctx, time.Second)
+		return "failed", nil
+	})
+	if err != nil {
+		return "", errors.New("failed to register query handler")
+	}
+	workflow.GetSignalChannel(ctx, "finish").Receive(ctx, nil)
+	return "hello", nil
+}
+
+func (w *Workflows) MutatingUpdateValidatorWorkflow(ctx workflow.Context) (string, error) {
+	err := workflow.SetUpdateHandlerWithOptions(ctx, "mutating_update", func(ctx workflow.Context) (string, error) {
+		workflow.Sleep(ctx, time.Second)
+		return "failed", nil
+	}, workflow.UpdateHandlerOptions{
+		Validator: func(ctx workflow.Context) error {
+			return workflow.Sleep(ctx, time.Second)
+		},
+	})
+	if err != nil {
+		return "", errors.New("failed to register query handler")
+	}
+	workflow.GetSignalChannel(ctx, "finish").Receive(ctx, nil)
+	return "hello", nil
+}
+
+func (w *Workflows) MutatingSideEffectWorkflow(ctx workflow.Context) (string, error) {
+	encodedValue := workflow.SideEffect(ctx, func(ctx workflow.Context) interface{} {
+		workflow.Sleep(ctx, 45*time.Second)
+		return "fail"
+	})
+	var sideEffectValue string
+	err := encodedValue.Get(&sideEffectValue)
+	return sideEffectValue, err
+}
+
+func (w *Workflows) MutatingMutableSideEffectWorkflow(ctx workflow.Context) (string, error) {
+	encodedValue := workflow.MutableSideEffect(ctx, "test-id", func(ctx workflow.Context) interface{} {
+		workflow.Sleep(ctx, 45*time.Second)
+		return "fail"
+	}, func(a, b interface{}) bool {
+		return false
+	})
+	var sideEffectValue string
+	err := encodedValue.Get(&sideEffectValue)
+	return sideEffectValue, err
+}
+
 func (w *Workflows) ConsistentQueryWorkflow(ctx workflow.Context, delay time.Duration) error {
 	queryResult := "starting-value"
 	err := workflow.SetQueryHandler(ctx, "consistent_query", func() (string, error) {
@@ -2187,6 +2237,10 @@ func (w *Workflows) register(worker worker.Worker) {
 	worker.RegisterWorkflow(w.ChildWorkflowCancelUnusualTransitionsRepro)
 	worker.RegisterWorkflow(w.ChildWorkflowDuplicatePanicRepro)
 	worker.RegisterWorkflow(w.ChildWorkflowDuplicateGetExecutionStuckRepro)
+	worker.RegisterWorkflow(w.MutatingQueryWorkflow)
+	worker.RegisterWorkflow(w.MutatingUpdateValidatorWorkflow)
+	worker.RegisterWorkflow(w.MutatingSideEffectWorkflow)
+	worker.RegisterWorkflow(w.MutatingMutableSideEffectWorkflow)
 	worker.RegisterWorkflow(w.ConsistentQueryWorkflow)
 	worker.RegisterWorkflow(w.ContextPropagator)
 	worker.RegisterWorkflow(w.ContinueAsNew)

--- a/test/workflow_test.go
+++ b/test/workflow_test.go
@@ -862,7 +862,7 @@ func (w *Workflows) LargeQueryResultWorkflow(ctx workflow.Context) (string, erro
 
 func (w *Workflows) MutatingQueryWorkflow(ctx workflow.Context) (string, error) {
 	err := workflow.SetQueryHandler(ctx, "mutating_query", func() (string, error) {
-		workflow.Sleep(ctx, time.Second)
+		_ = workflow.Sleep(ctx, time.Second)
 		return "failed", nil
 	})
 	if err != nil {
@@ -874,7 +874,7 @@ func (w *Workflows) MutatingQueryWorkflow(ctx workflow.Context) (string, error) 
 
 func (w *Workflows) MutatingUpdateValidatorWorkflow(ctx workflow.Context) (string, error) {
 	err := workflow.SetUpdateHandlerWithOptions(ctx, "mutating_update", func(ctx workflow.Context) (string, error) {
-		workflow.Sleep(ctx, time.Second)
+		_ = workflow.Sleep(ctx, time.Second)
 		return "failed", nil
 	}, workflow.UpdateHandlerOptions{
 		Validator: func(ctx workflow.Context) error {
@@ -890,7 +890,7 @@ func (w *Workflows) MutatingUpdateValidatorWorkflow(ctx workflow.Context) (strin
 
 func (w *Workflows) MutatingSideEffectWorkflow(ctx workflow.Context) (string, error) {
 	encodedValue := workflow.SideEffect(ctx, func(ctx workflow.Context) interface{} {
-		workflow.Sleep(ctx, 45*time.Second)
+		_ = workflow.Sleep(ctx, 45*time.Second)
 		return "fail"
 	})
 	var sideEffectValue string
@@ -900,7 +900,7 @@ func (w *Workflows) MutatingSideEffectWorkflow(ctx workflow.Context) (string, er
 
 func (w *Workflows) MutatingMutableSideEffectWorkflow(ctx workflow.Context) (string, error) {
 	encodedValue := workflow.MutableSideEffect(ctx, "test-id", func(ctx workflow.Context) interface{} {
-		workflow.Sleep(ctx, 45*time.Second)
+		_ = workflow.Sleep(ctx, 45*time.Second)
 		return "fail"
 	}, func(a, b interface{}) bool {
 		return false


### PR DESCRIPTION
Prevent modifying workflow state in read only contexts. Track the current execution state in the `dispatcher`

An alternative approach would be to check the state when the command is being recorded, I didn't like that option because workflow state can be modified without a command being generated (like reading from a channel) so it needs to be more generic.

closes https://github.com/temporalio/sdk-go/issues/1000
