### PR TITLE
Add doc links throughout our user-facing APIs

### DIFF
--- a/activity/doc.go
+++ b/activity/doc.go
@@ -102,7 +102,7 @@ the Temporal managed service.
 	}
 
 When the Activity times out due to a missed heartbeat, the last value of the details (progress in the above sample) is
-returned from the workflow.ExecuteActivity function as the details field of TimeoutError with TimeoutType_HEARTBEAT.
+returned from the [workflow.ExecuteActivity] function as the details field of [temporal.TimeoutError] with TimeoutType_HEARTBEAT.
 
 It is also possible to heartbeat an Activity from an external source:
 
@@ -113,7 +113,7 @@ It is also possible to heartbeat an Activity from an external source:
 	err := client.RecordActivityHeartbeat(ctx, taskToken, details)
 
 It expects an additional parameter, "taskToken", which is the value of the binary "TaskToken" field of the
-"ActivityInfo" struct retrieved inside the Activity (GetActivityInfo(ctx).TaskToken). "details" is the serializable
+[activity.Info] retrieved inside the Activity (GetActivityInfo(ctx).TaskToken). "details" is the serializable
 payload containing progress information.
 
 # Activity Cancellation

--- a/client/client.go
+++ b/client/client.go
@@ -25,6 +25,7 @@
 //go:generate mockgen -copyright_file ../LICENSE -package client -source client.go -destination client_mock.go
 
 // Package client is used by external programs to communicate with Temporal service.
+//
 // NOTE: DO NOT USE THIS API INSIDE OF ANY WORKFLOW CODE!!!
 package client
 
