### PR TITLE
loggerWith.WithCallerSkip expand keyvals

### DIFF
--- a/internal/log/memory_logger.go
+++ b/internal/log/memory_logger.go
@@ -31,21 +31,21 @@ import (
 	"go.temporal.io/sdk/log"
 )
 
-// MemoryLogger is Logger implementation that stores logs in memory (useful for testing). Use Lines() to get log lines.
-type MemoryLogger struct {
+// MemoryLoggerWithoutWith is Logger implementation that stores logs in memory (useful for testing). Use Lines() to get log lines.
+type MemoryLoggerWithoutWith struct {
 	lines         *[]string
 	globalKeyvals string
 }
 
-// NewMemoryLogger creates new instance of MemoryLogger.
-func NewMemoryLogger() *MemoryLogger {
+// NewMemoryLoggerWithoutWith creates new instance of MemoryLoggerWithoutWith.
+func NewMemoryLoggerWithoutWith() *MemoryLoggerWithoutWith {
 	var lines []string
-	return &MemoryLogger{
+	return &MemoryLoggerWithoutWith{
 		lines: &lines,
 	}
 }
 
-func (l *MemoryLogger) println(level, msg string, keyvals []interface{}) {
+func (l *MemoryLoggerWithoutWith) println(level, msg string, keyvals []interface{}) {
 	// To avoid extra space when globalKeyvals is not specified.
 	if l.globalKeyvals == "" {
 		*l.lines = append(*l.lines, fmt.Sprintln(append([]interface{}{level, msg}, keyvals...)...))
@@ -55,28 +55,44 @@ func (l *MemoryLogger) println(level, msg string, keyvals []interface{}) {
 }
 
 // Debug appends message to the log.
-func (l *MemoryLogger) Debug(msg string, keyvals ...interface{}) {
+func (l *MemoryLoggerWithoutWith) Debug(msg string, keyvals ...interface{}) {
 	l.println("DEBUG", msg, keyvals)
 }
 
 // Info appends message to the log.
-func (l *MemoryLogger) Info(msg string, keyvals ...interface{}) {
+func (l *MemoryLoggerWithoutWith) Info(msg string, keyvals ...interface{}) {
 	l.println("INFO ", msg, keyvals)
 }
 
 // Warn appends message to the log.
-func (l *MemoryLogger) Warn(msg string, keyvals ...interface{}) {
+func (l *MemoryLoggerWithoutWith) Warn(msg string, keyvals ...interface{}) {
 	l.println("WARN ", msg, keyvals)
 }
 
 // Error appends message to the log.
-func (l *MemoryLogger) Error(msg string, keyvals ...interface{}) {
+func (l *MemoryLoggerWithoutWith) Error(msg string, keyvals ...interface{}) {
 	l.println("ERROR", msg, keyvals)
+}
+
+// Lines returns written log lines.
+func (l *MemoryLoggerWithoutWith) Lines() []string {
+	return *l.lines
+}
+
+type MemoryLogger struct {
+	*MemoryLoggerWithoutWith
+}
+
+// NewMemoryLogger creates new instance of MemoryLogger.
+func NewMemoryLogger() *MemoryLogger {
+	return &MemoryLogger{
+		NewMemoryLoggerWithoutWith(),
+	}
 }
 
 // With returns new logger the prepend every log entry with keyvals.
 func (l *MemoryLogger) With(keyvals ...interface{}) log.Logger {
-	logger := &MemoryLogger{
+	logger := &MemoryLoggerWithoutWith{
 		lines: l.lines,
 	}
 
@@ -87,9 +103,4 @@ func (l *MemoryLogger) With(keyvals ...interface{}) log.Logger {
 	logger.globalKeyvals += strings.TrimSuffix(fmt.Sprintln(keyvals...), "\n")
 
 	return logger
-}
-
-// Lines returns written log lines.
-func (l *MemoryLogger) Lines() []string {
-	return *l.lines
 }

--- a/internal/log/memory_logger.go
+++ b/internal/log/memory_logger.go
@@ -31,7 +31,7 @@ import (
 	"go.temporal.io/sdk/log"
 )
 
-// MemoryLoggerWithoutWith is Logger implementation that stores logs in memory (useful for testing). Use Lines() to get log lines.
+// MemoryLoggerWithoutWith is a Logger implementation that stores logs in memory (useful for testing). Use Lines() to get log lines.
 type MemoryLoggerWithoutWith struct {
 	lines         *[]string
 	globalKeyvals string
@@ -90,7 +90,7 @@ func NewMemoryLogger() *MemoryLogger {
 	}
 }
 
-// With returns new logger the prepend every log entry with keyvals.
+// With returns new logger that prepend every log entry with keyvals.
 func (l *MemoryLogger) With(keyvals ...interface{}) log.Logger {
 	logger := &MemoryLoggerWithoutWith{
 		lines: l.lines,

--- a/internal/log/replay_logger.go
+++ b/internal/log/replay_logger.go
@@ -80,7 +80,7 @@ func (l *ReplayLogger) Error(msg string, keyvals ...interface{}) {
 	}
 }
 
-// With returns new logger the prepend every log entry with keyvals.
+// With returns new logger that prepend every log entry with keyvals.
 func (l *ReplayLogger) With(keyvals ...interface{}) log.Logger {
 	return NewReplayLogger(log.With(l.logger, keyvals...), l.isReplay, l.enableLoggingInReplay)
 }

--- a/log/with_logger.go
+++ b/log/with_logger.go
@@ -86,7 +86,7 @@ func (l *withLogger) Error(msg string, keyvals ...interface{}) {
 
 func (l *withLogger) WithCallerSkip(depth int) Logger {
 	if sl, ok := l.logger.(WithSkipCallers); ok {
-		return newWithLogger(sl.WithCallerSkip(depth), l.keyvals)
+		return newWithLogger(sl.WithCallerSkip(depth), l.keyvals...)
 	}
 	return l
 }

--- a/log/with_logger_test.go
+++ b/log/with_logger_test.go
@@ -37,3 +37,11 @@ func TestWithLogger(t *testing.T) {
 	allKeys := wl.prependKeyvals([]interface{}{"p4", 4})
 	assert.Equal(t, []interface{}{"p1", 1, "p2", "v2", "p4", 4}, allKeys)
 }
+
+func TestWithLoggerSkip(t *testing.T) {
+	wl := &withLogger{}
+	wl2 := With(wl, "p1", 1, "p2", "v2")
+	sl := Skip(wl2, 0)
+	wl, _ = sl.(*withLogger)
+	assert.Equal(t, []interface{}{"p1", 1, "p2", "v2"}, wl.keyvals)
+}


### PR DESCRIPTION
Fix a regression introduced in https://github.com/temporalio/sdk-go/pull/1219 that caused loggers wrapped with `withLogger` to log key values as a slice 

another option is to remove `WithCallerSkip` from `withLogger`

closes https://github.com/temporalio/sdk-go/issues/1266
