### PR TITLE
Typed Search Attributes

### DIFF
--- a/internal/client.go
+++ b/internal/client.go
@@ -606,8 +606,20 @@ type (
 		// Use GetSearchAttributes API to get valid key and corresponding value type.
 		// For supported operations on different server versions see [Visibility].
 		//
+		// Deprecated: use TypedSearchAttributes instead.
+		//
 		// [Visibility]: https://docs.temporal.io/visibility
 		SearchAttributes map[string]interface{}
+
+		// TypedSearchAttributes - Specifies Search Attributes that will be attached to the Workflow. Search Attributes are
+		// additional indexed information attributed to workflow and used for search and visibility. The search attributes
+		// can be used in query of List/Scan/Count workflow APIs. The key and its value type must be registered on Temporal
+		// server side. For supported operations on different server versions see [Visibility].
+		//
+		// Optional: default to none.
+		//
+		// [Visibility]: https://docs.temporal.io/visibility
+		TypedSearchAttributes SearchAttributes
 
 		// EnableEagerStart - request eager execution for this workflow, if a local worker is available.
 		//

--- a/internal/interceptor.go
+++ b/internal/interceptor.go
@@ -197,6 +197,9 @@ type WorkflowOutboundInterceptor interface {
 	// GetInfo intercepts workflow.GetInfo.
 	GetInfo(ctx Context) *WorkflowInfo
 
+	// GetTypedSearchAttributes intercepts workflow.GetTypedSearchAttributes.
+	GetTypedSearchAttributes(ctx Context) SearchAttributes
+
 	// GetUpdateInfo intercepts workflow.GetUpdateInfo.
 	//
 	// NOTE: Experimental
@@ -232,6 +235,9 @@ type WorkflowOutboundInterceptor interface {
 
 	// UpsertSearchAttributes intercepts workflow.UpsertSearchAttributes.
 	UpsertSearchAttributes(ctx Context, attributes map[string]interface{}) error
+
+	// UpsertTypedSearchAttributes intercepts workflow.UpsertTypedSearchAttributes.
+	UpsertTypedSearchAttributes(ctx Context, attributes ...SearchAttributeUpdate) error
 
 	// UpsertMemo intercepts workflow.UpsertMemo.
 	UpsertMemo(ctx Context, memo map[string]interface{}) error

--- a/internal/interceptor_base.go
+++ b/internal/interceptor_base.go
@@ -228,6 +228,11 @@ func (w *WorkflowOutboundInterceptorBase) GetInfo(ctx Context) *WorkflowInfo {
 	return w.Next.GetInfo(ctx)
 }
 
+// GetTypedSearchAttributes implements WorkflowOutboundInterceptor.GetTypedSearchAttributes.
+func (w *WorkflowOutboundInterceptorBase) GetTypedSearchAttributes(ctx Context) SearchAttributes {
+	return w.Next.GetTypedSearchAttributes(ctx)
+}
+
 // GetUpdateInfo implements WorkflowOutboundInterceptor.GetUpdateInfo.
 func (w *WorkflowOutboundInterceptorBase) GetUpdateInfo(ctx Context) *UpdateInfo {
 	return w.Next.GetUpdateInfo(ctx)
@@ -295,6 +300,12 @@ func (w *WorkflowOutboundInterceptorBase) SignalChildWorkflow(
 // WorkflowOutboundInterceptor.UpsertSearchAttributes.
 func (w *WorkflowOutboundInterceptorBase) UpsertSearchAttributes(ctx Context, attributes map[string]interface{}) error {
 	return w.Next.UpsertSearchAttributes(ctx, attributes)
+}
+
+// UpsertTypedSearchAttributes implements
+// WorkflowOutboundInterceptor.UpsertTypedSearchAttributes.
+func (w *WorkflowOutboundInterceptorBase) UpsertTypedSearchAttributes(ctx Context, attributes ...SearchAttributeUpdate) error {
+	return w.Next.UpsertTypedSearchAttributes(ctx, attributes...)
 }
 
 // UpsertMemo implements

--- a/internal/internal_event_handlers.go
+++ b/internal/internal_event_handlers.go
@@ -392,7 +392,7 @@ func (wc *workflowEnvironmentImpl) WorkflowInfo() *WorkflowInfo {
 }
 
 func (wc *workflowEnvironmentImpl) TypedSearchAttributes() SearchAttributes {
-	return convertToTypeSearchAttributes(wc.logger, wc.workflowInfo.SearchAttributes.GetIndexedFields())
+	return convertToTypedSearchAttributes(wc.logger, wc.workflowInfo.SearchAttributes.GetIndexedFields())
 }
 
 func (wc *workflowEnvironmentImpl) Complete(result *commonpb.Payloads, err error) {

--- a/internal/internal_event_handlers.go
+++ b/internal/internal_event_handlers.go
@@ -391,80 +391,6 @@ func (wc *workflowEnvironmentImpl) WorkflowInfo() *WorkflowInfo {
 	return wc.workflowInfo
 }
 
-func getIndexValue(payload *commonpb.Payload) enumspb.IndexedValueType {
-	return enumspb.IndexedValueType(enumspb.IndexedValueType_value[string(payload.GetMetadata()["type"][:])])
-}
-
-func convertToTypeSearchAttributes(logger log.Logger, attributes map[string]*commonpb.Payload) SearchAttributes {
-	updates := make([]SearchAttributeUpdate, 0, len(attributes))
-	for key, payload := range attributes {
-		if payload.Data == nil {
-			continue
-		}
-		switch index := getIndexValue(payload); index {
-		case enumspb.INDEXED_VALUE_TYPE_BOOL:
-			attr := NewSearchAttributeKeyBool(key)
-			var value bool
-			err := converter.GetDefaultDataConverter().FromPayload(payload, &value)
-			if err != nil {
-				panic(err)
-			}
-			updates = append(updates, attr.ValueSet(value))
-		case enumspb.INDEXED_VALUE_TYPE_KEYWORD:
-			attr := NewSearchAttributeKeyword(key)
-			var value string
-			err := converter.GetDefaultDataConverter().FromPayload(payload, &value)
-			if err != nil {
-				panic(err)
-			}
-			updates = append(updates, attr.ValueSet(value))
-		case enumspb.INDEXED_VALUE_TYPE_TEXT:
-			attr := NewSearchAttributeKeyString(key)
-			var value string
-			err := converter.GetDefaultDataConverter().FromPayload(payload, &value)
-			if err != nil {
-				panic(err)
-			}
-			updates = append(updates, attr.ValueSet(value))
-		case enumspb.INDEXED_VALUE_TYPE_INT:
-			attr := NewSearchAttributeKeyInt64(key)
-			var value int64
-			err := converter.GetDefaultDataConverter().FromPayload(payload, &value)
-			if err != nil {
-				panic(err)
-			}
-			updates = append(updates, attr.ValueSet(value))
-		case enumspb.INDEXED_VALUE_TYPE_DOUBLE:
-			attr := NewSearchAttributeKeyFloat64(key)
-			var value float64
-			err := converter.GetDefaultDataConverter().FromPayload(payload, &value)
-			if err != nil {
-				panic(err)
-			}
-			updates = append(updates, attr.ValueSet(value))
-		case enumspb.INDEXED_VALUE_TYPE_DATETIME:
-			attr := NewSearchAttributeKeyTime(key)
-			var value time.Time
-			err := converter.GetDefaultDataConverter().FromPayload(payload, &value)
-			if err != nil {
-				panic(err)
-			}
-			updates = append(updates, attr.ValueSet(value))
-		case enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST:
-			attr := NewSearchAttributeKeywordList(key)
-			var value []string
-			err := converter.GetDefaultDataConverter().FromPayload(payload, &value)
-			if err != nil {
-				panic(err)
-			}
-			updates = append(updates, attr.ValueSet(value))
-		default:
-			logger.Warn("Unrecognized indexed value type on search attribute key", "key", key, "index", index)
-		}
-	}
-	return NewSearchAttributes(updates...)
-}
-
 func (wc *workflowEnvironmentImpl) TypedSearchAttributes() SearchAttributes {
 	return convertToTypeSearchAttributes(wc.logger, wc.workflowInfo.SearchAttributes.GetIndexedFields())
 }
@@ -547,7 +473,7 @@ func validateAndSerializeSearchAttributes(attributes map[string]interface{}) (*c
 	if len(attributes) == 0 {
 		return nil, errSearchAttributesNotSet
 	}
-	attr, err := serializeSearchAttributes(attributes)
+	attr, err := serializeUntypedSearchAttributes(attributes)
 	if err != nil {
 		return nil, err
 	}
@@ -620,7 +546,7 @@ func (wc *workflowEnvironmentImpl) ExecuteChildWorkflow(
 		callback(nil, err)
 		return
 	}
-	searchAttr, err := serializeSearchAttributes(params.SearchAttributes)
+	searchAttr, err := serializeUntypedSearchAttributes(params.SearchAttributes)
 	if err != nil {
 		if wc.sdkFlags.tryUse(SDKFlagChildWorkflowErrorExecution, !wc.isReplay) {
 			startedHandler(WorkflowExecution{}, &ChildWorkflowExecutionAlreadyStartedError{})

--- a/internal/internal_schedule_client.go
+++ b/internal/internal_schedule_client.go
@@ -40,6 +40,7 @@ import (
 	workflowpb "go.temporal.io/api/workflow/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/sdk/converter"
+	"go.temporal.io/sdk/log"
 )
 
 type (
@@ -96,7 +97,7 @@ func (w *workflowClientInterceptor) CreateSchedule(ctx context.Context, in *Sche
 		return nil, err
 	}
 
-	searchAttr, err := serializeSearchAttributes(in.Options.SearchAttributes)
+	searchAttr, err := serializeSearchAttributes(in.Options.SearchAttributes, in.Options.TypedSearchAttributes)
 	if err != nil {
 		return nil, err
 	}
@@ -275,7 +276,7 @@ func (scheduleHandle *scheduleHandleImpl) Update(ctx context.Context, options Sc
 	if err != nil {
 		return err
 	}
-	scheduleDescription, err := scheduleDescriptionFromPB(describeResponse)
+	scheduleDescription, err := scheduleDescriptionFromPB(scheduleHandle.client.logger, describeResponse)
 	if err != nil {
 		return err
 	}
@@ -314,7 +315,7 @@ func (scheduleHandle *scheduleHandleImpl) Describe(ctx context.Context) (*Schedu
 	if err != nil {
 		return nil, err
 	}
-	return scheduleDescriptionFromPB(describeResponse)
+	return scheduleDescriptionFromPB(scheduleHandle.client.logger, describeResponse)
 }
 
 func (scheduleHandle *scheduleHandleImpl) Trigger(ctx context.Context, options ScheduleTriggerOptions) error {
@@ -454,7 +455,10 @@ func convertFromPBScheduleSpec(scheduleSpec *schedulepb.ScheduleSpec) *ScheduleS
 	}
 }
 
-func scheduleDescriptionFromPB(describeResponse *workflowservice.DescribeScheduleResponse) (*ScheduleDescription, error) {
+func scheduleDescriptionFromPB(
+	logger log.Logger,
+	describeResponse *workflowservice.DescribeScheduleResponse,
+) (*ScheduleDescription, error) {
 	if describeResponse == nil {
 		return nil, nil
 	}
@@ -474,7 +478,7 @@ func scheduleDescriptionFromPB(describeResponse *workflowservice.DescribeSchedul
 		nextActionTimes[i] = t.AsTime()
 	}
 
-	actionDescription, err := convertFromPBScheduleAction(describeResponse.Schedule.Action)
+	actionDescription, err := convertFromPBScheduleAction(logger, describeResponse.Schedule.Action)
 	if err != nil {
 		return nil, err
 	}
@@ -560,7 +564,11 @@ func convertFromPBScheduleListEntry(schedule *schedulepb.ScheduleListEntry) *Sch
 	}
 }
 
-func convertToPBScheduleAction(ctx context.Context, client *WorkflowClient, scheduleAction ScheduleAction) (*schedulepb.ScheduleAction, error) {
+func convertToPBScheduleAction(
+	ctx context.Context,
+	client *WorkflowClient,
+	scheduleAction ScheduleAction,
+) (*schedulepb.ScheduleAction, error) {
 	switch action := scheduleAction.(type) {
 	case *ScheduleWorkflowAction:
 		// Set header before interceptor run
@@ -590,9 +598,18 @@ func convertToPBScheduleAction(ctx context.Context, client *WorkflowClient, sche
 			return nil, err
 		}
 
-		searchAttr, err := serializeSearchAttributes(action.SearchAttributes)
+		searchAttrs, err := serializeSearchAttributes(nil, action.TypedSearchAttributes)
 		if err != nil {
 			return nil, err
+		}
+		// Add any untyped search attributes that aren't already there
+		for k, v := range action.UntypedSearchAttributes {
+			if searchAttrs.GetIndexedFields()[k] == nil {
+				if searchAttrs == nil || searchAttrs.IndexedFields == nil {
+					searchAttrs = &commonpb.SearchAttributes{IndexedFields: map[string]*commonpb.Payload{}}
+				}
+				searchAttrs.IndexedFields[k] = v
+			}
 		}
 
 		// get workflow headers from the context
@@ -613,7 +630,7 @@ func convertToPBScheduleAction(ctx context.Context, client *WorkflowClient, sche
 					WorkflowTaskTimeout:      durationpb.New(action.WorkflowTaskTimeout),
 					RetryPolicy:              convertToPBRetryPolicy(action.RetryPolicy),
 					Memo:                     memo,
-					SearchAttributes:         searchAttr,
+					SearchAttributes:         searchAttrs,
 					Header:                   header,
 				},
 			},
@@ -624,7 +641,7 @@ func convertToPBScheduleAction(ctx context.Context, client *WorkflowClient, sche
 	}
 }
 
-func convertFromPBScheduleAction(action *schedulepb.ScheduleAction) (ScheduleAction, error) {
+func convertFromPBScheduleAction(logger log.Logger, action *schedulepb.ScheduleAction) (ScheduleAction, error) {
 	switch action := action.Action.(type) {
 	case *schedulepb.ScheduleAction_StartWorkflow:
 		workflow := action.StartWorkflow
@@ -639,9 +656,19 @@ func convertFromPBScheduleAction(action *schedulepb.ScheduleAction) (ScheduleAct
 			memos[key] = element
 		}
 
-		searchAttributes := make(map[string]interface{})
-		for key, element := range workflow.GetSearchAttributes().GetIndexedFields() {
-			searchAttributes[key] = element
+		searchAttrs := convertToTypeSearchAttributes(logger, workflow.GetSearchAttributes().GetIndexedFields())
+		// Create untyped list for any attribute not in the existing list
+		untypedSearchAttrs := map[string]*commonpb.Payload{}
+		for k, v := range workflow.GetSearchAttributes().GetIndexedFields() {
+			var inTyped bool
+			for typedKey := range searchAttrs.untypedValue {
+				if inTyped = typedKey.GetName() == k; inTyped {
+					break
+				}
+			}
+			if !inTyped {
+				untypedSearchAttrs[k] = v
+			}
 		}
 
 		return &ScheduleWorkflowAction{
@@ -654,7 +681,8 @@ func convertFromPBScheduleAction(action *schedulepb.ScheduleAction) (ScheduleAct
 			WorkflowTaskTimeout:      workflow.GetWorkflowTaskTimeout().AsDuration(),
 			RetryPolicy:              convertFromPBRetryPolicy(workflow.RetryPolicy),
 			Memo:                     memos,
-			SearchAttributes:         searchAttributes,
+			TypedSearchAttributes:    searchAttrs,
+			UntypedSearchAttributes:  untypedSearchAttrs,
 		}, nil
 	default:
 		// TODO maybe just panic instead?

--- a/internal/internal_schedule_client.go
+++ b/internal/internal_schedule_client.go
@@ -656,7 +656,7 @@ func convertFromPBScheduleAction(logger log.Logger, action *schedulepb.ScheduleA
 			memos[key] = element
 		}
 
-		searchAttrs := convertToTypeSearchAttributes(logger, workflow.GetSearchAttributes().GetIndexedFields())
+		searchAttrs := convertToTypedSearchAttributes(logger, workflow.GetSearchAttributes().GetIndexedFields())
 		// Create untyped list for any attribute not in the existing list
 		untypedSearchAttrs := map[string]*commonpb.Payload{}
 		for k, v := range workflow.GetSearchAttributes().GetIndexedFields() {

--- a/internal/internal_search_attributes.go
+++ b/internal/internal_search_attributes.go
@@ -1,0 +1,365 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package internal
+
+import (
+	"reflect"
+	"time"
+
+	enumspb "go.temporal.io/api/enums/v1"
+)
+
+type (
+	// SearchAttributes represents a collection of typed search attributes
+	SearchAttributes struct {
+		untypedValue map[SearchAttributeKey]interface{}
+	}
+
+	// SearchAttributeUpdate represents a change to SearchAttributes
+	SearchAttributeUpdate func(*SearchAttributes)
+
+	// SearchAttributeKey represents a typed search attribute key.
+	SearchAttributeKey interface {
+		// GetName of the search attribute.
+		GetName() string
+		// GetValueType of the search attribute.
+		GetValueType() enumspb.IndexedValueType
+		// GetReflectType of the search attribute.
+		GetReflectType() reflect.Type
+	}
+
+	baseSearchAttributeKey struct {
+		name        string
+		valueType   enumspb.IndexedValueType
+		reflectType reflect.Type
+	}
+
+	// SearchAttributeKeyString represents a search attribute key for a text attribute type
+	SearchAttributeKeyString struct {
+		baseSearchAttributeKey
+	}
+
+	// SearchAttributeKeyString represents a search attribute key for a keyword attribute type
+	SearchAttributeKeyword struct {
+		baseSearchAttributeKey
+	}
+
+	// SearchAttributeKeyBool represents a search attribute key for a boolean attribute type
+	SearchAttributeKeyBool struct {
+		baseSearchAttributeKey
+	}
+
+	// SearchAttributeKeyInt64 represents a search attribute key for a integer attribute type
+	SearchAttributeKeyInt64 struct {
+		baseSearchAttributeKey
+	}
+
+	// SearchAttributeKeyFloat64 represents a search attribute key for a float attribute type
+	SearchAttributeKeyFloat64 struct {
+		baseSearchAttributeKey
+	}
+
+	// SearchAttributeKeyTime represents a search attribute key for a date time attribute type
+	SearchAttributeKeyTime struct {
+		baseSearchAttributeKey
+	}
+
+	// SearchAttributeKeywordList represents a search attribute key for a list of keyword attribute type
+	SearchAttributeKeywordList struct {
+		baseSearchAttributeKey
+	}
+)
+
+func (bk baseSearchAttributeKey) GetName() string {
+	return bk.name
+}
+
+func (bk baseSearchAttributeKey) GetValueType() enumspb.IndexedValueType {
+	return bk.valueType
+}
+
+func (bk baseSearchAttributeKey) GetReflectType() reflect.Type {
+	return bk.reflectType
+}
+
+func NewSearchAttributeKeyString(name string) SearchAttributeKeyString {
+	return SearchAttributeKeyString{
+		baseSearchAttributeKey: baseSearchAttributeKey{
+			name:        name,
+			valueType:   enumspb.INDEXED_VALUE_TYPE_TEXT,
+			reflectType: reflect.TypeOf(""),
+		},
+	}
+}
+
+func (k SearchAttributeKeyString) ValueSet(value string) SearchAttributeUpdate {
+	return func(sa *SearchAttributes) {
+		sa.untypedValue[k] = value
+	}
+}
+
+func (k SearchAttributeKeyString) ValueUnset() SearchAttributeUpdate {
+	return func(sa *SearchAttributes) {
+		sa.untypedValue[k] = nil
+	}
+}
+
+func NewSearchAttributeKeyword(name string) SearchAttributeKeyword {
+	return SearchAttributeKeyword{
+		baseSearchAttributeKey: baseSearchAttributeKey{
+			name:        name,
+			valueType:   enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+			reflectType: reflect.TypeOf(""),
+		},
+	}
+}
+
+func (k SearchAttributeKeyword) ValueSet(value string) SearchAttributeUpdate {
+	return func(sa *SearchAttributes) {
+		sa.untypedValue[k] = value
+	}
+}
+
+func (k SearchAttributeKeyword) ValueUnset() SearchAttributeUpdate {
+	return func(sa *SearchAttributes) {
+		sa.untypedValue[k] = nil
+	}
+}
+
+func NewSearchAttributeKeyBool(name string) SearchAttributeKeyBool {
+	return SearchAttributeKeyBool{
+		baseSearchAttributeKey: baseSearchAttributeKey{
+			name:        name,
+			valueType:   enumspb.INDEXED_VALUE_TYPE_BOOL,
+			reflectType: reflect.TypeOf(false),
+		},
+	}
+}
+
+func (k SearchAttributeKeyBool) ValueSet(value bool) SearchAttributeUpdate {
+	return func(sa *SearchAttributes) {
+		sa.untypedValue[k] = value
+	}
+}
+
+func (k SearchAttributeKeyBool) ValueUnset() SearchAttributeUpdate {
+	return func(sa *SearchAttributes) {
+		sa.untypedValue[k] = nil
+	}
+}
+
+func NewSearchAttributeKeyInt64(name string) SearchAttributeKeyInt64 {
+	return SearchAttributeKeyInt64{
+		baseSearchAttributeKey: baseSearchAttributeKey{
+			name:        name,
+			valueType:   enumspb.INDEXED_VALUE_TYPE_INT,
+			reflectType: reflect.TypeOf(int64(0)),
+		},
+	}
+}
+
+func (k SearchAttributeKeyInt64) ValueSet(value int64) SearchAttributeUpdate {
+	return func(sa *SearchAttributes) {
+		sa.untypedValue[k] = value
+	}
+}
+
+func (k SearchAttributeKeyInt64) ValueUnset() SearchAttributeUpdate {
+	return func(sa *SearchAttributes) {
+		sa.untypedValue[k] = nil
+	}
+}
+
+func NewSearchAttributeKeyFloat64(name string) SearchAttributeKeyFloat64 {
+	return SearchAttributeKeyFloat64{
+		baseSearchAttributeKey: baseSearchAttributeKey{
+			name:        name,
+			valueType:   enumspb.INDEXED_VALUE_TYPE_DOUBLE,
+			reflectType: reflect.TypeOf(float64(0)),
+		},
+	}
+}
+
+func (k SearchAttributeKeyFloat64) ValueSet(value float64) SearchAttributeUpdate {
+	return func(sa *SearchAttributes) {
+		sa.untypedValue[k] = value
+	}
+}
+
+func (k SearchAttributeKeyFloat64) ValueUnset() SearchAttributeUpdate {
+	return func(sa *SearchAttributes) {
+		sa.untypedValue[k] = nil
+	}
+}
+
+func NewSearchAttributeKeyTime(name string) SearchAttributeKeyTime {
+	return SearchAttributeKeyTime{
+		baseSearchAttributeKey: baseSearchAttributeKey{
+			name:        name,
+			valueType:   enumspb.INDEXED_VALUE_TYPE_DATETIME,
+			reflectType: reflect.TypeOf(time.Time{}),
+		},
+	}
+}
+
+func (k SearchAttributeKeyTime) ValueSet(value time.Time) SearchAttributeUpdate {
+	return func(sa *SearchAttributes) {
+		sa.untypedValue[k] = value
+	}
+}
+
+func (k SearchAttributeKeyTime) ValueUnset() SearchAttributeUpdate {
+	return func(sa *SearchAttributes) {
+		sa.untypedValue[k] = nil
+	}
+}
+
+func NewSearchAttributeKeywordList(name string) SearchAttributeKeywordList {
+	return SearchAttributeKeywordList{
+		baseSearchAttributeKey: baseSearchAttributeKey{
+			name:        name,
+			valueType:   enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST,
+			reflectType: reflect.TypeOf([]string{}),
+		},
+	}
+}
+
+func (k SearchAttributeKeywordList) ValueSet(values []string) SearchAttributeUpdate {
+	listCopy := append([]string(nil), values...)
+	return func(sa *SearchAttributes) {
+		sa.untypedValue[k] = listCopy
+	}
+}
+
+func (k SearchAttributeKeywordList) ValueUnset() SearchAttributeUpdate {
+	return func(sa *SearchAttributes) {
+		sa.untypedValue[k] = nil
+	}
+}
+
+func NewSearchAttributes(attributes ...SearchAttributeUpdate) SearchAttributes {
+	sa := SearchAttributes{
+		untypedValue: make(map[SearchAttributeKey]interface{}),
+	}
+	for _, attr := range attributes {
+		attr(&sa)
+	}
+	// remove nil values
+	for key, value := range sa.untypedValue {
+		if value == nil {
+			delete(sa.untypedValue, key)
+		}
+	}
+	return sa
+}
+
+func (sa *SearchAttributes) GetString(key SearchAttributeKeyString) (string, bool) {
+	value, ok := sa.untypedValue[key]
+	if !ok {
+		return "", false
+	}
+	return value.(string), true
+}
+
+func (sa *SearchAttributes) GetKeyword(key SearchAttributeKeyword) (string, bool) {
+	value, ok := sa.untypedValue[key]
+	if !ok {
+		return "", false
+	}
+	return value.(string), true
+}
+
+func (sa *SearchAttributes) GetBool(key SearchAttributeKeyBool) (bool, bool) {
+	value, ok := sa.untypedValue[key]
+	if !ok {
+		return false, false
+	}
+	return value.(bool), true
+}
+
+func (sa *SearchAttributes) GetInt(key SearchAttributeKeyInt64) (int64, bool) {
+	value, ok := sa.untypedValue[key]
+	if !ok {
+		return 0, false
+	}
+	return value.(int64), true
+}
+
+func (sa *SearchAttributes) GetFloat(key SearchAttributeKeyFloat64) (float64, bool) {
+	value, ok := sa.untypedValue[key]
+	if !ok {
+		return 0.0, false
+	}
+	return value.(float64), true
+}
+
+func (sa *SearchAttributes) GetTime(key SearchAttributeKeyTime) (time.Time, bool) {
+	value, ok := sa.untypedValue[key]
+	if !ok {
+		return time.Time{}, false
+	}
+	return value.(time.Time), true
+}
+
+func (sa *SearchAttributes) GetKeywordList(key SearchAttributeKeywordList) ([]string, bool) {
+	value, ok := sa.untypedValue[key]
+	if !ok {
+		return nil, false
+	}
+	result := value.([]string)
+	// Return a copy to prevent caller from mutating the underlying value
+	return append([]string(nil), result...), true
+}
+
+func (sa *SearchAttributes) ContainsKey(key SearchAttributeKey) bool {
+	_, ok := sa.untypedValue[key]
+	return ok
+}
+
+func (sa *SearchAttributes) Size() int {
+	return len(sa.untypedValue)
+}
+
+func (sa *SearchAttributes) GetUntypedValues() map[SearchAttributeKey]interface{} {
+	untypedValueCopy := make(map[SearchAttributeKey]interface{}, len(sa.untypedValue))
+	for key, value := range sa.untypedValue {
+		switch v := value.(type) {
+		case []string:
+			untypedValueCopy[key] = append([]string(nil), v...)
+		default:
+			untypedValueCopy[key] = v
+		}
+	}
+	return untypedValueCopy
+}
+
+func (sa *SearchAttributes) Copy() SearchAttributeUpdate {
+	return func(s *SearchAttributes) {
+		untypedValues := sa.GetUntypedValues()
+		for key, value := range untypedValues {
+			s.untypedValue[key] = value
+		}
+	}
+}

--- a/internal/internal_search_attributes.go
+++ b/internal/internal_search_attributes.go
@@ -25,10 +25,14 @@
 package internal
 
 import (
+	"fmt"
 	"reflect"
 	"time"
 
+	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/sdk/converter"
+	"go.temporal.io/sdk/log"
 )
 
 type (
@@ -56,50 +60,53 @@ type (
 		reflectType reflect.Type
 	}
 
-	// SearchAttributeKeyString represents a search attribute key for a text attribute type
+	// SearchAttributeKeyString represents a search attribute key for a text attribute type.
 	SearchAttributeKeyString struct {
 		baseSearchAttributeKey
 	}
 
-	// SearchAttributeKeyString represents a search attribute key for a keyword attribute type
-	SearchAttributeKeyword struct {
+	// SearchAttributeKeyKeyword represents a search attribute key for a keyword attribute type.
+	SearchAttributeKeyKeyword struct {
 		baseSearchAttributeKey
 	}
 
-	// SearchAttributeKeyBool represents a search attribute key for a boolean attribute type
+	// SearchAttributeKeyBool represents a search attribute key for a boolean attribute type.
 	SearchAttributeKeyBool struct {
 		baseSearchAttributeKey
 	}
 
-	// SearchAttributeKeyInt64 represents a search attribute key for a integer attribute type
+	// SearchAttributeKeyInt64 represents a search attribute key for a integer attribute type.
 	SearchAttributeKeyInt64 struct {
 		baseSearchAttributeKey
 	}
 
-	// SearchAttributeKeyFloat64 represents a search attribute key for a float attribute type
+	// SearchAttributeKeyFloat64 represents a search attribute key for a float attribute type.
 	SearchAttributeKeyFloat64 struct {
 		baseSearchAttributeKey
 	}
 
-	// SearchAttributeKeyTime represents a search attribute key for a date time attribute type
+	// SearchAttributeKeyTime represents a search attribute key for a date time attribute type.
 	SearchAttributeKeyTime struct {
 		baseSearchAttributeKey
 	}
 
-	// SearchAttributeKeywordList represents a search attribute key for a list of keyword attribute type
-	SearchAttributeKeywordList struct {
+	// SearchAttributeKeyKeywordList represents a search attribute key for a list of keyword attribute type.
+	SearchAttributeKeyKeywordList struct {
 		baseSearchAttributeKey
 	}
 )
 
+// GetName of the search attribute.
 func (bk baseSearchAttributeKey) GetName() string {
 	return bk.name
 }
 
+// GetValueType of the search attribute.
 func (bk baseSearchAttributeKey) GetValueType() enumspb.IndexedValueType {
 	return bk.valueType
 }
 
+// GetReflectType of the search attribute.
 func (bk baseSearchAttributeKey) GetReflectType() reflect.Type {
 	return bk.reflectType
 }
@@ -114,20 +121,22 @@ func NewSearchAttributeKeyString(name string) SearchAttributeKeyString {
 	}
 }
 
+// ValueSet creates an update to set the value of the attribute.
 func (k SearchAttributeKeyString) ValueSet(value string) SearchAttributeUpdate {
 	return func(sa *SearchAttributes) {
 		sa.untypedValue[k] = value
 	}
 }
 
+// ValueUnset creates an update to remove the attribute.
 func (k SearchAttributeKeyString) ValueUnset() SearchAttributeUpdate {
 	return func(sa *SearchAttributes) {
 		sa.untypedValue[k] = nil
 	}
 }
 
-func NewSearchAttributeKeyword(name string) SearchAttributeKeyword {
-	return SearchAttributeKeyword{
+func NewSearchAttributeKeyKeyword(name string) SearchAttributeKeyKeyword {
+	return SearchAttributeKeyKeyword{
 		baseSearchAttributeKey: baseSearchAttributeKey{
 			name:        name,
 			valueType:   enumspb.INDEXED_VALUE_TYPE_KEYWORD,
@@ -136,13 +145,15 @@ func NewSearchAttributeKeyword(name string) SearchAttributeKeyword {
 	}
 }
 
-func (k SearchAttributeKeyword) ValueSet(value string) SearchAttributeUpdate {
+// ValueSet creates an update to set the value of the attribute.
+func (k SearchAttributeKeyKeyword) ValueSet(value string) SearchAttributeUpdate {
 	return func(sa *SearchAttributes) {
 		sa.untypedValue[k] = value
 	}
 }
 
-func (k SearchAttributeKeyword) ValueUnset() SearchAttributeUpdate {
+// ValueUnset creates an update to remove the attribute.
+func (k SearchAttributeKeyKeyword) ValueUnset() SearchAttributeUpdate {
 	return func(sa *SearchAttributes) {
 		sa.untypedValue[k] = nil
 	}
@@ -158,12 +169,14 @@ func NewSearchAttributeKeyBool(name string) SearchAttributeKeyBool {
 	}
 }
 
+// ValueSet creates an update to set the value of the attribute.
 func (k SearchAttributeKeyBool) ValueSet(value bool) SearchAttributeUpdate {
 	return func(sa *SearchAttributes) {
 		sa.untypedValue[k] = value
 	}
 }
 
+// ValueUnset creates an update to remove the attribute.
 func (k SearchAttributeKeyBool) ValueUnset() SearchAttributeUpdate {
 	return func(sa *SearchAttributes) {
 		sa.untypedValue[k] = nil
@@ -180,12 +193,14 @@ func NewSearchAttributeKeyInt64(name string) SearchAttributeKeyInt64 {
 	}
 }
 
+// ValueSet creates an update to set the value of the attribute.
 func (k SearchAttributeKeyInt64) ValueSet(value int64) SearchAttributeUpdate {
 	return func(sa *SearchAttributes) {
 		sa.untypedValue[k] = value
 	}
 }
 
+// ValueUnset creates an update to remove the attribute.
 func (k SearchAttributeKeyInt64) ValueUnset() SearchAttributeUpdate {
 	return func(sa *SearchAttributes) {
 		sa.untypedValue[k] = nil
@@ -202,12 +217,14 @@ func NewSearchAttributeKeyFloat64(name string) SearchAttributeKeyFloat64 {
 	}
 }
 
+// ValueSet creates an update to set the value of the attribute.
 func (k SearchAttributeKeyFloat64) ValueSet(value float64) SearchAttributeUpdate {
 	return func(sa *SearchAttributes) {
 		sa.untypedValue[k] = value
 	}
 }
 
+// ValueUnset creates an update to remove the attribute.
 func (k SearchAttributeKeyFloat64) ValueUnset() SearchAttributeUpdate {
 	return func(sa *SearchAttributes) {
 		sa.untypedValue[k] = nil
@@ -224,20 +241,22 @@ func NewSearchAttributeKeyTime(name string) SearchAttributeKeyTime {
 	}
 }
 
+// ValueSet creates an update to set the value of the attribute.
 func (k SearchAttributeKeyTime) ValueSet(value time.Time) SearchAttributeUpdate {
 	return func(sa *SearchAttributes) {
 		sa.untypedValue[k] = value
 	}
 }
 
+// ValueUnset creates an update to remove the attribute.
 func (k SearchAttributeKeyTime) ValueUnset() SearchAttributeUpdate {
 	return func(sa *SearchAttributes) {
 		sa.untypedValue[k] = nil
 	}
 }
 
-func NewSearchAttributeKeywordList(name string) SearchAttributeKeywordList {
-	return SearchAttributeKeywordList{
+func NewSearchAttributeKeyKeywordList(name string) SearchAttributeKeyKeywordList {
+	return SearchAttributeKeyKeywordList{
 		baseSearchAttributeKey: baseSearchAttributeKey{
 			name:        name,
 			valueType:   enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST,
@@ -246,14 +265,16 @@ func NewSearchAttributeKeywordList(name string) SearchAttributeKeywordList {
 	}
 }
 
-func (k SearchAttributeKeywordList) ValueSet(values []string) SearchAttributeUpdate {
+// ValueSet creates an update to set the value of the attribute.
+func (k SearchAttributeKeyKeywordList) ValueSet(values []string) SearchAttributeUpdate {
 	listCopy := append([]string(nil), values...)
 	return func(sa *SearchAttributes) {
 		sa.untypedValue[k] = listCopy
 	}
 }
 
-func (k SearchAttributeKeywordList) ValueUnset() SearchAttributeUpdate {
+// ValueUnset creates an update to remove the attribute.
+func (k SearchAttributeKeyKeywordList) ValueUnset() SearchAttributeUpdate {
 	return func(sa *SearchAttributes) {
 		sa.untypedValue[k] = nil
 	}
@@ -275,6 +296,7 @@ func NewSearchAttributes(attributes ...SearchAttributeUpdate) SearchAttributes {
 	return sa
 }
 
+// GetString gets a value for the given key and whether it was present.
 func (sa *SearchAttributes) GetString(key SearchAttributeKeyString) (string, bool) {
 	value, ok := sa.untypedValue[key]
 	if !ok {
@@ -283,7 +305,8 @@ func (sa *SearchAttributes) GetString(key SearchAttributeKeyString) (string, boo
 	return value.(string), true
 }
 
-func (sa *SearchAttributes) GetKeyword(key SearchAttributeKeyword) (string, bool) {
+// GetKeyword gets a value for the given key and whether it was present.
+func (sa *SearchAttributes) GetKeyword(key SearchAttributeKeyKeyword) (string, bool) {
 	value, ok := sa.untypedValue[key]
 	if !ok {
 		return "", false
@@ -291,6 +314,7 @@ func (sa *SearchAttributes) GetKeyword(key SearchAttributeKeyword) (string, bool
 	return value.(string), true
 }
 
+// GetBool gets a value for the given key and whether it was present.
 func (sa *SearchAttributes) GetBool(key SearchAttributeKeyBool) (bool, bool) {
 	value, ok := sa.untypedValue[key]
 	if !ok {
@@ -299,7 +323,8 @@ func (sa *SearchAttributes) GetBool(key SearchAttributeKeyBool) (bool, bool) {
 	return value.(bool), true
 }
 
-func (sa *SearchAttributes) GetInt(key SearchAttributeKeyInt64) (int64, bool) {
+// GetInt64 gets a value for the given key and whether it was present.
+func (sa *SearchAttributes) GetInt64(key SearchAttributeKeyInt64) (int64, bool) {
 	value, ok := sa.untypedValue[key]
 	if !ok {
 		return 0, false
@@ -307,7 +332,8 @@ func (sa *SearchAttributes) GetInt(key SearchAttributeKeyInt64) (int64, bool) {
 	return value.(int64), true
 }
 
-func (sa *SearchAttributes) GetFloat(key SearchAttributeKeyFloat64) (float64, bool) {
+// GetFloat64 gets a value for the given key and whether it was present.
+func (sa *SearchAttributes) GetFloat64(key SearchAttributeKeyFloat64) (float64, bool) {
 	value, ok := sa.untypedValue[key]
 	if !ok {
 		return 0.0, false
@@ -315,6 +341,7 @@ func (sa *SearchAttributes) GetFloat(key SearchAttributeKeyFloat64) (float64, bo
 	return value.(float64), true
 }
 
+// GetTime gets a value for the given key and whether it was present.
 func (sa *SearchAttributes) GetTime(key SearchAttributeKeyTime) (time.Time, bool) {
 	value, ok := sa.untypedValue[key]
 	if !ok {
@@ -323,7 +350,8 @@ func (sa *SearchAttributes) GetTime(key SearchAttributeKeyTime) (time.Time, bool
 	return value.(time.Time), true
 }
 
-func (sa *SearchAttributes) GetKeywordList(key SearchAttributeKeywordList) ([]string, bool) {
+// GetKeywordList gets a value for the given key and whether it was present.
+func (sa *SearchAttributes) GetKeywordList(key SearchAttributeKeyKeywordList) ([]string, bool) {
 	value, ok := sa.untypedValue[key]
 	if !ok {
 		return nil, false
@@ -333,15 +361,18 @@ func (sa *SearchAttributes) GetKeywordList(key SearchAttributeKeywordList) ([]st
 	return append([]string(nil), result...), true
 }
 
+// ContainsKey gets whether a key is present.
 func (sa *SearchAttributes) ContainsKey(key SearchAttributeKey) bool {
 	_, ok := sa.untypedValue[key]
 	return ok
 }
 
+// Size gets the size of the attribute collection.
 func (sa *SearchAttributes) Size() int {
 	return len(sa.untypedValue)
 }
 
+// GetUntypedValues gets a copy of the collection with raw types.
 func (sa *SearchAttributes) GetUntypedValues() map[SearchAttributeKey]interface{} {
 	untypedValueCopy := make(map[SearchAttributeKey]interface{}, len(sa.untypedValue))
 	for key, value := range sa.untypedValue {
@@ -355,6 +386,7 @@ func (sa *SearchAttributes) GetUntypedValues() map[SearchAttributeKey]interface{
 	return untypedValueCopy
 }
 
+// Copy creates an update that copies existing values.
 func (sa *SearchAttributes) Copy() SearchAttributeUpdate {
 	return func(s *SearchAttributes) {
 		untypedValues := sa.GetUntypedValues()
@@ -362,4 +394,142 @@ func (sa *SearchAttributes) Copy() SearchAttributeUpdate {
 			s.untypedValue[key] = value
 		}
 	}
+}
+
+func serializeUntypedSearchAttributes(input map[string]interface{}) (*commonpb.SearchAttributes, error) {
+	if input == nil {
+		return nil, nil
+	}
+
+	attr := make(map[string]*commonpb.Payload)
+	for k, v := range input {
+		// If search attribute value is already of Payload type, then use it directly.
+		// This allows to copy search attributes from workflow info to child workflow options.
+		if vp, ok := v.(*commonpb.Payload); ok {
+			attr[k] = vp
+			continue
+		}
+		var err error
+		attr[k], err = converter.GetDefaultDataConverter().ToPayload(v)
+		if err != nil {
+			return nil, fmt.Errorf("encode search attribute [%s] error: %v", k, err)
+		}
+	}
+	return &commonpb.SearchAttributes{IndexedFields: attr}, nil
+}
+
+func serializeTypedSearchAttributes(searchAttributes map[SearchAttributeKey]interface{}) (*commonpb.SearchAttributes, error) {
+	if searchAttributes == nil {
+		return nil, nil
+	}
+
+	serializedAttr := make(map[string]*commonpb.Payload)
+	for k, v := range searchAttributes {
+		payload, err := converter.GetDefaultDataConverter().ToPayload(v)
+		if err != nil {
+			return nil, fmt.Errorf("encode search attribute [%s] error: %v", k, err)
+		}
+		// Server does not remove search attributes if they set a type
+		if payload.GetData() != nil {
+			payload.Metadata["type"] = []byte(enumspb.IndexedValueType_name[int32(k.GetValueType())])
+		}
+		serializedAttr[k.GetName()] = payload
+	}
+	return &commonpb.SearchAttributes{IndexedFields: serializedAttr}, nil
+}
+
+func serializeSearchAttributes(
+	untypedAttributes map[string]interface{},
+	typedAttributes SearchAttributes,
+) (*commonpb.SearchAttributes, error) {
+	var searchAttr *commonpb.SearchAttributes
+	var err error
+	if untypedAttributes != nil && typedAttributes.Size() != 0 {
+		return nil, fmt.Errorf("cannot specify both SearchAttributes and TypedSearchAttributes")
+	} else if untypedAttributes != nil {
+		searchAttr, err = serializeUntypedSearchAttributes(untypedAttributes)
+		if err != nil {
+			return nil, err
+		}
+	} else if typedAttributes.Size() != 0 {
+		searchAttr, err = serializeTypedSearchAttributes(typedAttributes.GetUntypedValues())
+		if err != nil {
+			return nil, err
+		}
+	}
+	return searchAttr, nil
+}
+
+func getIndexValue(payload *commonpb.Payload) enumspb.IndexedValueType {
+	return enumspb.IndexedValueType(enumspb.IndexedValueType_value[string(payload.GetMetadata()["type"][:])])
+}
+
+func convertToTypeSearchAttributes(logger log.Logger, attributes map[string]*commonpb.Payload) SearchAttributes {
+	updates := make([]SearchAttributeUpdate, 0, len(attributes))
+	for key, payload := range attributes {
+		if payload.Data == nil {
+			continue
+		}
+		switch index := getIndexValue(payload); index {
+		case enumspb.INDEXED_VALUE_TYPE_BOOL:
+			attr := NewSearchAttributeKeyBool(key)
+			var value bool
+			err := converter.GetDefaultDataConverter().FromPayload(payload, &value)
+			if err != nil {
+				panic(err)
+			}
+			updates = append(updates, attr.ValueSet(value))
+		case enumspb.INDEXED_VALUE_TYPE_KEYWORD:
+			attr := NewSearchAttributeKeyKeyword(key)
+			var value string
+			err := converter.GetDefaultDataConverter().FromPayload(payload, &value)
+			if err != nil {
+				panic(err)
+			}
+			updates = append(updates, attr.ValueSet(value))
+		case enumspb.INDEXED_VALUE_TYPE_TEXT:
+			attr := NewSearchAttributeKeyString(key)
+			var value string
+			err := converter.GetDefaultDataConverter().FromPayload(payload, &value)
+			if err != nil {
+				panic(err)
+			}
+			updates = append(updates, attr.ValueSet(value))
+		case enumspb.INDEXED_VALUE_TYPE_INT:
+			attr := NewSearchAttributeKeyInt64(key)
+			var value int64
+			err := converter.GetDefaultDataConverter().FromPayload(payload, &value)
+			if err != nil {
+				panic(err)
+			}
+			updates = append(updates, attr.ValueSet(value))
+		case enumspb.INDEXED_VALUE_TYPE_DOUBLE:
+			attr := NewSearchAttributeKeyFloat64(key)
+			var value float64
+			err := converter.GetDefaultDataConverter().FromPayload(payload, &value)
+			if err != nil {
+				panic(err)
+			}
+			updates = append(updates, attr.ValueSet(value))
+		case enumspb.INDEXED_VALUE_TYPE_DATETIME:
+			attr := NewSearchAttributeKeyTime(key)
+			var value time.Time
+			err := converter.GetDefaultDataConverter().FromPayload(payload, &value)
+			if err != nil {
+				panic(err)
+			}
+			updates = append(updates, attr.ValueSet(value))
+		case enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST:
+			attr := NewSearchAttributeKeyKeywordList(key)
+			var value []string
+			err := converter.GetDefaultDataConverter().FromPayload(payload, &value)
+			if err != nil {
+				panic(err)
+			}
+			updates = append(updates, attr.ValueSet(value))
+		default:
+			logger.Warn("Unrecognized indexed value type on search attribute key", "key", key, "index", index)
+		}
+	}
+	return NewSearchAttributes(updates...)
 }

--- a/internal/internal_search_attributes_test.go
+++ b/internal/internal_search_attributes_test.go
@@ -46,11 +46,11 @@ func TestSearchAttributes(t *testing.T) {
 	require.Equal(t, 0, sa.Size())
 
 	stringKey := NewSearchAttributeKeyString("stringKey")
-	keywordKey := NewSearchAttributeKeyword("keywordKey")
+	keywordKey := NewSearchAttributeKeyKeyword("keywordKey")
 	intKey := NewSearchAttributeKeyInt64("intKey")
 	floatKey := NewSearchAttributeKeyFloat64("floatKey")
 	timeKey := NewSearchAttributeKeyTime("timeKey")
-	keywordListKey := NewSearchAttributeKeywordList("keywordListKey")
+	keywordListKey := NewSearchAttributeKeyKeywordList("keywordListKey")
 
 	now := time.Now()
 	sa = NewSearchAttributes(
@@ -78,12 +78,12 @@ func TestSearchAttributes(t *testing.T) {
 	require.True(t, ok)
 
 	require.True(t, sa.ContainsKey(intKey))
-	intValue, ok := sa.GetInt(intKey)
+	intValue, ok := sa.GetInt64(intKey)
 	require.Equal(t, int64(10), intValue)
 	require.True(t, ok)
 
 	require.True(t, sa.ContainsKey(floatKey))
-	floatValue, ok := sa.GetFloat(floatKey)
+	floatValue, ok := sa.GetFloat64(floatKey)
 	require.Equal(t, float64(5.4), floatValue)
 	require.True(t, ok)
 
@@ -134,9 +134,9 @@ func TestSearchAttributes(t *testing.T) {
 	require.Equal(t, 7, sa.Size())
 }
 
-func TestSearchAttributesKeyWordList(t *testing.T) {
+func TestSearchAttributesKeywordList(t *testing.T) {
 	t.Parallel()
-	kw := NewSearchAttributeKeywordList("keywordList")
+	kw := NewSearchAttributeKeyKeywordList("keywordList")
 	kv := []string{"keyword1", "keyword2", "keyword3"}
 	sa := NewSearchAttributes(kw.ValueSet(kv))
 	// Modify the list and verify it doesn't change the search attribute
@@ -156,7 +156,7 @@ func TestSearchAttributesKeyWordList(t *testing.T) {
 func TestSearchAttributesDeepCopy(t *testing.T) {
 	t.Parallel()
 	key1 := NewSearchAttributeKeyString("stringKey1")
-	key2 := NewSearchAttributeKeywordList("keywordList")
+	key2 := NewSearchAttributeKeyKeywordList("keywordList")
 	keywordListValue := []string{"keyword1", "keyword2", "keyword3"}
 	sa := NewSearchAttributes(
 		key1.ValueSet("value"),

--- a/internal/internal_search_attributes_test.go
+++ b/internal/internal_search_attributes_test.go
@@ -1,0 +1,179 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package internal
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSearchAttributes(t *testing.T) {
+	t.Parallel()
+	sa := NewSearchAttributes()
+	boolKey := NewSearchAttributeKeyBool("boolKey")
+
+	require.False(t, sa.ContainsKey(boolKey))
+	boolValue, ok := sa.GetBool(boolKey)
+	require.False(t, boolValue)
+	require.False(t, ok)
+
+	require.NotNil(t, sa.GetUntypedValues())
+	require.Equal(t, 0, len(sa.GetUntypedValues()))
+	require.Equal(t, 0, sa.Size())
+
+	stringKey := NewSearchAttributeKeyString("stringKey")
+	keywordKey := NewSearchAttributeKeyword("keywordKey")
+	intKey := NewSearchAttributeKeyInt64("intKey")
+	floatKey := NewSearchAttributeKeyFloat64("floatKey")
+	timeKey := NewSearchAttributeKeyTime("timeKey")
+	keywordListKey := NewSearchAttributeKeywordList("keywordListKey")
+
+	now := time.Now()
+	sa = NewSearchAttributes(
+		boolKey.ValueSet(true),
+		stringKey.ValueSet("string"),
+		keywordKey.ValueSet("keyword"),
+		intKey.ValueSet(10),
+		floatKey.ValueSet(5.4),
+		timeKey.ValueSet(now),
+		keywordListKey.ValueSet([]string{"value1", "value2"}),
+	)
+	require.True(t, sa.ContainsKey(boolKey))
+	boolValue, ok = sa.GetBool(boolKey)
+	require.True(t, boolValue)
+	require.True(t, ok)
+
+	require.True(t, sa.ContainsKey(stringKey))
+	stringValue, ok := sa.GetString(stringKey)
+	require.Equal(t, "string", stringValue)
+	require.True(t, ok)
+
+	require.True(t, sa.ContainsKey(keywordKey))
+	keywordValue, ok := sa.GetKeyword(keywordKey)
+	require.Equal(t, "keyword", keywordValue)
+	require.True(t, ok)
+
+	require.True(t, sa.ContainsKey(intKey))
+	intValue, ok := sa.GetInt(intKey)
+	require.Equal(t, int64(10), intValue)
+	require.True(t, ok)
+
+	require.True(t, sa.ContainsKey(floatKey))
+	floatValue, ok := sa.GetFloat(floatKey)
+	require.Equal(t, float64(5.4), floatValue)
+	require.True(t, ok)
+
+	require.True(t, sa.ContainsKey(timeKey))
+	timeValue, ok := sa.GetTime(timeKey)
+	require.Equal(t, now, timeValue)
+	require.True(t, ok)
+
+	require.True(t, sa.ContainsKey(keywordListKey))
+	keywordListValue, ok := sa.GetKeywordList(keywordListKey)
+	require.Equal(t, []string{"value1", "value2"}, keywordListValue)
+	require.True(t, ok)
+
+	require.NotNil(t, sa.GetUntypedValues())
+	require.Equal(t, 7, len(sa.GetUntypedValues()))
+	require.Equal(t, 7, sa.Size())
+	// Verify copy and delete behaviors
+	stringKey2 := NewSearchAttributeKeyString("otherStringKey")
+
+	sa = NewSearchAttributes(
+		sa.Copy(),
+		boolKey.ValueUnset(),
+		stringKey2.ValueSet("other string"),
+	)
+
+	require.False(t, sa.ContainsKey(boolKey))
+	boolValue, ok = sa.GetBool(boolKey)
+	require.False(t, boolValue)
+	require.False(t, ok)
+
+	require.True(t, sa.ContainsKey(stringKey))
+	stringValue, ok = sa.GetString(stringKey)
+	require.True(t, ok)
+	require.Equal(t, "string", stringValue)
+
+	require.True(t, sa.ContainsKey(stringKey2))
+	stringValue, ok = sa.GetString(stringKey2)
+	require.Equal(t, "other string", stringValue)
+	require.True(t, ok)
+
+	require.True(t, sa.ContainsKey(keywordKey))
+	keywordValue, ok = sa.GetKeyword(keywordKey)
+	require.Equal(t, "keyword", keywordValue)
+	require.True(t, ok)
+
+	require.NotNil(t, sa.GetUntypedValues())
+	require.Equal(t, 7, len(sa.GetUntypedValues()))
+	require.Equal(t, 7, sa.Size())
+}
+
+func TestSearchAttributesKeyWordList(t *testing.T) {
+	t.Parallel()
+	kw := NewSearchAttributeKeywordList("keywordList")
+	kv := []string{"keyword1", "keyword2", "keyword3"}
+	sa := NewSearchAttributes(kw.ValueSet(kv))
+	// Modify the list and verify it doesn't change the search attribute
+	kv[0] = ""
+	require.Equal(t, 1, sa.Size())
+	values, ok := sa.GetKeywordList(kw)
+	require.True(t, ok)
+	require.Equal(t, []string{"keyword1", "keyword2", "keyword3"}, values)
+	// Modify the return value and verify it doesn't change the
+	// underlying value in the search attribute
+	values[0] = ""
+	values2, ok := sa.GetKeywordList(kw)
+	require.True(t, ok)
+	require.Equal(t, []string{"keyword1", "keyword2", "keyword3"}, values2)
+}
+
+func TestSearchAttributesDeepCopy(t *testing.T) {
+	t.Parallel()
+	key1 := NewSearchAttributeKeyString("stringKey1")
+	key2 := NewSearchAttributeKeywordList("keywordList")
+	keywordListValue := []string{"keyword1", "keyword2", "keyword3"}
+	sa := NewSearchAttributes(
+		key1.ValueSet("value"),
+		key2.ValueSet(keywordListValue),
+		NewSearchAttributeKeyString("stringKey2").ValueSet("value"),
+		NewSearchAttributeKeyString("stringKey3").ValueSet("value"),
+	)
+	// Modify the untyped map and show it doesn't effect the search attribute
+	untypedValues := sa.GetUntypedValues()
+	untypedValues[key1] = "new value"
+	value, ok := sa.GetString(key1)
+	require.True(t, ok)
+	require.Equal(t, "value", value)
+	// Test with a slice as well
+	keywordList := untypedValues[key2].([]string)
+	keywordList[0] = ""
+	keywordListSA, ok := sa.GetKeywordList(key2)
+	require.True(t, ok)
+	require.Equal(t, []string{"keyword1", "keyword2", "keyword3"}, keywordListSA)
+}

--- a/internal/internal_worker_base.go
+++ b/internal/internal_worker_base.go
@@ -86,6 +86,7 @@ type (
 		SideEffect(f func() (*commonpb.Payloads, error), callback ResultHandler)
 		GetVersion(changeID string, minSupported, maxSupported Version) Version
 		WorkflowInfo() *WorkflowInfo
+		TypedSearchAttributes() SearchAttributes
 		Complete(result *commonpb.Payloads, err error)
 		RegisterCancelHandler(handler func())
 		RequestCancelChildWorkflow(namespace, workflowID string)

--- a/internal/internal_workflow.go
+++ b/internal/internal_workflow.go
@@ -200,6 +200,7 @@ type (
 		ContextPropagators       []ContextPropagator
 		Memo                     map[string]interface{}
 		SearchAttributes         map[string]interface{}
+		TypedSearchAttributes    SearchAttributes
 		ParentClosePolicy        enumspb.ParentClosePolicy
 		signalChannels           map[string]Channel
 		queryHandlers            map[string]*queryHandler
@@ -279,7 +280,7 @@ var _ WaitGroup = (*waitGroupImpl)(nil)
 var _ dispatcher = (*dispatcherImpl)(nil)
 
 // 1MB buffer to fit combined stack trace of all active goroutines
-var stackBuf [1024*1024]byte
+var stackBuf [1024 * 1024]byte
 
 var (
 	errCoroStackNotFound   = errors.New("coroutine stack not found")

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -1450,67 +1450,6 @@ func getWorkflowMemo(input map[string]interface{}, dc converter.DataConverter) (
 	return &commonpb.Memo{Fields: memo}, nil
 }
 
-func serializeSearchAttributes(input map[string]interface{}) (*commonpb.SearchAttributes, error) {
-	if input == nil {
-		return nil, nil
-	}
-
-	attr := make(map[string]*commonpb.Payload)
-	for k, v := range input {
-		// If search attribute value is already of Payload type, then use it directly.
-		// This allows to copy search attributes from workflow info to child workflow options.
-		if vp, ok := v.(*commonpb.Payload); ok {
-			attr[k] = vp
-			continue
-		}
-		var err error
-		attr[k], err = converter.GetDefaultDataConverter().ToPayload(v)
-		if err != nil {
-			return nil, fmt.Errorf("encode search attribute [%s] error: %v", k, err)
-		}
-	}
-	return &commonpb.SearchAttributes{IndexedFields: attr}, nil
-}
-
-func serializeTypedSearchAttributes(searchAttributes map[SearchAttributeKey]interface{}) (*commonpb.SearchAttributes, error) {
-	if searchAttributes == nil {
-		return nil, nil
-	}
-
-	serializedAttr := make(map[string]*commonpb.Payload)
-	for k, v := range searchAttributes {
-		payload, err := converter.GetDefaultDataConverter().ToPayload(v)
-		if err != nil {
-			return nil, fmt.Errorf("encode search attribute [%s] error: %v", k, err)
-		}
-		// Server does not remove search attributes if they set a type
-		if payload.GetData() != nil {
-			payload.Metadata["type"] = []byte(enumspb.IndexedValueType_name[int32(k.GetValueType())])
-		}
-		serializedAttr[k.GetName()] = payload
-	}
-	return &commonpb.SearchAttributes{IndexedFields: serializedAttr}, nil
-}
-
-func GetSearchAttributes(untypedAttributes map[string]interface{}, typedAttributes SearchAttributes) (*commonpb.SearchAttributes, error) {
-	var searchAttr *commonpb.SearchAttributes
-	var err error
-	if untypedAttributes != nil && typedAttributes.Size() != 0 {
-		return nil, fmt.Errorf("cannot specify both SearchAttributes and TypedSearchAttributes")
-	} else if untypedAttributes != nil {
-		searchAttr, err = serializeSearchAttributes(untypedAttributes)
-		if err != nil {
-			return nil, err
-		}
-	} else if typedAttributes.Size() != 0 {
-		searchAttr, err = serializeTypedSearchAttributes(typedAttributes.GetUntypedValues())
-		if err != nil {
-			return nil, err
-		}
-	}
-	return searchAttr, nil
-}
-
 type workflowClientInterceptor struct {
 	client *WorkflowClient
 }
@@ -1545,7 +1484,7 @@ func (w *workflowClientInterceptor) ExecuteWorkflow(
 		return nil, err
 	}
 
-	searchAttr, err := GetSearchAttributes(in.Options.SearchAttributes, in.Options.TypedSearchAttributes)
+	searchAttr, err := serializeSearchAttributes(in.Options.SearchAttributes, in.Options.TypedSearchAttributes)
 	if err != nil {
 		return nil, err
 	}
@@ -1686,7 +1625,7 @@ func (w *workflowClientInterceptor) SignalWithStartWorkflow(
 		return nil, err
 	}
 
-	searchAttr, err := serializeSearchAttributes(in.Options.SearchAttributes)
+	searchAttr, err := serializeUntypedSearchAttributes(in.Options.SearchAttributes)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/internal_workflow_client_test.go
+++ b/internal/internal_workflow_client_test.go
@@ -1475,12 +1475,12 @@ func (s *workflowClientTestSuite) TestGetWorkflowMemo() {
 
 func (s *workflowClientTestSuite) TestSerializeSearchAttributes() {
 	var input1 map[string]interface{}
-	result1, err := serializeSearchAttributes(input1)
+	result1, err := serializeUntypedSearchAttributes(input1)
 	s.NoError(err)
 	s.Nil(result1)
 
 	input1 = make(map[string]interface{})
-	result2, err := serializeSearchAttributes(input1)
+	result2, err := serializeUntypedSearchAttributes(input1)
 	s.NoError(err)
 	s.NotNil(result2)
 	s.Equal(0, len(result2.IndexedFields))
@@ -1488,7 +1488,7 @@ func (s *workflowClientTestSuite) TestSerializeSearchAttributes() {
 	input1 = map[string]interface{}{
 		"t1": "v1",
 	}
-	result3, err := serializeSearchAttributes(input1)
+	result3, err := serializeUntypedSearchAttributes(input1)
 	s.NoError(err)
 	s.NotNil(result3)
 	s.Equal(1, len(result3.IndexedFields))
@@ -1502,7 +1502,7 @@ func (s *workflowClientTestSuite) TestSerializeSearchAttributes() {
 	input1 = map[string]interface{}{
 		"payload": p,
 	}
-	result4, err := serializeSearchAttributes(input1)
+	result4, err := serializeUntypedSearchAttributes(input1)
 	s.NoError(err)
 	s.NotNil(result3)
 	s.Equal(1, len(result3.IndexedFields))
@@ -1512,7 +1512,7 @@ func (s *workflowClientTestSuite) TestSerializeSearchAttributes() {
 	input1 = map[string]interface{}{
 		"non-serializable": make(chan int),
 	}
-	_, err = serializeSearchAttributes(input1)
+	_, err = serializeUntypedSearchAttributes(input1)
 	s.Error(err)
 }
 

--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -2060,7 +2060,7 @@ func (env *testWorkflowEnvironmentImpl) WorkflowInfo() *WorkflowInfo {
 }
 
 func (env *testWorkflowEnvironmentImpl) TypedSearchAttributes() SearchAttributes {
-	return convertToTypeSearchAttributes(env.logger, env.workflowInfo.SearchAttributes.GetIndexedFields())
+	return convertToTypedSearchAttributes(env.logger, env.workflowInfo.SearchAttributes.GetIndexedFields())
 }
 
 func (env *testWorkflowEnvironmentImpl) RegisterWorkflow(w interface{}) {

--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -2059,6 +2059,10 @@ func (env *testWorkflowEnvironmentImpl) WorkflowInfo() *WorkflowInfo {
 	return env.workflowInfo
 }
 
+func (env *testWorkflowEnvironmentImpl) TypedSearchAttributes() SearchAttributes {
+	return convertToTypeSearchAttributes(env.logger, env.workflowInfo.SearchAttributes.GetIndexedFields())
+}
+
 func (env *testWorkflowEnvironmentImpl) RegisterWorkflow(w interface{}) {
 	env.registry.RegisterWorkflow(w)
 }

--- a/internal/schedule_client.go
+++ b/internal/schedule_client.go
@@ -269,13 +269,18 @@ type (
 		// On ScheduleHandle.Describe() or ScheduleHandle.Update() Memo will be returned as *commonpb.Payload.
 		Memo map[string]interface{}
 
-		// SearchAttributes - Optional indexed info that can be used in query of List/Scan/Count workflow APIs. The key and value type must be registered on Temporal server side.
-		// Use GetSearchAttributes API to get valid key and corresponding value type.
-		// On ScheduleHandle.Describe() or ScheduleHandle.Update() SearchAttributes will be returned as *commonpb.Payload.
-		// For supported operations on different server versions see [Visibility].
+		// TypedSearchAttributes - Optional indexed info that can be used in query of List/Scan/Count workflow APIs. The key
+		// and value type must be registered on Temporal server side. For supported operations on different server versions
+		// see [Visibility].
 		//
 		// [Visibility]: https://docs.temporal.io/visibility
-		SearchAttributes map[string]interface{}
+		TypedSearchAttributes SearchAttributes
+
+		// UntypedSearchAttributes - These are set upon update for older schedules that did not have typed attributes. This
+		// should never be used for create.
+		//
+		// Deprecated - This is only for update of older search attributes. This may be removed in a future version.
+		UntypedSearchAttributes map[string]*commonpb.Payload
 	}
 
 	// ScheduleOptions configure the parameters for creating a schedule.
@@ -344,8 +349,20 @@ type (
 		// Use GetSearchAttributes API to get valid key and corresponding value type.
 		// For supported operations on different server versions see [Visibility].
 		//
+		// Deprecated: use TypedSearchAttributes instead.
+		//
 		// [Visibility]: https://docs.temporal.io/visibility
 		SearchAttributes map[string]interface{}
+
+		// TypedSearchAttributes - Specifies Search Attributes that will be attached to the Workflow. Search Attributes are
+		// additional indexed information attributed to workflow and used for search and visibility. The search attributes
+		// can be used in query of List/Scan/Count workflow APIs. The key and its value type must be registered on Temporal
+		// server side. For supported operations on different server versions see [Visibility].
+		//
+		// Optional: default to none.
+		//
+		// [Visibility]: https://docs.temporal.io/visibility
+		TypedSearchAttributes SearchAttributes
 	}
 
 	// ScheduleWorkflowExecution contains details on a workflows execution stared by a schedule.

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -1313,7 +1313,6 @@ func signalExternalWorkflow(ctx Context, workflowID, runID, signalName string, a
 // UpsertSearchAttributes is used to add or update workflow search attributes.
 // The search attributes can be used in query of List/Scan/Count workflow APIs.
 // The key and value type must be registered on temporal server side;
-// The value has to deterministic when replay;
 // The value has to be Json serializable.
 // UpsertSearchAttributes will merge attributes to existing map in workflow, for example workflow code:
 //

--- a/internal/workflow_testsuite.go
+++ b/internal/workflow_testsuite.go
@@ -918,7 +918,7 @@ func (e *TestWorkflowEnvironment) SetMemoOnStart(memo map[string]interface{}) er
 
 // SetSearchAttributesOnStart sets the search attributes when start workflow.
 func (e *TestWorkflowEnvironment) SetSearchAttributesOnStart(searchAttributes map[string]interface{}) error {
-	attr, err := serializeSearchAttributes(searchAttributes)
+	attr, err := serializeUntypedSearchAttributes(searchAttributes)
 	if err != nil {
 		return err
 	}

--- a/temporal/search_attributes.go
+++ b/temporal/search_attributes.go
@@ -1,0 +1,91 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package temporal
+
+import "go.temporal.io/sdk/internal"
+
+type (
+	// SearchAttributes represents a collection of typed search attributes
+	SearchAttributes = internal.SearchAttributes
+
+	// SearchAttributesUpdate represents a change to SearchAttributes
+	SearchAttributeUpdate = internal.SearchAttributeUpdate
+
+	// SearchAttributeKey represents a typed search attribute key.
+	SearchAttributeKey = internal.SearchAttributeKey
+
+	// SearchAttributeKeyString represents a search attribute key for a text attribute type
+	SearchAttributeKeyString = internal.SearchAttributeKeyString
+
+	// SearchAttributeKeyString represents a search attribute key for a keyword attribute type
+	SearchAttributeKeyword = internal.SearchAttributeKeyword
+
+	// SearchAttributeKeyBool represents a search attribute key for a boolean attribute type
+	SearchAttributeKeyBool = internal.SearchAttributeKeyBool
+
+	// SearchAttributeKeyInt64 represents a search attribute key for a integer attribute type
+	SearchAttributeKeyInt64 = internal.SearchAttributeKeyInt64
+
+	// SearchAttributeKeyFloat64 represents a search attribute key for a double attribute type
+	SearchAttributeKeyFloat64 = internal.SearchAttributeKeyFloat64
+
+	// SearchAttributeKeyTime represents a search attribute key for a time attribute type
+	SearchAttributeKeyTime = internal.SearchAttributeKeyTime
+
+	// SearchAttributeKeywordList represents a search attribute key for a keyword list attribute type
+	SearchAttributeKeywordList = internal.SearchAttributeKeywordList
+)
+
+func NewSearchAttributeKeyString(name string) SearchAttributeKeyString {
+	return internal.NewSearchAttributeKeyString(name)
+}
+
+func NewSearchAttributeKeyword(name string) SearchAttributeKeyword {
+	return internal.NewSearchAttributeKeyword(name)
+}
+
+func NewSearchAttributeKeyBool(name string) SearchAttributeKeyBool {
+	return internal.NewSearchAttributeKeyBool(name)
+}
+
+func NewSearchAttributeKeyInt64(name string) SearchAttributeKeyInt64 {
+	return internal.NewSearchAttributeKeyInt64(name)
+}
+
+func NewSearchAttributeKeyFloat64(name string) SearchAttributeKeyFloat64 {
+	return internal.NewSearchAttributeKeyFloat64(name)
+}
+
+func NewSearchAttributeKeyTime(name string) SearchAttributeKeyTime {
+	return internal.NewSearchAttributeKeyTime(name)
+}
+
+func NewSearchAttributeKeywordList(name string) SearchAttributeKeywordList {
+	return internal.NewSearchAttributeKeywordList(name)
+}
+
+func NewSearchAttributes(attributes ...SearchAttributeUpdate) SearchAttributes {
+	return internal.NewSearchAttributes(attributes...)
+}

--- a/temporal/search_attributes.go
+++ b/temporal/search_attributes.go
@@ -27,65 +27,80 @@ package temporal
 import "go.temporal.io/sdk/internal"
 
 type (
-	// SearchAttributes represents a collection of typed search attributes
+	// SearchAttributes represents a collection of typed search attributes. Create with [NewSearchAttributes].
 	SearchAttributes = internal.SearchAttributes
 
-	// SearchAttributesUpdate represents a change to SearchAttributes
+	// SearchAttributesUpdate represents a change to SearchAttributes.
 	SearchAttributeUpdate = internal.SearchAttributeUpdate
 
 	// SearchAttributeKey represents a typed search attribute key.
 	SearchAttributeKey = internal.SearchAttributeKey
 
-	// SearchAttributeKeyString represents a search attribute key for a text attribute type
+	// SearchAttributeKeyString represents a search attribute key for a text attribute type. Create with
+	// [NewSearchAttributeKeyString].
 	SearchAttributeKeyString = internal.SearchAttributeKeyString
 
-	// SearchAttributeKeyString represents a search attribute key for a keyword attribute type
-	SearchAttributeKeyword = internal.SearchAttributeKeyword
+	// SearchAttributeKeyKeyword represents a search attribute key for a keyword attribute type. Create with
+	// [NewSearchAttributeKeyKeyword].
+	SearchAttributeKeyKeyword = internal.SearchAttributeKeyKeyword
 
-	// SearchAttributeKeyBool represents a search attribute key for a boolean attribute type
+	// SearchAttributeKeyBool represents a search attribute key for a boolean attribute type. Create with
+	// [NewSearchAttributeKeyBool].
 	SearchAttributeKeyBool = internal.SearchAttributeKeyBool
 
-	// SearchAttributeKeyInt64 represents a search attribute key for a integer attribute type
+	// SearchAttributeKeyInt64 represents a search attribute key for a integer attribute type. Create with
+	// [NewSearchAttributeKeyInt64].
 	SearchAttributeKeyInt64 = internal.SearchAttributeKeyInt64
 
-	// SearchAttributeKeyFloat64 represents a search attribute key for a double attribute type
+	// SearchAttributeKeyFloat64 represents a search attribute key for a double attribute type. Create with
+	// [NewSearchAttributeKeyFloat64].
 	SearchAttributeKeyFloat64 = internal.SearchAttributeKeyFloat64
 
-	// SearchAttributeKeyTime represents a search attribute key for a time attribute type
+	// SearchAttributeKeyTime represents a search attribute key for a time attribute type. Create with
+	// [NewSearchAttributeKeyTime].
 	SearchAttributeKeyTime = internal.SearchAttributeKeyTime
 
-	// SearchAttributeKeywordList represents a search attribute key for a keyword list attribute type
-	SearchAttributeKeywordList = internal.SearchAttributeKeywordList
+	// SearchAttributeKeyKeywordList represents a search attribute key for a keyword list attribute type. Create with
+	// [NewSearchAttributeKeyKeywordList].
+	SearchAttributeKeyKeywordList = internal.SearchAttributeKeyKeywordList
 )
 
+// NewSearchAttributeKeyString creates a new string-based key.
 func NewSearchAttributeKeyString(name string) SearchAttributeKeyString {
 	return internal.NewSearchAttributeKeyString(name)
 }
 
-func NewSearchAttributeKeyword(name string) SearchAttributeKeyword {
-	return internal.NewSearchAttributeKeyword(name)
+// NewSearchAttributeKeyKeyword creates a new keyword-based key.
+func NewSearchAttributeKeyKeyword(name string) SearchAttributeKeyKeyword {
+	return internal.NewSearchAttributeKeyKeyword(name)
 }
 
+// NewSearchAttributeKeyBool creates a new bool-based key.
 func NewSearchAttributeKeyBool(name string) SearchAttributeKeyBool {
 	return internal.NewSearchAttributeKeyBool(name)
 }
 
+// NewSearchAttributeKeyInt64 creates a new int64-based key.
 func NewSearchAttributeKeyInt64(name string) SearchAttributeKeyInt64 {
 	return internal.NewSearchAttributeKeyInt64(name)
 }
 
+// NewSearchAttributeKeyFloat64 creates a new float64-based key.
 func NewSearchAttributeKeyFloat64(name string) SearchAttributeKeyFloat64 {
 	return internal.NewSearchAttributeKeyFloat64(name)
 }
 
+// NewSearchAttributeKeyTime creates a new time-based key.
 func NewSearchAttributeKeyTime(name string) SearchAttributeKeyTime {
 	return internal.NewSearchAttributeKeyTime(name)
 }
 
-func NewSearchAttributeKeywordList(name string) SearchAttributeKeywordList {
-	return internal.NewSearchAttributeKeywordList(name)
+// NewSearchAttributeKeyKeywordList creates a new keyword-list-based key.
+func NewSearchAttributeKeyKeywordList(name string) SearchAttributeKeyKeywordList {
+	return internal.NewSearchAttributeKeyKeywordList(name)
 }
 
+// NewSearchAttributes creates a new search attribute collection for the given updates.
 func NewSearchAttributes(attributes ...SearchAttributeUpdate) SearchAttributes {
 	return internal.NewSearchAttributes(attributes...)
 }

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -1223,6 +1223,8 @@ func (ts *IntegrationTestSuite) TestWorkflowWithParallelMutableSideEffects() {
 
 func (ts *IntegrationTestSuite) TestWorkflowTypedSearchAttributes() {
 	options := ts.startWorkflowOptions("test-wf-typed-search-attributes")
+	// Need to disable eager workflow start until https://github.com/temporalio/temporal/pull/5124 fixed
+	options.EnableEagerStart = false
 	// Create initial set of search attributes
 	stringKey := temporal.NewSearchAttributeKeyString("CustomStringField")
 	options.TypedSearchAttributes = temporal.NewSearchAttributes(stringKey.ValueSet("CustomStringFieldValue"))

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -1221,6 +1221,15 @@ func (ts *IntegrationTestSuite) TestWorkflowWithParallelMutableSideEffects() {
 	ts.NoError(ts.executeWorkflow("test-wf-parallel-mutable-side-effects", ts.workflows.WorkflowWithParallelMutableSideEffects, nil))
 }
 
+func (ts *IntegrationTestSuite) TestWorkflowTypedSearchAttributes() {
+	options := ts.startWorkflowOptions("test-wf-typed-search-attributes")
+	// Create initial set of search attributes
+	stringKey := temporal.NewSearchAttributeKeyString("CustomStringField")
+	options.TypedSearchAttributes = temporal.NewSearchAttributes(stringKey.ValueSet("CustomStringFieldValue"))
+	ts.NoError(ts.executeWorkflowWithOption(options, ts.workflows.UpsertTypedSearchAttributesWorkflow, nil, true))
+	ts.NoError(ts.executeWorkflowWithOption(options, ts.workflows.UpsertTypedSearchAttributesWorkflow, nil, false))
+}
+
 func (ts *IntegrationTestSuite) TestLargeQueryResultError() {
 	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
 	defer cancel()
@@ -3372,9 +3381,9 @@ func (ts *IntegrationTestSuite) TestUpsertMemoWithExistingMemo() {
 	ts.Equal(expectedMemo, memo)
 }
 
-func (ts *IntegrationTestSuite) createBasicScheduleWorkflowAction(ID string) client.ScheduleAction {
+func (ts *IntegrationTestSuite) createBasicScheduleWorkflowAction(ID string, workflow interface{}) client.ScheduleAction {
 	return &client.ScheduleWorkflowAction{
-		Workflow:                 ts.workflows.SimplestWorkflow,
+		Workflow:                 workflow,
 		ID:                       ID,
 		TaskQueue:                ts.taskQueueName,
 		WorkflowExecutionTimeout: 15 * time.Second,
@@ -3388,7 +3397,7 @@ func (ts *IntegrationTestSuite) TestScheduleCreate() {
 	handle, err := ts.client.ScheduleClient().Create(ctx, client.ScheduleOptions{
 		ID:     "test-schedule-create-schedule",
 		Spec:   client.ScheduleSpec{},
-		Action: ts.createBasicScheduleWorkflowAction("test-schedule-create-workflow"),
+		Action: ts.createBasicScheduleWorkflowAction("test-schedule-create-workflow", ts.workflows.SimplestWorkflow),
 	})
 	ts.NoError(err)
 	ts.EqualValues("test-schedule-create-schedule", handle.GetID())
@@ -3399,6 +3408,37 @@ func (ts *IntegrationTestSuite) TestScheduleCreate() {
 	description, err := handle.Describe(ctx)
 	ts.IsType(&serviceerror.NotFound{}, err)
 	ts.Nil(description)
+}
+
+func (ts *IntegrationTestSuite) TestScheduleTypedSearchAttributes() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	scheduleID := "test-schedule-typed-search-attributes"
+	handle, err := ts.client.ScheduleClient().Create(ctx, client.ScheduleOptions{
+		ID:               scheduleID,
+		RemainingActions: 1,
+		Spec: client.ScheduleSpec{
+			CronExpressions: []string{
+				"* * * * * * *",
+			},
+		},
+		Action: ts.createBasicScheduleWorkflowAction("test-schedule-typed-search-attributes", ts.workflows.ScheduleTypedSearchAttributesWorkflow),
+	})
+	ts.NoError(err)
+	defer func() {
+		ts.NoError(handle.Delete(ctx))
+	}()
+	// Wait for the schedule to run
+	time.Sleep(2 * time.Second)
+	desc, err := handle.Describe(ctx)
+	ts.NoError(err)
+	ts.Len(desc.Info.RecentActions, 1)
+	startWorkflowResult := desc.Info.RecentActions[0].StartWorkflowResult
+	run := ts.client.GetWorkflow(ctx, startWorkflowResult.WorkflowID, startWorkflowResult.FirstExecutionRunID)
+	var result string
+	err = run.Get(ctx, &result)
+	ts.NoError(err)
+	ts.Equal(scheduleID, result)
 }
 
 func (ts *IntegrationTestSuite) TestScheduleCalendarDefault() {
@@ -3413,7 +3453,7 @@ func (ts *IntegrationTestSuite) TestScheduleCalendarDefault() {
 				},
 			},
 		},
-		Action: ts.createBasicScheduleWorkflowAction("test-schedule-calendar-default-workflow"),
+		Action: ts.createBasicScheduleWorkflowAction("test-schedule-calendar-default-workflow", ts.workflows.SimplestWorkflow),
 		Paused: true,
 	})
 	ts.NoError(err)
@@ -3461,7 +3501,7 @@ func (ts *IntegrationTestSuite) TestScheduleCreateDuplicate() {
 	scheduleOptions := client.ScheduleOptions{
 		ID:     "test-schedule-create-duplicate-schedule",
 		Spec:   client.ScheduleSpec{},
-		Action: ts.createBasicScheduleWorkflowAction("test-schedule-create-duplicate-workflow"),
+		Action: ts.createBasicScheduleWorkflowAction("test-schedule-create-duplicate-workflow", ts.workflows.SimplestWorkflow),
 	}
 
 	handle, err := ts.client.ScheduleClient().Create(ctx, scheduleOptions)
@@ -3544,7 +3584,7 @@ func (ts *IntegrationTestSuite) TestScheduleDescribeSpec() {
 				},
 			},
 		},
-		Action: ts.createBasicScheduleWorkflowAction("test-schedule-describe-spec-workflow"),
+		Action: ts.createBasicScheduleWorkflowAction("test-schedule-describe-spec-workflow", ts.workflows.SimplestWorkflow),
 	})
 	ts.NoError(err)
 	ts.EqualValues("test-schedule-describe-spec-schedule", handle.GetID())
@@ -3646,7 +3686,7 @@ func (ts *IntegrationTestSuite) TestScheduleDescribeSpecCron() {
 				"0 12 * * MON",
 			},
 		},
-		Action: ts.createBasicScheduleWorkflowAction("test-schedule-describe-spec-cron-workflow"),
+		Action: ts.createBasicScheduleWorkflowAction("test-schedule-describe-spec-cron-workflow", ts.workflows.SimplestWorkflow),
 	})
 	ts.NoError(err)
 	ts.EqualValues("test-schedule-describe-spec-cron-schedule", handle.GetID())
@@ -3781,7 +3821,7 @@ func (ts *IntegrationTestSuite) TestSchedulePause() {
 	handle, err := ts.client.ScheduleClient().Create(ctx, client.ScheduleOptions{
 		ID:     "test-schedule-pause-schedule",
 		Spec:   client.ScheduleSpec{},
-		Action: ts.createBasicScheduleWorkflowAction("test-schedule-pause-workflow"),
+		Action: ts.createBasicScheduleWorkflowAction("test-schedule-pause-workflow", ts.workflows.SimplestWorkflow),
 		Paused: true,
 	})
 	ts.NoError(err)
@@ -3827,7 +3867,7 @@ func (ts *IntegrationTestSuite) TestScheduleTrigger() {
 	handle, err := ts.client.ScheduleClient().Create(ctx, client.ScheduleOptions{
 		ID:      "test-schedule-trigger-schedule",
 		Spec:    client.ScheduleSpec{},
-		Action:  ts.createBasicScheduleWorkflowAction("test-schedule-trigger-workflow"),
+		Action:  ts.createBasicScheduleWorkflowAction("test-schedule-trigger-workflow", ts.workflows.SimplestWorkflow),
 		Paused:  true,
 		Overlap: enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL,
 	})
@@ -3871,7 +3911,7 @@ func (ts *IntegrationTestSuite) TestScheduleBackfillCreate() {
 			},
 			EndAt: endTime,
 		},
-		Action: ts.createBasicScheduleWorkflowAction("test-schedule-backfill-create-workflow"),
+		Action: ts.createBasicScheduleWorkflowAction("test-schedule-backfill-create-workflow", ts.workflows.SimplestWorkflow),
 		ScheduleBackfill: []client.ScheduleBackfill{
 			{
 				Start:   now.Add(-time.Hour),
@@ -3910,7 +3950,7 @@ func (ts *IntegrationTestSuite) TestScheduleBackfill() {
 				},
 			},
 		},
-		Action: ts.createBasicScheduleWorkflowAction("test-schedule-backfill-workflow"),
+		Action: ts.createBasicScheduleWorkflowAction("test-schedule-backfill-workflow", ts.workflows.SimplestWorkflow),
 		Paused: true,
 	})
 	ts.NoError(err)
@@ -3986,7 +4026,7 @@ func (ts *IntegrationTestSuite) TestScheduleUpdate() {
 	handle, err := ts.client.ScheduleClient().Create(ctx, client.ScheduleOptions{
 		ID:     "test-schedule-update-schedule",
 		Spec:   client.ScheduleSpec{},
-		Action: ts.createBasicScheduleWorkflowAction("test-schedule-update-workflow"),
+		Action: ts.createBasicScheduleWorkflowAction("test-schedule-update-workflow", ts.workflows.SimplestWorkflow),
 		Paused: true,
 	})
 	ts.NoError(err)
@@ -4020,7 +4060,7 @@ func (ts *IntegrationTestSuite) TestScheduleUpdateCancelUpdate() {
 	handle, err := ts.client.ScheduleClient().Create(ctx, client.ScheduleOptions{
 		ID:     "test-schedule-update-schedule",
 		Spec:   client.ScheduleSpec{},
-		Action: ts.createBasicScheduleWorkflowAction("test-schedule-update-workflow"),
+		Action: ts.createBasicScheduleWorkflowAction("test-schedule-update-workflow", ts.workflows.SimplestWorkflow),
 		Paused: true,
 	})
 	ts.NoError(err)
@@ -4063,7 +4103,7 @@ func (ts *IntegrationTestSuite) TestScheduleUpdateError() {
 	handle, err := ts.client.ScheduleClient().Create(ctx, client.ScheduleOptions{
 		ID:     "test-schedule-update-schedule",
 		Spec:   client.ScheduleSpec{},
-		Action: ts.createBasicScheduleWorkflowAction("test-schedule-update-workflow"),
+		Action: ts.createBasicScheduleWorkflowAction("test-schedule-update-workflow", ts.workflows.SimplestWorkflow),
 		Paused: true,
 	})
 	ts.NoError(err)
@@ -4088,7 +4128,7 @@ func (ts *IntegrationTestSuite) TestScheduleUpdateNewAction() {
 	handle, err := ts.client.ScheduleClient().Create(ctx, client.ScheduleOptions{
 		ID:     "test-schedule-update-new-action-schedule",
 		Spec:   client.ScheduleSpec{},
-		Action: ts.createBasicScheduleWorkflowAction("test-schedule-update-new-action-workflow"),
+		Action: ts.createBasicScheduleWorkflowAction("test-schedule-update-new-action-workflow", ts.workflows.SimplestWorkflow),
 		Paused: true,
 	})
 	ts.NoError(err)
@@ -4131,7 +4171,7 @@ func (ts *IntegrationTestSuite) TestScheduleUpdateAction() {
 	handle, err := ts.client.ScheduleClient().Create(ctx, client.ScheduleOptions{
 		ID:     "test-schedule-update-action-schedule",
 		Spec:   client.ScheduleSpec{},
-		Action: ts.createBasicScheduleWorkflowAction("test-schedule-update-action-workflow"),
+		Action: ts.createBasicScheduleWorkflowAction("test-schedule-update-action-workflow", ts.workflows.SimplestWorkflow),
 		Paused: true,
 	})
 	ts.NoError(err)

--- a/test/test_utils_test.go
+++ b/test/test_utils_test.go
@@ -314,7 +314,7 @@ func (ts *ConfigAndClientSuiteBase) ensureSearchAttributes() error {
 	}
 	defer client.Close()
 
-	// Add CustomKeywordField attribute if not already present
+	// Add CustomKeywordField and CustomStringField attribute if not already present
 	saResp, err := client.OperatorService().ListSearchAttributes(ctx, &operatorservice.ListSearchAttributesRequest{
 		Namespace: ts.config.Namespace,
 	})
@@ -324,8 +324,11 @@ func (ts *ConfigAndClientSuiteBase) ensureSearchAttributes() error {
 		return nil
 	}
 	_, err = client.OperatorService().AddSearchAttributes(ctx, &operatorservice.AddSearchAttributesRequest{
-		Namespace:        ts.config.Namespace,
-		SearchAttributes: map[string]enumspb.IndexedValueType{"CustomKeywordField": enumspb.INDEXED_VALUE_TYPE_KEYWORD},
+		Namespace: ts.config.Namespace,
+		SearchAttributes: map[string]enumspb.IndexedValueType{
+			"CustomKeywordField": enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+			"CustomStringField":  enumspb.INDEXED_VALUE_TYPE_TEXT,
+		},
 	})
 	if err != nil {
 		return fmt.Errorf("failed adding search attribute: %w", err)

--- a/test/workflow_test.go
+++ b/test/workflow_test.go
@@ -2290,7 +2290,7 @@ func (w *Workflows) ScheduleTypedSearchAttributesWorkflow(ctx workflow.Context) 
 	attributes := workflow.GetTypedSearchAttributes(ctx)
 
 	scheduleStartTimeKey := temporal.NewSearchAttributeKeyTime("TemporalScheduledStartTime")
-	scheduleByIDKey := temporal.NewSearchAttributeKeyword("TemporalScheduledById")
+	scheduleByIDKey := temporal.NewSearchAttributeKeyKeyword("TemporalScheduledById")
 
 	_, ok := attributes.GetTime(scheduleStartTimeKey)
 	if !ok {
@@ -2314,7 +2314,7 @@ func (w *Workflows) UpsertTypedSearchAttributesWorkflow(ctx workflow.Context, sl
 	}
 
 	// Add a new search attribute
-	key := temporal.NewSearchAttributeKeyword("CustomKeywordField")
+	key := temporal.NewSearchAttributeKeyKeyword("CustomKeywordField")
 	err := workflow.UpsertTypedSearchAttributes(ctx, key.ValueSet("CustomKeywordFieldValue"))
 	if err != nil {
 		return err

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -31,6 +31,7 @@ import (
 	"go.temporal.io/sdk/internal"
 	"go.temporal.io/sdk/internal/common/metrics"
 	"go.temporal.io/sdk/log"
+	"go.temporal.io/sdk/temporal"
 	"golang.org/x/exp/constraints"
 )
 
@@ -196,6 +197,11 @@ func ExecuteChildWorkflow(ctx Context, childWorkflow interface{}, args ...interf
 // GetInfo extracts info of a current workflow from a context.
 func GetInfo(ctx Context) *Info {
 	return internal.GetWorkflowInfo(ctx)
+}
+
+// GetTypedSearchAttributes returns a collection of the search attributes currently set for this workflow
+func GetTypedSearchAttributes(ctx Context) temporal.SearchAttributes {
+	return internal.GetTypedSearchAttributes(ctx)
 }
 
 func GetUpdateInfo(ctx Context) *UpdateInfo {
@@ -571,9 +577,15 @@ func GetLastError(ctx Context) error {
 //
 // For supported operations on different server versions see [Visibility].
 //
+// Deprecated: use [UpsertTypedSearchAttributes] instead.
+//
 // [Visibility]: https://docs.temporal.io/visibility
 func UpsertSearchAttributes(ctx Context, attributes map[string]interface{}) error {
 	return internal.UpsertSearchAttributes(ctx, attributes)
+}
+
+func UpsertTypedSearchAttributes(ctx Context, searchAttributeUpdate ...temporal.SearchAttributeUpdate) error {
+	return internal.UpsertTypedSearchAttributes(ctx, searchAttributeUpdate...)
 }
 
 // UpsertMemo is used to add or update workflow memo.

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -584,6 +584,26 @@ func UpsertSearchAttributes(ctx Context, attributes map[string]interface{}) erro
 	return internal.UpsertSearchAttributes(ctx, attributes)
 }
 
+// UpsertTypedSearchAttributes is used to add, update, or remove workflow search attributes. The search attributes can
+// be used in query of List/Scan/Count workflow APIs. The key and value type must be registered on temporal server side;
+// The value has to deterministic when replay; The value has to be Json serializable.
+// UpsertTypedSearchAttributes will merge attributes to existing map in workflow, for example workflow code:
+//
+//	var intKey = temporal.NewSearchAttributeKeyInt64("CustomIntField")
+//	var boolKey = temporal.NewSearchAttributeKeyBool("CustomBoolField")
+//	var keywordKey = temporal.NewSearchAttributeKeyBool("CustomKeywordField")
+//
+//	func MyWorkflow(ctx workflow.Context, input string) error {
+//		err = workflow.UpsertTypedSearchAttributes(ctx, intAttrKey.ValueSet(1), boolAttrKey.ValueSet(true))
+//		// ...
+//
+//		err = workflow.UpsertSearchAttributes(ctx, intKey.ValueSet(2), keywordKey.ValueUnset())
+//		// ...
+//	}
+//
+// For supported operations on different server versions see [Visibility].
+//
+// [Visibility]: https://docs.temporal.io/visibility
 func UpsertTypedSearchAttributes(ctx Context, searchAttributeUpdate ...temporal.SearchAttributeUpdate) error {
 	return internal.UpsertTypedSearchAttributes(ctx, searchAttributeUpdate...)
 }

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -549,7 +549,6 @@ func GetLastError(ctx Context) error {
 // UpsertSearchAttributes is used to add or update workflow search attributes.
 // The search attributes can be used in query of List/Scan/Count workflow APIs.
 // The key and value type must be registered on temporal server side;
-// The value has to deterministic when replay;
 // The value has to be Json serializable.
 // UpsertSearchAttributes will merge attributes to existing map in workflow, for example workflow code:
 //
@@ -585,8 +584,7 @@ func UpsertSearchAttributes(ctx Context, attributes map[string]interface{}) erro
 }
 
 // UpsertTypedSearchAttributes is used to add, update, or remove workflow search attributes. The search attributes can
-// be used in query of List/Scan/Count workflow APIs. The key and value type must be registered on temporal server side;
-// The value has to deterministic when replay; The value has to be Json serializable.
+// be used in query of List/Scan/Count workflow APIs. The key and value type must be registered on temporal server side.
 // UpsertTypedSearchAttributes will merge attributes to existing map in workflow, for example workflow code:
 //
 //	var intKey = temporal.NewSearchAttributeKeyInt64("CustomIntField")


### PR DESCRIPTION
## What was changed

Implementation of [typed search attributes](https://github.com/temporalio/proposals/blob/master/sdk-typed-search-attributes.md). Specifically:

* Added `TypedSearchAttributes` to `client.StartWorkflowOptions` and deprecated `SearchAttributes`
* Added several new things to `temporal` package including:
  * `SearchAttributes` collection with methods and constructor
  * `SearchAttributeKey` and `SearchAttributeUpdate` interfaces
  * `SearchAttributeKeyX` types and constructors for typed keys
* Added `TypedSearchAttributes` to `client.ScheduleWorkflowAction` and 💥removed `SearchAttributes` and added `UntypedSearchAttributes` (needed until https://github.com/temporalio/temporal/issues/4787 is fixed)
* Added `TypedSearchAttributes` to `client.ScheduleOptions` and deprecated `SearchAttributes`
* Added `GetTypedSearchAttributes` to `workflow` and deprecated `WorkflowInfo.SearchAttributes`
* Added `UpsertTypedSearchAttributes` to `workflow` and deprecated `UpsertSearchAttributes`
* Tests

Much of this work was done by @Quinn-With-Two-Ns

### 💥 BREAKING CHANGE

Users that used `SearchAttributes` on `client.ScheduleWorkflowAction` will now have a compile-time failure (not to be confused with search attributes on the schedule itself). There was no good way to have both untyped and typed coexist for create, describe, and update of a workflow action on a schedule. The release notes should document this break intentionally. This is the same decision we reached [in Python](https://github.com/temporalio/sdk-python/pull/366).

## Checklist

1. Closes #1218

*NOTE:* Currently there are two dev-server bugs (lack of `TemporalScheduledX` search attrs in workflow and a case where a SA name is appearing as `Text01`) that I'm hoping have since been fixed and are awaiting CLI release. That's why CI is failing, but can still review.