### PR TITLE
Run cloud tests in series to avoid wfID conflict

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,8 +88,8 @@ jobs:
     strategy:
       matrix:
         go-version: ["1.20", "1.21"]
-        # Try to avoid running tests in parallel to avoid workflow ID conflict
-        max-parallel: 1
+      # Try to avoid running tests in parallel to avoid workflow ID conflict
+      max-parallel: 1
     # Only supported in non-fork runs, since secrets are not available in forks.
     if: ${{ github.event.pull_request.head.repo.full_name == '' || github.event.pull_request.head.repo.full_name == 'temporalio/sdk-go' }}
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,8 @@ jobs:
     strategy:
       matrix:
         go-version: ["1.20", "1.21"]
+        # Try to avoid running tests in parallel to avoid workflow ID conflict
+        max-parallel: 1
     # Only supported in non-fork runs, since secrets are not available in forks.
     if: ${{ github.event.pull_request.head.repo.full_name == '' || github.event.pull_request.head.repo.full_name == 'temporalio/sdk-go' }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
Run cloud tests in series to avoid workflow ID conflict. When running parallel integration tests against the same cloud namespace it is possible if the same test runs at the same time the workflow IDs will conflict causing test failure.

example:
https://github.com/temporalio/sdk-go/actions/runs/7049993619/job/19189705118

Note: this isn't a perfect, the only way to properly fix is to run in separate namespaces or modify all the tests to add a UUID to every workflow and child workflow ID.