### PR TITLE
Expose StartDelay in StartWorkflowOptions

### DIFF
--- a/internal/client.go
+++ b/internal/client.go
@@ -608,6 +608,14 @@ type (
 		//
 		// NOTE: Experimental
 		EnableEagerStart bool
+
+		// StartDelay - Time to wait before dispatching the first workflow task.
+		// If the workflow gets a signal before the delay, a workflow task will be dispatched and the rest
+		// of the delay will be ignored. A signal from signal with start will not trigger a workflow task.
+		// Cannot be set the same time as a CronSchedule.
+		//
+		// NOTE: Experimental
+		StartDelay time.Duration
 	}
 
 	// RetryPolicy defines the retry policy.

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -1514,6 +1514,10 @@ func (w *workflowClientInterceptor) ExecuteWorkflow(
 		eagerExecutor = w.client.eagerDispatcher.applyToRequest(startRequest)
 	}
 
+	if in.Options.StartDelay != 0 {
+		startRequest.WorkflowStartDelay = &in.Options.StartDelay
+	}
+
 	var response *workflowservice.StartWorkflowExecutionResponse
 
 	grpcCtx, cancel := newGRPCContext(ctx, grpcMetricsHandler(
@@ -1645,6 +1649,10 @@ func (w *workflowClientInterceptor) SignalWithStartWorkflow(
 		SearchAttributes:         searchAttr,
 		WorkflowIdReusePolicy:    in.Options.WorkflowIDReusePolicy,
 		Header:                   header,
+	}
+
+	if in.Options.StartDelay != 0 {
+		signalWithStartRequest.WorkflowStartDelay = &in.Options.StartDelay
 	}
 
 	var response *workflowservice.SignalWithStartWorkflowExecutionResponse


### PR DESCRIPTION
Expose StartDelay in StartWorkflowOptions. I didn't test the server behaviour since I didn't want to duplicate the server tests and timing tests in the SDK have proven to be flaky

closes https://github.com/temporalio/sdk-go/issues/1243