### PR TITLE
Reassign runningWorkflows workflow ID in test environment

### DIFF
--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -2431,6 +2431,10 @@ func (env *testWorkflowEnvironmentImpl) setStartWorkflowOptions(options StartWor
 		wf.WorkflowTaskTimeout = options.WorkflowTaskTimeout
 	}
 	if len(options.ID) > 0 {
+		// Reassign the ID in running Workflows so SignalWorkflowByID can find the workflow
+		originalID := wf.WorkflowExecution.ID
+		env.runningWorkflows[options.ID] = env.runningWorkflows[wf.WorkflowExecution.ID]
+		delete(env.runningWorkflows, originalID)
 		wf.WorkflowExecution.ID = options.ID
 	}
 	if len(options.TaskQueue) > 0 {


### PR DESCRIPTION
Update the runningWorkflows map with the specified ID if set

closes: https://github.com/temporalio/sdk-go/issues/1160