### PR TITLE
Add note on heart beating and async activities

### DIFF
--- a/activity/activity.go
+++ b/activity/activity.go
@@ -71,6 +71,9 @@ func GetMetricsHandler(ctx context.Context) metrics.Handler {
 //
 // details - the details that you provided here can be seen in the workflow when it receives TimeoutError, you
 // can check error with TimeoutType()/Details().
+//
+// Note: If using asynchronous activity completion,
+// after returning [ErrResultPending] users should heartbeat with [client.Client.RecordActivityHeartbeat]
 func RecordHeartbeat(ctx context.Context, details ...interface{}) {
 	internal.RecordActivityHeartbeat(ctx, details...)
 }


### PR DESCRIPTION
Saw this multiple times in the past month were users are using `RecordHeartbeat` incorrectly 