### PR TITLE
Refactor NextCommandEvents

### DIFF
--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -309,10 +309,10 @@ func isCommandEvent(eventType enumspb.EventType) bool {
 	}
 }
 
-// NextTask returns the next task to be processed.
-func (eh *history) NextTask() (*preparedTask, error) {
+// nextTask returns the next task to be processed.
+func (eh *history) nextTask() (*preparedTask, error) {
 	if eh.next == nil {
-		firstTask, err := eh.nextTask()
+		firstTask, err := eh.prepareTask()
 		if err != nil {
 			return nil, err
 		}
@@ -327,7 +327,7 @@ func (eh *history) NextTask() (*preparedTask, error) {
 	var markers []*historypb.HistoryEvent
 	var msgs []*protocolpb.Message
 	if len(result) > 0 {
-		nextTaskEvents, err := eh.nextTask()
+		nextTaskEvents, err := eh.prepareTask()
 		if err != nil {
 			return nil, err
 		}
@@ -370,7 +370,7 @@ func (eh *history) verifyAllEventsProcessed() error {
 	return nil
 }
 
-func (eh *history) nextTask() (*preparedTask, error) {
+func (eh *history) prepareTask() (*preparedTask, error) {
 	if eh.currentIndex == len(eh.loadedEvents) && !eh.hasMoreEvents() {
 		if err := eh.verifyAllEventsProcessed(); err != nil {
 			return nil, err
@@ -945,7 +945,7 @@ func (w *workflowExecutionContextImpl) ProcessWorkflowTask(workflowTask *workflo
 
 ProcessEvents:
 	for {
-		nextTask, err := reorderedHistory.NextTask()
+		nextTask, err := reorderedHistory.nextTask()
 		if err != nil {
 			return nil, err
 		}

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -189,7 +189,7 @@ type (
 		message string
 	}
 
-	processedTask struct {
+	preparedTask struct {
 		events         []*historypb.HistoryEvent
 		markers        []*historypb.HistoryEvent
 		flags          []sdkFlag
@@ -310,14 +310,14 @@ func isCommandEvent(eventType enumspb.EventType) bool {
 }
 
 // NextTask returns the next task to be processed.
-func (eh *history) NextTask() (*processedTask, error) {
+func (eh *history) NextTask() (*preparedTask, error) {
 	if eh.next == nil {
 		firstTask, err := eh.nextTask()
-		eh.next = firstTask.events
-		eh.nextFlags = firstTask.flags
 		if err != nil {
 			return nil, err
 		}
+		eh.next = firstTask.events
+		eh.nextFlags = firstTask.flags
 	}
 
 	result := eh.next
@@ -336,7 +336,7 @@ func (eh *history) NextTask() (*processedTask, error) {
 		markers = nextTaskEvents.markers
 		msgs = nextTaskEvents.msgs
 	}
-	return &processedTask{
+	return &preparedTask{
 		events:         result,
 		markers:        markers,
 		flags:          sdkFlags,
@@ -370,16 +370,16 @@ func (eh *history) verifyAllEventsProcessed() error {
 	return nil
 }
 
-func (eh *history) nextTask() (*processedTask, error) {
+func (eh *history) nextTask() (*preparedTask, error) {
 	if eh.currentIndex == len(eh.loadedEvents) && !eh.hasMoreEvents() {
 		if err := eh.verifyAllEventsProcessed(); err != nil {
 			return nil, err
 		}
-		return &processedTask{}, nil
+		return &preparedTask{}, nil
 	}
 
 	// Process events
-	var taskEvents processedTask
+	var taskEvents preparedTask
 OrderEvents:
 	for {
 		// load more history events if needed

--- a/internal/internal_task_handlers_interfaces_test.go
+++ b/internal/internal_task_handlers_interfaces_test.go
@@ -189,7 +189,7 @@ func (s *PollLayerInterfacesTestSuite) TestGetNextCommands() {
 
 	eh := newHistory(workflowTask, nil)
 
-	nextTask, err := eh.NextTask()
+	nextTask, err := eh.nextTask()
 
 	s.NoError(err)
 	s.Equal(3, len(nextTask.events))
@@ -232,7 +232,7 @@ func (s *PollLayerInterfacesTestSuite) TestGetNextCommandsSdkFlags() {
 
 	eh := newHistory(workflowTask, nil)
 
-	nextTask, err := eh.NextTask()
+	nextTask, err := eh.nextTask()
 
 	s.NoError(err)
 	s.Equal(2, len(nextTask.events))
@@ -242,7 +242,7 @@ func (s *PollLayerInterfacesTestSuite) TestGetNextCommandsSdkFlags() {
 	s.Equal(1, len(nextTask.flags))
 	s.EqualValues(SDKFlagLimitChangeVersionSASize, nextTask.flags[0])
 
-	nextTask, err = eh.NextTask()
+	nextTask, err = eh.nextTask()
 
 	s.NoError(err)
 	s.Equal(4, len(nextTask.events))
@@ -299,7 +299,7 @@ func (s *PollLayerInterfacesTestSuite) TestMessageCommands() {
 
 	eh := newHistory(workflowTask, nil)
 
-	nextTask, err := eh.NextTask()
+	nextTask, err := eh.nextTask()
 	s.NoError(err)
 	s.Equal(2, len(nextTask.events))
 	s.Equal(enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED, nextTask.events[0].GetEventType())
@@ -308,7 +308,7 @@ func (s *PollLayerInterfacesTestSuite) TestMessageCommands() {
 	s.Equal(1, len(nextTask.msgs))
 	s.Equal("test", nextTask.msgs[0].GetProtocolInstanceId())
 
-	nextTask, err = eh.NextTask()
+	nextTask, err = eh.nextTask()
 	s.NoError(err)
 	s.Equal(3, len(nextTask.events))
 	s.Equal(enumspb.EVENT_TYPE_WORKFLOW_TASK_COMPLETED, nextTask.events[0].GetEventType())
@@ -421,7 +421,7 @@ func (s *PollLayerInterfacesTestSuite) TestEmptyPages() {
 	}
 
 	for _, expected := range expectedResults {
-		nexTask, err := eh.NextTask()
+		nexTask, err := eh.nextTask()
 		s.NoError(err)
 		s.Equal(len(expected.events), len(nexTask.events))
 		for i, event := range nexTask.events {


### PR DESCRIPTION
Finally doing a long asked for refactor of `NextCommandEvents` from 5 return values to a struct. The logic of the code still isn't great, but it is a bit better now. 

Doing now because I know I'll touch this code more when I do: https://github.com/temporalio/sdk-go/issues/1194