### PR TITLE
Clarified description of workflow.Now

### DIFF
--- a/workflow/deterministic_wrappers.go
+++ b/workflow/deterministic_wrappers.go
@@ -152,7 +152,7 @@ func NewFuture(ctx Context) (Future, Settable) {
 	return internal.NewFuture(ctx)
 }
 
-// Now returns the current time when the workflow task is started or replayed.
+// Now returns the time when the workflow task was first started, even during replay.
 // Workflows must use this Now() to get the wall clock time, instead of Go's time.Now().
 func Now(ctx Context) time.Time {
 	return internal.Now(ctx)


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
I updated the description of `workflow.Now`, which appears in the Go SDK API documentation, to clarify that the value it returns during replay is the same as it did before. 

## Why?
The original wording was confusing and could be misinterpreted as suggesting that, during replay, it returned the current time instead of the time that was current when that task was initially started.

## Checklist
<!--- add/delete as needed --->

1. Closes N/A

2. How was this tested:
I discussed this with members of the SDK team. They confirmed my understanding that the value returned by this function didn't change during replay. The wording I propose here was suggested by Chad Retz.

3. Any docs updates needed?
This is a change to the Go SDK API documentation. I don't believe that any other changes are necessary.
