### PR TITLE
Fix flaky test

### DIFF
--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -2689,7 +2689,7 @@ func (ts *IntegrationTestSuite) testNonDeterminismFailureCause(historyMismatch b
 	ts.NoError(histErr)
 	ts.Equal(enumspb.WORKFLOW_TASK_FAILED_CAUSE_NON_DETERMINISTIC_ERROR, taskFailed.Cause)
 	taskFailedMetric = fetchMetrics()
-	ts.True(taskFailedMetric > 1)
+	ts.True(taskFailedMetric >= 1)
 }
 
 func (ts *IntegrationTestSuite) TestDeterminismUpsertSearchAttributesConditional() {


### PR DESCRIPTION
Fix assertion is TestNonDeterminismFailureCauseHistoryMismatch. Can cause one or more task failures, depending on the exact timing, the test was incorrect to assert more then one.

https://github.com/temporalio/sdk-go/actions/runs/7089287292/job/19293691402

