### PR TITLE
Fix race condition with eager workflow start and close

### DIFF
--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -951,6 +951,9 @@ func (aw *AggregatedWorker) Start() error {
 		if err := aw.workflowWorker.Start(); err != nil {
 			return err
 		}
+		if aw.client.eagerDispatcher != nil {
+			aw.client.eagerDispatcher.registerWorker(aw.workflowWorker)
+		}
 	}
 	if !util.IsInterfaceNil(aw.activityWorker) {
 		if err := aw.activityWorker.Start(); err != nil {
@@ -1567,9 +1570,6 @@ func NewAggregatedWorker(client *WorkflowClient, taskQueue string, options Worke
 			workflowWorker = newWorkflowWorkerWithPressurePoints(client.workflowService, workerParams, testTags, registry)
 		} else {
 			workflowWorker = newWorkflowWorker(client.workflowService, workerParams, nil, registry)
-		}
-		if client.eagerDispatcher != nil {
-			client.eagerDispatcher.registerWorker(workflowWorker)
 		}
 	}
 

--- a/internal/internal_worker_base.go
+++ b/internal/internal_worker_base.go
@@ -311,7 +311,7 @@ func (bw *baseWorker) runPoller() {
 }
 
 func (bw *baseWorker) tryReserveSlot() bool {
-	if !bw.isWorkerStarted || bw.isStop() {
+	if bw.isStop() {
 		return false
 	}
 	// Reserve a executor slot via a non-blocking attempt to take a poller


### PR DESCRIPTION
Fix race condition in eager WF start reported by `roadrunner`

https://github.com/roadrunner-server/rr-e2e-tests/actions/runs/5790984816/job/15695006300#step:10:963

removed checking `isWorkerStarted` because  `pollerRequestCh` will not have any slots if the worker has not started, also moved when the worker is registered to after it is started instead of when it is created.
