### PR TITLE
Hardcode noop metrics handler during replay

### DIFF
--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -1352,6 +1352,9 @@ func (aw *WorkflowReplayer) replayWorkflowHistory(logger log.Logger, service wor
 		FailureConverter:      aw.failureConverter,
 		ContextPropagators:    aw.contextPropagators,
 		EnableLoggingInReplay: aw.enableLoggingInReplay,
+		// Hardcoding NopHandler avoids "No metrics handler configured for temporal worker"
+		// logs during replay.
+		MetricsHandler: metrics.NopHandler,
 		capabilities: &workflowservice.GetSystemInfoResponse_Capabilities{
 			SignalAndQueryHeader:            true,
 			InternalErrorDifferentiation:    true,


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
During replay, the no-op metrics handler is hardcoded in the worker execution parameters.

## Why?
<!-- Tell your future self why have you made these changes -->
Previously `MetricsHandler` was always nil. This caused "No metrics handler configured for temporal worker" logs to be emitted during replay, which could get noisy and cause confusion about whether this was due to some sort of misconfiguration.

## Checklist
<!--- add/delete as needed --->

1. Closes

N/A

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Manually verified the log line is removed during replay.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

No