### PR TITLE
Make client Dial context controlable by callers

### DIFF
--- a/internal/client.go
+++ b/internal/client.go
@@ -715,35 +715,35 @@ type Credentials interface {
 }
 
 // DialClient creates a client and attempts to connect to the server.
-func DialClient(options ClientOptions) (Client, error) {
+func DialClient(ctx context.Context, options ClientOptions) (Client, error) {
 	options.ConnectionOptions.disableEagerConnection = false
-	return NewClient(options)
+	return NewClient(ctx, options)
 }
 
 // NewLazyClient creates a client and does not attempt to connect to the server.
 func NewLazyClient(options ClientOptions) (Client, error) {
 	options.ConnectionOptions.disableEagerConnection = true
-	return NewClient(options)
+	return NewClient(context.Background(), options)
 }
 
 // NewClient creates an instance of a workflow client
 //
 // Deprecated: Use DialClient or NewLazyClient instead.
-func NewClient(options ClientOptions) (Client, error) {
-	return newClient(options, nil)
+func NewClient(ctx context.Context, options ClientOptions) (Client, error) {
+	return newClient(ctx, options, nil)
 }
 
 // NewClientFromExisting creates a new client using the same connection as the
 // existing client.
-func NewClientFromExisting(existingClient Client, options ClientOptions) (Client, error) {
+func NewClientFromExisting(ctx context.Context, existingClient Client, options ClientOptions) (Client, error) {
 	existing, _ := existingClient.(*WorkflowClient)
 	if existing == nil {
 		return nil, fmt.Errorf("existing client must have been created directly from a client package call")
 	}
-	return newClient(options, existing)
+	return newClient(ctx, options, existing)
 }
 
-func newClient(options ClientOptions, existing *WorkflowClient) (Client, error) {
+func newClient(ctx context.Context, options ClientOptions, existing *WorkflowClient) (Client, error) {
 	if options.Namespace == "" {
 		options.Namespace = DefaultNamespace
 	}
@@ -788,13 +788,13 @@ func newClient(options ClientOptions, existing *WorkflowClient) (Client, error) 
 	// the new connection. Otherwise, only load server capabilities eagerly if not
 	// disabled.
 	if existing != nil {
-		if client.capabilities, err = existing.loadCapabilities(); err != nil {
+		if client.capabilities, err = existing.loadCapabilities(ctx); err != nil {
 			return nil, err
 		}
 		client.unclosedClients = existing.unclosedClients
 	} else {
 		if !options.ConnectionOptions.disableEagerConnection {
-			if _, err := client.loadCapabilities(); err != nil {
+			if _, err := client.loadCapabilities(ctx); err != nil {
 				client.Close()
 				return nil, err
 			}

--- a/internal/client.go
+++ b/internal/client.go
@@ -792,13 +792,13 @@ func newClient(ctx context.Context, options ClientOptions, existing *WorkflowCli
 	// the new connection. Otherwise, only load server capabilities eagerly if not
 	// disabled.
 	if existing != nil {
-		if client.capabilities, err = existing.loadCapabilities(ctx, withGetSystemInfoTimeout(options.ConnectionOptions.GetSystemInfoTimeout)); err != nil {
+		if client.capabilities, err = existing.loadCapabilities(ctx, options.ConnectionOptions.GetSystemInfoTimeout); err != nil {
 			return nil, err
 		}
 		client.unclosedClients = existing.unclosedClients
 	} else {
 		if !options.ConnectionOptions.disableEagerConnection {
-			if _, err := client.loadCapabilities(ctx, withGetSystemInfoTimeout(options.ConnectionOptions.GetSystemInfoTimeout)); err != nil {
+			if _, err := client.loadCapabilities(ctx, options.ConnectionOptions.GetSystemInfoTimeout); err != nil {
 				client.Close()
 				return nil, err
 			}

--- a/internal/client.go
+++ b/internal/client.go
@@ -508,6 +508,10 @@ type (
 		// default: 15s
 		KeepAliveTimeout time.Duration
 
+		// GetSystemInfoTimeout is the timeout for the RPC made by the
+		// client to fetch server capabilities.
+		GetSystemInfoTimeout time.Duration
+
 		// if true, when there are no active RPCs, Time and Timeout will be ignored and no
 		// keepalive pings will be sent.
 		// If false, client sends keepalive pings even with no active RPCs
@@ -788,13 +792,13 @@ func newClient(ctx context.Context, options ClientOptions, existing *WorkflowCli
 	// the new connection. Otherwise, only load server capabilities eagerly if not
 	// disabled.
 	if existing != nil {
-		if client.capabilities, err = existing.loadCapabilities(ctx); err != nil {
+		if client.capabilities, err = existing.loadCapabilities(ctx, withGetSystemInfoTimeout(options.ConnectionOptions.GetSystemInfoTimeout)); err != nil {
 			return nil, err
 		}
 		client.unclosedClients = existing.unclosedClients
 	} else {
 		if !options.ConnectionOptions.disableEagerConnection {
-			if _, err := client.loadCapabilities(ctx); err != nil {
+			if _, err := client.loadCapabilities(ctx, withGetSystemInfoTimeout(options.ConnectionOptions.GetSystemInfoTimeout)); err != nil {
 				client.Close()
 				return nil, err
 			}

--- a/internal/grpc_dialer_test.go
+++ b/internal/grpc_dialer_test.go
@@ -171,7 +171,7 @@ func TestMissingGetServerInfo(t *testing.T) {
 	require.NoError(t, lastErr)
 
 	// Create a new client and confirm client has empty capabilities set
-	client, err := DialClient(ClientOptions{HostPort: l.Addr().String()})
+	client, err := DialClient(context.Background(), ClientOptions{HostPort: l.Addr().String()})
 	require.NoError(t, err)
 	workflowClient := client.(*WorkflowClient)
 	require.True(t, proto.Equal(&workflowservice.GetSystemInfoResponse_Capabilities{}, workflowClient.capabilities))
@@ -192,7 +192,7 @@ func TestInternalErrorRetry(t *testing.T) {
 	srv.signalWorkflowExecutionResponseError = status.Error(codes.Internal, "oh no, an internal error")
 
 	// Create client and make call
-	client, err := DialClient(ClientOptions{HostPort: srv.addr})
+	client, err := DialClient(context.Background(), ClientOptions{HostPort: srv.addr})
 	require.NoError(t, err)
 	defer client.Close()
 	_, err = client.WorkflowService().SignalWorkflowExecution(ctx, &workflowservice.SignalWorkflowExecutionRequest{})
@@ -213,7 +213,7 @@ func TestInternalErrorRetry(t *testing.T) {
 	srv.signalWorkflowExecutionResponseError = status.Error(codes.Internal, "oh no, an internal error")
 
 	// Create client and make call
-	client, err = DialClient(ClientOptions{HostPort: srv.addr})
+	client, err = DialClient(context.Background(), ClientOptions{HostPort: srv.addr})
 	require.NoError(t, err)
 	defer client.Close()
 	_, err = client.WorkflowService().SignalWorkflowExecution(ctx, &workflowservice.SignalWorkflowExecutionRequest{})
@@ -231,7 +231,7 @@ func TestEagerAndLazyClient(t *testing.T) {
 	srv.getSystemInfoResponseError = fmt.Errorf("some server failure")
 
 	// Confirm eager dial fails
-	_, err = DialClient(ClientOptions{HostPort: srv.addr})
+	_, err = DialClient(context.Background(), ClientOptions{HostPort: srv.addr})
 	require.EqualError(t, err, "failed reaching server: some server failure")
 
 	// Confirm lazy dial succeeds but fails signal workflow
@@ -247,7 +247,7 @@ func TestEagerAndLazyClient(t *testing.T) {
 	require.NoError(t, err)
 
 	// Now that there's no sys info response error, eager should succeed
-	c, err = DialClient(ClientOptions{HostPort: srv.addr})
+	c, err = DialClient(context.Background(), ClientOptions{HostPort: srv.addr})
 	require.NoError(t, err)
 	defer c.Close()
 
@@ -316,7 +316,7 @@ func TestDialOptions(t *testing.T) {
 			return invoker(ctx, method, req, reply, cc, opts...)
 		}
 	}
-	client, err := DialClient(ClientOptions{
+	client, err := DialClient(context.Background(), ClientOptions{
 		HostPort: srv.addr,
 		ConnectionOptions: ConnectionOptions{
 			DialOptions: []grpc.DialOption{
@@ -353,7 +353,7 @@ func TestCustomResolver(t *testing.T) {
 	builder := manual.NewBuilderWithScheme(scheme)
 	builder.InitialState(resolver.State{Addresses: []resolver.Address{{Addr: s1.addr}, {Addr: s2.addr}}})
 	resolver.Register(builder)
-	client, err := DialClient(ClientOptions{HostPort: scheme + ":///whatever"})
+	client, err := DialClient(context.Background(), ClientOptions{HostPort: scheme + ":///whatever"})
 	require.NoError(t, err)
 	defer client.Close()
 
@@ -417,12 +417,12 @@ func TestResourceExhaustedCause(t *testing.T) {
 		Cause: enums.RESOURCE_EXHAUSTED_CAUSE_CONCURRENT_LIMIT,
 	})
 	srv.getSystemInfoResponseError = s.Err()
-	_, err = DialClient(ClientOptions{HostPort: srv.addr, MetricsHandler: handler})
+	_, err = DialClient(context.Background(), ClientOptions{HostPort: srv.addr, MetricsHandler: handler})
 	require.Error(t, err)
 
 	// Attempt dial with a cause-less resource exhausted
 	srv.getSystemInfoResponseError = status.New(codes.ResourceExhausted, "some resource exhausted").Err()
-	_, err = DialClient(ClientOptions{HostPort: srv.addr, MetricsHandler: handler})
+	_, err = DialClient(context.Background(), ClientOptions{HostPort: srv.addr, MetricsHandler: handler})
 	require.Error(t, err)
 
 	// Make sure we have 1 metric with cause and 1 without

--- a/internal/grpc_dialer_test.go
+++ b/internal/grpc_dialer_test.go
@@ -445,7 +445,7 @@ func TestCredentialsAPIKey(t *testing.T) {
 	defer srv.Stop()
 
 	// Fixed string
-	client, err := DialClient(ClientOptions{
+	client, err := DialClient(context.Background(), ClientOptions{
 		HostPort:    srv.addr,
 		Credentials: NewAPIKeyStaticCredentials("my-api-key"),
 	})
@@ -470,7 +470,7 @@ func TestCredentialsAPIKey(t *testing.T) {
 	)
 
 	// Callback
-	client, err = DialClient(ClientOptions{
+	client, err = DialClient(context.Background(), ClientOptions{
 		HostPort: srv.addr,
 		Credentials: NewAPIKeyDynamicCredentials(func(ctx context.Context) (string, error) {
 			return "my-callback-api-key", nil

--- a/internal/internal_schedule_client.go
+++ b/internal/internal_schedule_client.go
@@ -171,7 +171,7 @@ func (w *workflowClientInterceptor) CreateSchedule(ctx context.Context, in *Sche
 }
 
 func (sc *scheduleClient) Create(ctx context.Context, options ScheduleOptions) (ScheduleHandle, error) {
-	if err := sc.workflowClient.ensureInitialized(); err != nil {
+	if err := sc.workflowClient.ensureInitialized(ctx); err != nil {
 		return nil, err
 	}
 

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -947,7 +947,7 @@ func (aw *AggregatedWorker) Start() error {
 		return err
 	}
 	// Populate the capabilities. This should be the only time it is written too.
-	capabilities, err := aw.client.loadCapabilities(context.Background())
+	capabilities, err := aw.client.loadCapabilities(context.Background(), defaultGetSystemInfoTimeout)
 	if err != nil {
 		return err
 	}

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -943,11 +943,11 @@ func (aw *AggregatedWorker) Start() error {
 	aw.assertNotStopped()
 	if err := initBinaryChecksum(); err != nil {
 		return fmt.Errorf("failed to get executable checksum: %v", err)
-	} else if err = aw.client.ensureInitialized(); err != nil {
+	} else if err = aw.client.ensureInitialized(context.Background()); err != nil {
 		return err
 	}
 	// Populate the capabilities. This should be the only time it is written too.
-	capabilities, err := aw.client.loadCapabilities()
+	capabilities, err := aw.client.loadCapabilities(context.Background())
 	if err != nil {
 		return err
 	}

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -220,7 +220,7 @@ type (
 // subjected to change in the future.
 // NOTE: the context.Context should have a fairly large timeout, since workflow execution may take a while to be finished
 func (wc *WorkflowClient) ExecuteWorkflow(ctx context.Context, options StartWorkflowOptions, workflow interface{}, args ...interface{}) (WorkflowRun, error) {
-	if err := wc.ensureInitialized(); err != nil {
+	if err := wc.ensureInitialized(ctx); err != nil {
 		return nil, err
 	}
 
@@ -296,7 +296,7 @@ func (wc *WorkflowClient) GetWorkflow(ctx context.Context, workflowID string, ru
 
 // SignalWorkflow signals a workflow in execution.
 func (wc *WorkflowClient) SignalWorkflow(ctx context.Context, workflowID string, runID string, signalName string, arg interface{}) error {
-	if err := wc.ensureInitialized(); err != nil {
+	if err := wc.ensureInitialized(ctx); err != nil {
 		return err
 	}
 
@@ -316,7 +316,7 @@ func (wc *WorkflowClient) SignalWorkflow(ctx context.Context, workflowID string,
 func (wc *WorkflowClient) SignalWithStartWorkflow(ctx context.Context, workflowID string, signalName string, signalArg interface{},
 	options StartWorkflowOptions, workflowFunc interface{}, workflowArgs ...interface{},
 ) (WorkflowRun, error) {
-	if err := wc.ensureInitialized(); err != nil {
+	if err := wc.ensureInitialized(ctx); err != nil {
 		return nil, err
 	}
 
@@ -358,7 +358,7 @@ func (wc *WorkflowClient) SignalWithStartWorkflow(ctx context.Context, workflowI
 // workflowID is required, other parameters are optional.
 // If runID is omit, it will terminate currently running workflow (if there is one) based on the workflowID.
 func (wc *WorkflowClient) CancelWorkflow(ctx context.Context, workflowID string, runID string) error {
-	if err := wc.ensureInitialized(); err != nil {
+	if err := wc.ensureInitialized(ctx); err != nil {
 		return err
 	}
 
@@ -369,7 +369,7 @@ func (wc *WorkflowClient) CancelWorkflow(ctx context.Context, workflowID string,
 // workflowID is required, other parameters are optional.
 // If runID is omit, it will terminate currently running workflow (if there is one) based on the workflowID.
 func (wc *WorkflowClient) TerminateWorkflow(ctx context.Context, workflowID string, runID string, reason string, details ...interface{}) error {
-	if err := wc.ensureInitialized(); err != nil {
+	if err := wc.ensureInitialized(ctx); err != nil {
 		return err
 	}
 
@@ -439,7 +439,7 @@ func (wc *WorkflowClient) getWorkflowHistory(
 func (wc *WorkflowClient) getWorkflowExecutionHistory(ctx context.Context, rpcMetricsHandler metrics.Handler, isLongPoll bool,
 	request *workflowservice.GetWorkflowExecutionHistoryRequest, filterType enumspb.HistoryEventFilterType,
 ) (*workflowservice.GetWorkflowExecutionHistoryResponse, error) {
-	if err := wc.ensureInitialized(); err != nil {
+	if err := wc.ensureInitialized(ctx); err != nil {
 		return nil, err
 	}
 
@@ -471,7 +471,7 @@ func (wc *WorkflowClient) getWorkflowExecutionHistory(ctx context.Context, rpcMe
 // completed event will be reported; if err is CanceledError, activity task canceled event will be reported; otherwise,
 // activity task failed event will be reported.
 func (wc *WorkflowClient) CompleteActivity(ctx context.Context, taskToken []byte, result interface{}, err error) error {
-	if err := wc.ensureInitialized(); err != nil {
+	if err := wc.ensureInitialized(ctx); err != nil {
 		return err
 	}
 
@@ -524,7 +524,7 @@ func (wc *WorkflowClient) CompleteActivityByID(ctx context.Context, namespace, w
 
 // RecordActivityHeartbeat records heartbeat for an activity.
 func (wc *WorkflowClient) RecordActivityHeartbeat(ctx context.Context, taskToken []byte, details ...interface{}) error {
-	if err := wc.ensureInitialized(); err != nil {
+	if err := wc.ensureInitialized(ctx); err != nil {
 		return err
 	}
 
@@ -540,7 +540,7 @@ func (wc *WorkflowClient) RecordActivityHeartbeat(ctx context.Context, taskToken
 func (wc *WorkflowClient) RecordActivityHeartbeatByID(ctx context.Context,
 	namespace, workflowID, runID, activityID string, details ...interface{},
 ) error {
-	if err := wc.ensureInitialized(); err != nil {
+	if err := wc.ensureInitialized(ctx); err != nil {
 		return err
 	}
 
@@ -559,7 +559,7 @@ func (wc *WorkflowClient) RecordActivityHeartbeatByID(ctx context.Context,
 //   - serviceerror.Unavailable
 //   - serviceerror.NamespaceNotFound
 func (wc *WorkflowClient) ListClosedWorkflow(ctx context.Context, request *workflowservice.ListClosedWorkflowExecutionsRequest) (*workflowservice.ListClosedWorkflowExecutionsResponse, error) {
-	if err := wc.ensureInitialized(); err != nil {
+	if err := wc.ensureInitialized(ctx); err != nil {
 		return nil, err
 	}
 
@@ -582,7 +582,7 @@ func (wc *WorkflowClient) ListClosedWorkflow(ctx context.Context, request *workf
 //   - serviceerror.Unavailable
 //   - serviceerror.NamespaceNotFound
 func (wc *WorkflowClient) ListOpenWorkflow(ctx context.Context, request *workflowservice.ListOpenWorkflowExecutionsRequest) (*workflowservice.ListOpenWorkflowExecutionsResponse, error) {
-	if err := wc.ensureInitialized(); err != nil {
+	if err := wc.ensureInitialized(ctx); err != nil {
 		return nil, err
 	}
 
@@ -600,7 +600,7 @@ func (wc *WorkflowClient) ListOpenWorkflow(ctx context.Context, request *workflo
 
 // ListWorkflow implementation
 func (wc *WorkflowClient) ListWorkflow(ctx context.Context, request *workflowservice.ListWorkflowExecutionsRequest) (*workflowservice.ListWorkflowExecutionsResponse, error) {
-	if err := wc.ensureInitialized(); err != nil {
+	if err := wc.ensureInitialized(ctx); err != nil {
 		return nil, err
 	}
 
@@ -618,7 +618,7 @@ func (wc *WorkflowClient) ListWorkflow(ctx context.Context, request *workflowser
 
 // ListArchivedWorkflow implementation
 func (wc *WorkflowClient) ListArchivedWorkflow(ctx context.Context, request *workflowservice.ListArchivedWorkflowExecutionsRequest) (*workflowservice.ListArchivedWorkflowExecutionsResponse, error) {
-	if err := wc.ensureInitialized(); err != nil {
+	if err := wc.ensureInitialized(ctx); err != nil {
 		return nil, err
 	}
 
@@ -648,7 +648,7 @@ func (wc *WorkflowClient) ListArchivedWorkflow(ctx context.Context, request *wor
 
 // ScanWorkflow implementation
 func (wc *WorkflowClient) ScanWorkflow(ctx context.Context, request *workflowservice.ScanWorkflowExecutionsRequest) (*workflowservice.ScanWorkflowExecutionsResponse, error) {
-	if err := wc.ensureInitialized(); err != nil {
+	if err := wc.ensureInitialized(ctx); err != nil {
 		return nil, err
 	}
 
@@ -666,7 +666,7 @@ func (wc *WorkflowClient) ScanWorkflow(ctx context.Context, request *workflowser
 
 // CountWorkflow implementation
 func (wc *WorkflowClient) CountWorkflow(ctx context.Context, request *workflowservice.CountWorkflowExecutionsRequest) (*workflowservice.CountWorkflowExecutionsResponse, error) {
-	if err := wc.ensureInitialized(); err != nil {
+	if err := wc.ensureInitialized(ctx); err != nil {
 		return nil, err
 	}
 
@@ -684,7 +684,7 @@ func (wc *WorkflowClient) CountWorkflow(ctx context.Context, request *workflowse
 
 // GetSearchAttributes implementation
 func (wc *WorkflowClient) GetSearchAttributes(ctx context.Context) (*workflowservice.GetSearchAttributesResponse, error) {
-	if err := wc.ensureInitialized(); err != nil {
+	if err := wc.ensureInitialized(ctx); err != nil {
 		return nil, err
 	}
 
@@ -704,7 +704,7 @@ func (wc *WorkflowClient) GetSearchAttributes(ctx context.Context) (*workflowser
 //   - serviceerror.Unavailable
 //   - serviceerror.NotFound
 func (wc *WorkflowClient) DescribeWorkflowExecution(ctx context.Context, workflowID, runID string) (*workflowservice.DescribeWorkflowExecutionResponse, error) {
-	if err := wc.ensureInitialized(); err != nil {
+	if err := wc.ensureInitialized(ctx); err != nil {
 		return nil, err
 	}
 
@@ -738,7 +738,7 @@ func (wc *WorkflowClient) DescribeWorkflowExecution(ctx context.Context, workflo
 //   - serviceerror.NotFound
 //   - serviceerror.QueryFailed
 func (wc *WorkflowClient) QueryWorkflow(ctx context.Context, workflowID string, runID string, queryType string, args ...interface{}) (converter.EncodedValue, error) {
-	if err := wc.ensureInitialized(); err != nil {
+	if err := wc.ensureInitialized(ctx); err != nil {
 		return nil, err
 	}
 
@@ -886,7 +886,7 @@ type QueryWorkflowWithOptionsResponse struct {
 //   - serviceerror.NotFound
 //   - serviceerror.QueryFailed
 func (wc *WorkflowClient) QueryWorkflowWithOptions(ctx context.Context, request *QueryWorkflowWithOptionsRequest) (*QueryWorkflowWithOptionsResponse, error) {
-	if err := wc.ensureInitialized(); err != nil {
+	if err := wc.ensureInitialized(ctx); err != nil {
 		return nil, err
 	}
 
@@ -925,7 +925,7 @@ func (wc *WorkflowClient) QueryWorkflowWithOptions(ctx context.Context, request 
 //   - serviceerror.Unavailable
 //   - serviceerror.NotFound
 func (wc *WorkflowClient) DescribeTaskQueue(ctx context.Context, taskQueue string, taskQueueType enumspb.TaskQueueType) (*workflowservice.DescribeTaskQueueResponse, error) {
-	if err := wc.ensureInitialized(); err != nil {
+	if err := wc.ensureInitialized(ctx); err != nil {
 		return nil, err
 	}
 
@@ -949,7 +949,7 @@ func (wc *WorkflowClient) DescribeTaskQueue(ctx context.Context, taskQueue strin
 // And it will immediately terminating the current execution instance.
 // RequestId is used to deduplicate requests. It will be autogenerated if not set.
 func (wc *WorkflowClient) ResetWorkflowExecution(ctx context.Context, request *workflowservice.ResetWorkflowExecutionRequest) (*workflowservice.ResetWorkflowExecutionResponse, error) {
-	if err := wc.ensureInitialized(); err != nil {
+	if err := wc.ensureInitialized(ctx); err != nil {
 		return nil, err
 	}
 
@@ -971,7 +971,7 @@ func (wc *WorkflowClient) ResetWorkflowExecution(ctx context.Context, request *w
 // task queue. This is used in conjunction with workers who specify their build id and thus opt into the
 // feature.
 func (wc *WorkflowClient) UpdateWorkerBuildIdCompatibility(ctx context.Context, options *UpdateWorkerBuildIdCompatibilityOptions) error {
-	if err := wc.ensureInitialized(); err != nil {
+	if err := wc.ensureInitialized(ctx); err != nil {
 		return err
 	}
 
@@ -992,7 +992,7 @@ func (wc *WorkflowClient) GetWorkerBuildIdCompatibility(ctx context.Context, opt
 	if options.MaxSets < 0 {
 		return nil, errors.New("maxDepth must be >= 0")
 	}
-	if err := wc.ensureInitialized(); err != nil {
+	if err := wc.ensureInitialized(ctx); err != nil {
 		return nil, err
 	}
 
@@ -1014,7 +1014,7 @@ func (wc *WorkflowClient) GetWorkerBuildIdCompatibility(ctx context.Context, opt
 
 // GetWorkerTaskReachability returns which versions are is still in use by open or closed workflows.
 func (wc *WorkflowClient) GetWorkerTaskReachability(ctx context.Context, options *GetWorkerTaskReachabilityOptions) (*WorkerTaskReachability, error) {
-	if err := wc.ensureInitialized(); err != nil {
+	if err := wc.ensureInitialized(ctx); err != nil {
 		return nil, err
 	}
 
@@ -1039,7 +1039,7 @@ func (wc *WorkflowClient) UpdateWorkflowWithOptions(
 	ctx context.Context,
 	req *UpdateWorkflowWithOptionsRequest,
 ) (WorkflowUpdateHandle, error) {
-	if err := wc.ensureInitialized(); err != nil {
+	if err := wc.ensureInitialized(ctx); err != nil {
 		return nil, err
 	}
 	// Default update ID
@@ -1082,7 +1082,7 @@ func (wc *WorkflowClient) PollWorkflowUpdate(
 	ctx context.Context,
 	ref *updatepb.UpdateRef,
 ) (converter.EncodedValue, error) {
-	if err := wc.ensureInitialized(); err != nil {
+	if err := wc.ensureInitialized(ctx); err != nil {
 		return nil, err
 	}
 	ctx = contextWithNewHeader(ctx)
@@ -1098,7 +1098,7 @@ func (wc *WorkflowClient) UpdateWorkflow(
 	updateName string,
 	args ...interface{},
 ) (WorkflowUpdateHandle, error) {
-	if err := wc.ensureInitialized(); err != nil {
+	if err := wc.ensureInitialized(ctx); err != nil {
 		return nil, err
 	}
 
@@ -1121,7 +1121,7 @@ type CheckHealthResponse struct{}
 // CheckHealth performs a server health check using the gRPC health check
 // API. If the check fails, an error is returned.
 func (wc *WorkflowClient) CheckHealth(ctx context.Context, request *CheckHealthRequest) (*CheckHealthResponse, error) {
-	if err := wc.ensureInitialized(); err != nil {
+	if err := wc.ensureInitialized(ctx); err != nil {
 		return nil, err
 	}
 
@@ -1148,7 +1148,7 @@ func (wc *WorkflowClient) OperatorService() operatorservice.OperatorServiceClien
 }
 
 // Get capabilities, lazily fetching from server if not already obtained.
-func (wc *WorkflowClient) loadCapabilities() (*workflowservice.GetSystemInfoResponse_Capabilities, error) {
+func (wc *WorkflowClient) loadCapabilities(ctx context.Context) (*workflowservice.GetSystemInfoResponse_Capabilities, error) {
 	// While we want to memoize the result here, we take care not to lock during
 	// the call. This means that in racy situations where this is called multiple
 	// times at once, it may result in multiple calls. This is far more preferable
@@ -1162,8 +1162,15 @@ func (wc *WorkflowClient) loadCapabilities() (*workflowservice.GetSystemInfoResp
 	}
 
 	// Fetch the capabilities
-	ctx, cancel := context.WithTimeout(context.Background(), getSystemInfoTimeout)
-	defer cancel()
+
+	// We set a default timeout if none is set in the context to stay
+	// backward compatible with the old behavior where the timeout was
+	// hardcoded to 5s.
+	if _, ok := ctx.Deadline(); !ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, getSystemInfoTimeout)
+		defer cancel()
+	}
 	resp, err := wc.workflowService.GetSystemInfo(ctx, &workflowservice.GetSystemInfoRequest{})
 	// We ignore unimplemented
 	if _, isUnimplemented := err.(*serviceerror.Unimplemented); err != nil && !isUnimplemented {
@@ -1185,9 +1192,9 @@ func (wc *WorkflowClient) loadCapabilities() (*workflowservice.GetSystemInfoResp
 	return capabilities, nil
 }
 
-func (wc *WorkflowClient) ensureInitialized() error {
+func (wc *WorkflowClient) ensureInitialized(ctx context.Context) error {
 	// Just loading the capabilities is enough
-	_, err := wc.loadCapabilities()
+	_, err := wc.loadCapabilities(ctx)
 	return err
 }
 

--- a/internal/internal_workflow_client_test.go
+++ b/internal/internal_workflow_client_test.go
@@ -1624,7 +1624,7 @@ func TestClientCloseCount(t *testing.T) {
 	server, err := startTestGRPCServer()
 	require.NoError(t, err)
 	defer server.Stop()
-	client, err := DialClient(ClientOptions{HostPort: server.addr})
+	client, err := DialClient(context.Background(), ClientOptions{HostPort: server.addr})
 	require.NoError(t, err)
 	workflowClient := client.(*WorkflowClient)
 
@@ -1632,11 +1632,11 @@ func TestClientCloseCount(t *testing.T) {
 	require.EqualValues(t, 1, atomic.LoadInt32(workflowClient.unclosedClients))
 
 	// Create two more and confirm counts
-	client2, err := NewClientFromExisting(client, ClientOptions{})
+	client2, err := NewClientFromExisting(context.Background(), client, ClientOptions{})
 	require.NoError(t, err)
 	require.EqualValues(t, 2, atomic.LoadInt32(workflowClient.unclosedClients))
 	require.Same(t, workflowClient.unclosedClients, client2.(*WorkflowClient).unclosedClients)
-	client3, err := NewClientFromExisting(client, ClientOptions{})
+	client3, err := NewClientFromExisting(context.Background(), client, ClientOptions{})
 	require.NoError(t, err)
 	require.EqualValues(t, 3, atomic.LoadInt32(workflowClient.unclosedClients))
 	require.Same(t, workflowClient.unclosedClients, client3.(*WorkflowClient).unclosedClients)


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

This PR exposes new `DialContext` and `NewClientFromExistingWithContext` APIs that take a context as input and propagates it down the stack until all synchronous server calls so timeout and cancellation can be controlled by the callers.

The PR also replaces `grpc.Dial` call by `grpc.DialContext` and propagate user defined context down to the grpc dial call properly. Doing so means when users use `grpc.WithBlock()` dial option, they will be in control of the dial timeout

## Why?
<!-- Tell your future self why have you made these changes -->

When clients use `Dial` or `NewClientFromExisting` APIs to start, they connect to the server and try to load capabilities synchronously. However, clients have no control over the timeouts and cancellation of such requests. They can't extend timeouts to accommodate slow networks or appropriately cancel those calls.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

I expect no behavior change. Timeouts are kept the same unless you use the new APIs and define proper context deadlines.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

Godoc updates might be enough?

--- 

I noticed that the gRPC client uses the `Dial` API

https://github.com/temporalio/sdk-go/blob/efabf4622182554045df2bb9ab9f78d159ffd928/internal/grpc_dialer.go#L144

and not the `DialContext` one. However, it seems that users have the possibility to set arbitrary `grpc.DialOption` via the `ConnectionOptions`

https://github.com/temporalio/sdk-go/blob/efabf4622182554045df2bb9ab9f78d159ffd928/internal/client.go#L517-L525

which includes the `grpc.WithBlock()` one. When that's set it's probably better to use `DialContext` with a context having a proper timeout value set. I am not sure the direction maintainers would like to go. Propagating a context and switch over to `DialContext` or stay with `Dial` and not promote usage of `grpc.WithBlock()` option like [recommended upstream](https://github.com/grpc/grpc-go/blob/master/Documentation/anti-patterns.md)