### PR TITLE
Fix race in WaitSignalReturnParam

### DIFF
--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -851,7 +851,7 @@ func (ts *IntegrationTestSuite) TestWorkflowIDReuseIgnoreDuplicateWhileRunning()
 
 	// Send signal to each (though in practice they both have the same ID and run
 	// ID, so it's really just two signals)
-	err = ts.client.SignalWorkflow(ctx, run1.GetID(), run1.GetRunID(), "done-signal", true)
+	err = ts.client.SignalWorkflow(ctx, run1.GetID(), run1.GetRunID(), "done-signal", false)
 	ts.NoError(err)
 	err = ts.client.SignalWorkflow(ctx, run2.GetID(), run2.GetRunID(), "done-signal", true)
 	ts.NoError(err)

--- a/test/workflow_test.go
+++ b/test/workflow_test.go
@@ -1749,12 +1749,14 @@ func (w *Workflows) WaitSignalReturnParam(ctx workflow.Context, v interface{}) (
 	// Wait for signal before returning
 	s := workflow.NewSelector(ctx)
 	signalCh := workflow.GetSignalChannel(ctx, "done-signal")
+	var finishWf bool
 	s.AddReceive(signalCh, func(c workflow.ReceiveChannel, more bool) {
-		var ignore bool
-		c.Receive(ctx, &ignore)
+		c.Receive(ctx, &finishWf)
 		workflow.GetLogger(ctx).Info("Received signal")
 	})
-	s.Select(ctx)
+	for !finishWf {
+		s.Select(ctx)
+	}
 	return v, nil
 }
 


### PR DESCRIPTION
`TestWorkflowIDReuseIgnoreDuplicateWhileRunning` was failing because the workflow `WaitSignalReturnParam` was exiting before receiving the second signal.

Fixes https://github.com/temporalio/sdk-go/actions/runs/7040203549/job/19160706031
