### PR TITLE
Add slog adapter

### DIFF
--- a/internal/internal_event_handlers.go
+++ b/internal/internal_event_handlers.go
@@ -239,7 +239,8 @@ func newWorkflowExecutionEventHandler(
 		mutableSideEffectCallCounter: make(map[string]int),
 		sdkFlags:                     newSDKFlags(capabilities),
 	}
-	context.logger = ilog.NewReplayLogger(
+	// Attempt to skip 1 log level to remove the ReplayLogger from the stack.
+	context.logger = log.Skip(ilog.NewReplayLogger(
 		log.With(logger,
 			tagWorkflowType, workflowInfo.WorkflowType.Name,
 			tagWorkflowID, workflowInfo.WorkflowExecution.ID,
@@ -247,7 +248,7 @@ func newWorkflowExecutionEventHandler(
 			tagAttempt, workflowInfo.Attempt,
 		),
 		&context.isReplay,
-		&context.enableLoggingInReplay)
+		&context.enableLoggingInReplay), 1)
 
 	if metricsHandler != nil {
 		context.metricsHandler = metrics.NewReplayAwareHandler(&context.isReplay, metricsHandler).

--- a/internal/log/replay_logger.go
+++ b/internal/log/replay_logger.go
@@ -80,3 +80,11 @@ func (l *ReplayLogger) Error(msg string, keyvals ...interface{}) {
 func (l *ReplayLogger) With(keyvals ...interface{}) log.Logger {
 	return NewReplayLogger(log.With(l.logger, keyvals...), l.isReplay, l.enableLoggingInReplay)
 }
+
+// AddCallerSkip increases the caller skip depth if the underlying logger supports it.
+func (l *ReplayLogger) AddCallerSkip(depth int) log.Logger {
+	if sl, ok := l.logger.(log.WithSkipCallers); ok {
+		return NewReplayLogger(sl.AddCallerSkip(depth), l.isReplay, l.enableLoggingInReplay)
+	}
+	return l
+}

--- a/internal/log/replay_logger.go
+++ b/internal/log/replay_logger.go
@@ -81,10 +81,9 @@ func (l *ReplayLogger) With(keyvals ...interface{}) log.Logger {
 	return NewReplayLogger(log.With(l.logger, keyvals...), l.isReplay, l.enableLoggingInReplay)
 }
 
-// AddCallerSkip increases the caller skip depth if the underlying logger supports it.
 func (l *ReplayLogger) AddCallerSkip(depth int) log.Logger {
 	if sl, ok := l.logger.(log.WithSkipCallers); ok {
-		return NewReplayLogger(sl.AddCallerSkip(depth), l.isReplay, l.enableLoggingInReplay)
+		return NewReplayLogger(sl.WithCallerSkip(depth), l.isReplay, l.enableLoggingInReplay)
 	}
 	return l
 }

--- a/log/logger.go
+++ b/log/logger.go
@@ -34,8 +34,9 @@ type (
 	}
 
 	// WithSkipCallers is an optional interface that a Logger can implement that
-	// indicate the number of stack frames to skip.
+	// may create a new child logger that skips the number of stack frames of the caller.
+	// This call must not mutate the original logger.
 	WithSkipCallers interface {
-		AddCallerSkip(int) Logger
+		WithCallerSkip(int) Logger
 	}
 )

--- a/log/slog.go
+++ b/log/slog.go
@@ -86,7 +86,7 @@ func (s *slogLogger) With(keyvals ...interface{}) Logger {
 	}
 }
 
-func (s *slogLogger) AddCallerSkip(depth int) Logger {
+func (s *slogLogger) WithCallerSkip(depth int) Logger {
 	return &slogLogger{
 		logger: s.logger,
 		depth:  s.depth + depth,

--- a/log/slog.go
+++ b/log/slog.go
@@ -1,0 +1,94 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+//go:build go1.21
+
+package log
+
+import (
+	"context"
+	"log/slog"
+	"runtime"
+	"time"
+)
+
+type slogLogger struct {
+	logger *slog.Logger
+	depth  int
+}
+
+// NewStructuredLogger creates an adapter around the given logger to be passed to Temporal.
+func NewStructuredLogger(logger *slog.Logger) Logger {
+	return &slogLogger{
+		logger: logger,
+		depth:  3,
+	}
+}
+
+func (s *slogLogger) Debug(msg string, keyvals ...interface{}) {
+	s.log(context.Background(), slog.LevelDebug, msg, keyvals...)
+}
+
+func (s *slogLogger) Info(msg string, keyvals ...interface{}) {
+	s.log(context.Background(), slog.LevelInfo, msg, keyvals...)
+}
+
+func (s *slogLogger) Warn(msg string, keyvals ...interface{}) {
+	s.log(context.Background(), slog.LevelWarn, msg, keyvals...)
+}
+
+func (s *slogLogger) Error(msg string, keyvals ...interface{}) {
+	s.log(context.Background(), slog.LevelError, msg, keyvals...)
+}
+
+func (s *slogLogger) log(ctx context.Context, level slog.Level, msg string, args ...any) {
+	if !s.logger.Enabled(ctx, level) {
+		return
+	}
+
+	var pcs [1]uintptr
+	runtime.Callers(s.depth, pcs[:])
+
+	record := slog.NewRecord(time.Now(), level, msg, pcs[0])
+	record.Add(args...)
+
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	_ = s.logger.Handler().Handle(ctx, record)
+}
+
+func (s *slogLogger) With(keyvals ...interface{}) Logger {
+	return &slogLogger{
+		logger: s.logger.With(keyvals...),
+		depth:  s.depth,
+	}
+}
+
+func (s *slogLogger) AddCallerSkip(depth int) Logger {
+	return &slogLogger{
+		logger: s.logger,
+		depth:  s.depth + depth,
+	}
+}

--- a/log/slog_test.go
+++ b/log/slog_test.go
@@ -22,20 +22,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+//go:build go1.21
+
 package log
 
-type (
-	// Logger is an interface that can be passed to ClientOptions.Logger.
-	Logger interface {
-		Debug(msg string, keyvals ...interface{})
-		Info(msg string, keyvals ...interface{})
-		Warn(msg string, keyvals ...interface{})
-		Error(msg string, keyvals ...interface{})
-	}
+import "testing"
 
-	// WithSkipCallers is an optional interface that a Logger can implement that
-	// indicate the number of stack frames to skip.
-	WithSkipCallers interface {
-		AddCallerSkip(int) Logger
-	}
-)
+func TestSlogAddapter(t *testing.T) {}

--- a/log/slog_test.go
+++ b/log/slog_test.go
@@ -26,6 +26,120 @@
 
 package log
 
-import "testing"
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
 
-func TestSlogAddapter(t *testing.T) {}
+	"github.com/stretchr/testify/require"
+)
+
+func addCallerDepth(log Logger) {
+	log.Info("calling AddCallerDepth")
+}
+
+func TestTemporalSlogAdapter(t *testing.T) {
+	var buf bytes.Buffer
+	th := slog.NewJSONHandler(&buf, &slog.HandlerOptions{AddSource: true, Level: slog.LevelDebug})
+	sl := NewStructuredLogger(slog.New(th))
+
+	sl.Info("info log", "Key", "Value")
+	addCallerDepth(sl)
+	addCallerDepth(Skip(sl, 1))
+	With(sl, "WithKey", "WithValue").Debug("With")
+	sl.Debug("debug log", "Key", "Value", "OtherKey", "OtherValue")
+
+	// Parse logs
+	var ms []map[string]any
+	for _, line := range bytes.Split(buf.Bytes(), []byte{'\n'}) {
+		if len(line) == 0 {
+			continue
+		}
+		var m map[string]any
+		err := json.Unmarshal(line, &m)
+		require.NoError(t, err)
+		ms = append(ms, m)
+	}
+
+	expectedLogs := []map[string]any{
+		{
+			"level": "INFO",
+			"Key":   "Value",
+			"msg":   "info log",
+			"source": map[string]string{
+				"file":     "log/slog_test.go",
+				"function": "go.temporal.io/sdk/log.TestTemporalSlogAdapter",
+				"line":     "",
+			},
+			"time": "",
+		},
+		{
+			"level": "INFO",
+			"msg":   "calling AddCallerDepth",
+			"source": map[string]string{
+				"file":     "log/slog_test.go",
+				"function": "go.temporal.io/sdk/log.addCallerDepth",
+				"line":     "",
+			},
+			"time": "",
+		},
+		{
+			"level": "INFO",
+			"msg":   "calling AddCallerDepth",
+			"source": map[string]string{
+				"file":     "log/slog_test.go",
+				"function": "go.temporal.io/sdk/log.TestTemporalSlogAdapter",
+				"line":     "",
+			},
+			"time": "",
+		},
+		{
+			"level":   "DEBUG",
+			"WithKey": "WithValue",
+			"msg":     "With",
+			"source": map[string]string{
+				"file":     "log/slog_test.go",
+				"function": "go.temporal.io/sdk/log.TestTemporalSlogAdapter",
+				"line":     "",
+			},
+			"time": "",
+		},
+		{
+			"level":    "DEBUG",
+			"Key":      "Value",
+			"OtherKey": "OtherValue",
+			"msg":      "debug log",
+			"source": map[string]string{
+				"file":     "log/slog_test.go",
+				"function": "go.temporal.io/sdk/log.TestTemporalSlogAdapter",
+				"line":     "",
+			},
+			"time": "",
+		},
+	}
+	// Compare expected vs actual logs. We don't do a strict comparison because
+	// we know some fields will be different
+	require.Equal(t, len(expectedLogs), len(ms))
+	for i, expectedLog := range expectedLogs {
+		actualLog := ms[i]
+		require.Equal(t, len(expectedLog), len(actualLog))
+		for k, v := range expectedLog {
+			if k == slog.TimeKey {
+				// Skip time because we know it will be different
+				require.Contains(t, actualLog, slog.TimeKey)
+			} else if k == slog.SourceKey {
+				require.Contains(t, actualLog, slog.SourceKey)
+				expectedSource := v.(map[string]string)
+				actualSource := actualLog[slog.SourceKey].(map[string]any)
+				require.True(t, strings.HasSuffix(actualSource["file"].(string), expectedSource["file"]))
+				require.Equal(t, expectedSource["function"], actualSource["function"])
+				// Skip line to make the test less annoying to maintain
+				require.Contains(t, actualSource, "line")
+			} else {
+				require.Equal(t, v, actualLog[k])
+			}
+		}
+	}
+}

--- a/log/with_logger.go
+++ b/log/with_logger.go
@@ -43,7 +43,7 @@ func With(logger Logger, keyvals ...interface{}) Logger {
 // implements [WithSkipCallers]. Otherwise returns the original logger.
 func Skip(logger Logger, depth int) Logger {
 	if sl, ok := logger.(WithSkipCallers); ok {
-		return sl.AddCallerSkip(depth)
+		return sl.WithCallerSkip(depth)
 	}
 	return logger
 }
@@ -81,10 +81,9 @@ func (l *withLogger) Error(msg string, keyvals ...interface{}) {
 	l.logger.Error(msg, l.prependKeyvals(keyvals)...)
 }
 
-// AddCallerSkip increases the caller skip depth if the underlying logger supports it.
-func (l *withLogger) AddCallerSkip(depth int) Logger {
+func (l *withLogger) WithCallerSkip(depth int) Logger {
 	if sl, ok := l.logger.(WithSkipCallers); ok {
-		return newWithLogger(sl.AddCallerSkip(depth), l.keyvals)
+		return newWithLogger(sl.WithCallerSkip(depth), l.keyvals)
 	}
 	return l
 }

--- a/test/logger_test.go
+++ b/test/logger_test.go
@@ -1,0 +1,164 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+//go:build go1.21
+
+package test_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"log/slog"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/log"
+	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/workflow"
+)
+
+func logWorkflow(ctx workflow.Context, name string) error {
+	ao := workflow.ActivityOptions{
+		StartToCloseTimeout: 10 * time.Second,
+	}
+	ctx = workflow.WithActivityOptions(ctx, ao)
+
+	logger := workflow.GetLogger(ctx)
+	logger.Info("Logging from workflow", "name", name)
+
+	var result interface{}
+	err := workflow.ExecuteActivity(ctx, loggingActivity, name).Get(ctx, &result)
+	if err != nil {
+		logger.Error("LoggingActivity failed.", "Error", err)
+		return err
+	}
+
+	err = workflow.ExecuteActivity(ctx, loggingErrorActivity).Get(ctx, &result)
+	if err != nil {
+		logger.Error("LoggingActivity failed.", "Error", err)
+		return err
+	}
+
+	logger.Info("Workflow completed.")
+	return nil
+}
+
+func loggingActivity(ctx context.Context, name string) error {
+	logger := activity.GetLogger(ctx)
+	withLogger := logger.(log.WithLogger).With("activity", "LoggingActivity")
+
+	withLogger.Info("Executing LoggingActivity.", "name", name)
+	withLogger.Debug("Debugging LoggingActivity.", "value", "important debug data")
+	return nil
+}
+
+func loggingErrorActivity(ctx context.Context) error {
+	logger := activity.GetLogger(ctx)
+	logger.Warn("Ignore next error message. It is just for demo purpose.")
+	logger.Error("Unable to execute LoggingErrorAcctivity.", "error", errors.New("random error"))
+	return nil
+}
+
+func Test_StructuredLogger(t *testing.T) {
+	testSuite := &testsuite.WorkflowTestSuite{}
+
+	var buf bytes.Buffer
+	th := slog.NewJSONHandler(&buf, &slog.HandlerOptions{AddSource: true, Level: slog.LevelDebug})
+	testSuite.SetLogger(log.NewStructuredLogger(slog.New(th)))
+	env := testSuite.NewTestWorkflowEnvironment()
+
+	// Mock activity implementation
+	env.RegisterActivity(loggingActivity)
+	env.RegisterActivity(loggingErrorActivity)
+
+	env.ExecuteWorkflow(logWorkflow, "Temporal")
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+	require.NoError(t, env.GetWorkflowResult(nil))
+
+	// Parse logs
+	var ms []map[string]any
+	for _, line := range bytes.Split(buf.Bytes(), []byte{'\n'}) {
+		if len(line) == 0 {
+			continue
+		}
+		var m map[string]any
+		err := json.Unmarshal(line, &m)
+		require.NoError(t, err)
+		fmt.Println(m)
+		ms = append(ms, m)
+	}
+
+	expectedLogs := []slog.Source{
+		{
+			File:     "logger_test.go",
+			Function: "go.temporal.io/sdk/test_test.logWorkflow",
+		},
+		{
+			File:     "logger_test.go",
+			Function: "go.temporal.io/sdk/test_test.loggingActivity",
+		},
+		{
+			File:     "logger_test.go",
+			Function: "go.temporal.io/sdk/test_test.loggingActivity",
+		},
+		{
+			File:     "internal_workflow_testsuite.go",
+			Function: "go.temporal.io/sdk/internal.(*testWorkflowEnvironmentImpl).handleActivityResult",
+		},
+		{
+			File:     "logger_test.go",
+			Function: "go.temporal.io/sdk/test_test.loggingErrorActivity",
+		},
+		{
+			File:     "logger_test.go",
+			Function: "go.temporal.io/sdk/test_test.loggingErrorActivity",
+		},
+		{
+			File:     "internal_workflow_testsuite.go",
+			Function: "go.temporal.io/sdk/internal.(*testWorkflowEnvironmentImpl).handleActivityResult",
+		},
+		{
+			File:     "logger_test.go",
+			Function: "go.temporal.io/sdk/test_test.logWorkflow",
+		},
+	}
+
+	require.Equal(t, len(expectedLogs), len(ms))
+	for i, expectedLog := range expectedLogs {
+		fmt.Println(i)
+		actualSource := ms[i][slog.SourceKey].(map[string]any)
+		require.True(t, strings.HasSuffix(actualSource["file"].(string), expectedLog.File))
+		require.Equal(t, expectedLog.Function, actualSource["function"])
+		// Skip line to make the test less annoying to maintain
+	}
+}


### PR DESCRIPTION
Add an adapter for the new `slog` and add support for an optional interface `Logger` can implement to skip caller stacks.

Marking as draft because the adapter and skip feature need unit tests and I need to read how to test `slog`

closes https://github.com/temporalio/sdk-go/issues/1158

closes https://github.com/temporalio/sdk-go/issues/685

closes https://github.com/temporalio/sdk-go/issues/960
