### PR TITLE
Replace go.uber.org/atomic with sync/atomic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/robfig/cron v1.2.0
 	github.com/stretchr/testify v1.8.4
 	go.temporal.io/api v1.26.1-0.20240103185939-608bdd111e4b
-	go.uber.org/atomic v1.9.0
 	golang.org/x/sys v0.15.0
 	golang.org/x/time v0.3.0
 	google.golang.org/grpc v1.60.1

--- a/go.sum
+++ b/go.sum
@@ -60,7 +60,6 @@ github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSS
 github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
-github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
@@ -72,8 +71,6 @@ github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1
 go.temporal.io/api v1.26.1-0.20240103185939-608bdd111e4b h1:Fi5NWG08z7pfxBolgjchVp4PnmWrGIHjqboDlXve5Sg=
 go.temporal.io/api v1.26.1-0.20240103185939-608bdd111e4b/go.mod h1:mix7Bpl8mFEfYud66rjYInxNpP43sqXvr1UiHv+mur0=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
-go.uber.org/atomic v1.9.0 h1:ECmE8Bn/WFTYwEW/bpKD3M8VtR/zQVbavAoalC1PYyE=
-go.uber.org/atomic v1.9.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/internal/client.go
+++ b/internal/client.go
@@ -35,7 +35,6 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/operatorservice/v1"
 	"go.temporal.io/api/workflowservice/v1"
-	uberatomic "go.uber.org/atomic"
 	"google.golang.org/grpc"
 
 	"go.temporal.io/sdk/converter"
@@ -532,7 +531,7 @@ type (
 		// other gRPC errors. If not present during service client creation, it will
 		// be created as false. This is set to true when server capabilities are
 		// fetched.
-		excludeInternalFromRetry *uberatomic.Bool
+		excludeInternalFromRetry *atomic.Bool
 	}
 
 	// StartWorkflowOptions configuration parameters for starting a workflow execution.
