### PR TITLE
Stop using the tinycicd namespace for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,8 +56,8 @@ jobs:
     if: ${{ github.event.pull_request.head.repo.full_name == '' || github.event.pull_request.head.repo.full_name == 'temporalio/sdk-go' }}
     runs-on: ubuntu-latest
     env:
-      SERVICE_ADDR: tinycicd.sdk.tmprl.cloud:7233
-      TEMPORAL_NAMESPACE: tinycicd.sdk
+      SERVICE_ADDR: sdk-ci.a2dd6.tmprl.cloud:7233
+      TEMPORAL_NAMESPACE: sdk-ci.a2dd6
       TEMPORAL_CLIENT_CERT: ${{ secrets.TEMPORAL_CLIENT_CERT }}
       TEMPORAL_CLIENT_KEY: ${{ secrets.TEMPORAL_CLIENT_KEY }}
     steps:
@@ -77,4 +77,3 @@ jobs:
       go-repo-path: ${{github.event.pull_request.head.repo.full_name}}
       version: ${{github.event.pull_request.head.ref}}
       version-is-repo-ref: true
-


### PR DESCRIPTION
## What was changed
Switch to our regular `sdk-ci` namespace instead.

## Why?
The `tinycicd` namespace is going away.

## Checklist

2. How was this tested: Testing in GHA via this PR
3. Any docs updates needed? No
