### PR TITLE
Rename insert_compatible_redirect_rule to add_compatible_redirect_rule in api

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -321,11 +321,11 @@ type (
 	// WARNING: Worker versioning-2 is currently experimental
 	VersioningOpDeleteAssignmentRule = internal.VersioningOpDeleteAssignmentRule
 
-	// VersioningOpInsertRedirectRule is an operation for UpdateWorkerVersioningRulesOptions
+	// VersioningOpAddRedirectRule is an operation for UpdateWorkerVersioningRulesOptions
 	// that adds the rule to the list of redirect rules for this Task Queue. There
 	// can be at most one redirect rule for each distinct Source BuildID.
 	// WARNING: Worker versioning-2 is currently experimental
-	VersioningOpInsertRedirectRule = internal.VersioningOpInsertRedirectRule
+	VersioningOpAddRedirectRule = internal.VersioningOpAddRedirectRule
 
 	// VersioningOpReplaceRedirectRule is an operation for UpdateWorkerVersioningRulesOptions
 	// that replaces the routing rule with the given source BuildID.

--- a/internal/worker_versioning_rules.go
+++ b/internal/worker_versioning_rules.go
@@ -105,7 +105,7 @@ type (
 	//   - [VersioningOpInsertAssignmentRule]
 	//   - [VersioningOpReplaceAssignmentRule]
 	//   - [VersioningOpDeleteAssignmentRule]
-	//   - [VersioningOpInsertRedirectRule]
+	//   - [VersioningOpAddRedirectRule]
 	//   - [VersioningOpReplaceRedirectRule]
 	//   - [VersioningOpDeleteRedirectRule]
 	//   - [VersioningOpCommitBuildID]
@@ -149,11 +149,11 @@ type (
 		Force     bool
 	}
 
-	// VersioningOpInsertRedirectRule is an operation for UpdateWorkerVersioningRulesOptions
+	// VersioningOpAddRedirectRule is an operation for UpdateWorkerVersioningRulesOptions
 	// that adds the rule to the list of redirect rules for this Task Queue. There
 	// can be at most one redirect rule for each distinct Source BuildID.
 	// WARNING: Worker versioning-2 is currently experimental
-	VersioningOpInsertRedirectRule struct {
+	VersioningOpAddRedirectRule struct {
 		Rule VersioningRedirectRule
 	}
 
@@ -237,9 +237,9 @@ func (uw *UpdateWorkerVersioningRulesOptions) validateAndConvertToProto(namespac
 				Force:     v.Force,
 			},
 		}
-	case *VersioningOpInsertRedirectRule:
-		req.Operation = &workflowservice.UpdateWorkerVersioningRulesRequest_InsertCompatibleRedirectRule{
-			InsertCompatibleRedirectRule: &workflowservice.UpdateWorkerVersioningRulesRequest_AddCompatibleBuildIdRedirectRule{
+	case *VersioningOpAddRedirectRule:
+		req.Operation = &workflowservice.UpdateWorkerVersioningRulesRequest_AddCompatibleRedirectRule{
+			AddCompatibleRedirectRule: &workflowservice.UpdateWorkerVersioningRulesRequest_AddCompatibleBuildIdRedirectRule{
 				Rule: versioningRedirectRuleToProto(&v.Rule),
 			},
 		}
@@ -440,7 +440,7 @@ func (r *VersioningRedirectRule) validateRule() error {
 func (u *VersioningOpInsertAssignmentRule) validateOp() error  { return u.Rule.validateRule() }
 func (u *VersioningOpReplaceAssignmentRule) validateOp() error { return u.Rule.validateRule() }
 func (u *VersioningOpDeleteAssignmentRule) validateOp() error  { return nil }
-func (u *VersioningOpInsertRedirectRule) validateOp() error    { return u.Rule.validateRule() }
+func (u *VersioningOpAddRedirectRule) validateOp() error       { return u.Rule.validateRule() }
 func (u *VersioningOpReplaceRedirectRule) validateOp() error   { return u.Rule.validateRule() }
 
 func (u *VersioningOpDeleteRedirectRule) validateOp() error {

--- a/test/worker_versioning_test.go
+++ b/test/worker_versioning_test.go
@@ -141,7 +141,7 @@ func (ts *WorkerVersioningTestSuite) TestManipulateRules() {
 	resp, err = ts.client.UpdateWorkerVersioningRules(ctx, &client.UpdateWorkerVersioningRulesOptions{
 		TaskQueue:     ts.taskQueueName,
 		ConflictToken: resp.ConflictToken,
-		Operation: &client.VersioningOpInsertRedirectRule{
+		Operation: &client.VersioningOpAddRedirectRule{
 			Rule: client.VersioningRedirectRule{
 				SourceBuildID: "1.0",
 				TargetBuildID: "2.0",
@@ -768,7 +768,7 @@ func (ts *WorkerVersioningTestSuite) TestBuildIDChangesOverWorkflowLifetimeWithR
 	resp, err = ts.client.UpdateWorkerVersioningRules(ctx, &client.UpdateWorkerVersioningRulesOptions{
 		TaskQueue:     ts.taskQueueName,
 		ConflictToken: resp.ConflictToken,
-		Operation: &client.VersioningOpInsertRedirectRule{
+		Operation: &client.VersioningOpAddRedirectRule{
 			Rule: client.VersioningRedirectRule{
 				SourceBuildID: "1.0",
 				TargetBuildID: "1.1",


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->

The api is renaming insert_compatible_redirect_rule to add_compatible_redirect_rule to reflect that there can only be one rule
active per source. 

This trivial PR just renames types to be consistent with the new api, and uses the new go proto stubs.

