### PR TITLE
Add replay option to disable deadlock detection

### DIFF
--- a/test/replaytests/deadlocked-workflow.json
+++ b/test/replaytests/deadlocked-workflow.json
@@ -1,0 +1,91 @@
+{
+  "events": [
+    {
+      "eventId": "1",
+      "eventTime": "2020-07-30T00:30:02.971655189Z",
+      "eventType": "WorkflowExecutionStarted",
+      "version": "-24",
+      "taskId": "1048576",
+      "workflowExecutionStartedEventAttributes": {
+        "workflowType": {
+          "name": "DeadlockedWorkflow"
+        },
+        "taskQueue": {
+          "name": "replay-test",
+          "kind": "Normal"
+        },
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "IldvcmtmbG93MSI="
+            }
+          ]
+        },
+        "workflowExecutionTimeout": "315360000s",
+        "workflowRunTimeout": "315360000s",
+        "workflowTaskTimeout": "10s",
+        "initiator": "Workflow",
+        "originalExecutionRunId": "32c62bbb-dfa3-4558-8bab-11cd5b4e17b7",
+        "identity": "22866@ShtinUbuntu2@",
+        "firstExecutionRunId": "32c62bbb-dfa3-4558-8bab-11cd5b4e17b7",
+        "attempt": 1,
+        "workflowExecutionExpirationTime": "0001-01-01T00:00:00Z",
+        "firstWorkflowTaskBackoff": "0s",
+        "header": {}
+      }
+    },
+    {
+      "eventId": "2",
+      "eventTime": "2020-07-30T00:30:02.971668264Z",
+      "eventType": "WorkflowTaskScheduled",
+      "version": "-24",
+      "taskId": "1048577",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "replay-test",
+          "kind": "Normal"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": "1"
+      }
+    },
+    {
+      "eventId": "3",
+      "eventTime": "2020-07-30T00:30:02.981403193Z",
+      "eventType": "WorkflowTaskStarted",
+      "version": "-24",
+      "taskId": "1048582",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "2",
+        "identity": "22866@ShtinUbuntu2@",
+        "requestId": "43107987-202a-44ca-b718-4aecc6cd6f3b"
+      }
+    },
+    {
+      "eventId": "4",
+      "eventTime": "2020-07-30T00:30:02.992586820Z",
+      "eventType": "WorkflowTaskCompleted",
+      "version": "-24",
+      "taskId": "1048585",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "2",
+        "startedEventId": "3",
+        "identity": "22866@ShtinUbuntu2@",
+        "binaryChecksum": "01c85c2da1ff4eb3ef3641a5746edef0"
+      }
+    },
+    {
+      "eventId": "5",
+      "eventTime": "2020-07-30T00:30:03.070438610Z",
+      "eventType": "WorkflowExecutionCompleted",
+      "version": "-24",
+      "taskId": "1048640",
+      "workflowExecutionCompletedEventAttributes": {
+        "workflowTaskCompletedEventId": "4"
+      }
+    }
+  ]
+}

--- a/test/replaytests/workflows.go
+++ b/test/replaytests/workflows.go
@@ -31,6 +31,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+
 	"go.temporal.io/sdk/activity"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
@@ -218,6 +219,12 @@ func SideEffectWorkflow(ctx workflow.Context, field string) error {
 }
 
 func EmptyWorkflow(ctx workflow.Context, _ string) error {
+	return nil
+}
+
+func DeadlockedWorkflow(ctx workflow.Context, _ string) error {
+	// Sleep for just over 1 second to trigger deadlock detection
+	time.Sleep(1100 * time.Millisecond)
 	return nil
 }
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
This PR adds a new field `DisableDeadlockDetection` to `WorkflowReplayerOptions`. Setting this to `true` disables deadlock detection during replay.

## Why?
<!-- Tell your future self why have you made these changes -->
The `TEMPORAL_DEBUG` environment variable is intended to serve a similar purpose, but can be [tricky to configure](https://github.com/temporalio/sdk-go/issues/329#issuecomment-1464894075) and is a global setting.

Deadlock detection can be disabled programmatically using `DeadlockDetectionTimeout` on `worker.Options`. It makes sense to support something similar in `WorkflowReplayerOptions` since attaching a debugger is such a common use case when replaying workflows.

## Checklist
<!--- add/delete as needed --->

### How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Please see included unit test.

### Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
The updated godoc is probably enough, though this would be a useful feature to mention in tutorials about workflow debugging.