### PR TITLE
Change UpdateWorkerVersioningRules response to match GetWorkerVersioningRules

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -673,7 +673,7 @@ type (
 		// The errors it can return:
 		//  - serviceerror.FailedPrecondition when the conflict token is invalid
 		// WARNING: Worker versioning-2 is currently experimental, and requires server 1.XX+
-		UpdateWorkerVersioningRules(ctx context.Context, options *UpdateWorkerVersioningRulesOptions) (VersioningConflictToken, error)
+		UpdateWorkerVersioningRules(ctx context.Context, options *UpdateWorkerVersioningRulesOptions) (*WorkerVersioningRules, error)
 
 		// GetWorkerVersioningRules
 		// Returns the worker-build-id assignment and redirect rules for a task queue.

--- a/internal/client.go
+++ b/internal/client.go
@@ -357,7 +357,7 @@ type (
 		// The errors it can return:
 		//  - serviceerror.FailedPrecondition when the conflict token is invalid
 		// WARNING: Worker versioning-2 is currently experimental, and requires server 1.XX+
-		UpdateWorkerVersioningRules(ctx context.Context, options *UpdateWorkerVersioningRulesOptions) (VersioningConflictToken, error)
+		UpdateWorkerVersioningRules(ctx context.Context, options *UpdateWorkerVersioningRulesOptions) (*WorkerVersioningRules, error)
 
 		// GetWorkerVersioningRules returns the worker-build-id assignment and redirect rules for a task queue.
 		// WARNING: Worker versioning-2 is currently experimental, and requires server 1.XX+

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -1039,23 +1039,23 @@ func (wc *WorkflowClient) GetWorkerTaskReachability(ctx context.Context, options
 // task queue. This is used in conjunction with workers who specify their build id and thus opt into the feature.
 // The errors it can return:
 //   - serviceerror.FailedPrecondition when the conflict token is invalid
-func (wc *WorkflowClient) UpdateWorkerVersioningRules(ctx context.Context, options *UpdateWorkerVersioningRulesOptions) (VersioningConflictToken, error) {
+func (wc *WorkflowClient) UpdateWorkerVersioningRules(ctx context.Context, options *UpdateWorkerVersioningRulesOptions) (*WorkerVersioningRules, error) {
 	if err := wc.ensureInitialized(); err != nil {
-		return VersioningConflictToken{}, err
+		return nil, err
 	}
 
 	request, err := options.validateAndConvertToProto(wc.namespace)
 	if err != nil {
-		return VersioningConflictToken{}, err
+		return nil, err
 	}
 
 	grpcCtx, cancel := newGRPCContext(ctx, defaultGrpcRetryParameters(ctx))
 	defer cancel()
 	resp, err := wc.workflowService.UpdateWorkerVersioningRules(grpcCtx, request)
 	if err != nil {
-		return VersioningConflictToken{}, err
+		return nil, err
 	}
-	return workerVersioningConflictTokenFromProtoResponse(resp), nil
+	return workerVersioningRulesFromProtoUpdateResponse(resp), nil
 }
 
 // GetWorkerVersioningRules returns the worker-build-id assignment and redirect rules for a task queue.
@@ -1076,7 +1076,7 @@ func (wc *WorkflowClient) GetWorkerVersioningRules(ctx context.Context, options 
 	if err != nil {
 		return nil, err
 	}
-	return workerVersioningRulesFromProtoResponse(resp), nil
+	return workerVersioningRulesFromProtoGetResponse(resp), nil
 }
 
 func (wc *WorkflowClient) UpdateWorkflowWithOptions(

--- a/internal/worker_versioning_rules_test.go
+++ b/internal/worker_versioning_rules_test.go
@@ -31,7 +31,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-func Test_WorkerVersioningRules_fromProtoResponse(t *testing.T) {
+func Test_WorkerVersioningRules_fromProtoGetResponse(t *testing.T) {
 	nowProto := timestamppb.Now()
 	timestamp := nowProto.AsTime()
 	tests := []struct {
@@ -78,7 +78,7 @@ func Test_WorkerVersioningRules_fromProtoResponse(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equalf(t, tt.want, workerVersioningRulesFromProtoResponse(tt.response), "workerVersioningRulesFromProtoResponse(%v)", tt.response)
+			assert.Equalf(t, tt.want, workerVersioningRulesFromProtoGetResponse(tt.response), "workerVersioningRulesFromProtoGetResponse(%v)", tt.response)
 		})
 	}
 }

--- a/mocks/Client.go
+++ b/mocks/Client.go
@@ -856,23 +856,23 @@ func (_m *Client) UpdateWorkerBuildIdCompatibility(ctx context.Context, options 
 }
 
 // UpdateWorkerVersioningRules provides a mock function with given fields: ctx, options
-func (_m *Client) UpdateWorkerVersioningRules(ctx context.Context, options *client.UpdateWorkerVersioningRulesOptions) (client.VersioningConflictToken, error) {
+func (_m *Client) UpdateWorkerVersioningRules(ctx context.Context, options *client.UpdateWorkerVersioningRulesOptions) (*client.WorkerVersioningRules, error) {
 	ret := _m.Called(ctx, options)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpdateWorkerVersioningRules")
 	}
 
-	var r0 client.VersioningConflictToken
+	var r0 *client.WorkerVersioningRules
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, *client.UpdateWorkerVersioningRulesOptions) (client.VersioningConflictToken, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, *client.UpdateWorkerVersioningRulesOptions) (*client.WorkerVersioningRules, error)); ok {
 		return rf(ctx, options)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, *client.UpdateWorkerVersioningRulesOptions) client.VersioningConflictToken); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, *client.UpdateWorkerVersioningRulesOptions) *client.WorkerVersioningRules); ok {
 		r0 = rf(ctx, options)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(client.VersioningConflictToken)
+			r0 = ret.Get(0).(*client.WorkerVersioningRules)
 		}
 	}
 

