### PR TITLE
Support Update and Get for the new versioning rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ test.log
 .gobincache
 go.work
 go.work.sum
+*~

--- a/client/client.go
+++ b/client/client.go
@@ -259,7 +259,7 @@ type (
 	// WARNING: Worker versioning is currently experimental
 	TaskQueueReachability = internal.TaskQueueReachability
 
-	// UpdateWorkerVersioningRulesOptions is the input to Client.UpdateWorkerVersioningRules.
+	// UpdateWorkerVersioningRulesOptions is the input to [Client.UpdateWorkerVersioningRules].
 	// WARNING: Worker versioning-2 is currently experimental
 	UpdateWorkerVersioningRulesOptions = internal.UpdateWorkerVersioningRulesOptions
 
@@ -271,7 +271,7 @@ type (
 	VersioningConflictToken = internal.VersioningConflictToken
 
 	// VersioningRampByPercentage is a VersionRamp that sends a proportion of the traffic
-	// to the target Build ID
+	// to the target Build ID.
 	// WARNING: Worker versioning-2 is currently experimental
 	VersioningRampByPercentage = internal.VersioningRampByPercentage
 
@@ -280,10 +280,20 @@ type (
 	// WARNING: Worker versioning-2 is currently experimental
 	VersioningAssignmentRule = internal.VersioningAssignmentRule
 
+	// VersioningAssignmentRuleWithTimestamp contains an assignment rule annotated
+	// by the server with its creation time.
+	// WARNING: Worker versioning-2 is currently experimental
+	VersioningAssignmentRuleWithTimestamp = internal.VersioningAssignmentRuleWithTimestamp
+
 	// VersioningAssignmentRule is a BuildID redirect rule for a task queue.
 	// It changes the behavior of currently running workflows and new ones.
 	// WARNING: Worker versioning-2 is currently experimental
 	VersioningRedirectRule = internal.VersioningRedirectRule
+
+	// VersioningRedirectRuleWithTimestamp contains a redirect rule annotated
+	// by the server with its creation time.
+	// WARNING: Worker versioning-2 is currently experimental
+	VersioningRedirectRuleWithTimestamp = internal.VersioningRedirectRuleWithTimestamp
 
 	// VersioningOpInsertAssignmentRule is an operation for UpdateWorkerVersioningRulesOptions
 	// that inserts the rule to the list of assignment rules for this Task Queue.
@@ -327,7 +337,7 @@ type (
 	// WARNING: Worker versioning-2 is currently experimental
 	VersioningOpDeleteRedirectRule = internal.VersioningOpDeleteRedirectRule
 
-	// VersioningOpCommitBuildId is an operation for UpdateWorkerVersioningRulesOptions
+	// VersioningOpCommitBuildID is an operation for UpdateWorkerVersioningRulesOptions
 	// that completes  the rollout of a BuildID and cleanup unnecessary rules possibly
 	// created during a gradual rollout. Specifically, this command will make the following changes
 	// atomically:
@@ -341,13 +351,13 @@ type (
 	// pollers have been seen recently for this Build ID. Use the `force`
 	// option to disable this validation.
 	// WARNING: Worker versioning-2 is currently experimental
-	VersioningOpCommitBuildId = internal.VersioningOpCommitBuildId
+	VersioningOpCommitBuildID = internal.VersioningOpCommitBuildID
 
-	// GetWorkerVersioningOptions is the input to Client.GetWorkerVersioningRules.
+	// GetWorkerVersioningOptions is the input to [Client.GetWorkerVersioningRules].
 	// WARNING: Worker versioning-2 is currently experimental
 	GetWorkerVersioningOptions = internal.GetWorkerVersioningOptions
 
-	// WorkerVersioningRules is the response for Client.GetWorkerVersioningRules.
+	// WorkerVersioningRules is the response for [Client.GetWorkerVersioningRules].
 	// WARNING: Worker versioning-2 is currently experimental
 	WorkerVersioningRules = internal.WorkerVersioningRules
 

--- a/client/client.go
+++ b/client/client.go
@@ -259,6 +259,98 @@ type (
 	// WARNING: Worker versioning is currently experimental
 	TaskQueueReachability = internal.TaskQueueReachability
 
+	// UpdateWorkerVersioningRulesOptions is the input to Client.UpdateWorkerVersioningRules.
+	// WARNING: Worker versioning-2 is currently experimental
+	UpdateWorkerVersioningRulesOptions = internal.UpdateWorkerVersioningRulesOptions
+
+	// VersioningConflictToken is a conflict token to serialize calls to Client.UpdateWorkerVersioningRules.
+	// An update with an old token fails with `serviceerror.FailedPrecondition`.
+	// The current token can be obtained with [GetWorkerVersioningRules],
+	// or returned by a successful [UpdateWorkerVersioningRules].
+	// WARNING: Worker versioning-2 is currently experimental
+	VersioningConflictToken = internal.VersioningConflictToken
+
+	// VersioningRampByPercentage is a VersionRamp that sends a proportion of the traffic
+	// to the target Build ID
+	// WARNING: Worker versioning-2 is currently experimental
+	VersioningRampByPercentage = internal.VersioningRampByPercentage
+
+	// VersioningAssignmentRule is a BuildID  assigment rule for a task queue.
+	// Assignment rules only affect new workflows.
+	// WARNING: Worker versioning-2 is currently experimental
+	VersioningAssignmentRule = internal.VersioningAssignmentRule
+
+	// VersioningAssignmentRule is a BuildID redirect rule for a task queue.
+	// It changes the behavior of currently running workflows and new ones.
+	// WARNING: Worker versioning-2 is currently experimental
+	VersioningRedirectRule = internal.VersioningRedirectRule
+
+	// VersioningOpInsertAssignmentRule is an operation for UpdateWorkerVersioningRulesOptions
+	// that inserts the rule to the list of assignment rules for this Task Queue.
+	// The rules are evaluated in order, starting from index 0. The first
+	// applicable rule will be applied and the rest will be ignored.
+	// By default, the new rule is inserted at the beginning of the list
+	// (index 0). If the given index is too larger the rule will be
+	// inserted at the end of the list.
+	// WARNING: Worker versioning-2 is currently experimental
+	VersioningOpInsertAssignmentRule = internal.VersioningOpInsertAssignmentRule
+
+	// VersioningOpReplaceAssignmentRule is an operation for UpdateWorkerVersioningRulesOptions
+	// that replaces the assignment rule at a given index. By default presence of one
+	// unconditional rule, i.e., no hint filter or ramp, is enforced, otherwise
+	// the delete operation will be rejected. Set `force` to true to
+	// bypass this validation.
+	// WARNING: Worker versioning-2 is currently experimental
+	VersioningOpReplaceAssignmentRule = internal.VersioningOpReplaceAssignmentRule
+
+	// VersioningOpDeleteAssignmentRule is an operation for UpdateWorkerVersioningRulesOptions
+	// that deletes the assignment rule at a given index. By default presence of one
+	// unconditional rule, i.e., no hint filter or ramp, is enforced, otherwise
+	// the delete operation will be rejected. Set `force` to true to
+	// bypass this validation.
+	// WARNING: Worker versioning-2 is currently experimental
+	VersioningOpDeleteAssignmentRule = internal.VersioningOpDeleteAssignmentRule
+
+	// VersioningOpInsertRedirectRule is an operation for UpdateWorkerVersioningRulesOptions
+	// that adds the rule to the list of redirect rules for this Task Queue. There
+	// can be at most one redirect rule for each distinct Source BuildID.
+	// WARNING: Worker versioning-2 is currently experimental
+	VersioningOpInsertRedirectRule = internal.VersioningOpInsertRedirectRule
+
+	// VersioningOpReplaceRedirectRule is an operation for UpdateWorkerVersioningRulesOptions
+	// that replaces the routing rule with the given source BuildID.
+	// WARNING: Worker versioning-2 is currently experimental
+	VersioningOpReplaceRedirectRule = internal.VersioningOpReplaceRedirectRule
+
+	// VersioningOpDeleteRedirectRule is an operation for UpdateWorkerVersioningRulesOptions
+	// that deletes the routing rule with the given source Build ID.
+	// WARNING: Worker versioning-2 is currently experimental
+	VersioningOpDeleteRedirectRule = internal.VersioningOpDeleteRedirectRule
+
+	// VersioningOpCommitBuildId is an operation for UpdateWorkerVersioningRulesOptions
+	// that completes  the rollout of a BuildID and cleanup unnecessary rules possibly
+	// created during a gradual rollout. Specifically, this command will make the following changes
+	// atomically:
+	//  1. Adds an assignment rule (with full ramp) for the target Build ID at
+	//     the end of the list.
+	//  2. Removes all previously added assignment rules to the given target
+	//     Build ID (if any).
+	//  3. Removes any fully-ramped assignment rule for other Build IDs.
+	//
+	// To prevent committing invalid Build IDs, we reject the request if no
+	// pollers have been seen recently for this Build ID. Use the `force`
+	// option to disable this validation.
+	// WARNING: Worker versioning-2 is currently experimental
+	VersioningOpCommitBuildId = internal.VersioningOpCommitBuildId
+
+	// GetWorkerVersioningOptions is the input to Client.GetWorkerVersioningRules.
+	// WARNING: Worker versioning-2 is currently experimental
+	GetWorkerVersioningOptions = internal.GetWorkerVersioningOptions
+
+	// WorkerVersioningRules is the response for Client.GetWorkerVersioningRules.
+	// WARNING: Worker versioning-2 is currently experimental
+	WorkerVersioningRules = internal.WorkerVersioningRules
+
 	// Client is the client for starting and getting information about a workflow executions as well as
 	// completing activities asynchronously.
 	Client interface {
@@ -550,17 +642,33 @@ type (
 		// Allows you to update the worker-build-id based version sets for a particular task queue. This is used in
 		// conjunction with workers who specify their build id and thus opt into the feature.
 		// WARNING: Worker versioning is currently experimental
+		// Deprecated: Use [UpdateWorkerVersioningRules] with the versioning-2 api.
 		UpdateWorkerBuildIdCompatibility(ctx context.Context, options *UpdateWorkerBuildIdCompatibilityOptions) error
 
 		// GetWorkerBuildIdCompatibility
 		// Returns the worker-build-id based version sets for a particular task queue.
 		// WARNING: Worker versioning is currently experimental
+		// Deprecated: Use [GetWorkerVersioningRules] with the versioning-2 api.
 		GetWorkerBuildIdCompatibility(ctx context.Context, options *GetWorkerBuildIdCompatibilityOptions) (*WorkerBuildIDVersionSets, error)
 
 		// GetWorkerTaskReachability
 		// Returns which versions are is still in use by open or closed workflows
 		// WARNING: Worker versioning is currently experimental
+		// Deprecated: Use [DescribeTaskQueue] with the versioning-2 api.
 		GetWorkerTaskReachability(ctx context.Context, options *GetWorkerTaskReachabilityOptions) (*WorkerTaskReachability, error)
+
+		// UpdateWorkerVersioningRules
+		// Allows updating the worker-build-id based assignment and redirect rules for a given task queue. This is used in
+		// conjunction with workers who specify their build id and thus opt into the feature.
+		// The errors it can return:
+		//  - serviceerror.FailedPrecondition when the conflict token is invalid
+		// WARNING: Worker versioning-2 is currently experimental, and requires server 1.XX+
+		UpdateWorkerVersioningRules(ctx context.Context, options *UpdateWorkerVersioningRulesOptions) (VersioningConflictToken, error)
+
+		// GetWorkerVersioningRules
+		// Returns the worker-build-id assignment and redirect rules for a task queue.
+		// WARNING: Worker versioning-2 is currently experimental, and requires server 1.XX+
+		GetWorkerVersioningRules(ctx context.Context, options *GetWorkerVersioningOptions) (*WorkerVersioningRules, error)
 
 		// CheckHealth performs a server health check using the gRPC health check
 		// API. If the check fails, an error is returned.

--- a/internal/client.go
+++ b/internal/client.go
@@ -352,6 +352,17 @@ type (
 		// GetWorkerTaskReachability returns which versions are is still in use by open or closed workflows.
 		GetWorkerTaskReachability(ctx context.Context, options *GetWorkerTaskReachabilityOptions) (*WorkerTaskReachability, error)
 
+		// UpdateWorkerVersioningRules allows updating the worker-build-id based assignment and redirect rules for a given
+		// task queue. This is used in conjunction with workers who specify their build id and thus opt into the feature.
+		// The errors it can return:
+		//  - serviceerror.FailedPrecondition when the conflict token is invalid
+		// WARNING: Worker versioning-2 is currently experimental, and requires server 1.XX+
+		UpdateWorkerVersioningRules(ctx context.Context, options *UpdateWorkerVersioningRulesOptions) (VersioningConflictToken, error)
+
+		// GetWorkerVersioningRules returns the worker-build-id assignment and redirect rules for a task queue.
+		// WARNING: Worker versioning-2 is currently experimental, and requires server 1.XX+
+		GetWorkerVersioningRules(ctx context.Context, options *GetWorkerVersioningOptions) (*WorkerVersioningRules, error)
+
 		// CheckHealth performs a server health check using the gRPC health check
 		// API. If the check fails, an error is returned.
 		CheckHealth(ctx context.Context, request *CheckHealthRequest) (*CheckHealthResponse, error)

--- a/internal/worker_versioning_rules.go
+++ b/internal/worker_versioning_rules.go
@@ -406,7 +406,7 @@ func (r *VersioningRampByPercentage) validateRamp() error {
 
 func (r *VersioningAssignmentRule) validateRule() error {
 	if r.TargetBuildID == "" {
-		return errors.New("Missing TargetBuildID in assigment rule")
+		return errors.New("missing TargetBuildID in assigment rule")
 	}
 	switch ramp := r.Ramp.(type) {
 	case *VersioningRampByPercentage:
@@ -420,10 +420,10 @@ func (r *VersioningAssignmentRule) validateRule() error {
 
 func (r *VersioningRedirectRule) validateRule() error {
 	if r.TargetBuildID == "" {
-		return errors.New("Missing TargetBuildID in redirect rule")
+		return errors.New("missing TargetBuildID in redirect rule")
 	}
 	if r.SourceBuildID == "" {
-		return errors.New("Missing SourceBuildID in redirect rule")
+		return errors.New("missing SourceBuildID in redirect rule")
 	}
 	return nil
 }
@@ -436,14 +436,14 @@ func (u *VersioningOpReplaceRedirectRule) validateOp() error   { return u.Rule.v
 
 func (u *VersioningOpDeleteRedirectRule) validateOp() error {
 	if u.SourceBuildID == "" {
-		return errors.New("Missing SourceBuildID")
+		return errors.New("missing SourceBuildID")
 	}
 	return nil
 }
 
 func (u *VersioningOpCommitBuildID) validateOp() error {
 	if u.TargetBuildID == "" {
-		return errors.New("Missing TargetBuildID")
+		return errors.New("missing TargetBuildID")
 	}
 	return nil
 }

--- a/internal/worker_versioning_rules.go
+++ b/internal/worker_versioning_rules.go
@@ -1,0 +1,338 @@
+// The MIT License
+//
+// Copyright (c) 2024 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package internal
+
+import (
+	"errors"
+	"time"
+
+	taskqueuepb "go.temporal.io/api/taskqueue/v1"
+	"go.temporal.io/api/workflowservice/v1"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+type (
+	// VersioningRamp is an interface for the different strategies of gradual workflow deployments.
+	VersioningRamp interface {
+		isValidVersioningRamp() bool
+	}
+
+	// VersioningRampByPercentage sends a proportion of the traffic to the target Build ID.
+	VersioningRampByPercentage struct {
+		// Percentage of traffic with a value in [0,100)
+		Percentage float32
+	}
+
+	// VersioningAssignmentRule is a BuildID assigment rule for a task queue.
+	// Assignment rules only affect new workflows.
+	VersioningAssignmentRule struct {
+		// The BuildID of new workflows affected by this rule.
+		TargetBuildId string
+		// A strategy for gradual workflow deployment.
+		Ramp VersioningRamp
+		// An optional registration time set by the server.
+		Timestamp *time.Time
+	}
+
+	// VersioningAssignmentRule is a BuildID redirect rule for a task queue.
+	// It changes the behavior of currently running workflows and new ones.
+	VersioningRedirectRule struct {
+		SourceBuildId string
+		TargetBuildId string
+		// An optional registration time set by the server.
+		Timestamp *time.Time
+	}
+
+	//VersioningConflictToken is a conflict token to serialize updates.
+	// An update with an old token fails with `serviceerror.FailedPrecondition`.
+	// The current token can be obtained with [GetWorkerVersioningRules], or returned by a successful [UpdateWorkerVersioningRules].
+	VersioningConflictToken struct {
+		token []byte
+	}
+
+	// UpdateWorkerVersioningRulesOptions is the input to Client.UpdateWorkerVersioningRules.
+	UpdateWorkerVersioningRulesOptions struct {
+		// The task queue to update the versioning rules of.
+		TaskQueue string
+		// A conflict token to serialize updates.
+		ConflictToken VersioningConflictToken
+		Operation     UpdateVersioningOp
+	}
+
+	// UpdateVersioningOp is an interface for the different operations that can be
+	// performed when updating the worker versioning rules for a task queue.
+	//
+	// Possible operations are:
+	//   - VersioningOpInsertAssignmentRule
+	//   - VersioningOpReplaceAssignmentRule
+	//   - VersioningOpDeleteAssignmentRule
+	//   - VersioningOpInsertRedirectRule
+	//   - VersioningOpReplaceRedirectRule
+	//   - VersioningOpDeleteRedirectRule
+	//   - VersioningOpCommitBuildId
+	UpdateVersioningOp interface {
+		isValidUpdateVersioningOp() bool
+	}
+	VersioningOpInsertAssignmentRule struct {
+		RuleIndex int32
+		Rule      VersioningAssignmentRule
+	}
+	VersioningOpReplaceAssignmentRule struct {
+		RuleIndex int32
+		Rule      VersioningAssignmentRule
+		Force     bool
+	}
+	VersioningOpDeleteAssignmentRule struct {
+		RuleIndex int32
+		Force     bool
+	}
+	VersioningOpInsertRedirectRule struct {
+		Rule VersioningRedirectRule
+	}
+	VersioningOpReplaceRedirectRule struct {
+		Rule VersioningRedirectRule
+	}
+	VersioningOpDeleteRedirectRule struct {
+		SourceBuildId string
+	}
+	VersioningOpCommitBuildId struct {
+		TargetBuildId string
+		Force         bool
+	}
+)
+
+func (uw *UpdateWorkerVersioningRulesOptions) validateAndConvertToProto(namespace string) (*workflowservice.UpdateWorkerVersioningRulesRequest, error) {
+	if namespace == "" {
+		return nil, errors.New("missing namespace argument")
+	}
+	if uw.TaskQueue == "" {
+		return nil, errors.New("missing TaskQueue field")
+	}
+	if !uw.Operation.isValidUpdateVersioningOp() {
+		return nil, errors.New("invalid Operation BuildID field")
+	}
+	req := &workflowservice.UpdateWorkerVersioningRulesRequest{
+		Namespace:     namespace,
+		TaskQueue:     uw.TaskQueue,
+		ConflictToken: uw.ConflictToken.token,
+	}
+
+	switch v := uw.Operation.(type) {
+	case *VersioningOpInsertAssignmentRule:
+		req.Operation = &workflowservice.UpdateWorkerVersioningRulesRequest_InsertAssignmentRule{
+			InsertAssignmentRule: &workflowservice.UpdateWorkerVersioningRulesRequest_InsertBuildIdAssignmentRule{
+				RuleIndex: v.RuleIndex,
+				Rule:      versioningAssignmentRuleToProto(&v.Rule),
+			},
+		}
+	case *VersioningOpReplaceAssignmentRule:
+		req.Operation = &workflowservice.UpdateWorkerVersioningRulesRequest_ReplaceAssignmentRule{
+			ReplaceAssignmentRule: &workflowservice.UpdateWorkerVersioningRulesRequest_ReplaceBuildIdAssignmentRule{
+				RuleIndex: v.RuleIndex,
+				Rule:      versioningAssignmentRuleToProto(&v.Rule),
+				Force:     v.Force,
+			},
+		}
+	case *VersioningOpDeleteAssignmentRule:
+		req.Operation = &workflowservice.UpdateWorkerVersioningRulesRequest_DeleteAssignmentRule{
+			DeleteAssignmentRule: &workflowservice.UpdateWorkerVersioningRulesRequest_DeleteBuildIdAssignmentRule{
+				RuleIndex: v.RuleIndex,
+				Force:     v.Force,
+			},
+		}
+	case *VersioningOpInsertRedirectRule:
+		req.Operation = &workflowservice.UpdateWorkerVersioningRulesRequest_InsertCompatibleRedirectRule{
+			InsertCompatibleRedirectRule: &workflowservice.UpdateWorkerVersioningRulesRequest_AddCompatibleBuildIdRedirectRule{
+				Rule: versioningRedirectRuleToProto(&v.Rule),
+			},
+		}
+	case *VersioningOpReplaceRedirectRule:
+		req.Operation = &workflowservice.UpdateWorkerVersioningRulesRequest_ReplaceCompatibleRedirectRule{
+			ReplaceCompatibleRedirectRule: &workflowservice.UpdateWorkerVersioningRulesRequest_ReplaceCompatibleBuildIdRedirectRule{
+				Rule: versioningRedirectRuleToProto(&v.Rule),
+			},
+		}
+	case *VersioningOpDeleteRedirectRule:
+		req.Operation = &workflowservice.UpdateWorkerVersioningRulesRequest_DeleteCompatibleRedirectRule{
+			DeleteCompatibleRedirectRule: &workflowservice.UpdateWorkerVersioningRulesRequest_DeleteCompatibleBuildIdRedirectRule{
+				SourceBuildId: v.SourceBuildId,
+			},
+		}
+	case *VersioningOpCommitBuildId:
+		req.Operation = &workflowservice.UpdateWorkerVersioningRulesRequest_CommitBuildId_{
+			CommitBuildId: &workflowservice.UpdateWorkerVersioningRulesRequest_CommitBuildId{
+				TargetBuildId: v.TargetBuildId,
+				Force:         v.Force,
+			},
+		}
+	}
+
+	return req, nil
+}
+
+type GetWorkerVersioningOptions struct {
+	// The task queue to get the versioning rules from.
+	TaskQueue string
+}
+
+func (gw *GetWorkerVersioningOptions) validateAndConvertToProto(namespace string) (*workflowservice.GetWorkerVersioningRulesRequest, error) {
+	if namespace == "" {
+		return nil, errors.New("missing namespace argument")
+	}
+
+	if gw.TaskQueue == "" {
+		return nil, errors.New("missing  TaskQueue field")
+	}
+	req := &workflowservice.GetWorkerVersioningRulesRequest{
+		Namespace: namespace,
+		TaskQueue: gw.TaskQueue,
+	}
+
+	return req, nil
+}
+
+type WorkerVersioningRules struct {
+	AssignmentRules []*VersioningAssignmentRule
+	RedirectRules   []*VersioningRedirectRule
+	ConflictToken   VersioningConflictToken
+}
+
+func versioningAssignmentRuleToProto(rule *VersioningAssignmentRule) *taskqueuepb.BuildIdAssignmentRule {
+	// Assumed `rule` already validated
+	result := &taskqueuepb.BuildIdAssignmentRule{
+		TargetBuildId: rule.TargetBuildId,
+	}
+
+	switch r := rule.Ramp.(type) {
+	case *VersioningRampByPercentage:
+		result.Ramp = &taskqueuepb.BuildIdAssignmentRule_PercentageRamp{
+			PercentageRamp: &taskqueuepb.RampByPercentage{
+				RampPercentage: r.Percentage,
+			},
+		}
+	}
+	// Ignore `rule.Timestamp`
+
+	return result
+}
+
+func versioningRedirectRuleToProto(rule *VersioningRedirectRule) *taskqueuepb.CompatibleBuildIdRedirectRule {
+	// Assumed `rule` already validated
+	result := &taskqueuepb.CompatibleBuildIdRedirectRule{
+		SourceBuildId: rule.SourceBuildId,
+		TargetBuildId: rule.TargetBuildId,
+	}
+	// Ignore `rule.Timestamp`
+
+	return result
+}
+
+func versioningAssignmentRuleFromProto(rule *taskqueuepb.BuildIdAssignmentRule, timestamp *timestamppb.Timestamp) *VersioningAssignmentRule {
+	if rule == nil {
+		return nil
+	}
+
+	result := &VersioningAssignmentRule{
+		TargetBuildId: rule.GetTargetBuildId(),
+	}
+
+	switch r := rule.GetRamp().(type) {
+	case *taskqueuepb.BuildIdAssignmentRule_PercentageRamp:
+		result.Ramp = &VersioningRampByPercentage{
+			Percentage: r.PercentageRamp.GetRampPercentage(),
+		}
+	}
+
+	if timestamp != nil {
+		t := timestamp.AsTime()
+		result.Timestamp = &t
+	}
+	return result
+}
+
+func versioningRedirectRuleFromProto(rule *taskqueuepb.CompatibleBuildIdRedirectRule, timestamp *timestamppb.Timestamp) *VersioningRedirectRule {
+	if rule == nil {
+		return nil
+	}
+
+	result := &VersioningRedirectRule{
+		SourceBuildId: rule.GetSourceBuildId(),
+		TargetBuildId: rule.GetTargetBuildId(),
+	}
+
+	if timestamp != nil {
+		t := timestamp.AsTime()
+		result.Timestamp = &t
+	}
+	return result
+}
+
+func workerVersioningRulesFromProtoResponse(response *workflowservice.GetWorkerVersioningRulesResponse) *WorkerVersioningRules {
+	if response == nil {
+		return nil
+	}
+	aRules := make([]*VersioningAssignmentRule, len(response.GetAssignmentRules()))
+	for i, s := range response.GetAssignmentRules() {
+		aRules[i] = versioningAssignmentRuleFromProto(s.GetRule(), s.GetCreateTime())
+	}
+
+	rRules := make([]*VersioningRedirectRule, len(response.GetCompatibleRedirectRules()))
+	for i, s := range response.GetCompatibleRedirectRules() {
+		rRules[i] = versioningRedirectRuleFromProto(s.GetRule(), s.GetCreateTime())
+	}
+
+	conflictToken := VersioningConflictToken{
+		token: response.GetConflictToken(),
+	}
+	return &WorkerVersioningRules{
+		AssignmentRules: aRules,
+		RedirectRules:   rRules,
+		ConflictToken:   conflictToken,
+	}
+}
+
+func workerVersioningConflictTokenFromProtoResponse(response *workflowservice.UpdateWorkerVersioningRulesResponse) VersioningConflictToken {
+	if response == nil {
+		return VersioningConflictToken{}
+	}
+	return VersioningConflictToken{
+		token: response.GetConflictToken(),
+	}
+}
+
+func (r *VersioningRampByPercentage) isValidVersioningRamp() bool { return true }
+
+func (r *VersioningAssignmentRule) isValid() bool { return r.TargetBuildId != "" }
+func (r *VersioningRedirectRule) isValid() bool {
+	return r.TargetBuildId != "" && r.SourceBuildId != ""
+}
+
+func (u *VersioningOpInsertAssignmentRule) isValidUpdateVersioningOp() bool  { return u.Rule.isValid() }
+func (u *VersioningOpReplaceAssignmentRule) isValidUpdateVersioningOp() bool { return u.Rule.isValid() }
+func (u *VersioningOpDeleteAssignmentRule) isValidUpdateVersioningOp() bool  { return true }
+func (u *VersioningOpInsertRedirectRule) isValidUpdateVersioningOp() bool    { return u.Rule.isValid() }
+func (u *VersioningOpReplaceRedirectRule) isValidUpdateVersioningOp() bool   { return u.Rule.isValid() }
+func (u *VersioningOpDeleteRedirectRule) isValidUpdateVersioningOp() bool {
+	return u.SourceBuildId != ""
+}
+func (u *VersioningOpCommitBuildId) isValidUpdateVersioningOp() bool { return u.TargetBuildId != "" }

--- a/internal/worker_versioning_rules.go
+++ b/internal/worker_versioning_rules.go
@@ -191,6 +191,13 @@ type (
 	}
 )
 
+// Token
+// Returns an internal representation of this token, mostly for debugging purposes.
+// WARNING: Worker versioning-2 is currently experimental
+func (c *VersioningConflictToken) Token() []byte {
+	return c.token
+}
+
 func (uw *UpdateWorkerVersioningRulesOptions) validateAndConvertToProto(namespace string) (*workflowservice.UpdateWorkerVersioningRulesRequest, error) {
 	if namespace == "" {
 		return nil, errors.New("missing namespace argument")

--- a/internal/worker_versioning_rules_test.go
+++ b/internal/worker_versioning_rules_test.go
@@ -63,12 +63,12 @@ func Test_WorkerVersioningRules_fromProtoResponse(t *testing.T) {
 				ConflictToken: []byte("This is a token"),
 			},
 			want: &WorkerVersioningRules{
-				AssignmentRules: []*VersioningAssignmentRule{
-					{TargetBuildId: "one", Ramp: &VersioningRampByPercentage{Percentage: 50.0}, Timestamp: &timestamp},
+				AssignmentRules: []*VersioningAssignmentRuleWithTimestamp{
+					{Rule: VersioningAssignmentRule{TargetBuildID: "one", Ramp: &VersioningRampByPercentage{Percentage: 50.0}}, CreateTime: timestamp},
 				},
-				RedirectRules: []*VersioningRedirectRule{
-					{SourceBuildId: "one", TargetBuildId: "two", Timestamp: &timestamp},
-					{SourceBuildId: "two", TargetBuildId: "three", Timestamp: &timestamp},
+				RedirectRules: []*VersioningRedirectRuleWithTimestamp{
+					{Rule: VersioningRedirectRule{SourceBuildID: "one", TargetBuildID: "two"}, CreateTime: timestamp},
+					{Rule: VersioningRedirectRule{SourceBuildID: "two", TargetBuildID: "three"}, CreateTime: timestamp},
 				},
 				ConflictToken: VersioningConflictToken{
 					token: []byte("This is a token"),

--- a/internal/worker_versioning_rules_test.go
+++ b/internal/worker_versioning_rules_test.go
@@ -1,0 +1,84 @@
+// The MIT License
+//
+// Copyright (c) 2024 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package internal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	taskqueuepb "go.temporal.io/api/taskqueue/v1"
+	"go.temporal.io/api/workflowservice/v1"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func Test_WorkerVersioningRules_fromProtoResponse(t *testing.T) {
+	nowProto := timestamppb.Now()
+	timestamp := nowProto.AsTime()
+	tests := []struct {
+		name     string
+		response *workflowservice.GetWorkerVersioningRulesResponse
+		want     *WorkerVersioningRules
+	}{
+		{
+			name:     "nil response",
+			response: nil,
+			want:     nil,
+		},
+		{
+			name: "normal rules",
+			response: &workflowservice.GetWorkerVersioningRulesResponse{
+				AssignmentRules: []*taskqueuepb.TimestampedBuildIdAssignmentRule{
+					{Rule: &taskqueuepb.BuildIdAssignmentRule{
+						TargetBuildId: "one", Ramp: &taskqueuepb.BuildIdAssignmentRule_PercentageRamp{
+							PercentageRamp: &taskqueuepb.RampByPercentage{RampPercentage: 50.0},
+						},
+					},
+						CreateTime: nowProto,
+					},
+				},
+				CompatibleRedirectRules: []*taskqueuepb.TimestampedCompatibleBuildIdRedirectRule{
+					{Rule: &taskqueuepb.CompatibleBuildIdRedirectRule{SourceBuildId: "one", TargetBuildId: "two"}, CreateTime: nowProto},
+					{Rule: &taskqueuepb.CompatibleBuildIdRedirectRule{SourceBuildId: "two", TargetBuildId: "three"}, CreateTime: nowProto},
+				},
+				ConflictToken: []byte("This is a token"),
+			},
+			want: &WorkerVersioningRules{
+				AssignmentRules: []*VersioningAssignmentRule{
+					{TargetBuildId: "one", Ramp: &VersioningRampByPercentage{Percentage: 50.0}, Timestamp: &timestamp},
+				},
+				RedirectRules: []*VersioningRedirectRule{
+					{SourceBuildId: "one", TargetBuildId: "two", Timestamp: &timestamp},
+					{SourceBuildId: "two", TargetBuildId: "three", Timestamp: &timestamp},
+				},
+				ConflictToken: VersioningConflictToken{
+					token: []byte("This is a token"),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, workerVersioningRulesFromProtoResponse(tt.response), "workerVersioningRulesFromProtoResponse(%v)", tt.response)
+		})
+	}
+}

--- a/mocks/Client.go
+++ b/mocks/Client.go
@@ -30,6 +30,7 @@ package mocks
 
 import (
 	"context"
+
 	"go.temporal.io/sdk/client"
 
 	"go.temporal.io/api/enums/v1"
@@ -341,6 +342,36 @@ func (_m *Client) GetWorkerTaskReachability(ctx context.Context, options *client
 	}
 
 	if rf, ok := ret.Get(1).(func(context.Context, *client.GetWorkerTaskReachabilityOptions) error); ok {
+		r1 = rf(ctx, options)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GetWorkerVersioningRules provides a mock function with given fields: ctx, options
+func (_m *Client) GetWorkerVersioningRules(ctx context.Context, options *client.GetWorkerVersioningOptions) (*client.WorkerVersioningRules, error) {
+	ret := _m.Called(ctx, options)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetWorkerVersioningRules")
+	}
+
+	var r0 *client.WorkerVersioningRules
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *client.GetWorkerVersioningOptions) (*client.WorkerVersioningRules, error)); ok {
+		return rf(ctx, options)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *client.GetWorkerVersioningOptions) *client.WorkerVersioningRules); ok {
+		r0 = rf(ctx, options)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*client.WorkerVersioningRules)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *client.GetWorkerVersioningOptions) error); ok {
 		r1 = rf(ctx, options)
 	} else {
 		r1 = ret.Error(1)
@@ -822,6 +853,36 @@ func (_m *Client) UpdateWorkerBuildIdCompatibility(ctx context.Context, options 
 	}
 
 	return r0
+}
+
+// UpdateWorkerVersioningRules provides a mock function with given fields: ctx, options
+func (_m *Client) UpdateWorkerVersioningRules(ctx context.Context, options *client.UpdateWorkerVersioningRulesOptions) (client.VersioningConflictToken, error) {
+	ret := _m.Called(ctx, options)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateWorkerVersioningRules")
+	}
+
+	var r0 client.VersioningConflictToken
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *client.UpdateWorkerVersioningRulesOptions) (client.VersioningConflictToken, error)); ok {
+		return rf(ctx, options)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *client.UpdateWorkerVersioningRulesOptions) client.VersioningConflictToken); ok {
+		r0 = rf(ctx, options)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(client.VersioningConflictToken)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *client.UpdateWorkerVersioningRulesOptions) error); ok {
+		r1 = rf(ctx, options)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // UpdateWorkflow provides a mock function with given fields: ctx, workflowID, workflowRunID, updateName, args

--- a/test/worker_versioning_test.go
+++ b/test/worker_versioning_test.go
@@ -117,7 +117,7 @@ func (ts *WorkerVersioningTestSuite) TestManipulateRules() {
 		Operation: &client.VersioningOpInsertAssignmentRule{
 			RuleIndex: 0,
 			Rule: client.VersioningAssignmentRule{
-				TargetBuildId: "1.0",
+				TargetBuildID: "1.0",
 			},
 		},
 	})
@@ -129,7 +129,7 @@ func (ts *WorkerVersioningTestSuite) TestManipulateRules() {
 		Operation: &client.VersioningOpInsertAssignmentRule{
 			RuleIndex: 0,
 			Rule: client.VersioningAssignmentRule{
-				TargetBuildId: "2.0",
+				TargetBuildID: "2.0",
 				Ramp: &client.VersioningRampByPercentage{
 					Percentage: 45.0,
 				},
@@ -143,8 +143,8 @@ func (ts *WorkerVersioningTestSuite) TestManipulateRules() {
 		ConflictToken: token,
 		Operation: &client.VersioningOpInsertRedirectRule{
 			Rule: client.VersioningRedirectRule{
-				SourceBuildId: "1.0",
-				TargetBuildId: "2.0",
+				SourceBuildID: "1.0",
+				TargetBuildID: "2.0",
 			},
 		},
 	})
@@ -155,15 +155,15 @@ func (ts *WorkerVersioningTestSuite) TestManipulateRules() {
 	})
 	ts.NoError(err)
 
-	ts.Equal("2.0", res.AssignmentRules[0].TargetBuildId)
-	r, ok := res.AssignmentRules[0].Ramp.(*client.VersioningRampByPercentage)
+	ts.Equal("2.0", res.AssignmentRules[0].Rule.TargetBuildID)
+	r, ok := res.AssignmentRules[0].Rule.Ramp.(*client.VersioningRampByPercentage)
 	ts.Truef(ok, "Not a percentage ramp")
 	ts.Equal(float32(45.0), r.Percentage)
 
-	ts.Equal("1.0", res.AssignmentRules[1].TargetBuildId)
+	ts.Equal("1.0", res.AssignmentRules[1].Rule.TargetBuildID)
 
-	ts.Equal("1.0", res.RedirectRules[0].SourceBuildId)
-	ts.Equal("2.0", res.RedirectRules[0].TargetBuildId)
+	ts.Equal("1.0", res.RedirectRules[0].Rule.SourceBuildID)
+	ts.Equal("2.0", res.RedirectRules[0].Rule.TargetBuildID)
 }
 
 func (ts *WorkerVersioningTestSuite) TestReplaceDeleteRules() {
@@ -181,7 +181,7 @@ func (ts *WorkerVersioningTestSuite) TestReplaceDeleteRules() {
 		Operation: &client.VersioningOpInsertAssignmentRule{
 			RuleIndex: 0,
 			Rule: client.VersioningAssignmentRule{
-				TargetBuildId: "1.0",
+				TargetBuildID: "1.0",
 			},
 		},
 	})
@@ -194,7 +194,7 @@ func (ts *WorkerVersioningTestSuite) TestReplaceDeleteRules() {
 		Operation: &client.VersioningOpReplaceAssignmentRule{
 			RuleIndex: 0,
 			Rule: client.VersioningAssignmentRule{
-				TargetBuildId: "1.1",
+				TargetBuildID: "1.1",
 			},
 		},
 	})
@@ -207,7 +207,7 @@ func (ts *WorkerVersioningTestSuite) TestReplaceDeleteRules() {
 		Operation: &client.VersioningOpReplaceAssignmentRule{
 			RuleIndex: 0,
 			Rule: client.VersioningAssignmentRule{
-				TargetBuildId: "2.0",
+				TargetBuildID: "2.0",
 				Ramp: &client.VersioningRampByPercentage{
 					Percentage: 45.0,
 				},
@@ -225,7 +225,7 @@ func (ts *WorkerVersioningTestSuite) TestReplaceDeleteRules() {
 		Operation: &client.VersioningOpReplaceAssignmentRule{
 			RuleIndex: 0,
 			Rule: client.VersioningAssignmentRule{
-				TargetBuildId: "2.0",
+				TargetBuildID: "2.0",
 				Ramp: &client.VersioningRampByPercentage{
 					Percentage: 45.0,
 				},
@@ -273,7 +273,7 @@ func (ts *WorkerVersioningTestSuite) TestCommitRules() {
 		Operation: &client.VersioningOpInsertAssignmentRule{
 			RuleIndex: 0,
 			Rule: client.VersioningAssignmentRule{
-				TargetBuildId: "1.0",
+				TargetBuildID: "1.0",
 			},
 		},
 	})
@@ -285,7 +285,7 @@ func (ts *WorkerVersioningTestSuite) TestCommitRules() {
 		Operation: &client.VersioningOpInsertAssignmentRule{
 			RuleIndex: 0,
 			Rule: client.VersioningAssignmentRule{
-				TargetBuildId: "2.0",
+				TargetBuildID: "2.0",
 				Ramp: &client.VersioningRampByPercentage{
 					Percentage: 45.0,
 				},
@@ -298,8 +298,8 @@ func (ts *WorkerVersioningTestSuite) TestCommitRules() {
 	_, err = ts.client.UpdateWorkerVersioningRules(ctx, &client.UpdateWorkerVersioningRulesOptions{
 		TaskQueue:     ts.taskQueueName,
 		ConflictToken: token,
-		Operation: &client.VersioningOpCommitBuildId{
-			TargetBuildId: "2.0",
+		Operation: &client.VersioningOpCommitBuildID{
+			TargetBuildID: "2.0",
 			Force:         false,
 		},
 	})
@@ -310,8 +310,8 @@ func (ts *WorkerVersioningTestSuite) TestCommitRules() {
 	token, err = ts.client.UpdateWorkerVersioningRules(ctx, &client.UpdateWorkerVersioningRulesOptions{
 		TaskQueue:     ts.taskQueueName,
 		ConflictToken: token,
-		Operation: &client.VersioningOpCommitBuildId{
-			TargetBuildId: "2.0",
+		Operation: &client.VersioningOpCommitBuildID{
+			TargetBuildID: "2.0",
 			Force:         true,
 		},
 	})
@@ -324,8 +324,8 @@ func (ts *WorkerVersioningTestSuite) TestCommitRules() {
 
 	// replace all rules by unconditional "2.0"
 	ts.Equal(1, len(res.AssignmentRules))
-	ts.Equal("2.0", res.AssignmentRules[0].TargetBuildId)
-	_, ok := res.AssignmentRules[0].Ramp.(*client.VersioningRampByPercentage)
+	ts.Equal("2.0", res.AssignmentRules[0].Rule.TargetBuildID)
+	_, ok := res.AssignmentRules[0].Rule.Ramp.(*client.VersioningRampByPercentage)
 	ts.Falsef(ok, "Still has a percentage ramp")
 }
 
@@ -344,7 +344,7 @@ func (ts *WorkerVersioningTestSuite) TestConflictTokens() {
 		Operation: &client.VersioningOpInsertAssignmentRule{
 			RuleIndex: 0,
 			Rule: client.VersioningAssignmentRule{
-				TargetBuildId: "1.0",
+				TargetBuildID: "1.0",
 			},
 		},
 	})
@@ -356,7 +356,7 @@ func (ts *WorkerVersioningTestSuite) TestConflictTokens() {
 		Operation: &client.VersioningOpInsertAssignmentRule{
 			RuleIndex: 0,
 			Rule: client.VersioningAssignmentRule{
-				TargetBuildId: "2.0",
+				TargetBuildID: "2.0",
 			},
 		},
 	})
@@ -369,7 +369,7 @@ func (ts *WorkerVersioningTestSuite) TestConflictTokens() {
 		Operation: &client.VersioningOpInsertAssignmentRule{
 			RuleIndex: 0,
 			Rule: client.VersioningAssignmentRule{
-				TargetBuildId: "2.0",
+				TargetBuildID: "2.0",
 			},
 		},
 	})
@@ -392,7 +392,7 @@ func (ts *WorkerVersioningTestSuite) TestTwoWorkersGetDifferentTasks() {
 	ts.workflows.register(worker1)
 	ts.NoError(worker1.Start())
 	defer worker1.Stop()
-	worker2 := worker.New(ts.client, ts.taskQueueName, worker.Options{BuildID: "2.0", UseBuildIDForVersioning: true})
+	worker2 := worker.New(ts.client, ts.taskQueueName, worker.Options{BuildID: "1.1", UseBuildIDForVersioning: true})
 	ts.workflows.register(worker2)
 	ts.NoError(worker2.Start())
 	defer worker2.Stop()
@@ -411,6 +411,13 @@ func (ts *WorkerVersioningTestSuite) TestTwoWorkersGetDifferentTasks() {
 		},
 	})
 	ts.NoError(err)
+
+	// If we add the worker before the BuildID "2.0" has been registered, the worker poller ends up
+	// in the new versioning queue, and it only recovers after 1m timeout.
+	worker3 := worker.New(ts.client, ts.taskQueueName, worker.Options{BuildID: "2.0", UseBuildIDForVersioning: true})
+	ts.workflows.register(worker3)
+	ts.NoError(worker3.Start())
+	defer worker3.Stop()
 
 	// 2.0 workflows
 	handle21, err := ts.client.ExecuteWorkflow(ctx, ts.startWorkflowOptions("2-1"), ts.workflows.WaitSignalToStart)
@@ -446,7 +453,7 @@ func (ts *WorkerVersioningTestSuite) TestTwoWorkersGetDifferentTasksWithRules() 
 		Operation: &client.VersioningOpInsertAssignmentRule{
 			RuleIndex: 0,
 			Rule: client.VersioningAssignmentRule{
-				TargetBuildId: "1.0",
+				TargetBuildID: "1.0",
 			},
 		},
 	})
@@ -474,7 +481,7 @@ func (ts *WorkerVersioningTestSuite) TestTwoWorkersGetDifferentTasksWithRules() 
 		Operation: &client.VersioningOpInsertAssignmentRule{
 			RuleIndex: 0,
 			Rule: client.VersioningAssignmentRule{
-				TargetBuildId: "2.0",
+				TargetBuildID: "2.0",
 			},
 		},
 	})
@@ -712,7 +719,7 @@ func (ts *WorkerVersioningTestSuite) TestBuildIDChangesOverWorkflowLifetimeWithR
 		Operation: &client.VersioningOpInsertAssignmentRule{
 			RuleIndex: 0,
 			Rule: client.VersioningAssignmentRule{
-				TargetBuildId: "1.0",
+				TargetBuildID: "1.0",
 			},
 		},
 	})
@@ -749,7 +756,7 @@ func (ts *WorkerVersioningTestSuite) TestBuildIDChangesOverWorkflowLifetimeWithR
 		Operation: &client.VersioningOpInsertAssignmentRule{
 			RuleIndex: 0,
 			Rule: client.VersioningAssignmentRule{
-				TargetBuildId: "1.1",
+				TargetBuildID: "1.1",
 			},
 		},
 	})
@@ -759,8 +766,8 @@ func (ts *WorkerVersioningTestSuite) TestBuildIDChangesOverWorkflowLifetimeWithR
 		ConflictToken: token,
 		Operation: &client.VersioningOpInsertRedirectRule{
 			Rule: client.VersioningRedirectRule{
-				SourceBuildId: "1.0",
-				TargetBuildId: "1.1",
+				SourceBuildID: "1.0",
+				TargetBuildID: "1.1",
 			},
 		},
 	})


### PR DESCRIPTION
## What was changed
This is the first installment of supporting the new versioning rules in the go sdk. It provides
support for updating and listing both assignment and redirect rules.

It does not include reachability info yet.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->
Nothing to close yet

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Added unit and system tests. To pass system tests use a versioning-2 server branch as target. 

