### PR TITLE
Add `SetFailureConverter` to `WorkflowTestSuite`

### DIFF
--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -267,7 +267,7 @@ func newTestWorkflowEnvironmentImpl(s *WorkflowTestSuite, parentRegistry *regist
 		doneChannel:            make(chan struct{}),
 		workerStopChannel:      make(chan struct{}),
 		dataConverter:          converter.GetDefaultDataConverter(),
-		failureConverter:       GetDefaultFailureConverter(),
+		failureConverter:       s.failureConverter,
 		runTimeout:             maxWorkflowTimeout,
 		bufferedUpdateRequests: make(map[string][]func()),
 	}
@@ -288,6 +288,9 @@ func newTestWorkflowEnvironmentImpl(s *WorkflowTestSuite, parentRegistry *regist
 	}
 	if env.metricsHandler == nil {
 		env.metricsHandler = metrics.NopHandler
+	}
+	if env.failureConverter == nil {
+		env.failureConverter = GetDefaultFailureConverter()
 	}
 	env.contextPropagators = s.contextPropagators
 	env.header = s.header

--- a/internal/workflow_testsuite.go
+++ b/internal/workflow_testsuite.go
@@ -57,6 +57,7 @@ type (
 		logger                      log.Logger
 		metricsHandler              metrics.Handler
 		contextPropagators          []ContextPropagator
+		failureConverter            converter.FailureConverter
 		header                      *commonpb.Header
 		disableRegistrationAliasing bool
 	}
@@ -157,6 +158,12 @@ func (s *WorkflowTestSuite) SetMetricsHandler(metricsHandler metrics.Handler) {
 // test suite will not use context propagators
 func (s *WorkflowTestSuite) SetContextPropagators(ctxProps []ContextPropagator) {
 	s.contextPropagators = ctxProps
+}
+
+// SetFailureConverter sets the failure converter for this WorkflowTestSuite. If you don't set the failure converter,
+// the default failure converter will be used.
+func (s *WorkflowTestSuite) SetFailureConverter(failureConverter converter.FailureConverter) {
+	s.failureConverter = failureConverter
 }
 
 // SetHeader sets the headers for this WorkflowTestSuite. If you don't set header, test suite will not pass headers to


### PR DESCRIPTION
## What was changed
Adds a `SetFailureConverter` method to the `WorkflowTestSuite`.

## Why?
We use a custom failure converter to marshal/unmarshal structured errors in our application. These errors contain a "code" (similar to a gRPC status) which gets lost without the failure converter, so there are currently certain branches of our code that we're unable to test.
