### PR TITLE
fix typo in documentation

### DIFF
--- a/temporal/error.go
+++ b/temporal/error.go
@@ -91,6 +91,8 @@ if err != nil {
         switch timeoutErr.TimeoutType() {
         case enumspb.TIMEOUT_TYPE_SCHEDULE_TO_START:
 			// Handle ScheduleToStart timeout.
+        case enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE:
+			// Handle ScheduleToClose timeout.
         case enumspb.TIMEOUT_TYPE_START_TO_CLOSE:
             // Handle StartToClose timeout.
         case enumspb.TIMEOUT_TYPE_HEARTBEAT:

--- a/temporal/error.go
+++ b/temporal/error.go
@@ -61,16 +61,16 @@ Workflow code could handle errors based on different types of error. Below is sa
 err := workflow.ExecuteActivity(ctx, MyActivity, ...).Get(ctx, nil)
 if err != nil {
 	var applicationErr *ApplicationError
-	if errors.As(err, &applicationError) {
+	if errors.As(err, &applicationErr) {
 		// retrieve error message
-		fmt.Println(applicationError.Error())
+		fmt.Println(applicationErr.Error())
 
 		// handle activity errors (created via NewApplicationError() API)
 		var detailMsg string // assuming activity return error by NewApplicationError("message", true, "string details")
 		applicationErr.Details(&detailMsg) // extract strong typed details
 
 		// handle activity errors (errors created other than using NewApplicationError() API)
-		switch err.Type() {
+		switch applicationErr.Type() {
 		case "CustomErrTypeA":
 			// handle CustomErrTypeA
 		case CustomErrTypeB:
@@ -88,7 +88,7 @@ if err != nil {
 	var timeoutErr *TimeoutError
 	if errors.As(err, &timeoutErr) {
 		// handle timeout, could check timeout type by timeoutErr.TimeoutType()
-        switch err.TimeoutType() {
+        switch timeoutErr.TimeoutType() {
         case enumspb.TIMEOUT_TYPE_SCHEDULE_TO_START:
 			// Handle ScheduleToStart timeout.
         case enumspb.TIMEOUT_TYPE_START_TO_CLOSE:


### PR DESCRIPTION
Fix some typos in the example for handling errors

## What was changed
Fix some typos on the documentation about error handling

## Why?
This change was done for two reasons:
1. It was unsatisfying to see
2. If someone copies the example and uses it as a base for their own error handling the example should be working.

## Checklist
1. How was this tested:
This only includes some changes to comments so no executable code is affected. Therefor it is untested
