### PR TITLE
Remove experimental flag from Start Delay

### DIFF
--- a/internal/client.go
+++ b/internal/client.go
@@ -640,8 +640,6 @@ type (
 		// If the workflow gets a signal before the delay, a workflow task will be dispatched and the rest
 		// of the delay will be ignored. A signal from signal with start will not trigger a workflow task.
 		// Cannot be set the same time as a CronSchedule.
-		//
-		// NOTE: Experimental
 		StartDelay time.Duration
 	}
 


### PR DESCRIPTION
## What was changed
Removed the experimental flag from Start Delay option

## Why?
To properly indicate the current state of the Start Delay workflow option 