### PR TITLE
Override API key with user metadata

### DIFF
--- a/internal/client.go
+++ b/internal/client.go
@@ -967,13 +967,10 @@ func (a apiKeyCredentials) gRPCIntercept(
 	if apiKey, err := a(ctx); err != nil {
 		return err
 	} else if apiKey != "" {
-		// Do from-add-new instead of append to overwrite anything there
-		md, _ := metadata.FromOutgoingContext(ctx)
-		if md == nil {
-			md = metadata.MD{}
+		// Only add API key if it doesn't already exist
+		if md, _ := metadata.FromOutgoingContext(ctx); len(md.Get("authorization")) == 0 {
+			ctx = metadata.AppendToOutgoingContext(ctx, "authorization", "Bearer "+apiKey)
 		}
-		md["authorization"] = []string{"Bearer " + apiKey}
-		ctx = metadata.NewOutgoingContext(ctx, md)
 	}
 	return invoker(ctx, method, req, reply, cc, opts...)
 }

--- a/internal/grpc_dialer_test.go
+++ b/internal/grpc_dialer_test.go
@@ -457,6 +457,18 @@ func TestCredentialsAPIKey(t *testing.T) {
 		metadata.ValueFromIncomingContext(srv.getSystemInfoRequestContext, "Authorization"),
 	)
 
+	// Overwrite via context
+	_, err = client.WorkflowService().GetSystemInfo(
+		metadata.AppendToOutgoingContext(context.Background(), "authorization", "overridden value"),
+		&workflowservice.GetSystemInfoRequest{},
+	)
+	require.NoError(t, err)
+	require.Equal(
+		t,
+		[]string{"overridden value"},
+		metadata.ValueFromIncomingContext(srv.getSystemInfoRequestContext, "Authorization"),
+	)
+
 	// Callback
 	client, err = DialClient(ClientOptions{
 		HostPort: srv.addr,


### PR DESCRIPTION
## What was changed

To match other SDK implementations coming with API keys and in general, we decided that user-provided headers/metadata can override the client-level API key setting instead of the inverse.