### PR TITLE
Expose update interceptor input

### DIFF
--- a/interceptor/interceptor.go
+++ b/interceptor/interceptor.go
@@ -125,6 +125,12 @@ type HandleSignalInput = internal.HandleSignalInput
 // HandleQueryInput is input for WorkflowInboundInterceptor.HandleQuery.
 type HandleQueryInput = internal.HandleQueryInput
 
+// UpdateInput is input for WorkflowInboundInterceptor.ExecuteUpdate
+// and WorkflowInboundInterceptor.ValidateUpdate.
+//
+// NOTE: Experimental
+type UpdateInput = internal.UpdateInput
+
 // WorkflowOutboundInterceptor is an interface for all workflow calls
 // originating from the SDK.
 //

--- a/internal/interceptor.go
+++ b/internal/interceptor.go
@@ -127,12 +127,16 @@ type WorkflowInboundInterceptor interface {
 	// as part of its optional configuration. The same prohibition against
 	// mutating workflow state that is demanded of UpdateOptions.Validator
 	// functions also applies to this function.
+	//
+	// NOTE: Experimental
 	ValidateUpdate(ctx Context, in *UpdateInput) error
 
 	// ExecuteUpdate is called after ValidateUpdate if and only if the latter
 	// returns nil. interceptor.WorkflowHeader will return a non-nil map for
 	// this context. ExecuteUpdate is allowed to mutate workflow state and
 	// perform workflow actions such as scheduling activities, timers, etc.
+	//
+	// NOTE: Experimental
 	ExecuteUpdate(ctx Context, in *UpdateInput) (interface{}, error)
 
 	mustEmbedWorkflowInboundInterceptorBase()


### PR DESCRIPTION
`UpdateInput` that the interceptor uses is not exposed out of `internal`, also the interceptor was not marked as experimental.