### PR TITLE
Fix workflow update DeadlineExceeded errors

### DIFF
--- a/internal/cmd/build/main.go
+++ b/internal/cmd/build/main.go
@@ -116,6 +116,7 @@ func (b *builder) integrationTest() error {
 	runFlag := flagSet.String("run", "", "Passed to go test as -run")
 	devServerFlag := flagSet.Bool("dev-server", false, "Use an embedded dev server")
 	coverageFileFlag := flagSet.String("coverage-file", "", "If set, enables coverage output to this filename")
+	testifyFlag := flagSet.String("testify.m", "", "Passed to go test as -testify.m")
 	if err := flagSet.Parse(os.Args[2:]); err != nil {
 		return fmt.Errorf("failed parsing flags: %w", err)
 	}
@@ -162,6 +163,9 @@ func (b *builder) integrationTest() error {
 	args := []string{"go", "test", "-count", "1", "-race", "-v", "-timeout", "10m"}
 	if *runFlag != "" {
 		args = append(args, "-run", *runFlag)
+	}
+	if *testifyFlag != "" {
+		args = append(args, "-testify.m", *testifyFlag)
 	}
 	if *coverageFileFlag != "" {
 		args = append(args, "-coverprofile="+filepath.Join(b.rootDir, coverageDir, *coverageFileFlag), "-coverpkg=./...")

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -121,8 +121,8 @@ type (
 
 		// Get will fill the workflow execution result to valuePtr, if workflow
 		// execution is a success, or return corresponding error. If valuePtr is
-		// nil, valuePtr will be ignored and only the corresponding error of the 
-		// workflow will be returned (nil on workflow execution success). 
+		// nil, valuePtr will be ignored and only the corresponding error of the
+		// workflow will be returned (nil on workflow execution success).
 		// This is a blocking API.
 		//
 		// This call will follow execution runs to the latest result for this run
@@ -141,7 +141,7 @@ type (
 		// GetWithOptions will fill the workflow execution result to valuePtr, if
 		// workflow execution is a success, or return corresponding error. If
 		// valuePtr is nil, valuePtr will be ignored and only the corresponding
-		// error of the workflow will be returned (nil on workflow execution success). 
+		// error of the workflow will be returned (nil on workflow execution success).
 		// This is a blocking API.
 		//
 		// Note, values should not be reused for extraction here because merging on
@@ -1887,6 +1887,7 @@ func (w *workflowClientInterceptor) PollWorkflowUpdate(
 		cancel()
 		if err == context.DeadlineExceeded ||
 			status.Code(err) == codes.DeadlineExceeded ||
+			serviceerror.ToStatus(err).Code() == codes.DeadlineExceeded ||
 			(err == nil && resp.GetOutcome() == nil) {
 			continue
 		}
@@ -1932,7 +1933,7 @@ func (ch *completedUpdateHandle) Get(ctx context.Context, valuePtr interface{}) 
 
 func (luh *lazyUpdateHandle) Get(ctx context.Context, valuePtr interface{}) error {
 	enc, err := luh.client.PollWorkflowUpdate(ctx, luh.ref)
-	if err != nil {
+	if err != nil || valuePtr == nil {
 		return err
 	}
 	return enc.Get(valuePtr)

--- a/test/workflow_test.go
+++ b/test/workflow_test.go
@@ -2232,6 +2232,20 @@ func (w *Workflows) WaitOnUpdate(ctx workflow.Context) (int, error) {
 	return updatesRan, nil
 }
 
+func (w *Workflows) UpdateHighLatency(ctx workflow.Context) error {
+	var updated bool
+	workflow.SetUpdateHandler(ctx, "update", func(ctx workflow.Context) error {
+		if err := workflow.Sleep(ctx, time.Second*35); err != nil {
+			return err
+		}
+		updated = true
+		return nil
+	})
+	return workflow.Await(ctx, func() bool {
+		return updated
+	})
+}
+
 func (w *Workflows) UpdateSetHandlerOnly(ctx workflow.Context) (int, error) {
 	updatesRan := 0
 	updateHandle := func(ctx workflow.Context) error {
@@ -2605,6 +2619,7 @@ func (w *Workflows) register(worker worker.Worker) {
 	worker.RegisterWorkflow(w.WaitOnUpdate)
 	worker.RegisterWorkflow(w.UpdateOrdering)
 	worker.RegisterWorkflow(w.UpdateSetHandlerOnly)
+	worker.RegisterWorkflow(w.UpdateHighLatency)
 }
 
 func (w *Workflows) defaultActivityOptions() workflow.ActivityOptions {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Updated the following internal methods to handle `*serviceerror.DeadlineExceeded` errors:
- `*workflowClientInterceptor.UpdateWorkflow`
- `*workflowClientInterceptor.PollWorkflowUpdate` 

## Why?
Workflow Updates with expected latency higher than the default timeouts result in unexpected deadline exceeded errors.

## Checklist
<!--- add/delete as needed --->

1. Closes 
n/a

2. How was this tested:
- added additional integration tests
- tested against external code-base experiencing deadline exceed errors

3. Any docs updates needed?
n/a
