### PR TITLE
Add deterministic range over map helper

### DIFF
--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -31,6 +31,9 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/exp/constraints"
+	"golang.org/x/exp/slices"
+
 	"google.golang.org/protobuf/types/known/durationpb"
 
 	commonpb "go.temporal.io/api/common/v1"
@@ -2042,4 +2045,28 @@ func convertFromPBRetryPolicy(retryPolicy *commonpb.RetryPolicy) *RetryPolicy {
 // GetLastCompletionResultFromWorkflowInfo returns value of last completion result.
 func GetLastCompletionResultFromWorkflowInfo(info *WorkflowInfo) *commonpb.Payloads {
 	return info.lastCompletionResult
+}
+
+// DeterministicKeys returns the keys of a map in deterministic (sorted) order. To be used in for
+// loops in workflows for deterministic iteration.
+func DeterministicKeys[K constraints.Ordered, V any](m map[K]V) []K {
+	r := make([]K, 0, len(m))
+	for k := range m {
+		r = append(r, k)
+	}
+	slices.Sort(r)
+	return r
+}
+
+// DeterministicKeysFunc returns the keys of a map in a deterministic (sorted) order.
+// cmp(a, b) should return a negative number when a < b, a positive number when
+// a > b and zero when a == b. Keys are sorted by cmp.
+// To be used in for loops in workflows for deterministic iteration.
+func DeterministicKeysFunc[K comparable, V any](m map[K]V, cmp func(a K, b K) int) []K {
+	r := make([]K, 0, len(m))
+	for k := range m {
+		r = append(r, k)
+	}
+	slices.SortStableFunc(r, cmp)
+	return r
 }

--- a/internal/workflow_test.go
+++ b/internal/workflow_test.go
@@ -189,3 +189,75 @@ func _assertNonZero(t *testing.T, i interface{}, prefix string) {
 		}
 	}
 }
+
+func TestDeterministicKeys(t *testing.T) {
+	t.Parallel()
+
+	var tests = []struct {
+		unsorted map[int]int
+		sorted   []int
+	}{
+		{
+			map[int]int{1: 1, 2: 2, 3: 3},
+			[]int{1, 2, 3},
+		},
+		{
+			map[int]int{},
+			[]int{},
+		},
+		{
+			map[int]int{1: 1, 5: 5, 3: 3},
+			[]int{1, 3, 5},
+		},
+		{
+			map[int]int{3: 3, 2: 2, 1: 1},
+			[]int{1, 2, 3},
+		},
+	}
+
+	for _, tt := range tests {
+		testname := fmt.Sprintf("%d,%d", tt.unsorted, tt.sorted)
+		t.Run(testname, func(t *testing.T) {
+			assert.Equal(t, tt.sorted, DeterministicKeys(tt.unsorted))
+		})
+	}
+}
+
+func TestDeterministicKeysFunc(t *testing.T) {
+	t.Parallel()
+
+	type keyStruct struct {
+		i int
+	}
+
+	var tests = []struct {
+		unsorted map[keyStruct]int
+		sorted   []keyStruct
+	}{
+		{
+			map[keyStruct]int{{1}: 1, {2}: 2, {3}: 3},
+			[]keyStruct{{1}, {2}, {3}},
+		},
+		{
+			map[keyStruct]int{},
+			[]keyStruct{},
+		},
+		{
+			map[keyStruct]int{{1}: 1, {5}: 5, {3}: 3},
+			[]keyStruct{{1}, {3}, {5}},
+		},
+		{
+			map[keyStruct]int{{3}: 3, {2}: 2, {1}: 1},
+			[]keyStruct{{1}, {2}, {3}},
+		},
+	}
+
+	for _, tt := range tests {
+		testname := fmt.Sprintf("%d,%d", tt.unsorted, tt.sorted)
+		t.Run(testname, func(t *testing.T) {
+			assert.Equal(t, tt.sorted, DeterministicKeysFunc(tt.unsorted, func(a, b keyStruct) int {
+				return a.i - b.i
+			}))
+		})
+	}
+}

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -639,7 +639,7 @@ func DataConverterWithoutDeadlockDetection(c converter.DataConverter) converter.
 
 // DeterministicKeys returns the keys of a map in deterministic (sorted) order. To be used in for
 // loops in workflows for deterministic iteration.
-func SortedKeys[K constraints.Ordered, V any](m map[K]V) []K {
+func DeterministicKeys[K constraints.Ordered, V any](m map[K]V) []K {
 	return internal.DeterministicKeys(m)
 }
 
@@ -647,6 +647,6 @@ func SortedKeys[K constraints.Ordered, V any](m map[K]V) []K {
 // cmp(a, b) should return a negative number when a < b, a positive number when
 // a > b and zero when a == b. Keys are sorted by cmp.
 // To be used in for loops in workflows for deterministic iteration.
-func SortedKeysFunc[K comparable, V any](m map[K]V, cmp func(K, K) int) []K {
+func DeterministicKeysFunc[K comparable, V any](m map[K]V, cmp func(K, K) int) []K {
 	return internal.DeterministicKeysFunc(m, cmp)
 }

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -31,6 +31,7 @@ import (
 	"go.temporal.io/sdk/internal"
 	"go.temporal.io/sdk/internal/common/metrics"
 	"go.temporal.io/sdk/log"
+	"golang.org/x/exp/constraints"
 )
 
 type (
@@ -634,4 +635,18 @@ func IsContinueAsNewError(err error) bool {
 // timeout.
 func DataConverterWithoutDeadlockDetection(c converter.DataConverter) converter.DataConverter {
 	return internal.DataConverterWithoutDeadlockDetection(c)
+}
+
+// DeterministicKeys returns the keys of a map in deterministic (sorted) order. To be used in for
+// loops in workflows for deterministic iteration.
+func SortedKeys[K constraints.Ordered, V any](m map[K]V) []K {
+	return internal.DeterministicKeys(m)
+}
+
+// DeterministicKeysFunc returns the keys of a map in a deterministic (sorted) order.
+// cmp(a, b) should return a negative number when a < b, a positive number when
+// a > b and zero when a == b. Keys are sorted by cmp.
+// To be used in for loops in workflows for deterministic iteration.
+func SortedKeysFunc[K comparable, V any](m map[K]V, cmp func(K, K) int) []K {
+	return internal.DeterministicKeysFunc(m, cmp)
 }


### PR DESCRIPTION
Add deterministic range over map helpers for ordered and unordered maps.

Ideally this would be implemented with [range over func](https://github.com/golang/go/wiki/RangefuncExperiment), but it is only experimental in golang 1.22 so we would have to wait over a year to use it assuming it is stabilized in 1.23.

Closes https://github.com/temporalio/sdk-go/issues/359