### PR TITLE
Release v1.25.0

### DIFF
--- a/internal/version.go
+++ b/internal/version.go
@@ -30,7 +30,7 @@ package internal
 const (
 	// SDKVersion is a semver (https://semver.org/) that represents the version of this Temporal GoSDK.
 	// Server validates if SDKVersion fits its supported range and rejects request if it doesn't.
-	SDKVersion = "1.24.0"
+	SDKVersion = "1.25.0"
 
 	// SDKName represents the name of the SDK.
 	SDKName = clientNameHeaderValue


### PR DESCRIPTION
Release Go SDK v1.25.0

Draft release: https://github.com/temporalio/sdk-go/releases/tag/untagged-573dc8f1278b19aeffad