### PR TITLE
Remove override for propagateCancel

### DIFF
--- a/contrib/tools/workflowcheck/workflow/checker.go
+++ b/contrib/tools/workflowcheck/workflow/checker.go
@@ -39,9 +39,6 @@ import (
 // DefaultIdentRefs are additional overrides of determinism.DefaultIdentRefs for
 // safe Temporal library functions.
 var DefaultIdentRefs = determinism.DefaultIdentRefs.Clone().SetAll(determinism.IdentRefs{
-	// Reported as non-deterministic because it internally starts a goroutine, so
-	// mark deterministic explicitly
-	"go.temporal.io/sdk/internal.propagateCancel": false,
 	// Reported as non-deterministic because it iterates over a map, so mark
 	// deterministic explicitly
 	"(*go.temporal.io/sdk/internal.cancelCtx).cancel": false,


### PR DESCRIPTION
Remove override for `propagateCancel` from the determinism since it no longer starts a go routine.
