### PR TITLE
Convert panics in update protocol state machine to errors

### DIFF
--- a/internal/internal_command_state_machine.go
+++ b/internal/internal_command_state_machine.go
@@ -148,7 +148,7 @@ type (
 		versionMarkerLookup              map[int64]versionMarker
 	}
 
-	// panic when command state machine is in illegal state
+	// panic when command or message state machine is in illegal state
 	stateMachineIllegalStatePanic struct {
 		message string
 	}

--- a/internal/internal_event_handlers_test.go
+++ b/internal/internal_event_handlers_test.go
@@ -540,7 +540,7 @@ func TestUpdateEventsPanic(t *testing.T) {
 	require.True(t, proto.Equal(input.Args, gotArgs))
 
 	require.Panics(t, func() {
-		weh.ProcessMessage(&protocolpb.Message{
+		_ = weh.ProcessMessage(&protocolpb.Message{
 			ProtocolInstanceId: t.Name(),
 			Body:               body,
 		}, false, false)

--- a/internal/internal_event_handlers_test.go
+++ b/internal/internal_event_handlers_test.go
@@ -482,3 +482,67 @@ func TestUpdateEvents(t *testing.T) {
 		require.NoError(t, weh.ProcessEvent(&historypb.HistoryEvent{EventType: evtype}, false, false))
 	}
 }
+
+func TestUpdateEventsPanic(t *testing.T) {
+	mustPayload := func(i interface{}) *commonpb.Payload {
+		t.Helper()
+		p, err := converter.NewJSONPayloadConverter().ToPayload(i)
+		if err != nil {
+			t.FailNow()
+		}
+		return p
+	}
+
+	var (
+		gotName   string
+		gotID     string
+		gotArgs   *commonpb.Payloads
+		gotHeader *commonpb.Header
+	)
+
+	weh := &workflowExecutionEventHandlerImpl{
+		workflowEnvironmentImpl: &workflowEnvironmentImpl{
+			updateHandler: func(name string, id string, args *commonpb.Payloads, header *commonpb.Header, cb UpdateCallbacks) {
+				gotName = name
+				gotID = id
+				gotArgs = args
+				gotHeader = header
+			},
+			protocols: protocol.NewRegistry(),
+		},
+		workflowDefinition: &mockWorkflowDefinition{
+			OnWorkflowTaskStartedFunc: func(time.Duration) {},
+		},
+	}
+
+	meta := &updatepb.Meta{
+		UpdateId: t.Name() + "-id",
+		Identity: t.Name() + "-identity",
+	}
+	input := &updatepb.Input{
+		Header: &commonpb.Header{Fields: map[string]*commonpb.Payload{"a": mustPayload("b")}},
+		Name:   t.Name(),
+		Args:   &commonpb.Payloads{Payloads: []*commonpb.Payload{mustPayload("arg0")}},
+	}
+
+	body, err := types.MarshalAny(&updatepb.Request{Meta: meta, Input: input})
+	require.NoError(t, err)
+
+	err = weh.ProcessMessage(&protocolpb.Message{
+		ProtocolInstanceId: t.Name(),
+		Body:               body,
+	}, false, false)
+	require.NoError(t, err)
+
+	require.Equal(t, input.Name, gotName)
+	require.Equal(t, t.Name()+"-id", gotID)
+	require.True(t, proto.Equal(input.Header, gotHeader))
+	require.True(t, proto.Equal(input.Args, gotArgs))
+
+	require.Panics(t, func() {
+		weh.ProcessMessage(&protocolpb.Message{
+			ProtocolInstanceId: t.Name(),
+			Body:               body,
+		}, false, false)
+	})
+}

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -1066,11 +1066,17 @@ ProcessEvents:
 				if err != nil {
 					return nil, err
 				}
+				if w.isWorkflowCompleted && !shouldForceReplayCheck() {
+					break ProcessEvents
+				}
 			}
 
 			err = eventHandler.ProcessEvent(event, isInReplay, isLast)
 			if err != nil {
 				return nil, err
+			}
+			if w.isWorkflowCompleted && !shouldForceReplayCheck() {
+				break ProcessEvents
 			}
 
 			for _, msg := range msgs.takeLTE(event.GetEventId()) {
@@ -1078,10 +1084,9 @@ ProcessEvents:
 				if err != nil {
 					return nil, err
 				}
-			}
-
-			if w.isWorkflowCompleted && !shouldForceReplayCheck() {
-				break ProcessEvents
+				if w.isWorkflowCompleted && !shouldForceReplayCheck() {
+					break ProcessEvents
+				}
 			}
 		}
 

--- a/internal/internal_update.go
+++ b/internal/internal_update.go
@@ -131,7 +131,7 @@ func (up *updateProtocol) requireState(action string, valid ...updateState) {
 			return
 		}
 	}
-	panic(fmt.Sprintf("invalid action %q in update protocol from state %s", action, up.state))
+	panicIllegalState(fmt.Sprintf("invalid action %q in update protocol %v", action, up))
 }
 
 func (up *updateProtocol) HandleMessage(msg *protocolpb.Message) error {

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -4085,6 +4085,13 @@ func (ts *IntegrationTestSuite) TestSendsCorrectMeteringData() {
 	w.Stop()
 }
 
+func (ts *IntegrationTestSuite) TestNondeterministicUpdateRegistertion() {
+	var expected []string
+	err := ts.executeWorkflow("test-activity-retry-options-change", ts.workflows.ActivityRetryOptionsChange, &expected)
+	ts.NoError(err)
+	ts.EqualValues(expected, ts.activities.invoked())
+}
+
 // executeWorkflow executes a given workflow and waits for the result
 func (ts *IntegrationTestSuite) executeWorkflow(
 	wfID string, wfFunc interface{}, retValPtr interface{}, args ...interface{},


### PR DESCRIPTION
Fix a bug found during internal testing where the workflow state machine was panicing, but because the panics were not recovered properly the worker never responded and the task timed out.

added some unit tests, I couldn't come up with an integration test to test this because the server should never cause the update protocol state machine to panic. 

closes https://github.com/temporalio/sdk-go/issues/1252
