### PR TITLE
Expose DevServer methods that allow sending SIGSTOP/CONT/KILL.

### DIFF
--- a/testsuite/process_nonwindows.go
+++ b/testsuite/process_nonwindows.go
@@ -41,3 +41,15 @@ func newCmd(exePath string, args ...string) *exec.Cmd {
 func sendInterrupt(process *os.Process) error {
 	return process.Signal(syscall.SIGINT)
 }
+
+func sendStop(process *os.Process) error {
+	return process.Signal(syscall.SIGSTOP)
+}
+
+func sendContinue(process *os.Process) error {
+	return process.Signal(syscall.SIGCONT)
+}
+
+func sendKill(process *os.Process) error {
+	return process.Signal(syscall.SIGKILL)
+}

--- a/testsuite/process_windows.go
+++ b/testsuite/process_windows.go
@@ -23,6 +23,7 @@
 package testsuite
 
 import (
+	"errors"
 	"os"
 	"os/exec"
 	"syscall"
@@ -56,4 +57,16 @@ func sendInterrupt(process *os.Process) error {
 		return err
 	}
 	return nil
+}
+
+func sendStop(process *os.Process) error {
+	return errors.New("operation not supported on this platform")
+}
+
+func sendContinue(process *os.Process) error {
+	return errors.New("operation not supported on this platform")
+}
+
+func sendKill(process *os.Process) error {
+	return errors.New("operation not supported on this platform")
 }


### PR DESCRIPTION
## What was changed
* Add `Pause(<-chan struct{}) error` to send `SIGSTOP` and `SIGCONT` to a dev server
* Add `Kill() error` to send `SIGKILL` to a dev server

## Why?
This will enable writing [features repo](https://github.com/temporalio/features) tests that verify the client's retry behavior.  [A comment on features#326](https://github.com/temporalio/features/issues/326#issuecomment-1732071582) says that @rross reports that the Java SDK doesn't retry correctly on the first connection.  By starting a dev server and freezing it before opening the first connection, we can test that this works correctly in all SDKs.