### PR TITLE
Add the ability to soft launch SDK flags

### DIFF
--- a/internal/internal_event_handlers.go
+++ b/internal/internal_event_handlers.go
@@ -247,7 +247,7 @@ func newWorkflowExecutionEventHandler(
 		deadlockDetectionTimeout:     deadlockDetectionTimeout,
 		protocols:                    protocol.NewRegistry(),
 		mutableSideEffectCallCounter: make(map[string]int),
-		sdkFlags:                     newSDKFlags(capabilities),
+		sdkFlags:                     newSDKFlags(capabilities, SdkSoftLaunchFlags),
 		bufferedUpdateRequests:       make(map[string][]func()),
 	}
 	// Attempt to skip 1 log level to remove the ReplayLogger from the stack.

--- a/internal/internal_flags.go
+++ b/internal/internal_flags.go
@@ -104,7 +104,7 @@ func newSDKFlags(capabilities *workflowservice.GetSystemInfoResponse_Capabilitie
 	}
 }
 
-// tryUse returns true if this flag may currently be used. If record is true, always returns
+// tryUse returns true if this flag may currently be used. If record is true and the flag is not soft launched, always returns
 // true and records the flag as being used.
 func (sf *sdkFlags) tryUse(flag sdkFlag, record bool) bool {
 	if !sf.capabilities.GetSdkMetadata() {

--- a/internal/internal_flags_test.go
+++ b/internal/internal_flags_test.go
@@ -42,7 +42,7 @@ func TestSet(t *testing.T) {
 	t.Parallel()
 
 	t.Run("no server sdk metadata support", func(t *testing.T) {
-		flags := newSDKFlags(&metadataDisabled)
+		flags := newSDKFlags(&metadataDisabled, nil)
 		flags.set(testFlag)
 		require.Empty(t, flags.gatherNewSDKFlags(),
 			"flags assigned when servier does not support metadata are dropped")
@@ -51,10 +51,21 @@ func TestSet(t *testing.T) {
 	})
 
 	t.Run("with server sdk metadata support", func(t *testing.T) {
-		flags := newSDKFlags(&metadataEnabled)
+		flags := newSDKFlags(&metadataEnabled, nil)
 		flags.set(testFlag)
 		require.Empty(t, flags.gatherNewSDKFlags(),
 			"flag set via sdkFlags.set is not 'new'")
+		require.True(t, flags.tryUse(testFlag, false),
+			"flag set via sdkFlags.set should be immediately visible")
+	})
+
+	t.Run("with soft launch flag", func(t *testing.T) {
+		flags := newSDKFlags(&metadataEnabled, map[sdkFlag]bool{testFlag: true})
+		require.False(t, flags.tryUse(testFlag, true))
+		require.Empty(t, flags.gatherNewSDKFlags())
+		require.False(t, flags.tryUse(testFlag, false),
+			"soft launch flags should not be set")
+		flags.set(testFlag)
 		require.True(t, flags.tryUse(testFlag, false),
 			"flag set via sdkFlags.set should be immediately visible")
 	})

--- a/internal/internal_update_test.go
+++ b/internal/internal_update_test.go
@@ -86,6 +86,7 @@ var runOnCallingThread = &testUpdateScheduler{
 
 var testSDKFlags = newSDKFlags(
 	&workflowservice.GetSystemInfoResponse_Capabilities{SdkMetadata: true},
+	nil,
 )
 
 func TestUpdateHandlerPanicHandling(t *testing.T) {

--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -550,7 +550,7 @@ func (env *testWorkflowEnvironmentImpl) getWorkflowDefinition(wt WorkflowType) (
 }
 
 func (env *testWorkflowEnvironmentImpl) TryUse(flag sdkFlag) bool {
-	return true
+	return !SdkSoftLaunchFlags[flag]
 }
 
 func (env *testWorkflowEnvironmentImpl) QueueUpdate(name string, f func()) {

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -2602,6 +2602,9 @@ func (ts *IntegrationTestSuite) TestUpdateWithWrongHandleRejected() {
 }
 
 func (ts *IntegrationTestSuite) TestWaitOnUpdate() {
+	if internal.SdkSoftLaunchFlags[internal.SDKPriorityUpdateHandling] {
+		ts.T().Skip("This test requires priority update handling to be enabled")
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	options := ts.startWorkflowOptions("test-wait-on-update")
@@ -2622,7 +2625,7 @@ func (ts *IntegrationTestSuite) TestWaitOnUpdate() {
 
 func (ts *IntegrationTestSuite) TestUpdateOrdering() {
 	if internal.SdkSoftLaunchFlags[internal.SDKPriorityUpdateHandling] {
-		ts.T().Skip("This test is flaky and needs to be fixed")
+		ts.T().Skip("This test requires priority update handling to be enabled")
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -2656,7 +2659,7 @@ func (ts *IntegrationTestSuite) TestMultipleUpdateOrdering() {
 
 func (ts *IntegrationTestSuite) testUpdateOrderingCancel(cancelWf bool) {
 	if internal.SdkSoftLaunchFlags[internal.SDKPriorityUpdateHandling] {
-		ts.T().Skip("This test is flaky and needs to be fixed")
+		ts.T().Skip("This test requires priority update handling to be enabled")
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -2655,6 +2655,9 @@ func (ts *IntegrationTestSuite) TestMultipleUpdateOrdering() {
 }
 
 func (ts *IntegrationTestSuite) testUpdateOrderingCancel(cancelWf bool) {
+	if internal.SdkSoftLaunchFlags[internal.SDKPriorityUpdateHandling] {
+		ts.T().Skip("This test is flaky and needs to be fixed")
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	// Kill the worker so we can send multiple update requests and possibly a cancel in the same WFT

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -2621,6 +2621,9 @@ func (ts *IntegrationTestSuite) TestWaitOnUpdate() {
 }
 
 func (ts *IntegrationTestSuite) TestUpdateOrdering() {
+	if internal.SdkSoftLaunchFlags[internal.SDKPriorityUpdateHandling] {
+		ts.T().Skip("This test is flaky and needs to be fixed")
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	options := ts.startWorkflowOptions("test-update-ordering")
@@ -2701,6 +2704,9 @@ func (ts *IntegrationTestSuite) testUpdateOrderingCancel(cancelWf bool) {
 }
 
 func (ts *IntegrationTestSuite) TestUpdateAlwaysHandled() {
+	if internal.SdkSoftLaunchFlags[internal.SDKPriorityUpdateHandling] {
+		ts.T().Skip("This test is flaky and needs to be fixed")
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	options := ts.startWorkflowOptions("test-update-always-handled")


### PR DESCRIPTION
Add the ability to soft launch SDK flags. This allows us to add an SDK flag in one minor release of the SDK, but not use it. This will allow us to maintain backwards compatibility if the flags is set in a later release.
