### PR TITLE
Fix race condition in eager dispatch

### DIFF
--- a/internal/internal_eager.go
+++ b/internal/internal_eager.go
@@ -29,7 +29,7 @@ type eagerWorker interface {
 	tryReserveSlot() bool
 	// releaseSlot release a task slot acquired by tryReserveSlot
 	releaseSlot()
-	// processTaskAsync process a new task on the worker asynchronously and
-	// call callback once complete
-	processTaskAsync(task interface{}, callback func())
+	// pushEagerTask pushes a new eager workflow task to the workers task queue.
+	// should only be called with a reserved slot.
+	pushEagerTask(task eagerTask)
 }

--- a/internal/internal_eager_activity_test.go
+++ b/internal/internal_eager_activity_test.go
@@ -107,6 +107,8 @@ func TestEagerActivityCounts(t *testing.T) {
 	activityWorker := newActivityWorker(nil,
 		workerExecutionParameters{TaskQueue: "task-queue1", ConcurrentActivityExecutionSize: 5}, nil, newRegistry(), nil)
 	activityWorker.worker.isWorkerStarted = true
+	go activityWorker.worker.runEagerTaskDispatcher()
+	//defer close(activityWorker.worker.stopCh)
 
 	exec.activityWorker = activityWorker.worker
 	// Fill up the poller request channel

--- a/internal/internal_eager_activity_test.go
+++ b/internal/internal_eager_activity_test.go
@@ -108,7 +108,6 @@ func TestEagerActivityCounts(t *testing.T) {
 		workerExecutionParameters{TaskQueue: "task-queue1", ConcurrentActivityExecutionSize: 5}, nil, newRegistry(), nil)
 	activityWorker.worker.isWorkerStarted = true
 	go activityWorker.worker.runEagerTaskDispatcher()
-	//defer close(activityWorker.worker.stopCh)
 
 	exec.activityWorker = activityWorker.worker
 	// Fill up the poller request channel

--- a/internal/internal_eager_workflow.go
+++ b/internal/internal_eager_workflow.go
@@ -81,10 +81,8 @@ func (e *eagerWorkflowExecutor) handleResponse(response *workflowservice.PollWor
 			task: &eagerWorkflowTask{
 				task: response,
 			},
-			callback: func() {
-				// The processTaskAsync does not do this itself because our task is *eagerWorkflowTask, not *polledTask.
-				e.worker.releaseSlot()
-			},
+			// The processTaskAsync does not do this itself because our task is *eagerWorkflowTask, not *polledTask.
+			callback: e.worker.releaseSlot,
 		})
 }
 

--- a/internal/internal_eager_workflow.go
+++ b/internal/internal_eager_workflow.go
@@ -76,13 +76,16 @@ func (e *eagerWorkflowExecutor) handleResponse(response *workflowservice.PollWor
 		panic("eagerWorkflowExecutor trying to handle multiple responses")
 	}
 	// Asynchronously execute the task
-	task := &eagerWorkflowTask{
-		task: response,
-	}
-	e.worker.processTaskAsync(task, func() {
-		// The processTaskAsync does not do this itself because our task is *eagerWorkflowTask, not *polledTask.
-		e.worker.releaseSlot()
-	})
+	e.worker.pushEagerTask(
+		eagerTask{
+			task: &eagerWorkflowTask{
+				task: response,
+			},
+			callback: func() {
+				// The processTaskAsync does not do this itself because our task is *eagerWorkflowTask, not *polledTask.
+				e.worker.releaseSlot()
+			},
+		})
 }
 
 // release the executor task slot this eagerWorkflowExecutor was holding.

--- a/internal/internal_eager_workflow_test.go
+++ b/internal/internal_eager_workflow_test.go
@@ -44,8 +44,8 @@ func (e *eagerWorkerMock) releaseSlot() {
 	e.releaseSlotCallback()
 }
 
-func (e *eagerWorkerMock) processTaskAsync(task interface{}, callback func()) {
-	e.processTaskAsyncCallback(task, callback)
+func (e *eagerWorkerMock) pushEagerTask(task eagerTask) {
+	e.processTaskAsyncCallback(task, task.callback)
 }
 
 func TestEagerWorkflowDispatchNoWorkerOnTaskQueue(t *testing.T) {

--- a/internal/internal_worker_base.go
+++ b/internal/internal_worker_base.go
@@ -368,6 +368,8 @@ func (bw *baseWorker) runTaskDispatcher() {
 		// wait for new task or worker stop
 		select {
 		case <-bw.stopCh:
+			// Currently we can drop any tasks received when closing.
+			// https://github.com/temporalio/sdk-go/issues/1197
 			return
 		case task := <-bw.taskQueueCh:
 			// for non-polled-task (local activity result as task or eager task), we don't need to rate limit


### PR DESCRIPTION
Fix a race condition on the `WaitGroup` in `baseWorker` with eager dispatch (activity and workflow) on worker shutdown.

In Go `WaitGroups` have confusing concurrency rules https://pkg.go.dev/sync#WaitGroup.Add:

```
Note that calls with a positive delta that occur when the counter is zero must happen before a Wait. Calls with a negative delta, or calls with a positive delta that start when the counter is greater than zero, may happen at any time. Typically this means the calls to Add should execute before the statement creating the goroutine or other event to be waited for. If a WaitGroup is reused to wait for several independent sets of events, new Add calls must happen after all previous Wait calls have returned. See the WaitGroup example.
```

Here is the situation

1. Eager executor reserves slot
2. In a different go routine `.stop()`  is called on the worker. This closes the `stopch`  and triggers all the go routines the baseWorker started to stop and decrement the `stopWG`  to zero
after In another go routine `stopWG.wait()`  is called
3. Eager executor attempts to give a task to the base worker, base worker tries to increment `stopWG` because it will launch a go routine to process the task, but `stopWG` is zero and `stopWG.wait()` is called so that is a illegal.

The basic issue is we cannot increment `stopWG` from a go routine the `baseWorker` did not start.

To fix this I created a new go routine to launch all eager workflow tasks that the `baseWorker` now owns so it can interact with the wait group.