### PR TITLE
[WIP] Clear workflowExecutionIsCancelling on new WFT

### DIFF
--- a/internal/internal_command_state_machine.go
+++ b/internal/internal_command_state_machine.go
@@ -912,6 +912,8 @@ func (h *commandsHelper) setCurrentWorkflowTaskStartedEventID(workflowTaskStarte
 	// We must change the counter here so that others who mutate
 	// commandsCancelledDuringWFCancellation know it has since been reset
 	h.nextCommandEventIDResetCounter++
+	// Once we have handled the cancellation, we can reset the flag
+	h.workflowExecutionIsCancelling = false
 }
 
 func (h *commandsHelper) getNextID() int64 {

--- a/test/activity_test.go
+++ b/test/activity_test.go
@@ -76,6 +76,23 @@ func LocalSleep(_ context.Context, delay time.Duration) error {
 	return nil
 }
 
+func (a *Activities) ActivityToBeCanceled(ctx context.Context) (string, error) {
+	a.append("ActivityToBeCanceled")
+	for {
+		select {
+		case <-time.After(1 * time.Second):
+			activity.RecordHeartbeat(ctx, "")
+		case <-ctx.Done():
+			return "I am canceled by Done", nil
+		}
+	}
+}
+
+func (a *Activities) EmptyActivity(ctx context.Context) error {
+	a.append("EmptyActivity")
+	return nil
+}
+
 func (a *Activities) HeartbeatAndSleep(ctx context.Context, seq int, delay time.Duration) (int, error) {
 	a.append("heartbeatAndSleep")
 	activity.GetLogger(ctx).Info("Running HeartbeatAndSleep activity")

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -1189,6 +1189,18 @@ func (ts *IntegrationTestSuite) TestMutatingUpdateValidator() {
 	ts.Nil(ts.client.CancelWorkflow(ctx, "test-mutating-update-validator", ""))
 }
 
+func (ts *IntegrationTestSuite) TestWaitForCancelWithDisconnectedContext() {
+	ctx := context.Background()
+	run, err := ts.client.ExecuteWorkflow(ctx,
+		ts.startWorkflowOptions("test-wait-for-cancel-with-disconnected-contex"), ts.workflows.WaitForCancelWithDisconnectedContextWorkflow)
+	ts.Nil(err)
+
+	ts.waitForQueryTrue(run, "timer-created", 1)
+
+	ts.Nil(ts.client.CancelWorkflow(ctx, run.GetID(), run.GetRunID()))
+	ts.Nil(run.Get(ctx, nil))
+}
+
 func (ts *IntegrationTestSuite) TestMutatingSideEffect() {
 	ctx := context.Background()
 	err := ts.executeWorkflowWithContextAndOption(ctx, ts.startWorkflowOptions("test-mutating-side-effect"), ts.workflows.MutatingSideEffectWorkflow, nil)

--- a/test/workflow_test.go
+++ b/test/workflow_test.go
@@ -1571,6 +1571,59 @@ func (w *Workflows) CronWorkflow(ctx workflow.Context) (int, error) {
 	return retme, nil
 }
 
+func (w *Workflows) WaitForCancelWithDisconnectedContextWorkflow(ctx workflow.Context) (err error) {
+	ao := workflow.ActivityOptions{
+		StartToCloseTimeout: 1 * time.Minute,
+		HeartbeatTimeout:    5 * time.Second,
+		WaitForCancellation: true,
+	}
+	ctx = workflow.WithActivityOptions(ctx, ao)
+
+	var activities *Activities
+	defer func() {
+		if !errors.Is(ctx.Err(), workflow.ErrCanceled) {
+			return
+		}
+		// When the Workflow is canceled, it has to get a new disconnected context to execute any Activities
+		newCtx, _ := workflow.NewDisconnectedContext(ctx)
+		err = workflow.ExecuteActivity(newCtx, activities.EmptyActivity).Get(newCtx, nil)
+	}()
+
+	//Create selector
+	s := workflow.NewSelector(ctx)
+
+	newCtx, _ := workflow.NewDisconnectedContext(ctx)
+	newCtx, cancel := workflow.WithCancel(newCtx)
+
+	timer1 := workflow.NewTimer(newCtx, 5*time.Minute)
+
+	err = workflow.SetQueryHandler(newCtx, "timer-created", func() (bool, error) {
+		return true, nil
+	})
+	if err != nil {
+		return err
+	}
+
+	s.AddFuture(timer1, func(f workflow.Future) {
+		err = f.Get(newCtx, nil)
+		if !errors.Is(ctx.Err(), workflow.ErrCanceled) {
+			panic("error is not canceled error")
+		}
+	})
+
+	s.AddReceive(ctx.Done(), func(c workflow.ReceiveChannel, more bool) {
+		c.Receive(ctx, nil)
+		cancel()
+		s.Select(ctx)
+	})
+
+	s.Select(ctx)
+
+	var result string
+	err = workflow.ExecuteActivity(ctx, activities.EmptyActivity).Get(ctx, &result)
+	return
+}
+
 func (w *Workflows) CancelTimerConcurrentWithOtherCommandWorkflow(ctx workflow.Context) (int, error) {
 	ao := workflow.ActivityOptions{
 		ScheduleToStartTimeout: time.Minute,
@@ -2247,6 +2300,7 @@ func (w *Workflows) register(worker worker.Worker) {
 	worker.RegisterWorkflow(w.CancelTimerAfterActivity)
 	worker.RegisterWorkflow(w.CancelTimerViaDeferAfterWFTFailure)
 	worker.RegisterWorkflow(w.CascadingCancellation)
+	worker.RegisterWorkflow(w.WaitForCancelWithDisconnectedContextWorkflow)
 	worker.RegisterWorkflow(w.ChildWorkflowRetryOnError)
 	worker.RegisterWorkflow(w.ChildWorkflowRetryOnTimeout)
 	worker.RegisterWorkflow(w.ChildWorkflowSuccess)


### PR DESCRIPTION
 Clear `workflowExecutionIsCancelling` on new WFT. 
 
 As far as I can tell `workflowExecutionIsCancelling` is only needed because on workflow cancelation we generate the cancel commands eagerly before the WFT started and when we process the WFT started event we reset the eventID the Go SDK uses for counting so this throws off everything in the SDK. The problem with the current implementation is it assumes all cancels after a workflow cancel request are a result of the cancel request and that is not true. 
 
 I believe after the cancel request callback is processed this whole `workflowExecutionIsCancelling` logic should not be needed since all the out of workflow execution callbacks should be done, but I could be wrong on this point. 
 
 I think the best solution would be to remove this `workflowExecutionIsCancelling` and generate the cancel commands after setting the eventID on WFT started, but there is a 2+ year history of cancellation issues around this so It is very possible I am missing something.
 
 Summary of the history of this flag:
https://github.com/temporalio/sdk-go/pull/726



Fix for https://github.com/temporalio/sdk-go/issues/1176