### PR TITLE
Add TaskReachability API

### DIFF
--- a/.github/workflows/docker/dynamic-config-custom.yaml
+++ b/.github/workflows/docker/dynamic-config-custom.yaml
@@ -15,3 +15,5 @@ frontend.workerVersioningWorkflowAPIs:
   - value: true
 worker.buildIdScavengerEnabled:
   - value: true
+worker.removableBuildIdDurationSinceDefault:
+  - value: 1

--- a/client/client.go
+++ b/client/client.go
@@ -50,9 +50,6 @@ import (
 type TaskReachability = internal.TaskReachability
 
 const (
-	// TaskReachabilityNotFetched indicates that reachability for this task
-	// was not fetched
-	TaskReachabilityNotFetched = internal.TaskReachabilityNotFetched
 	// TaskReachabilityUnspecified indicates the reachability was not specified
 	TaskReachabilityUnspecified = internal.TaskReachabilityUnspecified
 	// TaskReachabilityNewWorkflows indicates the Build Id might be used by new workflows

--- a/client/client.go
+++ b/client/client.go
@@ -44,6 +44,28 @@ import (
 	"go.temporal.io/sdk/internal/common/metrics"
 )
 
+// TaskReachability specifies which category of tasks may reach a worker on a versioned task queue.
+// Used both in a reachability query and its response.
+// WARNING: Worker versioning is currently experimental
+type TaskReachability = internal.TaskReachability
+
+const (
+	// TaskReachabilityNotFetched indicates that reachability for this task
+	// was not fetched
+	TaskReachabilityNotFetched = internal.TaskReachabilityNotFetched
+	// TaskReachabilityUnspecified indicates the reachability was not specified
+	TaskReachabilityUnspecified = internal.TaskReachabilityUnspecified
+	// TaskReachabilityNewWorkflows indicates the Build Id might be used by new workflows
+	TaskReachabilityNewWorkflows = internal.TaskReachabilityNewWorkflows
+	// TaskReachabilityExistingWorkflows indicates the Build Id might be used by open workflows
+	// and/or closed workflows.
+	TaskReachabilityExistingWorkflows = internal.TaskReachabilityExistingWorkflows
+	// TaskReachabilityOpenWorkflows indicates the Build Id might be used by open workflows.
+	TaskReachabilityOpenWorkflows = internal.TaskReachabilityOpenWorkflows
+	// TaskReachabilityClosedWorkflows indicates the Build Id might be used by closed workflows
+	TaskReachabilityClosedWorkflows = internal.TaskReachabilityClosedWorkflows
+)
+
 const (
 	// DefaultHostPort is the host:port which is used if not passed with options.
 	DefaultHostPort = internal.LocalHostPort
@@ -58,6 +80,10 @@ const (
 	// QueryTypeOpenSessions is the build in query type for Client.QueryWorkflow() call. Use this query type to get all open
 	// sessions in the workflow. The result will be a list of SessionInfo encoded in the converter.EncodedValue.
 	QueryTypeOpenSessions string = internal.QueryTypeOpenSessions
+
+	// UnversionedBuildID is a stand-in for a Build Id for unversioned Workers.
+	// WARNING: Worker versioning is currently experimental
+	UnversionedBuildID string = internal.UnversionedBuildID
 )
 
 type (
@@ -215,6 +241,22 @@ type (
 	// promote a BuildID within a set to be the default.
 	// WARNING: Worker versioning is currently experimental
 	BuildIDOpPromoteIDWithinSet = internal.BuildIDOpPromoteIDWithinSet
+
+	// GetWorkerTaskReachabilityOptions is the input to Client.GetWorkerTaskReachability.
+	// WARNING: Worker versioning is currently experimental
+	GetWorkerTaskReachabilityOptions = internal.GetWorkerTaskReachabilityOptions
+
+	// WorkerTaskReachability is the response for Client.GetWorkerTaskReachability.
+	// WARNING: Worker versioning is currently experimental
+	WorkerTaskReachability = internal.WorkerTaskReachability
+
+	// BuildIDReachability describes the reachability of a buildID
+	// WARNING: Worker versioning is currently experimental
+	BuildIDReachability = internal.BuildIDReachability
+
+	// TaskQueueReachability Describes how the Build ID may be reachable from the task queue.
+	// WARNING: Worker versioning is currently experimental
+	TaskQueueReachability = internal.TaskQueueReachability
 
 	// Client is the client for starting and getting information about a workflow executions as well as
 	// completing activities asynchronously.
@@ -512,6 +554,11 @@ type (
 		// Returns the worker-build-id based version sets for a particular task queue.
 		// WARNING: Worker versioning is currently experimental
 		GetWorkerBuildIdCompatibility(ctx context.Context, options *GetWorkerBuildIdCompatibilityOptions) (*WorkerBuildIDVersionSets, error)
+
+		// GetWorkerTaskReachability
+		// Returns which versions are is still in use by open or closed workflows
+		// WARNING: Worker versioning is currently experimental
+		GetWorkerTaskReachability(ctx context.Context, options *GetWorkerTaskReachabilityOptions) (*WorkerTaskReachability, error)
 
 		// CheckHealth performs a server health check using the gRPC health check
 		// API. If the check fails, an error is returned.

--- a/internal/client.go
+++ b/internal/client.go
@@ -349,6 +349,9 @@ type (
 		// GetWorkerBuildIdCompatibility returns the worker-build-id based version sets for a particular task queue.
 		GetWorkerBuildIdCompatibility(ctx context.Context, options *GetWorkerBuildIdCompatibilityOptions) (*WorkerBuildIDVersionSets, error)
 
+		// GetWorkerTaskReachability returns which versions are is still in use by open or closed workflows.
+		GetWorkerTaskReachability(ctx context.Context, options *GetWorkerTaskReachabilityOptions) (*WorkerTaskReachability, error)
+
 		// CheckHealth performs a server health check using the gRPC health check
 		// API. If the check fails, an error is returned.
 		CheckHealth(ctx context.Context, request *CheckHealthRequest) (*CheckHealthResponse, error)

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -1007,6 +1007,29 @@ func (wc *WorkflowClient) GetWorkerBuildIdCompatibility(ctx context.Context, opt
 	return converted, nil
 }
 
+// GetWorkerTaskReachability returns which versions are is still in use by open or closed workflows.
+func (wc *WorkflowClient) GetWorkerTaskReachability(ctx context.Context, options *GetWorkerTaskReachabilityOptions) (*WorkerTaskReachability, error) {
+	if err := wc.ensureInitialized(); err != nil {
+		return nil, err
+	}
+
+	grpcCtx, cancel := newGRPCContext(ctx, defaultGrpcRetryParameters(ctx))
+	defer cancel()
+
+	request := &workflowservice.GetWorkerTaskReachabilityRequest{
+		Namespace:    wc.namespace,
+		BuildIds:     options.BuildIDs,
+		TaskQueues:   options.TaskQueues,
+		Reachability: taskReachabilityToProto(options.Reachability),
+	}
+	resp, err := wc.workflowService.GetWorkerTaskReachability(grpcCtx, request)
+	if err != nil {
+		return nil, err
+	}
+	converted := workerTaskReachabilityFromProtoResponse(resp)
+	return converted, nil
+}
+
 func (wc *WorkflowClient) UpdateWorkflowWithOptions(
 	ctx context.Context,
 	req *UpdateWorkflowWithOptionsRequest,

--- a/internal/worker_version_sets.go
+++ b/internal/worker_version_sets.go
@@ -25,9 +25,13 @@ package internal
 import (
 	"errors"
 
+	enumspb "go.temporal.io/api/enums/v1"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	"go.temporal.io/api/workflowservice/v1"
 )
+
+// A stand-in for a Build Id for unversioned Workers.
+const UnversionedBuildID = ""
 
 // VersioningIntent indicates whether the user intends certain commands to be run on
 // a compatible worker build ID version or not.
@@ -45,6 +49,27 @@ const (
 	// VersioningIntentDefault indicates that the command should run on the target task queue's
 	// current overall-default build ID.
 	VersioningIntentDefault
+)
+
+// TaskReachability specifies which category of tasks may reach a worker on a versioned task queue.
+// Used both in a reachability query and its response.
+type TaskReachability int
+
+const (
+	// TaskReachabilityNotFetched indicates that reachability for this task
+	// was not fetched
+	TaskReachabilityNotFetched TaskReachability = iota - 1
+	// TaskReachabilityUnspecified indicates the reachability was not specified
+	TaskReachabilityUnspecified
+	// TaskReachabilityNewWorkflows indicates the Build Id might be used by new workflows
+	TaskReachabilityNewWorkflows
+	// TaskReachabilityExistingWorkflows indicates the Build Id might be used by open workflows
+	// and/or closed workflows.
+	TaskReachabilityExistingWorkflows
+	// TaskReachabilityOpenWorkflows indicates the Build Id might be used by open workflows.
+	TaskReachabilityOpenWorkflows
+	// TaskReachabilityClosedWorkflows indicates the Build Id might be used by closed workflows
+	TaskReachabilityClosedWorkflows
 )
 
 type (
@@ -130,6 +155,35 @@ type GetWorkerBuildIdCompatibilityOptions struct {
 	MaxSets   int
 }
 
+type GetWorkerTaskReachabilityOptions struct {
+	// BuildIDs - The build IDs to query the reachability of. At least one build ID must be provided.
+	BuildIDs []string
+	// TaskQueues - The task queues with Build IDs defined on them that the request is
+	// concerned with.
+	// Optional: defaults to all task queues
+	TaskQueues []string
+	// Reachability - The reachability this request is concerned with.
+	// Optional: defaults to all types of reachability
+	Reachability TaskReachability
+}
+
+type WorkerTaskReachability struct {
+	// Reachable - map of build IDs and their reachability information
+	// May contain an entry with [UnversionedBuildID] for an unversioned worker
+	Reachable map[string]*BuildIDReachability
+}
+
+type BuildIDReachability struct {
+	// TaskQueueReachable map of task queues and their reachability information
+	TaskQueueReachable map[string]*TaskQueueReachability
+}
+
+type TaskQueueReachability struct {
+	// Reachability for a worker in a single task queue.
+	// If Reachability is empty, this worker is considered unreachable in this task queue.
+	Reachability []TaskReachability
+}
+
 // WorkerBuildIDVersionSets is the response for Client.GetWorkerBuildIdCompatibility and represents the sets
 // of worker build id based versions.
 type WorkerBuildIDVersionSets struct {
@@ -174,6 +228,80 @@ func workerVersionSetsFromProto(sets []*taskqueuepb.CompatibleVersionSet) []*Com
 		}
 	}
 	return result
+}
+
+func workerTaskReachabilityFromProtoResponse(response *workflowservice.GetWorkerTaskReachabilityResponse) *WorkerTaskReachability {
+	if response == nil {
+		return nil
+	}
+	return &WorkerTaskReachability{
+		Reachable: buildIDReachabilityFromProto(response.GetBuildIdReachability()),
+	}
+}
+
+func buildIDReachabilityFromProto(sets []*taskqueuepb.BuildIdReachability) map[string]*BuildIDReachability {
+	if sets == nil {
+		return nil
+	}
+	result := make(map[string]*BuildIDReachability, len(sets))
+	for _, s := range sets {
+		result[s.GetBuildId()] = &BuildIDReachability{
+			TaskQueueReachable: taskQueueReachabilityFromProto(s.GetTaskQueueReachability()),
+		}
+	}
+	return result
+}
+
+func taskQueueReachabilityFromProto(sets []*taskqueuepb.TaskQueueReachability) map[string]*TaskQueueReachability {
+	if sets == nil {
+		return nil
+	}
+	result := make(map[string]*TaskQueueReachability, len(sets))
+	for _, s := range sets {
+		reachability := make([]TaskReachability, len(s.GetReachability()))
+		for i, r := range s.GetReachability() {
+			reachability[i] = taskReachabilityFromProto(r)
+		}
+		result[s.GetTaskQueue()] = &TaskQueueReachability{
+			Reachability: reachability,
+		}
+	}
+	return result
+}
+
+func taskReachabilityToProto(r TaskReachability) enumspb.TaskReachability {
+	switch r {
+	case TaskReachabilityUnspecified:
+		return enumspb.TASK_REACHABILITY_UNSPECIFIED
+	case TaskReachabilityNewWorkflows:
+		return enumspb.TASK_REACHABILITY_NEW_WORKFLOWS
+	case TaskReachabilityExistingWorkflows:
+		return enumspb.TASK_REACHABILITY_EXISTING_WORKFLOWS
+	case TaskReachabilityOpenWorkflows:
+		return enumspb.TASK_REACHABILITY_OPEN_WORKFLOWS
+	case TaskReachabilityClosedWorkflows:
+		return enumspb.TASK_REACHABILITY_CLOSED_WORKFLOWS
+	default:
+		panic("unknown task reachability")
+
+	}
+}
+
+func taskReachabilityFromProto(r enumspb.TaskReachability) TaskReachability {
+	switch r {
+	case enumspb.TASK_REACHABILITY_UNSPECIFIED:
+		return TaskReachabilityNotFetched
+	case enumspb.TASK_REACHABILITY_NEW_WORKFLOWS:
+		return TaskReachabilityNewWorkflows
+	case enumspb.TASK_REACHABILITY_EXISTING_WORKFLOWS:
+		return TaskReachabilityExistingWorkflows
+	case enumspb.TASK_REACHABILITY_OPEN_WORKFLOWS:
+		return TaskReachabilityOpenWorkflows
+	case enumspb.TASK_REACHABILITY_CLOSED_WORKFLOWS:
+		return TaskReachabilityClosedWorkflows
+	default:
+		panic("unknown task reachability")
+	}
 }
 
 func (v *BuildIDOpAddNewIDInNewDefaultSet) targetedBuildId() string { return v.BuildID }

--- a/mocks/Client.go
+++ b/mocks/Client.go
@@ -557,6 +557,29 @@ func (_m *Client) UpdateWorkerBuildIdCompatibility(ctx context.Context, options 
 	return r0
 }
 
+// GetWorkerTaskReachability provides a mock function with given fields: ctx, options
+func (_m *Client) GetWorkerTaskReachability(ctx context.Context, options *client.GetWorkerTaskReachabilityOptions) (*client.WorkerTaskReachability, error) {
+	ret := _m.Called(ctx, options)
+
+	var r0 *internal.WorkerTaskReachability
+	if rf, ok := ret.Get(0).(func(context.Context, *client.GetWorkerTaskReachabilityOptions) *client.WorkerTaskReachability); ok {
+		r0 = rf(ctx, options)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*internal.WorkerTaskReachability)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *client.GetWorkerTaskReachabilityOptions) error); ok {
+		r1 = rf(ctx, options)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetWorkerBuildIdCompatibility provides a mock function with given fields: ctx, options
 func (_m *Client) GetWorkerBuildIdCompatibility(ctx context.Context, options *client.GetWorkerBuildIdCompatibilityOptions) (*client.WorkerBuildIDVersionSets, error) {
 	ret := _m.Called(ctx, options)

--- a/test/worker_versioning_test.go
+++ b/test/worker_versioning_test.go
@@ -163,13 +163,13 @@ func (ts *WorkerVersioningTestSuite) TestReachabilityUnreachable() {
 		TaskQueues: []string{ts.taskQueueName},
 	})
 	ts.NoError(err)
-	ts.Equal(1, len(compatibility.Reachable))
-	buildIDReachable, ok := compatibility.Reachable[buildID]
+	ts.Equal(1, len(compatibility.BuildIDReachability))
+	buildIDReachable, ok := compatibility.BuildIDReachability[buildID]
 	ts.True(ok)
 	ts.Equal(1, len(buildIDReachable.TaskQueueReachable))
 	taskQueueReachable, ok := buildIDReachable.TaskQueueReachable[ts.taskQueueName]
 	ts.True(ok)
-	ts.Equal(0, len(taskQueueReachable.Reachability))
+	ts.Equal(0, len(taskQueueReachable.TaskQueueReachability))
 }
 
 func (ts *WorkerVersioningTestSuite) TestReachabilityUnversionedWorker() {
@@ -187,13 +187,13 @@ func (ts *WorkerVersioningTestSuite) TestReachabilityUnversionedWorker() {
 	})
 
 	ts.NoError(err)
-	ts.Equal(1, len(compatibility.Reachable))
-	buildIDReachable, ok := compatibility.Reachable[client.UnversionedBuildID]
+	ts.Equal(1, len(compatibility.BuildIDReachability))
+	buildIDReachable, ok := compatibility.BuildIDReachability[client.UnversionedBuildID]
 	ts.True(ok)
 	ts.Equal(1, len(buildIDReachable.TaskQueueReachable))
 	taskQueueReachable, ok := buildIDReachable.TaskQueueReachable[ts.taskQueueName]
 	ts.True(ok)
-	ts.Equal([]client.TaskReachability{client.TaskReachabilityNewWorkflows}, taskQueueReachable.Reachability)
+	ts.Equal([]client.TaskReachability{client.TaskReachabilityNewWorkflows}, taskQueueReachable.TaskQueueReachability)
 }
 
 func (ts *WorkerVersioningTestSuite) TestReachabilityVersions() {
@@ -251,23 +251,25 @@ func (ts *WorkerVersioningTestSuite) TestReachabilityVersions() {
 		Reachability: client.TaskReachabilityClosedWorkflows,
 	})
 	ts.NoError(err)
-	ts.Equal(2, len(compatibility.Reachable))
+	ts.Equal(2, len(compatibility.BuildIDReachability))
 
 	// Test the first worker
-	buildIDReachability, ok := compatibility.Reachable[buildID1]
+	buildIDReachability, ok := compatibility.BuildIDReachability[buildID1]
 	ts.True(ok)
+	ts.Equal(0, len(buildIDReachability.UnretrievedTaskQueues))
 	ts.Equal(1, len(buildIDReachability.TaskQueueReachable))
 	taskQueueReachability, ok := buildIDReachability.TaskQueueReachable[ts.taskQueueName]
 	ts.True(ok)
-	ts.Equal(2, len(taskQueueReachability.Reachability))
-	ts.Equal([]client.TaskReachability{client.TaskReachabilityNewWorkflows, client.TaskReachabilityClosedWorkflows}, taskQueueReachability.Reachability)
+	ts.Equal(2, len(taskQueueReachability.TaskQueueReachability))
+	ts.Equal([]client.TaskReachability{client.TaskReachabilityNewWorkflows, client.TaskReachabilityClosedWorkflows}, taskQueueReachability.TaskQueueReachability)
 
 	// Test the second worker
-	buildIDReachability, ok = compatibility.Reachable[buildID2]
+	buildIDReachability, ok = compatibility.BuildIDReachability[buildID2]
 	ts.True(ok)
+	ts.Equal(0, len(buildIDReachability.UnretrievedTaskQueues))
 	ts.Equal(1, len(buildIDReachability.TaskQueueReachable))
 	taskQueueReachability, ok = buildIDReachability.TaskQueueReachable[ts.taskQueueName]
 	ts.True(ok)
-	ts.Equal(1, len(taskQueueReachability.Reachability))
-	ts.Equal([]client.TaskReachability{client.TaskReachabilityNewWorkflows}, taskQueueReachability.Reachability)
+	ts.Equal(1, len(taskQueueReachability.TaskQueueReachability))
+	ts.Equal([]client.TaskReachability{client.TaskReachabilityNewWorkflows}, taskQueueReachability.TaskQueueReachability)
 }

--- a/test/worker_versioning_test.go
+++ b/test/worker_versioning_test.go
@@ -25,7 +25,9 @@ package test_test
 import (
 	"context"
 	"testing"
+	"time"
 
+	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.temporal.io/sdk/client"
@@ -149,4 +151,123 @@ func (ts *WorkerVersioningTestSuite) TestTwoWorkersGetDifferentTasks() {
 	ts.NoError(handle22.Get(ctx, nil))
 
 	// TODO: Actually assert they ran on the appropriate workers, once David's changes are ready
+}
+
+func (ts *WorkerVersioningTestSuite) TestReachabilityUnreachable() {
+	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
+	defer cancel()
+
+	buildID := uuid.New()
+	compatibility, err := ts.client.GetWorkerTaskReachability(ctx, &client.GetWorkerTaskReachabilityOptions{
+		BuildIDs:   []string{buildID},
+		TaskQueues: []string{ts.taskQueueName},
+	})
+	ts.NoError(err)
+	ts.Equal(1, len(compatibility.Reachable))
+	buildIDReachable, ok := compatibility.Reachable[buildID]
+	ts.True(ok)
+	ts.Equal(1, len(buildIDReachable.TaskQueueReachable))
+	taskQueueReachable, ok := buildIDReachable.TaskQueueReachable[ts.taskQueueName]
+	ts.True(ok)
+	ts.Equal(0, len(taskQueueReachable.Reachability))
+}
+
+func (ts *WorkerVersioningTestSuite) TestReachabilityUnversionedWorker() {
+	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
+	defer cancel()
+
+	worker1 := worker.New(ts.client, ts.taskQueueName, worker.Options{})
+	ts.workflows.register(worker1)
+	ts.NoError(worker1.Start())
+	defer worker1.Stop()
+
+	compatibility, err := ts.client.GetWorkerTaskReachability(ctx, &client.GetWorkerTaskReachabilityOptions{
+		BuildIDs:   []string{client.UnversionedBuildID},
+		TaskQueues: []string{ts.taskQueueName},
+	})
+
+	ts.NoError(err)
+	ts.Equal(1, len(compatibility.Reachable))
+	buildIDReachable, ok := compatibility.Reachable[client.UnversionedBuildID]
+	ts.True(ok)
+	ts.Equal(1, len(buildIDReachable.TaskQueueReachable))
+	taskQueueReachable, ok := buildIDReachable.TaskQueueReachable[ts.taskQueueName]
+	ts.True(ok)
+	ts.Equal([]client.TaskReachability{client.TaskReachabilityNewWorkflows}, taskQueueReachable.Reachability)
+}
+
+func (ts *WorkerVersioningTestSuite) TestReachabilityVersions() {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	buildID1 := uuid.New()
+	buildID2 := uuid.New()
+
+	err := ts.client.UpdateWorkerBuildIdCompatibility(ctx, &client.UpdateWorkerBuildIdCompatibilityOptions{
+		TaskQueue: ts.taskQueueName,
+		Operation: &client.BuildIDOpAddNewIDInNewDefaultSet{
+			BuildID: buildID1,
+		},
+	})
+	ts.NoError(err)
+
+	worker1 := worker.New(ts.client, ts.taskQueueName, worker.Options{BuildID: buildID1, UseBuildIDForVersioning: true})
+	ts.workflows.register(worker1)
+	ts.NoError(worker1.Start())
+	defer worker1.Stop()
+
+	// Start some workflows targeting 1.0
+	handle11, err := ts.client.ExecuteWorkflow(ctx, ts.startWorkflowOptions("1-1"), ts.workflows.WaitSignalToStart)
+	ts.NoError(err)
+	handle12, err := ts.client.ExecuteWorkflow(ctx, ts.startWorkflowOptions("1-2"), ts.workflows.WaitSignalToStart)
+	ts.NoError(err)
+
+	ts.NoError(ts.client.SignalWorkflow(ctx, handle11.GetID(), handle11.GetRunID(), "start-signal", ""))
+	ts.NoError(ts.client.SignalWorkflow(ctx, handle12.GetID(), handle12.GetRunID(), "start-signal", ""))
+
+	// Wait for all wfs to finish
+	ts.NoError(handle11.Get(ctx, nil))
+	ts.NoError(handle12.Get(ctx, nil))
+
+	// Start the second worker
+	worker2 := worker.New(ts.client, ts.taskQueueName, worker.Options{BuildID: buildID2, UseBuildIDForVersioning: true})
+	ts.workflows.register(worker2)
+	ts.NoError(worker2.Start())
+	defer worker2.Stop()
+
+	// Now add the 2.0 version
+	err = ts.client.UpdateWorkerBuildIdCompatibility(ctx, &client.UpdateWorkerBuildIdCompatibilityOptions{
+		TaskQueue: ts.taskQueueName,
+		Operation: &client.BuildIDOpAddNewIDInNewDefaultSet{
+			BuildID: buildID2,
+		},
+	})
+	ts.NoError(err)
+	time.Sleep(15 * time.Second)
+
+	compatibility, err := ts.client.GetWorkerTaskReachability(ctx, &client.GetWorkerTaskReachabilityOptions{
+		BuildIDs:     []string{buildID1, buildID2},
+		TaskQueues:   []string{ts.taskQueueName},
+		Reachability: client.TaskReachabilityClosedWorkflows,
+	})
+	ts.NoError(err)
+	ts.Equal(2, len(compatibility.Reachable))
+
+	// Test the first worker
+	buildIDReachability, ok := compatibility.Reachable[buildID1]
+	ts.True(ok)
+	ts.Equal(1, len(buildIDReachability.TaskQueueReachable))
+	taskQueueReachability, ok := buildIDReachability.TaskQueueReachable[ts.taskQueueName]
+	ts.True(ok)
+	ts.Equal(2, len(taskQueueReachability.Reachability))
+	ts.Equal([]client.TaskReachability{client.TaskReachabilityNewWorkflows, client.TaskReachabilityClosedWorkflows}, taskQueueReachability.Reachability)
+
+	// Test the second worker
+	buildIDReachability, ok = compatibility.Reachable[buildID2]
+	ts.True(ok)
+	ts.Equal(1, len(buildIDReachability.TaskQueueReachable))
+	taskQueueReachability, ok = buildIDReachability.TaskQueueReachable[ts.taskQueueName]
+	ts.True(ok)
+	ts.Equal(1, len(taskQueueReachability.Reachability))
+	ts.Equal([]client.TaskReachability{client.TaskReachabilityNewWorkflows}, taskQueueReachability.Reachability)
 }


### PR DESCRIPTION
Add task reachability API `GetWorkerTaskReachability` to Go.

closes https://github.com/temporalio/sdk-go/issues/1237