### PR TITLE
Disable running sessions on a versioned worker

### DIFF
--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -1483,6 +1483,12 @@ func NewAggregatedWorker(client *WorkflowClient, taskQueue string, options Worke
 		panic("cannot set MaxConcurrentWorkflowTaskExecutionSize to 1")
 	}
 
+	// Sessions are not currently compatible with worker versioning
+	// See: https://github.com/temporalio/sdk-go/issues/1227
+	if options.EnableSessionWorker && options.UseBuildIDForVersioning {
+		panic("cannot set both EnableSessionWorker and UseBuildIDForVersioning")
+	}
+
 	// Need reference to result for fatal error handler
 	var aw *AggregatedWorker
 	fatalErrorCallback := func(err error) {

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -2778,6 +2778,17 @@ func TestWorkerRegisterDisabledWorkflow(t *testing.T) {
 	require.Equal(t, "workflow worker disabled, cannot register workflow", recovered)
 }
 
+func TestWorkerBuildIDAndSessionPanic(t *testing.T) {
+	// Expect panic
+	var recovered interface{}
+	func() {
+		defer func() { recovered = recover() }()
+		worker := NewAggregatedWorker(&WorkflowClient{}, "some-task-queue", WorkerOptions{EnableSessionWorker: true, UseBuildIDForVersioning: true})
+		worker.RegisterWorkflow(testReplayWorkflow)
+	}()
+	require.Equal(t, "cannot set both EnableSessionWorker and UseBuildIDForVersioning", recovered)
+}
+
 func TestHistoryFromJSON(t *testing.T) {
 	// Load sample history and just make sure it has the right event count
 	r, err := os.Open("testdata/sampleHistory.json")

--- a/internal/worker.go
+++ b/internal/worker.go
@@ -238,6 +238,7 @@ type (
 		// operate on workflows it claims to be compatible with. You must set BuildID if this flag
 		// is true.
 		// NOTE: Experimental
+		// Note: Cannot be enabled at the same time as EnableSessionWorker
 		UseBuildIDForVersioning bool
 	}
 )


### PR DESCRIPTION
Disable running sessions and versioned workers together because they are not currently compatible

closes https://github.com/temporalio/sdk-go/issues/1234