### PR TITLE
Add interceptors for Await and AwaitWithTimeout

### DIFF
--- a/internal/interceptor.go
+++ b/internal/interceptor.go
@@ -171,6 +171,12 @@ type WorkflowOutboundInterceptor interface {
 	// Go intercepts workflow.Go.
 	Go(ctx Context, name string, f func(ctx Context)) Context
 
+	// Await intercepts workflow.Await.
+	Await(ctx Context, condition func() bool) error
+
+	// AwaitWithTimeout intercepts workflow.AwaitWithTimeout.
+	AwaitWithTimeout(ctx Context, timeout time.Duration, condition func() bool) (bool, error)
+
 	// ExecuteActivity intercepts workflow.ExecuteActivity.
 	// interceptor.WorkflowHeader will return a non-nil map for this context.
 	ExecuteActivity(ctx Context, activityType string, args ...interface{}) Future

--- a/internal/interceptor_base.go
+++ b/internal/interceptor_base.go
@@ -195,6 +195,16 @@ func (w *WorkflowOutboundInterceptorBase) ExecuteActivity(ctx Context, activityT
 	return w.Next.ExecuteActivity(ctx, activityType, args...)
 }
 
+// Await implements WorkflowOutboundInterceptor.Await.
+func (w *WorkflowOutboundInterceptorBase) Await(ctx Context, condition func() bool) error {
+	return w.Next.Await(ctx, condition)
+}
+
+// AwaitWithTimeout implements WorkflowOutboundInterceptor.AwaitWithTimeout.
+func (w *WorkflowOutboundInterceptorBase) AwaitWithTimeout(ctx Context, timeout time.Duration, condition func() bool) (bool, error) {
+	return w.Next.AwaitWithTimeout(ctx, timeout, condition)
+}
+
 // ExecuteLocalActivity implements WorkflowOutboundInterceptor.ExecuteLocalActivity.
 func (w *WorkflowOutboundInterceptorBase) ExecuteLocalActivity(
 	ctx Context,

--- a/internal/interceptortest/proxy.go
+++ b/internal/interceptortest/proxy.go
@@ -301,6 +301,18 @@ func (p *proxyWorkflowOutbound) Go(
 	return
 }
 
+func (p *proxyWorkflowOutbound) Await(ctx workflow.Context, condition func() bool) (ret error) {
+	ret, _ = p.invoke(ctx, condition)[0].Interface().(error)
+	return
+}
+
+func (p *proxyWorkflowOutbound) AwaitWithTimeout(ctx workflow.Context, timeout time.Duration, condition func() bool) (ret bool, err error) {
+	result := p.invoke(ctx, timeout, condition)
+	ret, _ = result[0].Interface().(bool)
+	err, _ = result[1].Interface().(error)
+	return
+}
+
 func (p *proxyWorkflowOutbound) ExecuteActivity(
 	ctx workflow.Context,
 	activityType string,

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -345,6 +345,11 @@ type (
 func Await(ctx Context, condition func() bool) error {
 	assertNotInReadOnlyState(ctx)
 	state := getState(ctx)
+	return state.dispatcher.interceptor.Await(ctx, condition)
+}
+
+func (wc *workflowEnvironmentInterceptor) Await(ctx Context, condition func() bool) error {
+	state := getState(ctx)
 	defer state.unblocked()
 
 	for !condition() {
@@ -364,6 +369,11 @@ func Await(ctx Context, condition func() bool) error {
 // Returns ok equals to false if timed out and err equals to CanceledError if the ctx is canceled.
 func AwaitWithTimeout(ctx Context, timeout time.Duration, condition func() bool) (ok bool, err error) {
 	assertNotInReadOnlyState(ctx)
+	state := getState(ctx)
+	return state.dispatcher.interceptor.AwaitWithTimeout(ctx, timeout, condition)
+}
+
+func (wc *workflowEnvironmentInterceptor) AwaitWithTimeout(ctx Context, timeout time.Duration, condition func() bool) (ok bool, err error) {
 	state := getState(ctx)
 	defer state.unblocked()
 	timer := NewTimer(ctx, timeout)


### PR DESCRIPTION
add interceptors for `Await` and `AwaitWithTimeout`

closes: https://github.com/temporalio/sdk-go/issues/1155
