### PR TITLE
Handle nil valuePtr case in update handler Get

### DIFF
--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -1910,7 +1910,7 @@ func (ch *completedUpdateHandle) Get(ctx context.Context, valuePtr interface{}) 
 
 func (luh *lazyUpdateHandle) Get(ctx context.Context, valuePtr interface{}) error {
 	enc, err := luh.client.PollWorkflowUpdate(ctx, luh.ref)
-	if err != nil {
+	if err != nil || valuePtr == nil {
 		return err
 	}
 	return enc.Get(valuePtr)

--- a/internal/internal_workflow_client_test.go
+++ b/internal/internal_workflow_client_test.go
@@ -1772,6 +1772,9 @@ func TestUpdate(t *testing.T) {
 		err = handle.Get(context.TODO(), &got)
 		require.NoError(t, err)
 		require.Equal(t, want, got)
+		// Verify that calling Get with nil does not panic
+		err = handle.Get(context.TODO(), nil)
+		require.NoError(t, err)
 	})
 	t.Run("sync error", func(t *testing.T) {
 		svc, client := init(t)
@@ -1810,13 +1813,16 @@ func TestUpdate(t *testing.T) {
 					Outcome: mustOutcome(t, want),
 				},
 				nil,
-			)
+			).Times(2)
 		handle, err := client.UpdateWorkflowWithOptions(context.TODO(), req)
 		require.NoError(t, err)
 		var got string
 		err = handle.Get(context.TODO(), &got)
 		require.NoError(t, err)
 		require.Equal(t, want, got)
+		// Verify that calling Get with nil does not panic
+		err = handle.Get(context.TODO(), nil)
+		require.NoError(t, err)
 	})
 	t.Run("async error", func(t *testing.T) {
 		svc, client := init(t)


### PR DESCRIPTION
Avoid passing a `nil` to `EncocedValue.Get`. This matches the behaviour of other `Get` calls in the SDK