@@ -746,7 +745,7 @@ func newClient(options ClientOptions, existing *WorkflowClient) (Client, error) 
 	var connection *grpc.ClientConn
 	var err error
 	if existing == nil {
-		options.ConnectionOptions.excludeInternalFromRetry = uberatomic.NewBool(false)
+		options.ConnectionOptions.excludeInternalFromRetry = &atomic.Bool{}
 		connection, err = dial(newDialParameters(&options, options.ConnectionOptions.excludeInternalFromRetry))
 		if err != nil {
 			return nil, err
@@ -780,7 +779,7 @@ func newClient(options ClientOptions, existing *WorkflowClient) (Client, error) 
 	return client, nil
 }
 
-func newDialParameters(options *ClientOptions, excludeInternalFromRetry *uberatomic.Bool) dialParameters {
+func newDialParameters(options *ClientOptions, excludeInternalFromRetry *atomic.Bool) dialParameters {
 	return dialParameters{
 		UserConnectionOptions: options.ConnectionOptions,
 		HostPort:              options.HostPort,
@@ -818,7 +817,7 @@ func NewServiceClient(workflowServiceClient workflowservice.WorkflowServiceClien
 	}
 
 	if options.ConnectionOptions.excludeInternalFromRetry == nil {
-		options.ConnectionOptions.excludeInternalFromRetry = uberatomic.NewBool(false)
+		options.ConnectionOptions.excludeInternalFromRetry = &atomic.Bool{}
 	}
 
 	// Collect set of applicable worker interceptors

--- a/internal/cmd/build/go.mod
+++ b/internal/cmd/build/go.mod
@@ -24,7 +24,6 @@ require (
 	github.com/stretchr/objx v0.5.0 // indirect
 	github.com/stretchr/testify v1.8.4 // indirect
 	go.temporal.io/api v1.26.1 // indirect
-	go.uber.org/atomic v1.9.0 // indirect
 	golang.org/x/exp v0.0.0-20231127185646-65229373498e // indirect
 	golang.org/x/exp/typeparams v0.0.0-20221208152030-732eee02a75a // indirect
 	golang.org/x/mod v0.14.0 // indirect

--- a/internal/cmd/build/go.sum
+++ b/internal/cmd/build/go.sum
@@ -64,7 +64,6 @@ github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSS
 github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
-github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
@@ -77,8 +76,6 @@ github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1
 go.temporal.io/api v1.26.1 h1:YqGQsOr/Tx4nVdA8wCv74AxesaIzCRHWb3KkHrYqI8k=
 go.temporal.io/api v1.26.1/go.mod h1:Y/rALXTprFO+bvAlAfLFoJj7KpQIcL4GDQVN6fhYIa4=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
-go.uber.org/atomic v1.9.0 h1:ECmE8Bn/WFTYwEW/bpKD3M8VtR/zQVbavAoalC1PYyE=
-go.uber.org/atomic v1.9.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/internal/common/retry/interceptor.go
+++ b/internal/common/retry/interceptor.go
@@ -27,14 +27,14 @@ package retry
 import (
 	"context"
 	"math"
+	"sync/atomic"
 	"time"
 
-	"google.golang.org/grpc/status"
 	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
 	"github.com/grpc-ecosystem/go-grpc-middleware/util/backoffutils"
-	uberatomic "go.uber.org/atomic"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 const (
@@ -127,7 +127,7 @@ var (
 // NewRetryOptionsInterceptor creates a new gRPC interceptor that populates retry options for each call based on values
 // provided in the context. The atomic bool is checked each call to determine whether internals are included in retry.
 // If not present or false, internals are assumed to be included.
-func NewRetryOptionsInterceptor(excludeInternal *uberatomic.Bool) grpc.UnaryClientInterceptor {
+func NewRetryOptionsInterceptor(excludeInternal *atomic.Bool) grpc.UnaryClientInterceptor {
 	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 		if rc, ok := ctx.Value(ConfigKey).(*GrpcRetryConfig); ok {
 			if _, ok := ctx.Deadline(); !ok {

--- a/internal/grpc_dialer.go
+++ b/internal/grpc_dialer.go
@@ -26,13 +26,13 @@ package internal
 
 import (
 	"context"
+	"sync/atomic"
 	"time"
 
 	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/sdk/internal/common/metrics"
 	"go.temporal.io/sdk/internal/common/retry"
-	uberatomic "go.uber.org/atomic"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/backoff"
 	"google.golang.org/grpc/credentials"
@@ -148,7 +148,7 @@ func requiredInterceptors(
 	metricsHandler metrics.Handler,
 	headersProvider HeadersProvider,
 	controller TrafficController,
-	excludeInternalFromRetry *uberatomic.Bool,
+	excludeInternalFromRetry *atomic.Bool,
 ) []grpc.UnaryClientInterceptor {
 	interceptors := []grpc.UnaryClientInterceptor{
 		errorInterceptor,

--- a/internal/internal_workflow.go
+++ b/internal/internal_workflow.go
@@ -33,6 +33,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 	"unicode"
 
@@ -40,7 +41,6 @@ import (
 
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
-	"go.uber.org/atomic"
 
 	"go.temporal.io/sdk/converter"
 	"go.temporal.io/sdk/internal/common/metrics"

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -36,7 +36,6 @@ import (
 	"time"
 
 	"github.com/pborman/uuid"
-	uberatomic "go.uber.org/atomic"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
@@ -91,7 +90,7 @@ type (
 		contextPropagators       []ContextPropagator
 		workerInterceptors       []WorkerInterceptor
 		interceptor              ClientOutboundInterceptor
-		excludeInternalFromRetry *uberatomic.Bool
+		excludeInternalFromRetry *atomic.Bool
 		capabilities             *workflowservice.GetSystemInfoResponse_Capabilities
 		capabilitiesLock         sync.RWMutex
 		eagerDispatcher          *eagerWorkflowDispatcher

--- a/internal/internal_workflow_client_test.go
+++ b/internal/internal_workflow_client_test.go
@@ -34,7 +34,6 @@ import (
 
 	updatepb "go.temporal.io/api/update/v1"
 	workflowpb "go.temporal.io/api/workflow/v1"
-	uberatomic "go.uber.org/atomic"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/connectivity"
@@ -174,7 +173,7 @@ func (s *historyEventIteratorSuite) SetupTest() {
 	s.wfClient = &WorkflowClient{
 		workflowService:          s.workflowServiceClient,
 		namespace:                DefaultNamespace,
-		excludeInternalFromRetry: uberatomic.NewBool(false),
+		excludeInternalFromRetry: &atomic.Bool{},
 	}
 }
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
go 1.19 introduced atomic types
https://tip.golang.org/doc/go1.19#atomic_types

## Why?
sync/atomic is already being used here. I intend to update dependencies so that `go.uber.org/atomic` can also be removed as an indirect dependency