### PR TITLE
Fix flake in TestQueryOnlyCoroutineUsage

### DIFF
--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -37,6 +37,7 @@ import (
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/pborman/uuid"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"github.com/uber-go/tally/v4"
@@ -2380,7 +2381,9 @@ func (ts *IntegrationTestSuite) TestQueryOnlyCoroutineUsage() {
 
 	// Check coroutines are cleaned up. Before the fix accompanying this test, the
 	// count was the same as the number of queries issued.
-	ts.Equal(0, counter.count())
+	ts.EventuallyWithT(func(c *assert.CollectT) {
+		assert.Zero(c, counter.count())
+	}, time.Second, 100*time.Millisecond)
 }
 
 func (ts *IntegrationTestSuite) TestLargeHistoryReplay() {


### PR DESCRIPTION
Fix flake in `TestQueryOnlyCoroutineUsage`. I believe the issue here is the coroutine is cleaned up after the query response is returned to the server so the test can assert before the last goroutine is cleaned up. 

Before my change the test would fail ~10% of the time locally. Not it does not fail after 1000 iterations

example failure: https://github.com/temporalio/sdk-go/actions/runs/5933076179/job/16087965782