### PR TITLE
Add note NextRetryDelay is not supported on the server

### DIFF
--- a/internal/error.go
+++ b/internal/error.go
@@ -131,6 +131,7 @@ type (
 		// Any value set from Workflow or LocalActivity will be silently ignored.
 		// It is impossible to specify immediate retry as it is indistinguishable from the default value. As a
 		// workaround you could set NextRetryDelay to some small value.
+		// NOTE: This is not currently supported by the Temporal Server as of 1.23.0.
 		NextRetryDelay time.Duration
 	}
 


### PR DESCRIPTION
Add a note NextRetryDelay is not supported on the server yet so users shouldn't expect it to work. We debated a few option internally, since we don't know what version of the server will support it the options are comment the option out or add a comment. I chose to add a comment since when the Server does add support users won't need to upgrade their SDKs, but I am open to other options.

