### PR TITLE
Don't run workflowCancelHandler in test harness

### DIFF
--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -877,16 +877,13 @@ func (env *testWorkflowEnvironmentImpl) Complete(result *commonpb.Payloads, err 
 		return
 	}
 	env.workflowDef.Close()
-	var canceledErr *CanceledError
-	if errors.As(err, &canceledErr) && env.workflowCancelHandler != nil {
-		env.workflowCancelHandler()
-	}
 
 	dc := env.GetDataConverter()
 	env.isWorkflowCompleted = true
 
 	if err != nil {
 		var continueAsNewErr *ContinueAsNewError
+		var canceledErr *CanceledError
 		var timeoutErr *TimeoutError
 		var workflowPanicErr *workflowPanicError
 		var workflowExecutionAlreadyStartedErr *serviceerror.WorkflowExecutionAlreadyStarted

--- a/internal/internal_workflow_testsuite_test.go
+++ b/internal/internal_workflow_testsuite_test.go
@@ -105,6 +105,15 @@ func (s *WorkflowTestSuiteUnitTest) Test_ActivityMockFunctionZero() {
 	env.AssertExpectations(s.T())
 }
 
+func (s *WorkflowTestSuiteUnitTest) Test_WorkflowReturnedCancel() {
+	env := s.NewTestWorkflowEnvironment()
+	env.RegisterWorkflow(testWorkflowCancelled)
+	env.ExecuteWorkflow(testWorkflowCancelled)
+
+	s.True(env.IsWorkflowCompleted())
+	s.Error(env.GetWorkflowError())
+}
+
 func (s *WorkflowTestSuiteUnitTest) Test_ActivityByNameMockFunction() {
 	mockActivity := func(ctx context.Context, msg string) (string, error) {
 		return "mock_" + msg, nil
@@ -608,6 +617,11 @@ func testWorkflowHello(ctx Context) (string, error) {
 		return "", err
 	}
 	return result, nil
+}
+
+func testWorkflowCancelled(ctx Context) error {
+	_ = NewTimer(ctx, 20*time.Minute)
+	return NewCanceledError()
 }
 
 func testWorkflowContext(ctx Context) (string, error) {


### PR DESCRIPTION
Don't run workflowCancelHandler in test harness on completed workflows. If a workflow is completed nothing else in the workflow function should run.

closes https://github.com/temporalio/sdk-go/issues/1287
