### PR TITLE
Don't register a versioned worker for eager start

### DIFF
--- a/internal/client.go
+++ b/internal/client.go
@@ -606,6 +606,8 @@ type (
 
 		// EnableEagerStart - request eager execution for this workflow, if a local worker is available.
 		//
+		// WARNING: Do not use in combination with a versioned task queue.
+		//
 		// NOTE: Experimental
 		EnableEagerStart bool
 

--- a/internal/internal_eager_workflow.go
+++ b/internal/internal_eager_workflow.go
@@ -38,6 +38,10 @@ type eagerWorkflowDispatcher struct {
 
 // registerWorker registers a worker that can be used for eager workflow dispatch
 func (e *eagerWorkflowDispatcher) registerWorker(worker *workflowWorker) {
+	// Currently eager workflow start does not work with versioning
+	if worker.executionParameters.UseBuildIDForVersioning {
+		return
+	}
 	e.lock.Lock()
 	defer e.lock.Unlock()
 	e.workersByTaskQueue[worker.executionParameters.TaskQueue] = append(e.workersByTaskQueue[worker.executionParameters.TaskQueue], worker.worker)

--- a/internal/internal_eager_workflow_test.go
+++ b/internal/internal_eager_workflow_test.go
@@ -114,3 +114,19 @@ func TestEagerWorkflowExecutor(t *testing.T) {
 		exec.handleResponse(&workflowservice.PollWorkflowTaskQueueResponse{})
 	})
 }
+
+func TestEagerWorkflowDispatchAndVersioning(t *testing.T) {
+	dispatcher := &eagerWorkflowDispatcher{
+		workersByTaskQueue: make(map[string][]eagerWorker),
+	}
+	dispatcher.registerWorker(&workflowWorker{
+		executionParameters: workerExecutionParameters{TaskQueue: "task-queue", UseBuildIDForVersioning: true},
+	})
+
+	request := &workflowservice.StartWorkflowExecutionRequest{
+		TaskQueue: &taskqueuepb.TaskQueue{Name: "task-queue"},
+	}
+	exec := dispatcher.applyToRequest(request)
+	require.Nil(t, exec)
+	require.False(t, request.GetRequestEagerExecution())
+}

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -1528,6 +1528,7 @@ func (w *workflowClientInterceptor) ExecuteWorkflow(
 	response, err = w.client.workflowService.StartWorkflowExecution(grpcCtx, startRequest)
 	eagerWorkflowTask := response.GetEagerWorkflowTask()
 	if eagerWorkflowTask != nil && eagerExecutor != nil {
+		w.client.logger.Error("Received eager task")
 		eagerExecutor.handleResponse(eagerWorkflowTask)
 	} else if eagerExecutor != nil {
 		eagerExecutor.release()

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -1528,7 +1528,6 @@ func (w *workflowClientInterceptor) ExecuteWorkflow(
 	response, err = w.client.workflowService.StartWorkflowExecution(grpcCtx, startRequest)
 	eagerWorkflowTask := response.GetEagerWorkflowTask()
 	if eagerWorkflowTask != nil && eagerExecutor != nil {
-		w.client.logger.Error("Received eager task")
 		eagerExecutor.handleResponse(eagerWorkflowTask)
 	} else if eagerExecutor != nil {
 		eagerExecutor.release()


### PR DESCRIPTION
Don't register a versioned worker for eager workflow start.

closes https://github.com/temporalio/sdk-go/issues/1250