### PR TITLE
Add a test to validate behavior when invalid UTF-8 data is present

### DIFF
--- a/test/activity_test.go
+++ b/test/activity_test.go
@@ -228,6 +228,11 @@ func (a *Activities) Echo(ctx context.Context, delayInSeconds int, value int) (i
 	return value, nil
 }
 
+func (a *Activities) EchoString(ctx context.Context, message string) (string, error) {
+	a.append("EchoString")
+	return message, nil
+}
+
 func (a *Activities) WaitForWorkerStop(ctx context.Context, timeout time.Duration) (string, error) {
 	stopCh := activity.GetWorkerStopChannel(ctx)
 	// Mark activity as invoked then wait for it to be stopped

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -83,6 +83,8 @@ const (
 	testContextKey1               = "test-context-key1"
 	testContextKey2               = "test-context-key2"
 	testContextKey3               = "test-context-key3"
+	// 0x8f01 is invalid UTF-8
+	invalidUTF8 = "\n\x8f\x01\n\x0ejunk\x12data"
 )
 
 type IntegrationTestSuite struct {
@@ -5007,4 +5009,124 @@ func (c *coroutineCountingWorkflowOutboundInterceptor) Go(
 		defer atomic.AddInt32(&c.root._count, -1)
 		f(ctx)
 	})
+}
+
+type InvalidUTF8Suite struct {
+	*require.Assertions
+	suite.Suite
+	ConfigAndClientSuiteBase
+	activities                *Activities
+	workflows                 *Workflows
+	worker                    worker.Worker
+	workerStopped             bool
+	tracer                    *tracingInterceptor
+	inboundSignalInterceptor  *signalInterceptor
+	trafficController         *test.SimpleTrafficController
+	metricsHandler            *metrics.CapturingHandler
+	tallyScope                tally.TestScope
+	interceptorCallRecorder   *interceptortest.CallRecordingInvoker
+	openTelemetryTracer       trace.Tracer
+	openTelemetrySpanRecorder *tracetest.SpanRecorder
+	openTracingTracer         opentracing.Tracer
+}
+
+func TestInvalidUTF8Suite(t *testing.T) {
+	suite.Run(t, new(InvalidUTF8Suite))
+}
+
+func (ts *InvalidUTF8Suite) SetupSuite() {
+	ts.Assertions = require.New(ts.T())
+	ts.activities = newActivities()
+	ts.workflows = &Workflows{}
+	ts.NoError(ts.InitConfigAndNamespace())
+}
+
+func (ts *InvalidUTF8Suite) TearDownSuite() {
+	ts.Assertions = require.New(ts.T())
+
+	// allow the pollers to stop, and ensure there are no goroutine leaks.
+	// this will wait for up to 1 minute for leaks to subside, but exit relatively quickly if possible.
+	max := time.After(time.Minute)
+	var last error
+	for {
+		select {
+		case <-max:
+			if last != nil {
+				ts.NoError(last)
+				return
+			}
+			ts.FailNow("leaks timed out but no error, should be impossible")
+		case <-time.After(time.Second):
+			// https://github.com/temporalio/go-sdk/issues/51
+			last = goleak.Find(goleak.IgnoreTopFunction("go.temporal.io/sdk/internal.(*coroutineState).initialYield"))
+			if last == nil {
+				// no leak, done waiting
+				return
+			}
+			// else wait for another check or the timeout (which will record the latest error)
+		}
+	}
+}
+
+func (ts *InvalidUTF8Suite) SetupTest() {
+	ts.metricsHandler = metrics.NewCapturingHandler()
+	var metricsHandler client.MetricsHandler = ts.metricsHandler
+	var clientInterceptors []interceptor.ClientInterceptor
+	var workerInterceptors []interceptor.WorkerInterceptor
+
+	var err error
+	trafficController := test.NewSimpleTrafficController()
+	ts.client, err = client.Dial(client.Options{
+		HostPort:  ts.config.ServiceAddr,
+		Namespace: ts.config.Namespace,
+		Identity:  "integration-test",
+		Logger:    ilog.NewDefaultLogger(),
+		ContextPropagators: []workflow.ContextPropagator{
+			NewKeysPropagator([]string{testContextKey1}),
+			NewKeysPropagator([]string{testContextKey2}),
+		},
+		MetricsHandler:    metricsHandler,
+		TrafficController: trafficController,
+		Interceptors:      clientInterceptors,
+		ConnectionOptions: client.ConnectionOptions{TLS: ts.config.TLS},
+	})
+	ts.NoError(err)
+
+	ts.trafficController = trafficController
+	ts.activities.clearInvoked()
+	ts.activities.client = ts.client
+	ts.taskQueueName = taskQueuePrefix + "-" + ts.T().Name()
+	ts.tracer = newTracingInterceptor()
+	ts.inboundSignalInterceptor = newSignalInterceptor()
+	workerInterceptors = append(workerInterceptors, ts.tracer, ts.inboundSignalInterceptor)
+	options := worker.Options{
+		Interceptors:        workerInterceptors,
+		WorkflowPanicPolicy: worker.FailWorkflow,
+	}
+
+	worker.SetStickyWorkflowCacheSize(ts.config.maxWorkflowCacheSize)
+
+	ts.worker = worker.New(ts.client, ts.taskQueueName, options)
+	ts.workerStopped = false
+
+	ts.workflows.register(ts.worker)
+	ts.activities.register(ts.worker)
+	ts.Nil(ts.worker.Start())
+}
+
+func (ts *InvalidUTF8Suite) TearDownTest() {
+	ts.client.Close()
+	if !ts.workerStopped {
+		ts.worker.Stop()
+		ts.workerStopped = true
+	}
+}
+
+func (ts *InvalidUTF8Suite) TestBasic() {
+	var response string
+	err := ts.executeWorkflow("test-basic", ts.workflows.Echo, &response, invalidUTF8)
+	ts.NoError(err)
+	ts.EqualValues([]string{"EchoString"}, ts.activities.invoked())
+	// Go's JSON coding stack will replace invalid bytes with the unicode substitute char U+FFFD
+	ts.Equal("\n�\x01\n\x0ejunk\x12data", response)
 }

