### PR TITLE
Release v1.25.1

### DIFF
--- a/internal/version.go
+++ b/internal/version.go
@@ -30,7 +30,7 @@ package internal
 const (
 	// SDKVersion is a semver (https://semver.org/) that represents the version of this Temporal GoSDK.
 	// Server validates if SDKVersion fits its supported range and rejects request if it doesn't.
-	SDKVersion = "1.25.0"
+	SDKVersion = "1.25.1"
 
 	// SDKName represents the name of the SDK.
 	SDKName = clientNameHeaderValue


### PR DESCRIPTION
Release Go SDK v1.25.1

https://github.com/temporalio/sdk-go/releases/edit/untagged-2ae75360b50773575f0b