### PR TITLE
Fix data race on desiredWorkflowCacheSize

### DIFF
--- a/internal/internal_worker_cache.go
+++ b/internal/internal_worker_cache.go
@@ -83,6 +83,10 @@ func PurgeStickyWorkflowCache() {
 // a hook to runtime.SetFinalizer (ie: When they are freed by the GC). When there are no reachable instances of
 // WorkerCache, shared caches will be cleared
 func NewWorkerCache() *WorkerCache {
+	sharedWorkerCacheLock.Lock()
+	desiredWorkflowCacheSize := desiredWorkflowCacheSize
+	sharedWorkerCacheLock.Unlock()
+
 	return newWorkerCache(sharedWorkerCachePtr, &sharedWorkerCacheLock, desiredWorkflowCacheSize)
 }
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Add lock/unlock to `desiredWorkflowCacheSize` in `func NewWorkerCache() *WorkerCache`.

## Why?
<!-- Tell your future self why have you made these changes -->
Prevent data race.

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-go/issues/1375

2. How was this tested: Run the test in ticket description to verify.

<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed? No
<!--- update README if applicable
      or point out where to update docs.temporal.io -->