### PR TITLE
Use the official features repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,5 +77,3 @@ jobs:
       go-repo-path: ${{github.event.pull_request.head.repo.full_name}}
       version: ${{github.event.pull_request.head.ref}}
       version-is-repo-ref: true
-      features-repo-path: "tdeebswihart/temporal-features"
-      features-repo-ref: "nomo-gogo"


### PR DESCRIPTION
## What was changed
sdk-go now uses the official features repo, not my fork.

## Why?
This needed to point at my fork temporarily so that I could release a new version of that repo (which relies on the go SDK).
