### PR TITLE
Switch github runner to macos-14 (m1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
   build-and-test:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-12, macos-14, windows-latest]
+        os: [ubuntu-latest, macos-intel, macos-arm, windows-latest]
         go-version: ["1.21", "1.22"]
         include:
           - os: ubuntu-latest
@@ -18,7 +18,12 @@ jobs:
             uploadCoverage: true
             # We only want to check docker compose on a single target
             testDockerCompose: true
-    runs-on: ${{ matrix.os }}
+          - os: macos-intel
+            runsOn: macos-12
+          - os: macos-arm
+            runsOn: macos-14
+            
+    runs-on: ${{ matrix.runsOn || matrix.os }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
   build-and-test:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-14, windows-latest]
+        os: [ubuntu-latest, macos-12, macos-14, windows-latest]
         go-version: ["1.21", "1.22"]
         include:
           - os: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
   build-and-test:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-14, windows-latest]
         go-version: ["1.21", "1.22"]
         include:
           - os: ubuntu-latest


### PR DESCRIPTION
Switch github runner to macos-14 (m1). Currently `macos-latest` runs on `macos-12` on intel. Reading some docs at some point github will change `macos-latest` to point at `macos-14`, but we can update our CI sooner.

https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/
