### PR TITLE
Allow setting activity timeouts in testsuite

### DIFF
--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -169,6 +169,9 @@ type (
 		onTimerScheduledListener         func(timerID string, duration time.Duration)
 		onTimerFiredListener             func(timerID string)
 		onTimerCanceledListener          func(timerID string)
+
+		activityScheduleToCloseTimeout time.Duration
+		activityStartToCloseTimeout    time.Duration
 	}
 
 	// testWorkflowEnvironmentImpl is the environment that runs the workflow/activity unit tests.
@@ -236,6 +239,9 @@ func newTestWorkflowEnvironmentImpl(s *WorkflowTestSuite, parentRegistry *regist
 			callbackChannel:   make(chan testCallbackHandle, 1000),
 			testTimeout:       3 * time.Second,
 			expectedMockCalls: make(map[string]struct{}),
+
+			activityScheduleToCloseTimeout: 600 * time.Second,
+			activityStartToCloseTimeout:    600 * time.Second,
 		},
 
 		workflowInfo: &WorkflowInfo{
@@ -544,8 +550,8 @@ func (env *testWorkflowEnvironmentImpl) executeActivity(
 
 	parameters := ExecuteActivityParams{
 		ExecuteActivityOptions: ExecuteActivityOptions{
-			ScheduleToCloseTimeout: 600 * time.Second,
-			StartToCloseTimeout:    600 * time.Second,
+			ScheduleToCloseTimeout: env.activityScheduleToCloseTimeout,
+			StartToCloseTimeout:    env.activityStartToCloseTimeout,
 		},
 		ActivityType: *activityType,
 		Input:        input,

--- a/internal/internal_workflow_testsuite_test.go
+++ b/internal/internal_workflow_testsuite_test.go
@@ -4031,3 +4031,49 @@ func (s *WorkflowTestSuiteUnitTest) Test_WorkflowGetCurrentHistoryLength() {
 	s.NoError(env.GetWorkflowResult(&result))
 	s.Equal(17, result)
 }
+
+func (s *WorkflowTestSuiteUnitTest) Test_ActivityWithStartToCloseTimeout() {
+	timeout := 100 * time.Millisecond
+
+	timeoutActivity := func(ctx context.Context) error {
+		time.Sleep(timeout * 2)
+		return nil
+	}
+
+	noTimeoutActivity := func(ctx context.Context) error {
+		time.Sleep(timeout / 2)
+		return nil
+	}
+
+	env := s.NewTestActivityEnvironment()
+	env.SetActivityStartToCloseTimeout(timeout)
+	env.RegisterActivity(timeoutActivity)
+	env.RegisterActivity(noTimeoutActivity)
+	_, err := env.ExecuteActivity(timeoutActivity)
+	s.Error(err)
+	_, err = env.ExecuteActivity(noTimeoutActivity)
+	s.NoError(err)
+}
+
+func (s *WorkflowTestSuiteUnitTest) Test_ActivityWithScheduleToCloseTimeout() {
+	timeout := 100 * time.Millisecond
+
+	timeoutActivity := func(ctx context.Context) error {
+		time.Sleep(timeout * 2)
+		return nil
+	}
+
+	noTimeoutActivity := func(ctx context.Context) error {
+		time.Sleep(timeout / 2)
+		return nil
+	}
+
+	env := s.NewTestActivityEnvironment()
+	env.SetActivityScheduleToCloseTimeout(timeout)
+	env.RegisterActivity(timeoutActivity)
+	env.RegisterActivity(noTimeoutActivity)
+	_, err := env.ExecuteActivity(timeoutActivity)
+	s.Error(err)
+	_, err = env.ExecuteActivity(noTimeoutActivity)
+	s.NoError(err)
+}

--- a/internal/workflow_testsuite.go
+++ b/internal/workflow_testsuite.go
@@ -262,6 +262,16 @@ func (t *TestActivityEnvironment) SetOnActivityHeartbeatListener(
 	return t
 }
 
+// SetActivityStartToCloseTimeout sets the start to close timeouts of activities in the test environment.
+func (e *TestActivityEnvironment) SetActivityStartToCloseTimeout(timeout time.Duration) {
+	e.impl.testWorkflowEnvironmentShared.activityStartToCloseTimeout = timeout
+}
+
+// SetActivityStartToCloseTimeout sets the schedule to close timeouts of activities in the test environment
+func (e *TestActivityEnvironment) SetActivityScheduleToCloseTimeout(timeout time.Duration) {
+	e.impl.testWorkflowEnvironmentShared.activityScheduleToCloseTimeout = timeout
+}
+
 // RegisterWorkflow registers workflow implementation with the TestWorkflowEnvironment
 func (e *TestWorkflowEnvironment) RegisterWorkflow(w interface{}) {
 	e.impl.RegisterWorkflow(w)


### PR DESCRIPTION


<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Added 2 method to TestActivityEnvironment:
- SetActivityStartToCloseTimeout
- SetActivityScheduleToCloseTimeout

This will allow changing the default 10 minute timeouts in the current test environments.

## Why?
<!-- Tell your future self why have you made these changes -->
There are cases where we would like to test long running activities, or test activity timeouts.
The current test suite did not support that, as it had a hardcoded 10 minute timeout.

## Checklist
<!--- add/delete as needed --->

1. Closes #1167 

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Set the StartToClose timeout to a specific duration, and test that:
- An activity which takes longer than that duration returns an error.
- An activity which takes less than that duration finishes successfully.

Same test for ScheduleToClose, I did not see a difference between them in case of the testsuite.

3. Any docs updates needed?
Comment added to the new method, I don't believe further updates are needed.