### PR TITLE
Exposing queryable Registry

### DIFF
--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -1831,3 +1831,43 @@ func executeFunction(fn interface{}, args []interface{}) (interface{}, error) {
 	}
 	return res, err
 }
+
+func (w *AggregatedWorker) ListRegisteredWorkflowNames() []string {
+	w.registry.Lock()
+	defer w.registry.Unlock()
+	names := make([]string, 0, len(w.registry.workflowFuncMap))
+	for k := range w.registry.workflowFuncMap {
+		names = append(names, k)
+	}
+	return names
+}
+
+func (w *AggregatedWorker) GetRegisteredWorkflowAliases() map[string]string {
+	w.registry.Lock()
+	defer w.registry.Unlock()
+	aliases := make(map[string]string)
+	for k, v := range w.registry.workflowAliasMap {
+		aliases[k] = v
+	}
+	return aliases
+}
+
+func (w *AggregatedWorker) ListRegisteredActivityNames() []string {
+	w.registry.Lock()
+	defer w.registry.Unlock()
+	names := make([]string, 0, len(w.registry.activityFuncMap))
+	for k := range w.registry.activityFuncMap {
+		names = append(names, k)
+	}
+	return names
+}
+
+func (w *AggregatedWorker) GetRegisteredActivityAliases() map[string]string {
+	w.registry.Lock()
+	defer w.registry.Unlock()
+	aliases := make(map[string]string)
+	for k, v := range w.registry.activityAliasMap {
+		aliases[k] = v
+	}
+	return aliases
+}

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -2850,3 +2850,21 @@ func TestAliasUnqualifiedNameClash(t *testing.T) {
 	require.Equal(t, "func3", executeWorkflow(false))
 	require.Equal(t, "func1", executeWorkflow(true))
 }
+
+func TestGetRegisteredActivities(t *testing.T) {
+	client := &WorkflowClient{}
+	taskQueue := "worker-options-tq"
+	aggWorker := NewAggregatedWorker(client, taskQueue, WorkerOptions{LocalActivityWorkerOnly: true})
+	aggWorker.RegisterActivityWithOptions(testActivity, RegisterActivityOptions{Name: "testSomeActivity"})
+	require.Equal(t, []string{"testSomeActivity"}, aggWorker.ListRegisteredActivityNames())
+	require.Equal(t, map[string]string{"testActivity": "testSomeActivity"}, aggWorker.GetRegisteredActivityAliases())
+}
+
+func TestGetRegisteredWorkflows(t *testing.T) {
+	client := &WorkflowClient{}
+	taskQueue := "worker-options-tq"
+	aggWorker := NewAggregatedWorker(client, taskQueue, WorkerOptions{LocalActivityWorkerOnly: true})
+	aggWorker.RegisterWorkflowWithOptions(sampleWorkflowExecute, RegisterWorkflowOptions{Name: "someSampleWorkflowExecute"})
+	require.Equal(t, []string{"someSampleWorkflowExecute"}, aggWorker.ListRegisteredWorkflowNames())
+	require.Equal(t, map[string]string{"sampleWorkflowExecute": "someSampleWorkflowExecute"}, aggWorker.GetRegisteredActivityAliases())
+}

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -97,6 +97,12 @@ type (
 		// This method panics if workflowFunc doesn't comply with the expected format or tries to register the same workflow
 		// type name twice. Use workflow.RegisterOptions.DisableAlreadyRegisteredCheck to allow multiple registrations.
 		RegisterWorkflowWithOptions(w interface{}, options workflow.RegisterOptions)
+
+		// ListRegisteredWorkflowNames - List registered workflow names
+		ListRegisteredWorkflowNames() []string
+
+		// GetRegisteredWorkflowAliases - Get the registered workflow aliases
+		GetRegisteredWorkflowAliases() map[string]string
 	}
 
 	// ActivityRegistry exposes activity registration functions to consumers.
@@ -148,6 +154,12 @@ type (
 		// which might be useful for integration tests.
 		// worker.RegisterActivityWithOptions(barActivity, RegisterActivityOptions{DisableAlreadyRegisteredCheck: true})
 		RegisterActivityWithOptions(a interface{}, options activity.RegisterOptions)
+
+		// ListRegisteredActivityNames - List registered activity names
+		ListRegisteredActivityNames() []string
+
+		// GetRegisteredActivityAliases - Get the registered workflow aliases
+		GetRegisteredActivityAliases() map[string]string
 	}
 
 	// WorkflowReplayer supports replaying a workflow from its event history.

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -158,7 +158,7 @@ type (
 		// ListRegisteredActivityNames - List registered activity names
 		ListRegisteredActivityNames() []string
 
-		// GetRegisteredActivityAliases - Get the registered workflow aliases
+		// GetRegisteredActivityAliases - Get the registered activity aliases
 		GetRegisteredActivityAliases() map[string]string
 	}
 


### PR DESCRIPTION
## What was changed

Allow the client code to query the worker for the list of registered workflows, activities and their aliases

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

See #1212 


3. How was this tested:

See unit tests

4. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
