### PR TITLE
Make it possible to cancel workflows by ID when testing

### DIFF
--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -2427,12 +2427,16 @@ func (env *testWorkflowEnvironmentImpl) getActivityInfo(activityID ActivityID, a
 }
 
 func (env *testWorkflowEnvironmentImpl) cancelWorkflow(callback ResultHandler) {
+	env.cancelWorkflowByID(env.workflowInfo.WorkflowExecution.ID, env.workflowInfo.WorkflowExecution.RunID, callback)
+}
+
+func (env *testWorkflowEnvironmentImpl) cancelWorkflowByID(workflowID string, runID string, callback ResultHandler) {
 	env.postCallback(func() {
 		// RequestCancelWorkflow needs to be run in main thread
 		env.RequestCancelExternalWorkflow(
 			env.workflowInfo.Namespace,
-			env.workflowInfo.WorkflowExecution.ID,
-			env.workflowInfo.WorkflowExecution.RunID,
+			workflowID,
+			runID,
 			callback,
 		)
 	}, true)

--- a/internal/workflow_testsuite.go
+++ b/internal/workflow_testsuite.go
@@ -861,6 +861,11 @@ func (e *TestWorkflowEnvironment) CancelWorkflow() {
 	e.impl.cancelWorkflow(func(result *commonpb.Payloads, err error) {})
 }
 
+// CancelWorkflowByID requests cancellation (through workflow Context) to the specified workflow.
+func (e *TestWorkflowEnvironment) CancelWorkflowByID(workflowID string, runID string) {
+	e.impl.cancelWorkflowByID(workflowID, runID, func(result *commonpb.Payloads, err error) {})
+}
+
 // SignalWorkflow sends signal to the currently running test workflow.
 func (e *TestWorkflowEnvironment) SignalWorkflow(name string, input interface{}) {
 	e.impl.signalWorkflow(name, input, true)


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Added a function in `TestWorkflowEnvironment` to allow canceling arbitrary workflows, in line with `SignalWorkflowByID` and `QueryWorkflowByID`

## Why?
This makes it possible to cancel child executions and test the behavior of doing so.
