### PR TITLE
Exit coroutine in order

### DIFF
--- a/internal/internal_coroutines_test.go
+++ b/internal/internal_coroutines_test.go
@@ -30,6 +30,8 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync/atomic"
+
 	"testing"
 	"time"
 
@@ -73,57 +75,58 @@ func TestDispatcher(t *testing.T) {
 }
 
 func TestDispatcherDeferClose(t *testing.T) {
-	value := "foo"
+	var value atomic.Bool
 	d := createNewDispatcher(func(ctx Context) {
 		// Block all coroutines on this channel
 		c1 := NewChannel(ctx)
 		defer func() {
-			value = "fizz"
+			value.Store(true)
 		}()
 		c1.Receive(ctx, nil)
 	})
 	defer d.Close()
-	require.Equal(t, "foo", value)
+	require.Equal(t, false, value.Load())
 	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked(defaultDeadlockDetectionTimeout))
 	// Closing the dispatcher will cause the blocked goroutine to stop executing, but defers
 	// will still run.
 	d.Close()
 	require.True(t, d.IsClosed())
-	require.Equal(t, "fizz", value)
+	require.Eventually(t, value.Load, time.Second, 10*time.Millisecond)
 }
 
 func TestDispatcherDeadlockedDefer(t *testing.T) {
-	value := "foo"
+	var value atomic.Bool
 	d := createNewDispatcher(func(ctx Context) {
 		// Block all coroutines on this channel
 		c1 := NewChannel(ctx)
 		defer func() {
 			// The blocking defer should not block the dispatcher closing
 			time.Sleep(time.Hour)
-			value = "fizz"
+			value.Store(true)
 		}()
 		c1.Receive(ctx, nil)
 	})
-	require.Equal(t, "foo", value)
+	require.Equal(t, false, value.Load())
 	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked(defaultDeadlockDetectionTimeout))
 	// Closing the dispatcher will cause the blocked goroutine to stop executing, but defers
 	// will still run.
 	d.Close()
 	require.True(t, d.IsClosed())
-	require.Equal(t, "foo", value)
+	require.Equal(t, false, value.Load())
 }
 
 func TestDispatcherDeferCloseRace(t *testing.T) {
-	value := ""
+	var value atomic.Int32
 	var d dispatcher
 	d = createNewDispatcher(func(ctx Context) {
 		// Block all coroutines on this channel
 		c1 := NewChannel(ctx)
 		for i := 0; i < 100; i++ {
-			id := "coroutine_" + strconv.Itoa(i)
+			index := i
+			id := "coroutine_" + strconv.Itoa(index)
 			d.NewCoroutine(ctx, id, false, func(ctx Context) {
 				defer func() {
-					value = id
+					value.Store(int32(index))
 				}()
 				c1.Receive(ctx, nil)
 			})
@@ -132,12 +135,15 @@ func TestDispatcherDeferCloseRace(t *testing.T) {
 	})
 	defer d.Close()
 
-	require.Equal(t, "", value)
+	require.Equal(t, int32(0), value.Load())
 	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked(defaultDeadlockDetectionTimeout))
 	// Closing the dispatcher will cause the blocked coroutine to stop executing, but defers
 	// will still run.
 	d.Close()
 	require.True(t, d.IsClosed())
+	require.Eventually(t, func() bool {
+		return value.Load() == int32(99)
+	}, time.Second, 10*time.Millisecond)
 }
 
 func TestNonBlockingChildren(t *testing.T) {

--- a/internal/internal_worker_base.go
+++ b/internal/internal_worker_base.go
@@ -154,6 +154,7 @@ type (
 		OnWorkflowTaskStarted(deadlockDetectionTimeout time.Duration)
 		// StackTrace of all coroutines owned by the Dispatcher instance.
 		StackTrace() string
+		// Close destroys all coroutines without waiting for their completion
 		Close()
 	}
 


### PR DESCRIPTION
Run coroutine exit in sequence to avoid race detector errors on defers in coroutines.

closes https://github.com/temporalio/sdk-go/issues/1235