### PR TITLE
Rectify the default values for keep-alive timeout

### DIFF
--- a/internal/client.go
+++ b/internal/client.go
@@ -496,13 +496,13 @@ type (
 		// After a duration of this time if the client doesn't see any activity it
 		// pings the server to see if the transport is still alive.
 		// If set below 10s, a minimum value of 10s will be used instead.
-		// default: 15s
+		// default: 30s
 		KeepAliveTime time.Duration
 
 		// After having pinged for keepalive check, the client waits for a duration
 		// of Timeout and if no activity is seen even after that the connection is
 		// closed.
-		// default: 30s
+		// default: 15s
 		KeepAliveTimeout time.Duration
 
 		// if true, when there are no active RPCs, Time and Timeout will be ignored and no

--- a/internal/grpc_dialer.go
+++ b/internal/grpc_dialer.go
@@ -72,10 +72,10 @@ const (
 	defaultMaxPayloadSize = 128 * mb
 
 	// defaultKeepAliveTime is the keep alive time if one is not specified.
-	defaultKeepAliveTime = 15 * time.Second
+	defaultKeepAliveTime = 30 * time.Second
 
 	// defaultKeepAliveTimeout is the keep alive timeout if one is not specified.
-	defaultKeepAliveTimeout = 30 * time.Second
+	defaultKeepAliveTimeout = 15 * time.Second
 )
 
 func dial(params dialParameters) (*grpc.ClientConn, error) {


### PR DESCRIPTION
## What was changed

The default values for keep-alive were mistakenly assigned earlier. This PR brings the alignment with the server other SDKs:

Java:
https://github.com/temporalio/sdk-java/blob/master/temporal-serviceclient/src/main/java/io/temporal/serviceclient/ServiceStubsOptions.java#L333-L334

TS:
https://github.com/temporalio/sdk-typescript/blob/main/packages/client/src/connection.ts#L130-L131

## Why?

Keep the default gRPC keep-alive consistent with server and other SDKs.