### PR TITLE
Include update state machine fields in panic

### DIFF
--- a/internal/internal_update.go
+++ b/internal/internal_update.go
@@ -130,7 +130,7 @@ func (up *updateProtocol) requireState(action string, valid ...updateState) {
 			return
 		}
 	}
-	panicIllegalState(fmt.Sprintf("invalid action %q in update protocol %v", action, up))
+	panicIllegalState(fmt.Sprintf("invalid action %q in update protocol %+v", action, up))
 }
 
 func (up *updateProtocol) HandleMessage(msg *protocolpb.Message) error {


### PR DESCRIPTION
Include update state machine fields in panic. This will help debug update issues by making it easier to interpret the panics message.
