### PR TITLE
Only set SDKPriorityUpdateHandling if workflow update is being used

### DIFF
--- a/internal/internal_event_handlers.go
+++ b/internal/internal_event_handlers.go
@@ -1360,7 +1360,6 @@ func (weh *workflowExecutionEventHandlerImpl) handleWorkflowExecutionStarted(
 	// replay sees the _final_ value of applied flags, not intermediate values
 	// as the value varies by WFT)
 	weh.sdkFlags.tryUse(SDKFlagProtocolMessageCommand, !weh.isReplay)
-	weh.sdkFlags.tryUse(SDKPriorityUpdateHandling, !weh.isReplay)
 
 	// Invoke the workflow.
 	weh.workflowDefinition.Execute(weh, attributes.Header, attributes.Input)

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -191,6 +191,10 @@ type (
 		message string
 	}
 
+	unknownSdkFlagError struct {
+		message string
+	}
+
 	preparedTask struct {
 		events         []*historypb.HistoryEvent
 		markers        []*historypb.HistoryEvent
@@ -239,6 +243,10 @@ func (h historyMismatchError) Error() string {
 	return h.message
 }
 
+func (s unknownSdkFlagError) Error() string {
+	return s.message
+}
+
 // Get workflow start event.
 func (eh *history) GetWorkflowStartedEvent() (*historypb.HistoryEvent, error) {
 	events := eh.workflowTask.task.History.Events
@@ -278,7 +286,9 @@ func (eh *history) isNextWorkflowTaskFailed() (task finishedTask, err error) {
 				f := sdkFlagFromUint(flag)
 				if !f.isValid() {
 					// If a flag is not recognized (value is too high or not defined), it must fail the workflow task
-					return finishedTask{}, errors.New("could not recognize SDK flag")
+					return finishedTask{}, unknownSdkFlagError{
+						message: fmt.Sprintf("unknown sdk flag: %d", flag),
+					}
 				}
 				flags = append(flags, f)
 			}

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -287,7 +287,7 @@ func (eh *history) isNextWorkflowTaskFailed() (task finishedTask, err error) {
 				if !f.isValid() {
 					// If a flag is not recognized (value is too high or not defined), it must fail the workflow task
 					return finishedTask{}, unknownSdkFlagError{
-						message: fmt.Sprintf("unknown sdk flag: %d", flag),
+						message: fmt.Sprintf("unknown SDK flag: %d", flag),
 					}
 				}
 				flags = append(flags, f)

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -33,6 +33,7 @@ import (
 	"sync"
 	"time"
 
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
@@ -463,6 +464,7 @@ func (wtp *workflowTaskPoller) RespondTaskCompleted(
 			}
 		}
 		eagerReserved := wtp.eagerActivityExecutor.applyToRequest(request)
+		wtp.logger.Info("RespondWorkflowTaskCompleted.", "request", protojson.Format(request))
 		response, err = wtp.service.RespondWorkflowTaskCompleted(grpcCtx, request)
 		if err != nil {
 			traceLog(func() {
@@ -493,6 +495,8 @@ func (wtp *workflowTaskPoller) errorToFailWorkflowTask(taskToken []byte, err err
 			cause = enumspb.WORKFLOW_TASK_FAILED_CAUSE_NON_DETERMINISTIC_ERROR
 		}
 	} else if _, mismatch := err.(historyMismatchError); mismatch {
+		cause = enumspb.WORKFLOW_TASK_FAILED_CAUSE_NON_DETERMINISTIC_ERROR
+	} else if _, unknown := err.(unknownSdkFlagError); unknown {
 		cause = enumspb.WORKFLOW_TASK_FAILED_CAUSE_NON_DETERMINISTIC_ERROR
 	}
 

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -33,7 +33,6 @@ import (
 	"sync"
 	"time"
 
-	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
@@ -464,7 +463,6 @@ func (wtp *workflowTaskPoller) RespondTaskCompleted(
 			}
 		}
 		eagerReserved := wtp.eagerActivityExecutor.applyToRequest(request)
-		wtp.logger.Info("RespondWorkflowTaskCompleted.", "request", protojson.Format(request))
 		response, err = wtp.service.RespondWorkflowTaskCompleted(grpcCtx, request)
 		if err != nil {
 			traceLog(func() {

--- a/internal/internal_workflow.go
+++ b/internal/internal_workflow.go
@@ -525,7 +525,6 @@ func (d *syncWorkflowDefinition) Execute(env WorkflowEnvironment, header *common
 			state.yield("yield before executing to setup state")
 			state.unblocked()
 
-			// TODO: @shreyassrivatsan - add workflow trace span here
 			r.workflowResult, r.error = d.workflow.Execute(d.rootCtx, input)
 			rpp := getWorkflowResultPointerPointer(ctx)
 			*rpp = r

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -787,7 +787,7 @@ type UpdateWorkflowWithOptionsRequest struct {
 
 // WorkflowUpdateHandle is a handle to a workflow execution update process. The
 // update may or may not have completed so an instance of this type functions
-// simlar to a Future with respect to the outcome of the update. If the update
+// similar to a Future with respect to the outcome of the update. If the update
 // is rejected or returns an error, the Get function on this type will return
 // that error through the output valuePtr.
 // NOTE: Experimental

--- a/test/workflow_test.go
+++ b/test/workflow_test.go
@@ -334,7 +334,6 @@ func (w *Workflows) UpdateInfoWorkflow(ctx workflow.Context) error {
 }
 
 func (w *Workflows) UpdateWithValidatorWorkflow(ctx workflow.Context) error {
-	workflow.GetLogger(ctx).Info("UpdateWithValidatorWorkflow started")
 	workflow.Go(ctx, func(ctx workflow.Context) {
 		_ = workflow.Sleep(ctx, time.Minute)
 	})


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Only set `SDKPriorityUpdateHandling` if workflow update is being used. Previously `SDKPriorityUpdateHandling` was set at the start of every workflow, this made it difficult to roll back the Go SDK to a previous version that did not understand `SDKPriorityUpdateHandling` without workflows getting stuck . Now rollback will only be blocked if a user was using workflow update.

Using workflow update in a workflow execution means:
* Registered an update handler
* Received any update requests

I also changed the type of an unknown SDK flag error to be treated as non deterministic to align with the behaviour of a missing workflow version call since SDK flags are basically internal SDK version calls.

## Why was the flag originally set in all workflow executions
* So all new workflow executions would always use the new correct update behaviour.
* Because that is what we believed we needed to do when we added `SDKFlagProtocolMessageCommand` flag to handle the ordering of update messages and the workflow task completed event (where the SDK reads the flags) since this is another update related flag the same logic applies. On review I couldn't find a good reason why we needed to always have set the flag. I think the actual issue was how the SDK was reading the messages,[ which I have fixed](https://github.com/temporalio/sdk-go/commit/2990ebf3124dcf542b143967d6e49ac201fc3ec6).

## Other options

We could not add a flag at all. This would be the simplest option, but would break all current users of update in the Go SDK. Since there are currently users activity using and paying for workflow update this option was not chosen.

## Release Notes

We will need to call out this lack of roll back support if a user is using workflow update in the release notes