@@ -401,15 +402,13 @@ type (
 		//  - "(WorkflowID = 'wid1' or (WorkflowType = 'type2' and WorkflowID = 'wid2'))".
 		//  - "CloseTime between '2019-08-27T15:04:05+00:00' and '2019-08-28T15:04:05+00:00'".
 		//  - to list only open workflow use "CloseTime is null"
-		// For supported operations on different server versions see [Visibility].
+		// For supported operations on different server versions see https://docs.temporal.io/visibility.
 		// Retrieved workflow executions are sorted by StartTime in descending order when list open workflow,
 		// and sorted by CloseTime in descending order for other queries.
 		// The errors it can return:
 		//  - serviceerror.InvalidArgument
 		//  - serviceerror.Internal
 		//  - serviceerror.Unavailable
-		//
-		// [Visibility]: https://docs.temporal.io/visibility
 		ListWorkflow(ctx context.Context, request *workflowservice.ListWorkflowExecutionsRequest) (*workflowservice.ListWorkflowExecutionsResponse, error)
 
 		// ListArchivedWorkflow gets archived workflow executions based on query. This API will return BadRequest if Temporal
@@ -424,7 +423,7 @@ type (
 
 		// ScanWorkflow gets workflow executions based on query. The query is basically the SQL WHERE clause
 		// (see ListWorkflow for query examples).
-		// For supported operations on different server versions see [Visibility].
+		// For supported operations on different server versions see https://docs.temporal.io/visibility.
 		// ScanWorkflow should be used when retrieving large amount of workflows and order is not needed.
 		// It will use more resources than ListWorkflow, but will be several times faster
 		// when retrieving millions of workflows.
@@ -432,19 +431,15 @@ type (
 		//  - serviceerror.InvalidArgument
 		//  - serviceerror.Internal
 		//  - serviceerror.Unavailable
-		//
-		// [Visibility]: https://docs.temporal.io/visibility
 		ScanWorkflow(ctx context.Context, request *workflowservice.ScanWorkflowExecutionsRequest) (*workflowservice.ScanWorkflowExecutionsResponse, error)
 
 		// CountWorkflow gets number of workflow executions based on query. The query is basically the SQL WHERE clause
 		// (see ListWorkflow for query examples).
-		// For supported operations on different server versions see [Visibility].
+		// For supported operations on different server versions see https://docs.temporal.io/visibility.
 		// The errors it can return:
 		//  - serviceerror.InvalidArgument
 		//  - serviceerror.Internal
 		//  - serviceerror.Unavailable
-		//
-		// [Visibility]: https://docs.temporal.io/visibility
 		CountWorkflow(ctx context.Context, request *workflowservice.CountWorkflowExecutionsRequest) (*workflowservice.CountWorkflowExecutionsResponse, error)
 
 		// GetSearchAttributes returns valid search attributes keys and value types.
@@ -678,7 +673,7 @@ var (
 	_ internal.NamespaceClient = NamespaceClient(nil)
 )
 
-// NewValue creates a new converter.EncodedValue which can be used to decode binary data returned by Temporal.  For example:
+// NewValue creates a new [converter.EncodedValue] which can be used to decode binary data returned by Temporal.  For example:
 // User had Activity.RecordHeartbeat(ctx, "my-heartbeat") and then got response from calling Client.DescribeWorkflowExecution.
 // The response contains binary field PendingActivityInfo.HeartbeatDetails,
 // which can be decoded by using:
@@ -689,7 +684,7 @@ func NewValue(data *commonpb.Payloads) converter.EncodedValue {
 	return internal.NewValue(data)
 }
 
-// NewValues creates a new converter.EncodedValues which can be used to decode binary data returned by Temporal. For example:
+// NewValues creates a new [converter.EncodedValues] which can be used to decode binary data returned by Temporal. For example:
 // User had Activity.RecordHeartbeat(ctx, "my-heartbeat", 123) and then got response from calling Client.DescribeWorkflowExecution.
 // The response contains binary field PendingActivityInfo.HeartbeatDetails,
 // which can be decoded by using:

--- a/contrib/tally/handler.go
+++ b/contrib/tally/handler.go
@@ -48,7 +48,7 @@ func NewMetricsHandler(scope tally.Scope) client.MetricsHandler {
 }
 
 // ScopeFromHandler returns the underlying scope of the handler. Callers may
-// need to check workflow.IsReplaying(ctx) to avoid recording metrics during
+// need to check [workflow.IsReplaying] to avoid recording metrics during
 // replay. If this handler was not created via this package, [github.com/uber-go/tally.NoopScope] is
 // returned.
 //

--- a/interceptor/interceptor.go
+++ b/interceptor/interceptor.go
@@ -37,12 +37,12 @@ import (
 // calls will be intercepted by it. If an implementation of this interceptor is
 // provided via worker options, all worker calls will be intercepted by it.
 //
-// All implementations of this should embed InterceptorBase but are not required
+// All implementations of this should embed [InterceptorBase] but are not required
 // to.
 type Interceptor = internal.Interceptor
 
 // InterceptorBase is a default implementation of Interceptor meant for
-// embedding. It simply embeds ClientInterceptorBase and WorkerInterceptorBase.
+// embedding. It simply embeds [ClientInterceptorBase] and [WorkerInterceptorBase].
 type InterceptorBase = internal.InterceptorBase
 
 // WorkerInterceptor is an interface for all calls that can be intercepted
@@ -55,9 +55,9 @@ type InterceptorBase = internal.InterceptorBase
 // changes.
 type WorkerInterceptor = internal.WorkerInterceptor
 
-// WorkerInterceptorBase is a default implementation of WorkerInterceptor that
-// simply instantiates ActivityInboundInterceptorBase or
-// WorkflowInboundInterceptorBase when called to intercept activities or
+// WorkerInterceptorBase is a default implementation of [WorkerInterceptor] that
+// simply instantiates [ActivityInboundInterceptorBase] or
+// [WorkflowInboundInterceptorBase] when called to intercept activities or
 // workflows respectively.
 //
 // This must be embedded into all WorkerInterceptor implementations to safely
@@ -69,15 +69,15 @@ type WorkerInterceptorBase = internal.WorkerInterceptorBase
 // activity calls, can change the outbound interceptor in Init before the next
 // call in the chain.
 //
-// All implementations must embed ActivityInboundInterceptorBase to safely
+// All implementations must embed [ActivityInboundInterceptorBase] to safely
 // handle future changes.
 type ActivityInboundInterceptor = internal.ActivityInboundInterceptor
 
 // ActivityInboundInterceptorBase is a default implementation of
-// ActivityInboundInterceptor that forwards calls to the next inbound
+// [ActivityInboundInterceptor] that forwards calls to the next inbound
 // interceptor and uses an ActivityOutboundInterceptorBase on Init.
 //
-// This must be embedded into all ActivityInboundInterceptor implementations to
+// This must be embedded into all [ActivityInboundInterceptor] implementations to
 // safely handle future changes.
 type ActivityInboundInterceptorBase = internal.ActivityInboundInterceptorBase
 
@@ -87,12 +87,12 @@ type ExecuteActivityInput = internal.ExecuteActivityInput
 // ActivityOutboundInterceptor is an interface for all activity calls
 // originating from the SDK.
 //
-// All implementations must embed ActivityOutboundInterceptorBase to safely
+// All implementations must embed [ActivityOutboundInterceptorBase] to safely
 // handle future changes.
 type ActivityOutboundInterceptor = internal.ActivityOutboundInterceptor
 
 // ActivityOutboundInterceptorBase is a default implementation of
-// ActivityOutboundInterceptor that forwards calls to the next outbound
+// [ActivityOutboundInterceptor] that forwards calls to the next outbound
 // interceptor.
 //
 // This must be embedded into all ActivityOutboundInterceptor implementations to
@@ -104,15 +104,15 @@ type ActivityOutboundInterceptorBase = internal.ActivityOutboundInterceptorBase
 // workflow calls, can change the outbound interceptor in Init before the next
 // call in the chain.
 //
-// All implementations must embed WorkflowInboundInterceptorBase to safely
+// All implementations must embed [WorkflowInboundInterceptorBase] to safely
 // handle future changes.
 type WorkflowInboundInterceptor = internal.WorkflowInboundInterceptor
 
 // WorkflowInboundInterceptorBase is a default implementation of
-// WorkflowInboundInterceptor that forwards calls to the next inbound
+// [WorkflowInboundInterceptor] that forwards calls to the next inbound
 // interceptor and uses an WorkflowOutboundInterceptorBase on Init.
 //
-// This must be embedded into all WorkflowInboundInterceptor implementations to
+// This must be embedded into all [WorkflowInboundInterceptor] implementations to
 // safely handle future changes.
 type WorkflowInboundInterceptorBase = internal.WorkflowInboundInterceptorBase
 
@@ -134,47 +134,47 @@ type UpdateInput = internal.UpdateInput
 // WorkflowOutboundInterceptor is an interface for all workflow calls
 // originating from the SDK.
 //
-// All implementations must embed WorkflowOutboundInterceptorBase to safely
+// All implementations must embed [WorkflowOutboundInterceptorBase] to safely
 // handle future changes.
 type WorkflowOutboundInterceptor = internal.WorkflowOutboundInterceptor
 
 // WorkflowOutboundInterceptorBase is a default implementation of
-// WorkflowOutboundInterceptor that forwards calls to the next outbound
+// [WorkflowOutboundInterceptor] that forwards calls to the next outbound
 // interceptor.
 //
-// This must be embedded into all WorkflowOutboundInterceptor implementations to
+// This must be embedded into all [WorkflowOutboundInterceptor] implementations to
 // safely handle future changes.
 type WorkflowOutboundInterceptorBase = internal.WorkflowOutboundInterceptorBase
 
-// ClientInterceptor for providing a ClientOutboundInterceptor to intercept
+// ClientInterceptor for providing a [ClientOutboundInterceptor] to intercept
 // certain workflow-specific client calls from the SDK. If an implementation of
 // this is provided via client or worker options, certain client calls will be
 // intercepted by it.
 //
-// All implementations must embed ClientInterceptorBase to safely handle future
+// All implementations must embed [ClientInterceptorBase] to safely handle future
 // changes.
 type ClientInterceptor = internal.ClientInterceptor
 
-// ClientInterceptorBase is a default implementation of ClientInterceptor that
-// simply instantiates ClientOutboundInterceptorBase when called to intercept
+// ClientInterceptorBase is a default implementation of [ClientInterceptor] that
+// simply instantiates [ClientOutboundInterceptorBase] when called to intercept
 // the client.
 //
-// This must be embedded into all ClientInterceptor implementations to safely
+// This must be embedded into all [ClientInterceptor] implementations to safely
 // handle future changes.
 type ClientInterceptorBase = internal.ClientInterceptorBase
 
 // ClientOutboundInterceptor is an interface for certain workflow-specific calls
 // originating from the SDK.
 //
-// All implementations must embed ClientOutboundInterceptorBase to safely handle
+// All implementations must embed [ClientOutboundInterceptorBase] to safely handle
 // future changes.
 type ClientOutboundInterceptor = internal.ClientOutboundInterceptor
 
 // ClientOutboundInterceptorBase is a default implementation of
-// ClientOutboundInterceptor that forwards calls to the next outbound
+// [ClientOutboundInterceptor] that forwards calls to the next outbound
 // interceptor.
 //
-// This must be embedded into all ActivityInboundInterceptor implementations to
+// This must be embedded into all [ClientOutboundInterceptor] implementations to
 // safely handle future changes.
 type ClientOutboundInterceptorBase = internal.ClientOutboundInterceptorBase
 

--- a/interceptor/tracing_interceptor.go
+++ b/interceptor/tracing_interceptor.go
@@ -100,7 +100,7 @@ type TracerOptions struct {
 	// never be nil.
 	//
 	// This is used internally to set the span on contexts not natively supported
-	// by tracing systems such as workflow.Context.
+	// by tracing systems such as [workflow.Context].
 	SpanContextKey interface{}
 
 	// HeaderKey is the key name on the Temporal header to serialize the span to.

--- a/temporal/doc.go
+++ b/temporal/doc.go
@@ -47,7 +47,7 @@ The root temporal package contains common data structures. The subpackages are:
     activity code.
   - testsuite - unit testing framework for activity and workflow testing
 
-How Temporal works
+# How Temporal works
 
 The Temporal hosted service brokers and persists events generated during workflow execution. Worker nodes owned and
 operated by customers execute the coordination and task logic. To facilitate the implementation of worker nodes Temporal
@@ -56,7 +56,7 @@ provides a client-side library for the Go language.
 In Temporal, you can code the logical flow of events separately as a workflow and code business logic as activities. The
 workflow identifies the activities and sequences them, while an activity executes the logic.
 
-Key Features
+# Key Features
 
 Dynamic workflow execution graphs - Determine the workflow execution graphs at runtime based on the data you are
 processing. Temporal does not pre-compute the execution graphs at compile time or at workflow start time. Therefore, you

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -78,7 +78,7 @@ type (
 	// WorkflowRegistry exposes workflow registration functions to consumers.
 	WorkflowRegistry interface {
 		// RegisterWorkflow - registers a workflow function with the worker.
-		// A workflow takes a workflow.Context and input and returns a (result, error) or just error.
+		// A workflow takes a [workflow.Context] and input and returns a (result, error) or just error.
 		// Examples:
 		//	func sampleWorkflow(ctx workflow.Context, input []byte) (result []byte, err error)
 		//	func sampleWorkflow(ctx workflow.Context, arg1 int, arg2 string) (result []byte, err error)
@@ -155,7 +155,7 @@ type (
 	// For example if a workflow failed in production then its history can be downloaded through UI or CLI
 	// and replayed in a debugger as many times as necessary.
 	// Use this class to create unit tests that check if workflow changes are backwards compatible.
-	// It is important to maintain backwards compatibility through use of workflow.GetVersion
+	// It is important to maintain backwards compatibility through use of [workflow.GetVersion]
 	// to ensure that new deployments are not going to break open workflows.
 	WorkflowReplayer interface {
 		// RegisterWorkflow registers workflow that is going to be replayed
@@ -206,7 +206,7 @@ type (
 
 	// WorkflowPanicPolicy is used for configuring how worker deals with workflow
 	// code panicking which includes non backwards compatible changes to the workflow code without appropriate
-	// versioning (see workflow.GetVersion).
+	// versioning (see [workflow.GetVersion]).
 	// The default behavior is to block workflow execution until the problem is fixed.
 	WorkflowPanicPolicy = internal.WorkflowPanicPolicy
 

--- a/workflow/deterministic_wrappers.go
+++ b/workflow/deterministic_wrappers.go
@@ -33,8 +33,8 @@ import (
 type (
 
 	// Channel must be used instead of a native go channel by workflow code.
-	// Use workflow.NewChannel(ctx) method to create a Channel instance.
-	// Channel extends both ReadChannel and SendChannel. Prefer using one of these interfaces
+	// Use [workflow.NewChannel] to create a Channel instance.
+	// Channel extends both [ReceiveChannel] and [SendChannel]. Prefer using one of these interfaces
 	// to share a Channel with consumers or producers.
 	Channel = internal.Channel
 
@@ -45,14 +45,14 @@ type (
 	SendChannel = internal.SendChannel
 
 	// Selector must be used instead of native go select by workflow code.
-	// Use workflow.NewSelector(ctx) method to create a Selector instance.
+	// Use [workflow.NewSelector] method to create a Selector instance.
 	Selector = internal.Selector
 
 	// Future represents the result of an asynchronous computation.
 	Future = internal.Future
 
 	// Settable is used to set value or error on a future.
-	// See more: workflow.NewFuture(ctx).
+	// See more: [workflow.NewFuture].
 	Settable = internal.Settable
 
 	// WaitGroup is used to wait for a collection of

--- a/workflow/doc.go
+++ b/workflow/doc.go
@@ -60,7 +60,7 @@ the sole parameter it receives as part of its initialization as a parameter to t
 		}
 		ctx = workflow.WithActivityOptions(ctx, ao)
 
-		future := workflow.ExecuteActivity(ctx, SimpleActivity, value)
+		future := [workflow.ExecuteActivity](ctx, SimpleActivity, value)
 		var result string
 		if err := future.Get(ctx, &result); err != nil {
 			return err
@@ -78,11 +78,11 @@ parameters the workflow accepts as well as any values it might return.
 
 	func SimpleWorkflow(ctx workflow.Context, value string) error
 
-The first parameter to the function is ctx workflow.Context. This is a required parameter for all workflow functions
+The first parameter to the function is ctx [workflow.Context]. This is a required parameter for all workflow functions
 and is used by the Temporal client library to pass execution context. Virtually all the client library functions that
 are callable from the workflow functions require this ctx parameter. This **context** parameter is the same concept as
 the standard context.Context provided by Go. The only difference between workflow.Context and context.Context is that
-the Done() function in workflow.Context returns workflow.Channel instead of the standard go chan.
+the Done() function in [workflow.Context] returns [workflow.Channel] instead of the standard go chan.
 
 The second string parameter is a custom workflow parameter that can be used to pass in data into the workflow on start.
 A workflow can have one or more such parameters. All parameters to an workflow function must be serializable, which
@@ -107,13 +107,13 @@ A simplistic way to think about these requirements is that the workflow code:
   - Should really not affect changes in external systems other than through
     invocation of activities
   - Should interact with time only through the functions provided by the
-    Temporal client library (i.e. workflow.Now(), workflow.Sleep())
+    Temporal client library (i.e. [workflow.Now](), [workflow.Sleep]())
   - Should not create and interact with goroutines directly, it should instead
     use the functions provided by the Temporal client library. (i.e.
-    workflow.Go() instead of go, workflow.Channel instead of chan,
-    workflow.Selector instead of select)
+    [workflow.Go]() instead of go, [workflow.Channel] instead of chan,
+    [workflow.Selector] instead of select)
   - Should do all logging via the logger provided by the Temporal client
-    library (i.e. workflow.GetLogger())
+    library (i.e. [workflow.GetLogger]())
   - Should not iterate over maps using range as order of map iteration is
     randomized
 
@@ -127,15 +127,15 @@ deterministic and repeatable within an execution context.
 
 Coroutine related constructs:
 
-  - workflow.Go : This is a replacement for the the go statement
-  - workflow.Channel : This is a replacement for the native chan type. Temporal
+  - [workflow.Go] : This is a replacement for the the go statement
+  - [workflow.Channel] : This is a replacement for the native chan type. Temporal
     provides support for both buffered and unbuffered channels
-  - workflow.Selector : This is a replacement for the select statement
+  - [workflow.Selector] : This is a replacement for the select statement
 
 Time related functions:
 
-  - workflow.Now() : This is a replacement for time.Now()
-  - workflow.Sleep() : This is a replacement for time.Sleep()
+  - [workflow.Now]() : This is a replacement for [time.Now]()
+  - [workflow.Sleep]() : This is a replacement for [time.Sleep]()
 
 # Failing a Workflow
 
@@ -146,7 +146,7 @@ workflow then any results returned are ignored.
 # Execute Activity
 
 The primary responsibility of the workflow implementation is to schedule activities for execution. The most
-straightforward way to do that is via the library method workflow.ExecuteActivity:
+straightforward way to do that is via the library method [workflow.ExecuteActivity]:
 
 	ao := workflow.ActivityOptions{
 		TaskQueue:               "sampleTaskQueue",
@@ -158,20 +158,20 @@ straightforward way to do that is via the library method workflow.ExecuteActivit
 	}
 	ctx = workflow.WithActivityOptions(ctx, ao)
 
-	future := workflow.ExecuteActivity(ctx, SimpleActivity, value)
+	future := [workflow.ExecuteActivity](ctx, SimpleActivity, value)
 	var result string
 	if err := future.Get(ctx, &result); err != nil {
 		return err
 	}
 
-Before calling workflow.ExecuteActivity(), ActivityOptions must be configured for the invocation. These are for the
+Before calling [workflow.ExecuteActivity](), [ActivityOptions] must be configured for the invocation. These are for the
 most part options to customize various execution timeouts. These options are passed in by creating a child context from
 the initial context and overwriting the desired values. The child context is then passed into the
-workflow.ExecuteActivity() call. If multiple activities are sharing the same exact option values then the same context
-instance can be used when calling workflow.ExecuteActivity().
+[workflow.ExecuteActivity]() call. If multiple activities are sharing the same exact option values then the same context
+instance can be used when calling [workflow.ExecuteActivity]().
 
 The first parameter to the call is the required workflow.Context object. This type is an exact copy of context.Context
-with the Done() method returning workflow.Channel instead of native go chan.
+with the Done() method returning [workflow.Channel] instead of native go chan.
 
 The second parameter is the function that we registered as an activity function. This parameter can also be the a
 string representing the fully qualified name of the activity function. The benefit of passing in the actual function
@@ -181,15 +181,15 @@ The remaining parameters are the parameters to pass to the activity as part of t
 single parameter: **value**. This list of parameters must match the list of parameters declared by the activity
 function. Like mentioned above the Temporal client library will validate that this is indeed the case.
 
-The method call returns immediately and returns a workflow.Future. This allows for more code to be executed without
+The method call returns immediately and returns a [workflow.Future]. This allows for more code to be executed without
 having to wait for the scheduled activity to complete.
 
 When we are ready to process the results of the activity we call the Get() method on the future object returned. The
-parameters to this method are the ctx object we passed to the workflow.ExecuteActivity() call and an output parameter
+parameters to this method are the ctx object we passed to the [workflow.ExecuteActivity]() call and an output parameter
 that will receive the output of the activity. The type of the output parameter must match the type of the return value
 declared by the activity function. The Get() method will block until the activity completes and results are available.
 
-The result value returned by workflow.ExecuteActivity() can be retrieved from the future and used like any normal
+The result value returned by [workflow.ExecuteActivity]() can be retrieved from the future and used like any normal
 result from a synchronous function call. If the result above is a string value we could use it as follows:
 
 	var result string
@@ -206,17 +206,17 @@ result from a synchronous function call. If the result above is a string value w
 		return err
 	}
 
-In the example above we called the Get() method on the returned future immediately after workflow.ExecuteActivity().
+In the example above we called the Get() method on the returned future immediately after [workflow.ExecuteActivity]().
 However, this is not necessary. If we wish to execute multiple activities in parallel we can repeatedly call
-workflow.ExecuteActivity() store the futures returned and then wait for all activities to complete by calling the
+[workflow.ExecuteActivity]() store the futures returned and then wait for all activities to complete by calling the
 Get() methods of the future at a later time.
 
-To implement more complex wait conditions on the returned future objects, use the workflow.Selector class. Take a look
-at our Pickfirst sample for an example of how to use of workflow.Selector.
+To implement more complex wait conditions on the returned future objects, use the [workflow.Selector] class. Take a look
+at our Pickfirst sample for an example of how to use of [workflow.Selector].
 
 # Child Workflow
 
-workflow.ExecuteChildWorkflow enables the scheduling of other workflows from within a workflow's implementation. The
+[workflow.ExecuteChildWorkflow] enables the scheduling of other workflows from within a workflow's implementation. The
 parent workflow has the ability to "monitor" and impact the life-cycle of the child workflow in a similar way it can do
 for an activity it invoked.
 
@@ -234,14 +234,14 @@ for an activity it invoked.
 		return err
 	}
 
-Before calling workflow.ExecuteChildWorkflow(), ChildWorkflowOptions must be configured for the invocation. These are
+Before calling [workflow.ExecuteChildWorkflow](), [ChildWorkflowOptions] must be configured for the invocation. These are
 for the most part options to customize various execution timeouts. These options are passed in by creating a child
 context from the initial context and overwriting the desired values. The child context is then passed into the
-workflow.ExecuteChildWorkflow() call. If multiple activities are sharing the same exact option values then the same
-context instance can be used when calling workflow.ExecuteChildWorkflow().
+[workflow.ExecuteChildWorkflow]() call. If multiple activities are sharing the same exact option values then the same
+context instance can be used when calling [workflow.ExecuteChildWorkflow]().
 
-The first parameter to the call is the required workflow.Context object. This type is an exact copy of context.Context
-with the Done() method returning workflow.Channel instead of the native go chan.
+The first parameter to the call is the required [workflow.Context] object. This type is an exact copy of context.Context
+with the Done() method returning [workflow.Channel] instead of the native go chan.
 
 The second parameter is the function that we registered as a workflow function. This parameter can also be a string
 representing the fully qualified name of the workflow function. What's the benefit? When you pass in the actual
@@ -254,13 +254,13 @@ The method call returns immediately and returns a workflow.Future. This allows f
 having to wait for the scheduled workflow to complete.
 
 When we are ready to process the results of the workflow we call the Get() method on the future object returned. The
-parameters to this method are the ctx object we passed to the workflow.ExecuteChildWorkflow() call and an output
+parameters to this method are the ctx object we passed to the [workflow.ExecuteChildWorkflow]() call and an output
 parameter that will receive the output of the workflow. The type of the output parameter must match the type of the
 return value declared by the workflow function. The Get() method will block until the workflow completes and results
 are available.
 
-The workflow.ExecuteChildWorkflow() function is very similar to the workflow.ExecuteActivity() function. All the
-patterns described for using the workflow.ExecuteActivity() apply to the workflow.ExecuteChildWorkflow() function as
+The [workflow.ExecuteChildWorkflow]() function is very similar to the [workflow.ExecuteActivity]() function. All the
+patterns described for using the [workflow.ExecuteActivity]() apply to the [workflow.ExecuteChildWorkflow]() function as
 well.
 
 Child workflows can also be configured to continue to exist once their parent workflow is closed. When using this
@@ -283,11 +283,11 @@ pattern, extra care needs to be taken to ensure the child workflow is started be
 
 # Error Handling
 
-Activities and child workflows can fail. Activity errors are *temporal.ActivityError and errors during child workflow
-execution are *temporal.ChildWorkflowExecutionError. The cause of the errors may be types like
-*temporal.ApplicationError, *temporal.TimeoutError, *temporal.CanceledError, and *temporal.PanicError.
+Activities and child workflows can fail. Activity errors are *[temporal.ActivityError] and errors during child workflow
+execution are *[temporal.ChildWorkflowExecutionError]. The cause of the errors may be types like
+*[temporal.ApplicationError], *[temporal.TimeoutError], *[temporal.CanceledError], and *[temporal.PanicError].
 
-See ExecuteActivity() and ExecuteChildWorkflow() for details.
+See [ExecuteActivity]() and [ExecuteChildWorkflow]() for details.
 
 # Signals
 
@@ -313,7 +313,7 @@ workflow also has the option to stop execution by blocking on a signal channel.
 	signalChan := workflow.GetSignalChannel(ctx, signalName)
 
 	s := workflow.NewSelector(ctx)
-	s.AddReceive(signalChan, func(c workflow.Channel, more bool) {
+	s.AddReceive(signalChan, func(c [workflow.Channel], more bool) {
 		c.Receive(ctx, &signalVal)
 		workflow.GetLogger(ctx).Info("Received signal!", "signal", signalName, "value", signalVal)
 	})
@@ -323,8 +323,8 @@ workflow also has the option to stop execution by blocking on a signal channel.
 		return errors.New("signalVal")
 	}
 
-In the example above, the workflow code uses workflow.GetSignalChannel to open a workflow.Channel for the named signal.
-We then use a workflow.Selector to wait on this channel and process the payload received with the signal.
+In the example above, the workflow code uses [workflow.GetSignalChannel] to open a [workflow.Channel] for the named signal.
+We then use a [workflow.Selector] to wait on this channel and process the payload received with the signal.
 
 # Updates
 
@@ -343,7 +343,7 @@ workflow state, schedule activities, launch child workflow, etc.
 	    return result, nil
 	})
 
-For more information see our docs at https://docs.temporal.io/dev-guide/go/features#handle-update
+For more information see our docs on [handling updates]
 
 ## Validate Updates
 
@@ -373,7 +373,7 @@ the update validator returns any error the update will fail and not be written i
 		return nil
 	}
 
-For more information see our docs at https://docs.temporal.io/dev-guide/go/features#validator-function
+For more information see our docs on [validator functions]
 
 # ContinueAsNew Workflow Completion
 
@@ -381,7 +381,7 @@ Workflows that need to rerun periodically could naively be implemented as a big 
 logic of the workflow is inside the body of the for loop. The problem with this approach is that the history for that
 workflow will keep growing to a point where it reaches the maximum size enforced by the service.
 
-ContinueAsNew is the low level construct that enables implementing such workflows without the risk of failures down the
+[ContinueAsNew] is the low level construct that enables implementing such workflows without the risk of failures down the
 road. The operation atomically completes the current execution and starts a new execution of the workflow with the same
 workflow ID. The new execution will not carry over any history from the old execution. To trigger this behavior, the
 workflow function should terminate by returning the special ContinueAsNewError error:
@@ -391,19 +391,19 @@ workflow function should terminate by returning the special ContinueAsNewError e
 	    return workflow.NewContinueAsNewError(ctx, SimpleWorkflow, value)
 	}
 
-For a complete example implementing this pattern please refer to the Cron example.
+For a complete example implementing this pattern please refer to our Cron example.
 
 # SideEffect API
 
-workflow.SideEffect executes the provided function once, records its result into the workflow history, and doesn't
+[workflow.SideEffect] executes the provided function once, records its result into the workflow history, and doesn't
 re-execute upon replay. Instead, it returns the recorded result. Use it only for short, nondeterministic code snippets,
 like getting a random value or generating a UUID. It can be seen as an "inline" activity. However, one thing to note
-about workflow.SideEffect is that whereas for activities Temporal guarantees "at-most-once" execution, no such guarantee
-exists for workflow.SideEffect. Under certain failure conditions, workflow.SideEffect can end up executing the function
+about [workflow.SideEffect] is that whereas for activities Temporal guarantees "at-most-once" execution, no such guarantee
+exists for [workflow.SideEffect]. Under certain failure conditions, [workflow.SideEffect] can end up executing the function
 more than once.
 
-The only way to fail SideEffect is to panic, which causes workflow task failure. The workflow task after timeout is
-rescheduled and re-executed giving SideEffect another chance to succeed. Be careful to not return any data from the
+The only way to fail [SideEffect] is to panic, which causes workflow task failure. The workflow task after timeout is
+rescheduled and re-executed giving [SideEffect] another chance to succeed. Be careful to not return any data from the
 SideEffect function any other way than through its recorded return value.
 
 	encodedRandom := SideEffect(func(ctx workflow.Context) interface{} {
@@ -428,7 +428,7 @@ the current call stack of a workflow execution. You can use tctl to do the query
 The above cli command uses __stack_trace as the query type. The __stack_trace is a built-in query type that is
 supported by temporal client library. You can also add your own custom query types to support thing like query current
 state of the workflow, or query how many activities the workflow has completed. To do so, you need to setup your own
-query handler using workflow.SetQueryHandler in your workflow code:
+query handler using [workflow.SetQueryHandler] in your workflow code:
 
 	func MyWorkflow(ctx workflow.Context, input string) error {
 	   currentState := "started" // this could be any serializable struct
@@ -550,11 +550,11 @@ The code below implements the unit tests for the SimpleWorkflow sample.
 
 # Setup
 
-First, we define a "test suite" struct that absorbs both the basic suite functionality from testify
-http://godoc.org/github.com/stretchr/testify/suite via suite.Suite and the suite functionality from the Temporal test
-framework via testsuite.WorkflowTestSuite. Since every test in this suite will test our workflow we add a property to
+First, we define a "test suite" struct that absorbs both the basic suite functionality from [testify]
+via suite.Suite and the suite functionality from the Temporal test
+framework via [testsuite.WorkflowTestSuite]. Since every test in this suite will test our workflow we add a property to
 our struct to hold an instance of the test environment. This will allow us to initialize the test environment in a
-setup method. For testing workflows we use a testsuite.TestWorkflowEnvironment.
+setup method. For testing workflows we use a [testsuite.TestWorkflowEnvironment].
 
 We then implement a SetupTest method to setup a new test environment before each test. Doing so ensure that each test
 runs in it's own isolated sandbox. We also implement an AfterTest function where we assert that all mocks we setup were
@@ -641,5 +641,9 @@ assert that the "value" param has the same content to the value param we passed 
 
 NOTE: The default MaximumAttempts for retry policy set by server is 0 which means unlimited retries.
 However, during a unit test the default MaximumAttempts is 10 to avoid a test getting stuck.
+
+[testify]: http://godoc.org/github.com/stretchr/testify/suite
+[handling updates]: https://docs.temporal.io/dev-guide/go/features#handle-update
+[validator functions]: https://docs.temporal.io/dev-guide/go/features#validator-function
 */
 package workflow

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -391,7 +391,7 @@ func GetVersion(ctx Context, changeID string, minSupported, maxSupported Version
 // code. When client calls Client.QueryWorkflow() to temporal server, a task will be generated on server that will be dispatched
 // to a workflow worker, which will replay the history events and then execute a query handler based on the query type.
 // The query handler will be invoked out of the context of the workflow, meaning that the handler code must not use workflow
-// context to do things like workflow.NewChannel(), workflow.Go() or to call any workflow blocking functions like
+// context to do things like [workflow.NewChannel](), [workflow.Go]() or to call any workflow blocking functions like
 // Channel.Get() or Future.Get(). Trying to do so in query handler code will fail the query and client will receive
 // QueryFailedError.
 // Example of workflow code that support query type "current_state":
@@ -440,7 +440,7 @@ func SetUpdateHandler(ctx Context, updateName string, handler interface{}) error
 // name such that update invocations specifying that name will invoke the
 // handler.  The handler function can take as input any number of parameters so
 // long as they can be serialized/deserialized by the system. The handler can
-// take a workflow.Context as its first parameter but this is not required. The
+// take a [workflow.Context] as its first parameter but this is not required. The
 // update handler must return either a single error or a single serializable
 // object along with a single error. The update handler function is invoked in
 // the context of the workflow and thus is subject to the same restrictions as
@@ -454,7 +454,7 @@ func SetUpdateHandler(ctx Context, updateName string, handler interface{}) error
 // the update request will be considered to have been rejected and as such will
 // not occupy any space in the workflow history. Validation functions must take
 // as inputs the same parameters as the associated update handler but my vary
-// from said handler by the presence/absence of a workflow.Context as the first
+// from said handler by the presence/absence of a [workflow.Context] as the first
 // parameter. Validation handlers must only return a single error. Validation
 // handlers must be deterministic and can observe workflow state but must not
 // mutate workflow state in any way.
@@ -495,8 +495,8 @@ func SetUpdateHandlerWithOptions(ctx Context, updateName string, handler interfa
 // Warning! Never make commands, like schedule activity/childWorkflow/timer or send/wait on future/channel, based on
 // this flag as it is going to break workflow determinism requirement.
 // The only reasonable use case for this flag is to avoid some external actions during replay, like custom logging or
-// metric reporting. Please note that Temporal already provide standard logging/metric via workflow.GetLogger(ctx) and
-// workflow.GetMetricsHandler(ctx), and those standard mechanism are replay-aware and it will automatically suppress
+// metric reporting. Please note that Temporal already provide standard logging/metric via [workflow.GetLogger] and
+// [workflow.GetMetricsHandler], and those standard mechanism are replay-aware and it will automatically suppress
 // during replay. Only use this flag if you need custom logging/metrics reporting, for example if you want to log to
 // kafka.
 //


### PR DESCRIPTION
## What was changed
I backfilled doc links throughout our user-facing APIs. I didn't touch the internal package as those aren't supposed to be for external consumption.

While here I cleaned up a few things, like adding links to referenced code samples and removing a doc comment in a spot where they're unsupported; you can't add links in the comments on interface methods or struct members.

## Why?
Linking readers to referenced APIs saves them time when trying to understand how to use temporal.

## Checklist
This was tested by running godoc locally and inspecting the rendered docs. Note that [cross-package doc links still don't work](https://github.com/golang/go/issues/56683) so cannot be verified locally.
