### PR TITLE
Evict workflow from cache on RespondTaskCompleted failure

### DIFF
--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -379,6 +379,8 @@ func (wtp *workflowTaskPoller) processWorkflowTask(task *workflowTask) error {
 		}
 		response, err := wtp.RespondTaskCompletedWithMetrics(completedRequest, taskErr, task.task, startTime)
 		if err != nil {
+			// If we get an error responding to the workflow task we need to evict the execution from the cache.
+			taskErr = err
 			return err
 		}
 

--- a/internal/internal_task_pollers_test.go
+++ b/internal/internal_task_pollers_test.go
@@ -155,10 +155,9 @@ func TestWFTCorruption(t *testing.T) {
 	wfType := commonpb.WorkflowType{Name: t.Name() + "-workflow-type"}
 	reg := newRegistry()
 	reg.RegisterWorkflowWithOptions(func(ctx Context) error {
-		Await(ctx, func() bool {
+		return Await(ctx, func() bool {
 			return false
 		})
-		return nil
 	}, RegisterWorkflowOptions{
 		Name: wfType.Name,
 	})


### PR DESCRIPTION
Evict workflow from cache on RespondTaskCompleted failure

closes https://github.com/temporalio/sdk-go/issues/1357