--- a/test/worker_versioning_test.go
+++ b/test/worker_versioning_test.go
@@ -111,7 +111,7 @@ func (ts *WorkerVersioningTestSuite) TestManipulateRules() {
 	})
 	ts.NoError(err)
 
-	token, err := ts.client.UpdateWorkerVersioningRules(ctx, &client.UpdateWorkerVersioningRulesOptions{
+	resp, err := ts.client.UpdateWorkerVersioningRules(ctx, &client.UpdateWorkerVersioningRulesOptions{
 		TaskQueue:     ts.taskQueueName,
 		ConflictToken: res.ConflictToken,
 		Operation: &client.VersioningOpInsertAssignmentRule{
@@ -123,9 +123,9 @@ func (ts *WorkerVersioningTestSuite) TestManipulateRules() {
 	})
 	ts.NoError(err)
 
-	token, err = ts.client.UpdateWorkerVersioningRules(ctx, &client.UpdateWorkerVersioningRulesOptions{
+	resp, err = ts.client.UpdateWorkerVersioningRules(ctx, &client.UpdateWorkerVersioningRulesOptions{
 		TaskQueue:     ts.taskQueueName,
-		ConflictToken: token,
+		ConflictToken: resp.ConflictToken,
 		Operation: &client.VersioningOpInsertAssignmentRule{
 			RuleIndex: 0,
 			Rule: client.VersioningAssignmentRule{
@@ -138,9 +138,9 @@ func (ts *WorkerVersioningTestSuite) TestManipulateRules() {
 	})
 	ts.NoError(err)
 
-	token, err = ts.client.UpdateWorkerVersioningRules(ctx, &client.UpdateWorkerVersioningRulesOptions{
+	resp, err = ts.client.UpdateWorkerVersioningRules(ctx, &client.UpdateWorkerVersioningRulesOptions{
 		TaskQueue:     ts.taskQueueName,
-		ConflictToken: token,
+		ConflictToken: resp.ConflictToken,
 		Operation: &client.VersioningOpInsertRedirectRule{
 			Rule: client.VersioningRedirectRule{
 				SourceBuildID: "1.0",
@@ -154,6 +154,8 @@ func (ts *WorkerVersioningTestSuite) TestManipulateRules() {
 		TaskQueue: ts.taskQueueName,
 	})
 	ts.NoError(err)
+
+	ts.Equal(res, resp)
 
 	ts.Equal("2.0", res.AssignmentRules[0].Rule.TargetBuildID)
 	r, ok := res.AssignmentRules[0].Rule.Ramp.(*client.VersioningRampByPercentage)
@@ -175,7 +177,7 @@ func (ts *WorkerVersioningTestSuite) TestReplaceDeleteRules() {
 	})
 	ts.NoError(err)
 
-	token, err := ts.client.UpdateWorkerVersioningRules(ctx, &client.UpdateWorkerVersioningRulesOptions{
+	resp, err := ts.client.UpdateWorkerVersioningRules(ctx, &client.UpdateWorkerVersioningRulesOptions{
 		TaskQueue:     ts.taskQueueName,
 		ConflictToken: res.ConflictToken,
 		Operation: &client.VersioningOpInsertAssignmentRule{
@@ -188,9 +190,9 @@ func (ts *WorkerVersioningTestSuite) TestReplaceDeleteRules() {
 	ts.NoError(err)
 
 	// Replace by unconditional rule is OK
-	token, err = ts.client.UpdateWorkerVersioningRules(ctx, &client.UpdateWorkerVersioningRulesOptions{
+	resp, err = ts.client.UpdateWorkerVersioningRules(ctx, &client.UpdateWorkerVersioningRulesOptions{
 		TaskQueue:     ts.taskQueueName,
-		ConflictToken: token,
+		ConflictToken: resp.ConflictToken,
 		Operation: &client.VersioningOpReplaceAssignmentRule{
 			RuleIndex: 0,
 			Rule: client.VersioningAssignmentRule{
@@ -203,7 +205,7 @@ func (ts *WorkerVersioningTestSuite) TestReplaceDeleteRules() {
 	// Replace by conditional rule fails
 	_, err = ts.client.UpdateWorkerVersioningRules(ctx, &client.UpdateWorkerVersioningRulesOptions{
 		TaskQueue:     ts.taskQueueName,
-		ConflictToken: token,
+		ConflictToken: resp.ConflictToken,
 		Operation: &client.VersioningOpReplaceAssignmentRule{
 			RuleIndex: 0,
 			Rule: client.VersioningAssignmentRule{
@@ -219,9 +221,9 @@ func (ts *WorkerVersioningTestSuite) TestReplaceDeleteRules() {
 	ts.Error(err)
 	ts.IsType(&serviceerror.FailedPrecondition{}, err)
 
-	token, err = ts.client.UpdateWorkerVersioningRules(ctx, &client.UpdateWorkerVersioningRulesOptions{
+	resp, err = ts.client.UpdateWorkerVersioningRules(ctx, &client.UpdateWorkerVersioningRulesOptions{
 		TaskQueue:     ts.taskQueueName,
-		ConflictToken: token,
+		ConflictToken: resp.ConflictToken,
 		Operation: &client.VersioningOpReplaceAssignmentRule{
 			RuleIndex: 0,
 			Rule: client.VersioningAssignmentRule{
@@ -237,7 +239,7 @@ func (ts *WorkerVersioningTestSuite) TestReplaceDeleteRules() {
 
 	_, err = ts.client.UpdateWorkerVersioningRules(ctx, &client.UpdateWorkerVersioningRulesOptions{
 		TaskQueue:     ts.taskQueueName,
-		ConflictToken: token,
+		ConflictToken: resp.ConflictToken,
 		Operation: &client.VersioningOpDeleteAssignmentRule{
 			RuleIndex: 0,
 			Force:     false,
@@ -249,7 +251,7 @@ func (ts *WorkerVersioningTestSuite) TestReplaceDeleteRules() {
 
 	_, err = ts.client.UpdateWorkerVersioningRules(ctx, &client.UpdateWorkerVersioningRulesOptions{
 		TaskQueue:     ts.taskQueueName,
-		ConflictToken: token,
+		ConflictToken: resp.ConflictToken,
 		Operation: &client.VersioningOpDeleteAssignmentRule{
 			RuleIndex: 0,
 			Force:     true,
@@ -267,7 +269,7 @@ func (ts *WorkerVersioningTestSuite) TestCommitRules() {
 	})
 	ts.NoError(err)
 
-	token, err := ts.client.UpdateWorkerVersioningRules(ctx, &client.UpdateWorkerVersioningRulesOptions{
+	resp, err := ts.client.UpdateWorkerVersioningRules(ctx, &client.UpdateWorkerVersioningRulesOptions{
 		TaskQueue:     ts.taskQueueName,
 		ConflictToken: res.ConflictToken,
 		Operation: &client.VersioningOpInsertAssignmentRule{
@@ -279,9 +281,9 @@ func (ts *WorkerVersioningTestSuite) TestCommitRules() {
 	})
 	ts.NoError(err)
 
-	token, err = ts.client.UpdateWorkerVersioningRules(ctx, &client.UpdateWorkerVersioningRulesOptions{
+	resp, err = ts.client.UpdateWorkerVersioningRules(ctx, &client.UpdateWorkerVersioningRulesOptions{
 		TaskQueue:     ts.taskQueueName,
-		ConflictToken: token,
+		ConflictToken: resp.ConflictToken,
 		Operation: &client.VersioningOpInsertAssignmentRule{
 			RuleIndex: 0,
 			Rule: client.VersioningAssignmentRule{
@@ -297,7 +299,7 @@ func (ts *WorkerVersioningTestSuite) TestCommitRules() {
 	// No worker recently polling so it should fail
 	_, err = ts.client.UpdateWorkerVersioningRules(ctx, &client.UpdateWorkerVersioningRulesOptions{
 		TaskQueue:     ts.taskQueueName,
-		ConflictToken: token,
+		ConflictToken: resp.ConflictToken,
 		Operation: &client.VersioningOpCommitBuildID{
 			TargetBuildID: "2.0",
 			Force:         false,
@@ -307,9 +309,9 @@ func (ts *WorkerVersioningTestSuite) TestCommitRules() {
 	ts.IsType(&serviceerror.FailedPrecondition{}, err)
 
 	// Use the `force`...
-	token, err = ts.client.UpdateWorkerVersioningRules(ctx, &client.UpdateWorkerVersioningRulesOptions{
+	resp, err = ts.client.UpdateWorkerVersioningRules(ctx, &client.UpdateWorkerVersioningRulesOptions{
 		TaskQueue:     ts.taskQueueName,
-		ConflictToken: token,
+		ConflictToken: resp.ConflictToken,
 		Operation: &client.VersioningOpCommitBuildID{
 			TargetBuildID: "2.0",
 			Force:         true,
@@ -321,6 +323,8 @@ func (ts *WorkerVersioningTestSuite) TestCommitRules() {
 		TaskQueue: ts.taskQueueName,
 	})
 	ts.NoError(err)
+
+	ts.Equal(res, resp)
 
 	// replace all rules by unconditional "2.0"
 	ts.Equal(1, len(res.AssignmentRules))
@@ -338,7 +342,7 @@ func (ts *WorkerVersioningTestSuite) TestConflictTokens() {
 	})
 	ts.NoError(err)
 
-	token, err := ts.client.UpdateWorkerVersioningRules(ctx, &client.UpdateWorkerVersioningRulesOptions{
+	resp, err := ts.client.UpdateWorkerVersioningRules(ctx, &client.UpdateWorkerVersioningRulesOptions{
 		TaskQueue:     ts.taskQueueName,
 		ConflictToken: res.ConflictToken,
 		Operation: &client.VersioningOpInsertAssignmentRule{
@@ -363,9 +367,9 @@ func (ts *WorkerVersioningTestSuite) TestConflictTokens() {
 	ts.Error(err)
 	ts.IsType(&serviceerror.FailedPrecondition{}, err)
 
-	token, err = ts.client.UpdateWorkerVersioningRules(ctx, &client.UpdateWorkerVersioningRulesOptions{
+	resp, err = ts.client.UpdateWorkerVersioningRules(ctx, &client.UpdateWorkerVersioningRulesOptions{
 		TaskQueue:     ts.taskQueueName,
-		ConflictToken: token, // original token
+		ConflictToken: resp.ConflictToken, // original token
 		Operation: &client.VersioningOpInsertAssignmentRule{
 			RuleIndex: 0,
 			Rule: client.VersioningAssignmentRule{
@@ -447,7 +451,7 @@ func (ts *WorkerVersioningTestSuite) TestTwoWorkersGetDifferentTasksWithRules() 
 	})
 	ts.NoError(err)
 
-	token, err := ts.client.UpdateWorkerVersioningRules(ctx, &client.UpdateWorkerVersioningRulesOptions{
+	resp, err := ts.client.UpdateWorkerVersioningRules(ctx, &client.UpdateWorkerVersioningRulesOptions{
 		TaskQueue:     ts.taskQueueName,
 		ConflictToken: res.ConflictToken,
 		Operation: &client.VersioningOpInsertAssignmentRule{
@@ -475,9 +479,9 @@ func (ts *WorkerVersioningTestSuite) TestTwoWorkersGetDifferentTasksWithRules() 
 	ts.NoError(err)
 
 	// Now add the 2.0 version
-	token, err = ts.client.UpdateWorkerVersioningRules(ctx, &client.UpdateWorkerVersioningRulesOptions{
+	_, err = ts.client.UpdateWorkerVersioningRules(ctx, &client.UpdateWorkerVersioningRulesOptions{
 		TaskQueue:     ts.taskQueueName,
-		ConflictToken: token,
+		ConflictToken: resp.ConflictToken,
 		Operation: &client.VersioningOpInsertAssignmentRule{
 			RuleIndex: 0,
 			Rule: client.VersioningAssignmentRule{
@@ -713,7 +717,7 @@ func (ts *WorkerVersioningTestSuite) TestBuildIDChangesOverWorkflowLifetimeWithR
 	})
 	ts.NoError(err)
 
-	token, err := ts.client.UpdateWorkerVersioningRules(ctx, &client.UpdateWorkerVersioningRulesOptions{
+	resp, err := ts.client.UpdateWorkerVersioningRules(ctx, &client.UpdateWorkerVersioningRulesOptions{
 		TaskQueue:     ts.taskQueueName,
 		ConflictToken: result.ConflictToken,
 		Operation: &client.VersioningOpInsertAssignmentRule{
@@ -750,9 +754,9 @@ func (ts *WorkerVersioningTestSuite) TestBuildIDChangesOverWorkflowLifetimeWithR
 	worker1.Stop()
 
 	// Add new compat ver
-	token, err = ts.client.UpdateWorkerVersioningRules(ctx, &client.UpdateWorkerVersioningRulesOptions{
+	resp, err = ts.client.UpdateWorkerVersioningRules(ctx, &client.UpdateWorkerVersioningRulesOptions{
 		TaskQueue:     ts.taskQueueName,
-		ConflictToken: token,
+		ConflictToken: resp.ConflictToken,
 		Operation: &client.VersioningOpInsertAssignmentRule{
 			RuleIndex: 0,
 			Rule: client.VersioningAssignmentRule{
@@ -761,9 +765,9 @@ func (ts *WorkerVersioningTestSuite) TestBuildIDChangesOverWorkflowLifetimeWithR
 		},
 	})
 
-	token, err = ts.client.UpdateWorkerVersioningRules(ctx, &client.UpdateWorkerVersioningRulesOptions{
+	resp, err = ts.client.UpdateWorkerVersioningRules(ctx, &client.UpdateWorkerVersioningRulesOptions{
 		TaskQueue:     ts.taskQueueName,
-		ConflictToken: token,
+		ConflictToken: resp.ConflictToken,
 		Operation: &client.VersioningOpInsertRedirectRule{
 			Rule: client.VersioningRedirectRule{
 				SourceBuildID: "1.0",


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->
Change the response of UpdateWorkerVersioningRules to match GetWorkerVersioningRules as suggested by @cretz 

## Why?
<!-- Tell your future self why have you made these changes -->
Eliminates unnecessary round-trips to the server, simpler API...
