### PR TITLE
Add `NotBefore` function to `testsuite.MockCallWrapper`

### DIFF
--- a/internal/workflow_testsuite.go
+++ b/internal/workflow_testsuite.go
@@ -584,10 +584,10 @@ func (c *MockCallWrapper) Panic(msg string) *MockCallWrapper {
 	return c
 }
 
-// NotBefore indicates that a call to this mock must not happen before the given calls have happened as expected. 
+// NotBefore indicates that a call to this mock must not happen before the given calls have happened as expected.
 // It calls `NotBefore` on the wrapped mock call.
 func (c *MockCallWrapper) NotBefore(calls ...*MockCallWrapper) *MockCallWrapper {
-	wrappedCalls := []*mock.Call{}
+	wrappedCalls := make([]*mock.Call, 0, len(calls))
 	for _, call := range calls {
 		wrappedCalls = append(wrappedCalls, call.call)
 	}

--- a/internal/workflow_testsuite.go
+++ b/internal/workflow_testsuite.go
@@ -584,6 +584,17 @@ func (c *MockCallWrapper) Panic(msg string) *MockCallWrapper {
 	return c
 }
 
+// NotBefore indicates that a call to this mock must not happen before the given calls have happened as expected. 
+// It calls `NotBefore` on the wrapped mock call.
+func (c *MockCallWrapper) NotBefore(calls ...*MockCallWrapper) *MockCallWrapper {
+	wrappedCalls := []*mock.Call{}
+	for _, call := range calls {
+		wrappedCalls = append(wrappedCalls, call.call)
+	}
+	c.call.NotBefore(wrappedCalls...)
+	return c
+}
+
 // ExecuteWorkflow executes a workflow, wait until workflow complete. It will fail the test if workflow is blocked and
 // cannot complete within TestTimeout (set by SetTestTimeout()).
 func (e *TestWorkflowEnvironment) ExecuteWorkflow(workflowFn interface{}, args ...interface{}) {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

This PR adds a `NotBefore` method to the `testsuite.MockCallWrapper`.
It indicates that a mock call must not happen before the given set of other mocks have been called as expected.
The actual functionality for this is already implemented in `github.com/stretchr/testify/mock`.
The new function forwards to the `.NotBefore()` method on the wrapped `mock` object.


## Why?
<!-- Tell your future self why have you made these changes -->
This change further improves the testability of workflows.
It allows to specify the exact sequence that activities and child-workflow executions must happen.
For example, "call activity abc, then execute child-workflow xyz"

## Checklist
<!--- add/delete as needed --->

1. Closes:
  No issue found. <!-- add issue number here -->
1. How was this tested:
  Added an additional unit test.
1. Any docs updates needed?:
  Go docs should update automatically.
