### PR TITLE
Remove unused info in CI workflow logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,6 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     steps:
-      - name: Print build information
-        run: "echo head_ref: ${{ github.head_ref }}, ref: ${{ github.ref }}"
       - uses: actions/checkout@v3
         with:
           submodules: recursive


### PR DESCRIPTION
## What was changed
Removing the ref and head_ref from the workflow logs.

## Why?
Directly using this user-modifiable information without setting it as a variable first is considered an injection vulnerability. However, since it's not really useful, just remove it.

## Checklist

How was this tested:
Just did the static analysis and unit tests.