### PR TITLE
Expose SetContinuedAsNewRunID in the TestWorkflowEnvironment

### DIFF
--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -353,7 +353,7 @@ func (env *testWorkflowEnvironmentImpl) setContinueAsNewSuggested(suggest bool) 
 	env.workflowInfo.continueAsNewSuggested = suggest
 }
 
-func (env *testWorkflowEnvironmentImpl) setContinuedExecutionID(rid string) {
+func (env *testWorkflowEnvironmentImpl) setContinuedExecutionRunID(rid string) {
 	env.workflowInfo.ContinuedExecutionRunID = rid
 }
 

--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -353,6 +353,10 @@ func (env *testWorkflowEnvironmentImpl) setContinueAsNewSuggested(suggest bool) 
 	env.workflowInfo.continueAsNewSuggested = suggest
 }
 
+func (env *testWorkflowEnvironmentImpl) setContinuedExecutionID(rid string) {
+	env.workflowInfo.ContinuedExecutionRunID = rid
+}
+
 func (env *testWorkflowEnvironmentImpl) newTestWorkflowEnvironmentForChild(params *ExecuteWorkflowParams, callback ResultHandler, startedHandler func(r WorkflowExecution, e error)) (*testWorkflowEnvironmentImpl, error) {
 	// create a new test env
 	childEnv := newTestWorkflowEnvironmentImpl(env.testSuite, env.registry)

--- a/internal/internal_workflow_testsuite_test.go
+++ b/internal/internal_workflow_testsuite_test.go
@@ -3747,6 +3747,12 @@ func (s *WorkflowTestSuiteUnitTest) Test_SetWorkerStopChannel() {
 	s.NotNil(env.workerStopChannel)
 }
 
+func (s *WorkflowTestSuiteUnitTest) Test_SetContinuedExecutionRunID() {
+	env := newTestWorkflowEnvironmentImpl(&s.WorkflowTestSuite, nil)
+	env.setContinuedExecutionID("some-run-id")
+	s.NotNil(env.workflowInfo.ContinuedExecutionRunID)
+}
+
 func (s *WorkflowTestSuiteUnitTest) Test_ActivityTimeoutWithDetails() {
 	count := 0
 	timeoutFn := func() error {

--- a/internal/internal_workflow_testsuite_test.go
+++ b/internal/internal_workflow_testsuite_test.go
@@ -3749,7 +3749,7 @@ func (s *WorkflowTestSuiteUnitTest) Test_SetWorkerStopChannel() {
 
 func (s *WorkflowTestSuiteUnitTest) Test_SetContinuedExecutionRunID() {
 	env := newTestWorkflowEnvironmentImpl(&s.WorkflowTestSuite, nil)
-	env.setContinuedExecutionID("some-run-id")
+	env.setContinuedExecutionRunID("some-run-id")
 	s.NotNil(env.workflowInfo.ContinuedExecutionRunID)
 }
 

--- a/internal/workflow_testsuite.go
+++ b/internal/workflow_testsuite.go
@@ -318,6 +318,12 @@ func (e *TestWorkflowEnvironment) SetContinueAsNewSuggested(suggest bool) {
 	e.impl.setContinueAsNewSuggested(suggest)
 }
 
+// SetContinuedExecutionID sets the value that is returned from
+// GetInfo(ctx).ContinuedExecutionRunID
+func (e *TestWorkflowEnvironment) SetContinuedAsNewRunID(rid string) {
+	e.impl.setContinuedExecutionID(rid)
+}
+
 // OnActivity setup a mock call for activity. Parameter activity must be activity function (func) or activity name (string).
 // You must call Return() with appropriate parameters on the returned *MockCallWrapper instance. The supplied parameters to
 // the Return() call should either be a function that has exact same signature as the mocked activity, or it should be

--- a/internal/workflow_testsuite.go
+++ b/internal/workflow_testsuite.go
@@ -318,10 +318,10 @@ func (e *TestWorkflowEnvironment) SetContinueAsNewSuggested(suggest bool) {
 	e.impl.setContinueAsNewSuggested(suggest)
 }
 
-// SetContinuedExecutionID sets the value that is returned from
+// SetContinuedExecutionRunID sets the value that is returned from
 // GetInfo(ctx).ContinuedExecutionRunID
-func (e *TestWorkflowEnvironment) SetContinuedAsNewRunID(rid string) {
-	e.impl.setContinuedExecutionID(rid)
+func (e *TestWorkflowEnvironment) SetContinuedExecutionRunID(rid string) {
+	e.impl.setContinuedExecutionRunID(rid)
 }
 
 // OnActivity setup a mock call for activity. Parameter activity must be activity function (func) or activity name (string).


### PR DESCRIPTION
## What was changed

This extends the `TestWorkflowEnvironment` to expose a new `SetContinuedAsNewRunID` API to set the workflow under test `ContinuedAsNewRunID` field in its `WorkflowInfo`.

## Why?

When building some workflows ("actors" like ones are a good example), you sometimes want to be able to distinguish when a workflow is starting and when it's being continued as new. This allows you to execute different behavior like restoring some state from an external system.

One way to check if your current workflow execution has been continued as new is to inspect the workflow info `ContinuedAsNewRunID` field. When it's set, then you now you are not starting fresh. It is nice because you don't need any special field in your workflow inputs to detect such cases.

Example:

```golang
func MyWorkflow(ctx workflow.Context, input string) error {
    if workflow.GetInfo(ctx).ContinuedAsNewRunID == "" {
        var v string
        err := workflow.ExecuteActivity(ctx, MyActivity).Get(ctx, &v)
        if err != nil {
            return err
        }
        input = v
    }

    s = selector.NewSelector()
    s.AddReceive(..., func() {
        c.Receive(ctx, &v)
        input = v
    })
    s.AddReceive(...)
    s.Select(ctx)

    return workflow.NewContinueAsNewError(ctx, MyWorkflow, input)
}
```

When testing such workflows though, you may want to test behavior only after a first `ContinueAsNew` call has been made. The easiest way to do that is to setup the test environment to fill up the workflow info `ContinuedAsNewRunID` field.

This is what this commit is doing, it extends the
`TestWorkflowEnvironment` to expose a `SetContinuedExecutionID` field to an arbitrary value.

This way in workflow unit tests, we can skip the code paths we don't care about and don't resort to mocking activities and child workflows for nothing leading to easier to implement and easier to read tests.

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

N/A

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

I only added a unit test (so far).

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

We probably want to rely on Godocs for that API.

--- 

Thoughts?