### PR TITLE
Fix support for typed search attributes in child workflow options

### DIFF
--- a/internal/internal_event_handlers.go
+++ b/internal/internal_event_handlers.go
@@ -563,7 +563,7 @@ func (wc *workflowEnvironmentImpl) ExecuteChildWorkflow(
 		callback(nil, err)
 		return
 	}
-	searchAttr, err := serializeUntypedSearchAttributes(params.SearchAttributes)
+	searchAttr, err := serializeSearchAttributes(params.SearchAttributes, params.TypedSearchAttributes)
 	if err != nil {
 		if wc.sdkFlags.tryUse(SDKFlagChildWorkflowErrorExecution, !wc.isReplay) {
 			startedHandler(WorkflowExecution{}, &ChildWorkflowExecutionAlreadyStartedError{})

--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -402,6 +402,13 @@ func (env *testWorkflowEnvironmentImpl) newTestWorkflowEnvironmentForChild(param
 	childEnv.workflowInfo.CronSchedule = cronSchedule
 	childEnv.workflowInfo.ParentWorkflowNamespace = env.workflowInfo.Namespace
 	childEnv.workflowInfo.ParentWorkflowExecution = &env.workflowInfo.WorkflowExecution
+
+	searchAttrs, err := serializeSearchAttributes(params.SearchAttributes, params.TypedSearchAttributes)
+	if err != nil {
+		return nil, err
+	}
+	childEnv.workflowInfo.SearchAttributes = searchAttrs
+
 	childEnv.runTimeout = params.WorkflowRunTimeout
 	if workflowHandler, ok := env.runningWorkflows[params.WorkflowID]; ok {
 		// duplicate workflow ID

--- a/internal/internal_workflow_testsuite_test.go
+++ b/internal/internal_workflow_testsuite_test.go
@@ -3437,6 +3437,40 @@ func (s *WorkflowTestSuiteUnitTest) Test_ChildWorkflowRetry() {
 	s.Equal("retry-done", result)
 }
 
+func (s *WorkflowTestSuiteUnitTest) Test_ChildWorkflowTypedSearchAttributes() {
+
+	childWorkflowFn := func(ctx Context) error {
+		sa := GetTypedSearchAttributes(ctx)
+		foo, ok := sa.GetString(NewSearchAttributeKeyString("foo"))
+		if !s.True(ok) || !s.Equal("bar", foo) {
+			return NewApplicationErrorWithOptions("invalid foo search attribute", "Internal", ApplicationErrorOptions{
+				Cause:        fmt.Errorf("expected foo search attribute to equal 'bar', got: %v", sa.untypedValue),
+				NonRetryable: true,
+			})
+		}
+		return nil
+	}
+
+	workflowFn := func(ctx Context) error {
+		cwo := ChildWorkflowOptions{
+			WorkflowRunTimeout: time.Minute,
+			TypedSearchAttributes: NewSearchAttributes(
+				NewSearchAttributeKeyString("foo").ValueSet("bar"),
+			),
+		}
+		ctx = WithChildWorkflowOptions(ctx, cwo)
+		return ExecuteChildWorkflow(ctx, childWorkflowFn).Get(ctx, nil)
+	}
+
+	env := s.NewTestWorkflowEnvironment()
+	env.RegisterWorkflow(childWorkflowFn)
+	env.RegisterWorkflow(workflowFn)
+	env.ExecuteWorkflow(workflowFn)
+
+	s.True(env.IsWorkflowCompleted())
+	s.NoError(env.GetWorkflowError())
+}
+
 func (s *WorkflowTestSuiteUnitTest) Test_SignalChildWorkflowRetry() {
 	childWorkflowFn := func(ctx Context) (string, error) {
 		info := GetWorkflowInfo(ctx)

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -936,6 +936,7 @@ func (wc *workflowEnvironmentInterceptor) ExecuteChildWorkflow(ctx Context, chil
 	options.ContextPropagators = workflowOptionsFromCtx.ContextPropagators
 	options.Memo = workflowOptionsFromCtx.Memo
 	options.SearchAttributes = workflowOptionsFromCtx.SearchAttributes
+	options.TypedSearchAttributes = workflowOptionsFromCtx.TypedSearchAttributes
 	options.VersioningIntent = workflowOptionsFromCtx.VersioningIntent
 
 	header, err := workflowHeaderPropagated(ctx, options.ContextPropagators)
@@ -1456,6 +1457,7 @@ func GetChildWorkflowOptions(ctx Context) ChildWorkflowOptions {
 		CronSchedule:             opts.CronSchedule,
 		Memo:                     opts.Memo,
 		SearchAttributes:         opts.SearchAttributes,
+		TypedSearchAttributes:    opts.TypedSearchAttributes,
 		ParentClosePolicy:        opts.ParentClosePolicy,
 		VersioningIntent:         opts.VersioningIntent,
 	}


### PR DESCRIPTION
## What was changed
Fix support for typed search attributes in child workflow options

## Why?
Specifying `TypedSearchAttributes` on `ChildWorkflowOptions` does not propagate search attributes to the child workflow.

## Checklist

1. Closes
n/a

2. How was this tested:
- Added unit test
- Tested against local temporal server

3. Any docs updates needed?
n/a
