### PR TITLE
Propogate Baggage in OTEL tracing interceptor

### DIFF
--- a/test/activity_test.go
+++ b/test/activity_test.go
@@ -28,6 +28,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"go.opentelemetry.io/otel/baggage"
 	"strconv"
 	"strings"
 	"sync"
@@ -376,6 +377,10 @@ func (a *Activities) ExternalSignalsAndQueries(ctx context.Context) error {
 		return err
 	}
 	return run.Get(ctx, nil)
+}
+
+func (a *Activities) CheckBaggage(ctx context.Context, key string) (string, error) {
+	return baggage.FromContext(ctx).Member(key).Value(), nil
 }
 
 func (*Activities) TooFewParams(

--- a/test/workflow_test.go
+++ b/test/workflow_test.go
@@ -1920,6 +1920,16 @@ func (w *Workflows) SignalsAndQueries(ctx workflow.Context, execChild, execActiv
 	return nil
 }
 
+func (w *Workflows) CheckOpenTelemetryBaggage(ctx workflow.Context, key string) (string, error) {
+	var baggage string
+	var a Activities
+	ctx = workflow.WithActivityOptions(ctx, w.defaultActivityOptions())
+	if err := workflow.ExecuteActivity(ctx, a.CheckBaggage, key).Get(ctx, &baggage); err != nil {
+		return "", fmt.Errorf("failed checking baggage: %w", err)
+	}
+	return baggage, nil
+}
+
 type AdvancedPostCancellationInput struct {
 	PreCancelActivity  bool
 	PostCancelActivity bool
@@ -2434,6 +2444,7 @@ func (w *Workflows) register(worker worker.Worker) {
 	worker.RegisterWorkflow(w.InterceptorCalls)
 	worker.RegisterWorkflow(w.WaitSignalToStart)
 	worker.RegisterWorkflow(w.SignalsAndQueries)
+	worker.RegisterWorkflow(w.CheckOpenTelemetryBaggage)
 	worker.RegisterWorkflow(w.AdvancedPostCancellation)
 	worker.RegisterWorkflow(w.AdvancedPostCancellationChildWithDone)
 	worker.RegisterWorkflow(w.TooFewParams)


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
This PR updates the OTEL tracing interceptor implementation to allow [OTEL Baggage](https://opentelemetry.io/docs/concepts/signals/baggage/) to be propagated.

## Why?
This seems to be an omission from the existing OTEL tracing interceptor implementation, and should be included so that Temporal doesn't break baggage propagation. For my particular use-case, this allows for spans to add baggage as attributes in the `SpanStarter` func.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
The existing unit tests were used to ensure this didn't break existing functionality. Though, there doesn't seem to be a way to include context (for the purpose of including baggage) in the emulated test environment. As such, I'm looking for guidance on how to best test this MR.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
No
