### PR TITLE
Release v1.24.0

### DIFF
--- a/internal/version.go
+++ b/internal/version.go
@@ -30,7 +30,7 @@ package internal
 const (
 	// SDKVersion is a semver (https://semver.org/) that represents the version of this Temporal GoSDK.
 	// Server validates if SDKVersion fits its supported range and rejects request if it doesn't.
-	SDKVersion = "1.23.1"
+	SDKVersion = "1.24.0"
 
 	// SupportedServerVersions is a semver rages (https://github.com/blang/semver#ranges) of server versions that
 	// are supported by this Temporal SDK.


### PR DESCRIPTION
Release Go SDK v1.24.0

Draft release: https://github.com/temporalio/sdk-go/releases/tag/untagged-4125c75251b0ddc509ce