### PR TITLE
allow client to request keep scheduled workflow id as is.

### DIFF
--- a/internal/internal_schedule_client.go
+++ b/internal/internal_schedule_client.go
@@ -39,6 +39,7 @@ import (
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	workflowpb "go.temporal.io/api/workflow/v1"
 	"go.temporal.io/api/workflowservice/v1"
+
 	"go.temporal.io/sdk/converter"
 	"go.temporal.io/sdk/log"
 )
@@ -136,9 +137,10 @@ func (w *workflowClientInterceptor) CreateSchedule(ctx context.Context, in *Sche
 			Spec:   convertToPBScheduleSpec(&in.Options.Spec),
 			Action: action,
 			Policies: &schedulepb.SchedulePolicies{
-				OverlapPolicy:  in.Options.Overlap,
-				CatchupWindow:  catchupWindow,
-				PauseOnFailure: in.Options.PauseOnFailure,
+				OverlapPolicy:          in.Options.Overlap,
+				CatchupWindow:          catchupWindow,
+				PauseOnFailure:         in.Options.PauseOnFailure,
+				KeepOriginalWorkflowId: in.Options.KeepOriginalWorkflowID,
 			},
 			State: &schedulepb.ScheduleState{
 				Notes:            in.Options.Note,

--- a/internal/schedule_client.go
+++ b/internal/schedule_client.go
@@ -363,6 +363,10 @@ type (
 		//
 		// [Visibility]: https://docs.temporal.io/visibility
 		TypedSearchAttributes SearchAttributes
+
+		// KeepOriginalWorkflowID - If true, and the action would start a workflow, a timestamp will not be
+		// appended to the scheduled workflow id.
+		KeepOriginalWorkflowID bool
 	}
 
 	// ScheduleWorkflowExecution contains details on a workflows execution stared by a schedule.


### PR DESCRIPTION
## What was changed
Add option to keep scheduled workflow id as is.

## Why?
User request.

## Checklist
1. How was this tested:
Not yet tested.