--- a/test/workflow_test.go
+++ b/test/workflow_test.go
@@ -69,6 +69,14 @@ func (w *Workflows) Basic(ctx workflow.Context) ([]string, error) {
 	return []string{"toUpperWithDelay", "toUpper"}, nil
 }
 
+func (w *Workflows) Echo(ctx workflow.Context, message string) (string, error) {
+	ctx = workflow.WithActivityOptions(ctx, w.defaultActivityOptions())
+	var ans1 string
+	workflow.GetLogger(ctx).Info("calling ExecuteActivity")
+	activityFut := workflow.ExecuteActivity(ctx, "EchoString", message)
+	return ans1, activityFut.Get(ctx, &ans1)
+}
+
 func (w *Workflows) Deadlocked(ctx workflow.Context) ([]string, error) {
 	// Simulates deadlock. Never call time.Sleep in production code!
 	time.Sleep(2 * time.Second)
@@ -2992,6 +3000,7 @@ func (w *Workflows) register(worker worker.Worker) {
 	worker.RegisterWorkflow(w.WaitOnUpdate)
 	worker.RegisterWorkflow(w.UpdateOrdering)
 	worker.RegisterWorkflow(w.UpdateSetHandlerOnly)
+	worker.RegisterWorkflow(w.Echo)
 }
 
 func (w *Workflows) defaultActivityOptions() workflow.ActivityOptions {


### PR DESCRIPTION
## What was changed

This PR adds an integration test to validate that we allow invalid UTF-8 data in strings.

## Testing

You will need to run the server locally as of https://github.com/temporalio/temporal/pull/5476, then execute the integration tests.

This test has been manually verified as passing on SDK version 1.25.0 and server version 1.22.5, so we should remain compatible with our pre-google/protobuf behavior

## Checklist
1. Ready this for review once the server and CLI support this
