### PR TITLE
Fix LA start to close timeout

### DIFF
--- a/internal/activity.go
+++ b/internal/activity.go
@@ -155,11 +155,13 @@ type (
 	// LocalActivityOptions stores local activity specific parameters that will be stored inside of a context.
 	LocalActivityOptions struct {
 		// ScheduleToCloseTimeout - The end to end timeout for the local activity including retries.
-		// This field is required.
+		// At least on of ScheduleToCloseTimeout or StartToCloseTimeout is required.
+		// defaults to StartToCloseTimeout if not set.
 		ScheduleToCloseTimeout time.Duration
 
 		// StartToCloseTimeout - The timeout for a single execution of the local activity.
-		// Optional: defaults to ScheduleToClose
+		// At least on of ScheduleToCloseTimeout or StartToCloseTimeout is required.
+		// defaults to ScheduleToCloseTimeout if not set.
 		StartToCloseTimeout time.Duration
 
 		// RetryPolicy specify how to retry activity if error happens.
@@ -253,25 +255,12 @@ func WithActivityTask(
 	contextPropagators []ContextPropagator,
 	interceptors []WorkerInterceptor,
 ) (context.Context, error) {
-	var deadline time.Time
 	scheduled := common.TimeValue(task.GetScheduledTime())
 	started := common.TimeValue(task.GetStartedTime())
 	scheduleToCloseTimeout := common.DurationValue(task.GetScheduleToCloseTimeout())
 	startToCloseTimeout := common.DurationValue(task.GetStartToCloseTimeout())
 	heartbeatTimeout := common.DurationValue(task.GetHeartbeatTimeout())
-
-	startToCloseDeadline := started.Add(startToCloseTimeout)
-	if scheduleToCloseTimeout > 0 {
-		scheduleToCloseDeadline := scheduled.Add(scheduleToCloseTimeout)
-		// Minimum of the two deadlines.
-		if scheduleToCloseDeadline.Before(startToCloseDeadline) {
-			deadline = scheduleToCloseDeadline
-		} else {
-			deadline = startToCloseDeadline
-		}
-	} else {
-		deadline = startToCloseDeadline
-	}
+	deadline := calculateActivityDeadline(scheduled, started, scheduleToCloseTimeout, startToCloseTimeout)
 
 	logger = log.With(logger,
 		tagActivityID, task.ActivityId,
@@ -332,6 +321,21 @@ func WithLocalActivityTask(
 		tagWorkflowID, task.params.WorkflowInfo.WorkflowExecution.ID,
 		tagRunID, task.params.WorkflowInfo.WorkflowExecution.RunID,
 	)
+	startedTime := time.Now()
+	scheduleToCloseTimeout := task.params.ScheduleToCloseTimeout
+	startToCloseTimeout := task.params.StartToCloseTimeout
+
+	if startToCloseTimeout == 0 {
+		startToCloseTimeout = scheduleToCloseTimeout
+	}
+	if scheduleToCloseTimeout == 0 {
+		scheduleToCloseTimeout = startToCloseTimeout
+	}
+	deadline := calculateActivityDeadline(task.scheduledTime, startedTime, scheduleToCloseTimeout, startToCloseTimeout)
+	if task.attempt > 1 && !task.expireTime.IsZero() && task.expireTime.Before(deadline) {
+		// this is attempt and expire time is before SCHEDULE_TO_CLOSE timeout
+		deadline = task.expireTime
+	}
 	return newActivityContext(ctx, interceptors, &activityEnvironment{
 		workflowType:      &workflowTypeLocal,
 		workflowNamespace: task.params.WorkflowInfo.Namespace,
@@ -342,6 +346,9 @@ func WithLocalActivityTask(
 		logger:            logger,
 		metricsHandler:    metricsHandler,
 		isLocalActivity:   true,
+		deadline:          deadline,
+		scheduledTime:     task.scheduledTime,
+		startedTime:       startedTime,
 		dataConverter:     dataConverter,
 		attempt:           task.attempt,
 	})
@@ -373,4 +380,19 @@ func newActivityContext(
 	ctx = context.WithValue(ctx, activityInterceptorContextKey, envInterceptor.outboundInterceptor)
 
 	return ctx, nil
+}
+
+func calculateActivityDeadline(scheduled, started time.Time, scheduleToCloseTimeout, startToCloseTimeout time.Duration) time.Time {
+	startToCloseDeadline := started.Add(startToCloseTimeout)
+	if scheduleToCloseTimeout > 0 {
+		scheduleToCloseDeadline := scheduled.Add(scheduleToCloseTimeout)
+		// Minimum of the two deadlines.
+		if scheduleToCloseDeadline.Before(startToCloseDeadline) {
+			return scheduleToCloseDeadline
+		} else {
+			return startToCloseDeadline
+		}
+	} else {
+		return startToCloseDeadline
+	}
 }

--- a/internal/activity.go
+++ b/internal/activity.go
@@ -155,12 +155,12 @@ type (
 	// LocalActivityOptions stores local activity specific parameters that will be stored inside of a context.
 	LocalActivityOptions struct {
 		// ScheduleToCloseTimeout - The end to end timeout for the local activity including retries.
-		// At least on of ScheduleToCloseTimeout or StartToCloseTimeout is required.
+		// At least one of ScheduleToCloseTimeout or StartToCloseTimeout is required.
 		// defaults to StartToCloseTimeout if not set.
 		ScheduleToCloseTimeout time.Duration
 
 		// StartToCloseTimeout - The timeout for a single execution of the local activity.
-		// At least on of ScheduleToCloseTimeout or StartToCloseTimeout is required.
+		// At least one of ScheduleToCloseTimeout or StartToCloseTimeout is required.
 		// defaults to ScheduleToCloseTimeout if not set.
 		StartToCloseTimeout time.Duration
 
@@ -389,10 +389,7 @@ func calculateActivityDeadline(scheduled, started time.Time, scheduleToCloseTime
 		// Minimum of the two deadlines.
 		if scheduleToCloseDeadline.Before(startToCloseDeadline) {
 			return scheduleToCloseDeadline
-		} else {
-			return startToCloseDeadline
 		}
-	} else {
-		return startToCloseDeadline
 	}
+	return startToCloseDeadline
 }

--- a/internal/internal_activity.go
+++ b/internal/internal_activity.go
@@ -217,7 +217,8 @@ func getValidatedLocalActivityOptions(ctx Context) (*ExecuteLocalActivityOptions
 	}
 	if p.ScheduleToCloseTimeout == 0 {
 		p.ScheduleToCloseTimeout = p.StartToCloseTimeout
-	} else {
+	}
+	if p.StartToCloseTimeout == 0 {
 		p.StartToCloseTimeout = p.ScheduleToCloseTimeout
 	}
 	return p, nil

--- a/internal/internal_event_handlers.go
+++ b/internal/internal_event_handlers.go
@@ -172,21 +172,20 @@ type (
 
 	localActivityTask struct {
 		sync.Mutex
-		workflowTask                *workflowTask
-		activityID                  string
-		params                      *ExecuteLocalActivityParams
-		callback                    LocalActivityResultHandler
-		wc                          *workflowExecutionContextImpl
-		canceled                    bool
-		cancelFunc                  func()
-		attempt                     int32  // attempt starting from 1
-		attemptsThisWFT             uint32 // Number of attempts started during this workflow task
-		pastFirstWFT                bool   // Set true once this LA has lived for more than one workflow task
-		retryPolicy                 *RetryPolicy
-		expireTime                  time.Time
-		scheduledTime               time.Time // Time the activity was scheduled initially.
-		currentAttemptScheduledTime time.Time // Time this attempt of the activity was scheduled.
-		header                      *commonpb.Header
+		workflowTask    *workflowTask
+		activityID      string
+		params          *ExecuteLocalActivityParams
+		callback        LocalActivityResultHandler
+		wc              *workflowExecutionContextImpl
+		canceled        bool
+		cancelFunc      func()
+		attempt         int32  // attempt starting from 1
+		attemptsThisWFT uint32 // Number of attempts started during this workflow task
+		pastFirstWFT    bool   // Set true once this LA has lived for more than one workflow task
+		retryPolicy     *RetryPolicy
+		expireTime      time.Time
+		scheduledTime   time.Time // Time the activity was scheduled initially.
+		header          *commonpb.Header
 	}
 
 	localActivityMarkerData struct {
@@ -684,14 +683,13 @@ func (wc *workflowEnvironmentImpl) ExecuteLocalActivity(params ExecuteLocalActiv
 
 func newLocalActivityTask(params ExecuteLocalActivityParams, callback LocalActivityResultHandler, activityID string) *localActivityTask {
 	task := &localActivityTask{
-		activityID:                  activityID,
-		params:                      &params,
-		callback:                    callback,
-		retryPolicy:                 params.RetryPolicy,
-		attempt:                     params.Attempt,
-		header:                      params.Header,
-		scheduledTime:               time.Now(),
-		currentAttemptScheduledTime: time.Now(),
+		activityID:    activityID,
+		params:        &params,
+		callback:      callback,
+		retryPolicy:   params.RetryPolicy,
+		attempt:       params.Attempt,
+		header:        params.Header,
+		scheduledTime: time.Now(),
 	}
 
 	if params.ScheduleToCloseTimeout > 0 {

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -861,7 +861,6 @@ processWorkflowLoop:
 						}
 
 						laRetry.attempt++
-						laRetry.currentAttemptScheduledTime = time.Now()
 
 						if !wth.laTunnel.sendTask(laRetry) {
 							laRetry.attempt--
@@ -1197,7 +1196,6 @@ func (w *workflowExecutionContextImpl) CompleteWorkflowTask(workflowTask *workfl
 				task.workflowTask = workflowTask
 
 				task.scheduledTime = time.Now()
-				task.currentAttemptScheduledTime = task.scheduledTime
 
 				if !w.laTunnel.sendTask(task) {
 					unstartedLaTasks[activityID] = struct{}{}

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -861,6 +861,7 @@ processWorkflowLoop:
 						}
 
 						laRetry.attempt++
+						laRetry.currentAttemptScheduledTime = time.Now()
 
 						if !wth.laTunnel.sendTask(laRetry) {
 							laRetry.attempt--
@@ -1194,6 +1195,10 @@ func (w *workflowExecutionContextImpl) CompleteWorkflowTask(workflowTask *workfl
 				task := eventHandler.pendingLaTasks[activityID]
 				task.wc = w
 				task.workflowTask = workflowTask
+
+				task.scheduledTime = time.Now()
+				task.currentAttemptScheduledTime = task.scheduledTime
+
 				if !w.laTunnel.sendTask(task) {
 					unstartedLaTasks[activityID] = struct{}{}
 					task.wc = nil

--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -634,9 +634,8 @@ func (env *testWorkflowEnvironmentImpl) executeLocalActivity(
 		params:     &params,
 		callback: func(lar *LocalActivityResultWrapper) {
 		},
-		attempt:                     1,
-		scheduledTime:               time.Now(),
-		currentAttemptScheduledTime: time.Now(),
+		attempt:       1,
+		scheduledTime: time.Now(),
 	}
 	taskHandler := localActivityTaskHandler{
 		userContext:    env.workerOptions.BackgroundActivityContext,

--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -634,7 +634,9 @@ func (env *testWorkflowEnvironmentImpl) executeLocalActivity(
 		params:     &params,
 		callback: func(lar *LocalActivityResultWrapper) {
 		},
-		attempt: 1,
+		attempt:                     1,
+		scheduledTime:               time.Now(),
+		currentAttemptScheduledTime: time.Now(),
 	}
 	taskHandler := localActivityTaskHandler{
 		userContext:    env.workerOptions.BackgroundActivityContext,

--- a/test/activity_test.go
+++ b/test/activity_test.go
@@ -71,6 +71,15 @@ func (a *Activities) Sleep(_ context.Context, delay time.Duration) error {
 	return nil
 }
 
+func (a *Activities) SleepN(ctx context.Context, delay time.Duration, times int) (int32, error) {
+	a.append("sleepN")
+	if activity.GetInfo(ctx).Attempt >= int32(times) {
+		return activity.GetInfo(ctx).Attempt, nil
+	}
+	time.Sleep(delay)
+	return activity.GetInfo(ctx).Attempt, nil
+}
+
 func LocalSleep(_ context.Context, delay time.Duration) error {
 	time.Sleep(delay)
 	return nil
@@ -185,6 +194,15 @@ func (a *Activities) InspectActivityInfo(ctx context.Context, namespace, taskQue
 	}
 	if info.TaskQueue != taskQueue {
 		return fmt.Errorf("expected taskQueue %v but got %v", taskQueue, info.TaskQueue)
+	}
+	if info.Deadline.IsZero() {
+		return errors.New("expected non zero deadline")
+	}
+	if info.StartedTime.IsZero() {
+		return errors.New("expected non zero started time")
+	}
+	if info.ScheduledTime.IsZero() {
+		return errors.New("expected non zero scheduled time")
 	}
 	if info.IsLocalActivity != isLocalActivity {
 		return fmt.Errorf("expected IsLocalActivity %v but got %v", isLocalActivity, info.IsLocalActivity)

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -1142,6 +1142,10 @@ func (ts *IntegrationTestSuite) TestWorkflowWithParallelSideEffects() {
 	ts.NoError(ts.executeWorkflow("test-wf-parallel-side-effects", ts.workflows.WorkflowWithParallelSideEffects, nil))
 }
 
+func (ts *IntegrationTestSuite) TestWorkflowWithLocalActivityStartToClose() {
+	ts.NoError(ts.executeWorkflow("test-wf-la-start-to-close", ts.workflows.WorkflowWithLocalActivityStartToCloseTimeout, nil))
+}
+
 func (ts *IntegrationTestSuite) TestActivityTimeoutsWorkflow() {
 	ts.NoError(ts.executeWorkflow("test-activity-timeout-workflow", ts.workflows.ActivityTimeoutsWorkflow, nil, workflow.ActivityOptions{
 		ScheduleToCloseTimeout: 5 * time.Second,


### PR DESCRIPTION
This PR fixes a few issues with local activities in Got

- `ScheduleToCloseTimeout` was overriding `StartToCloseTimeout` if both were set
- The docs in `LocalActivityOptions` were not accurate
- If a local activity did timeout it would always be considered a `SCHEDULE_TO_CLOSE` timeout and that is not retry able
- `ActivityInfo` in local activities was missing some fields 
