### PR TITLE
Allow eager workflow start on versioned worker

### DIFF
--- a/internal/client.go
+++ b/internal/client.go
@@ -609,7 +609,8 @@ type (
 
 		// EnableEagerStart - request eager execution for this workflow, if a local worker is available.
 		//
-		// WARNING: Do not use in combination with a versioned task queue.
+		// WARNING: Eager start does not respect worker versioning. An eagerly started workflow may run on
+		// any available local worker even if that worker is not in the default build ID set.
 		//
 		// NOTE: Experimental
 		EnableEagerStart bool

--- a/internal/internal_eager_workflow.go
+++ b/internal/internal_eager_workflow.go
@@ -38,10 +38,6 @@ type eagerWorkflowDispatcher struct {
 
 // registerWorker registers a worker that can be used for eager workflow dispatch
 func (e *eagerWorkflowDispatcher) registerWorker(worker *workflowWorker) {
-	// Currently eager workflow start does not work with versioning
-	if worker.executionParameters.UseBuildIDForVersioning {
-		return
-	}
 	e.lock.Lock()
 	defer e.lock.Unlock()
 	e.workersByTaskQueue[worker.executionParameters.TaskQueue] = append(e.workersByTaskQueue[worker.executionParameters.TaskQueue], worker.worker)

--- a/internal/internal_eager_workflow_test.go
+++ b/internal/internal_eager_workflow_test.go
@@ -114,19 +114,3 @@ func TestEagerWorkflowExecutor(t *testing.T) {
 		exec.handleResponse(&workflowservice.PollWorkflowTaskQueueResponse{})
 	})
 }
-
-func TestEagerWorkflowDispatchAndVersioning(t *testing.T) {
-	dispatcher := &eagerWorkflowDispatcher{
-		workersByTaskQueue: make(map[string][]eagerWorker),
-	}
-	dispatcher.registerWorker(&workflowWorker{
-		executionParameters: workerExecutionParameters{TaskQueue: "task-queue", UseBuildIDForVersioning: true},
-	})
-
-	request := &workflowservice.StartWorkflowExecutionRequest{
-		TaskQueue: &taskqueuepb.TaskQueue{Name: "task-queue"},
-	}
-	exec := dispatcher.applyToRequest(request)
-	require.Nil(t, exec)
-	require.False(t, request.GetRequestEagerExecution())
-}


### PR DESCRIPTION
After internal discussion it appears the consensus around eager workflow start and versioning is to accept and document that eager workflow start and worker versioning do not interact.

effectively reverts https://github.com/temporalio/sdk-go/pull/1251
