### PR TITLE
datadog: Add tracer option to check error eligibility in the span

### DIFF
--- a/contrib/datadog/tracing/interceptor.go
+++ b/contrib/datadog/tracing/interceptor.go
@@ -47,8 +47,10 @@ type TracerOptions struct {
 	// DisableQueryTracing can be set to disable query tracing.
 	DisableQueryTracing bool
 
-	// CheckError can be set to a custom function to determine if an error should be traced.
-	CheckError func(err error) bool
+	// OnFinish sets finish options.
+	// If unset, this will use [tracer.WithError]
+	// in case [interceptor.TracerFinishSpanOptions.Error] is non-nil and not [workflow.IsContinueAsNewError].
+	OnFinish func(options *interceptor.TracerFinishSpanOptions) []tracer.FinishOption
 }
 
 // NewTracingInterceptor convenience method that wraps a NeTracer() with a tracing interceptor
@@ -60,11 +62,23 @@ func NewTracingInterceptor(opts TracerOptions) interceptor.Interceptor {
 // NewTracer creates an interceptor for setting on client options
 // that implements Datadog tracing for workflows.
 func NewTracer(opts TracerOptions) interceptor.Tracer {
+	if opts.OnFinish == nil {
+		opts.OnFinish = func(options *interceptor.TracerFinishSpanOptions) []tracer.FinishOption {
+			var finishOpts []tracer.FinishOption
+
+			if err := options.Error; err != nil && !workflow.IsContinueAsNewError(err) {
+				finishOpts = append(finishOpts, tracer.WithError(err))
+			}
+
+			return finishOpts
+		}
+	}
+
 	return &tracerImpl{
 		opts: TracerOptions{
 			DisableSignalTracing: opts.DisableSignalTracing,
 			DisableQueryTracing:  opts.DisableQueryTracing,
-			CheckError:           opts.CheckError,
+			OnFinish:             opts.OnFinish,
 		},
 	}
 }
@@ -118,7 +132,7 @@ func (t *tracerImpl) SpanFromContext(ctx context.Context) interceptor.TracerSpan
 	if !ok {
 		return nil
 	}
-	return &tracerSpan{CheckError: t.opts.CheckError, Span: span}
+	return &tracerSpan{OnFinish: t.opts.OnFinish, Span: span}
 }
 
 func (t *tracerImpl) ContextWithSpan(ctx context.Context, span interceptor.TracerSpan) context.Context {
@@ -178,7 +192,7 @@ func (t *tracerImpl) StartSpan(options *interceptor.TracerStartSpanOptions) (int
 
 	// Start and return span
 	s := tracer.StartSpan(t.SpanName(options), startOpts...)
-	return &tracerSpan{CheckError: t.opts.CheckError, Span: s}, nil
+	return &tracerSpan{OnFinish: t.opts.OnFinish, Span: s}, nil
 }
 
 func (t *tracerImpl) GetLogger(logger log.Logger, ref interceptor.TracerSpanRef) log.Logger {
@@ -227,7 +241,7 @@ func (r spanContextReader) ForeachKey(handler func(key string, value string) err
 
 type tracerSpan struct {
 	ddtrace.Span
-	CheckError func(err error) bool
+	OnFinish func(options *interceptor.TracerFinishSpanOptions) []tracer.FinishOption
 }
 type tracerSpanCtx struct {
 	ddtrace.SpanContext
@@ -246,16 +260,7 @@ func (t *tracerSpan) ForeachBaggageItem(handler func(k string, v string) bool) {
 }
 
 func (t *tracerSpan) Finish(options *interceptor.TracerFinishSpanOptions) {
-	var opts []tracer.FinishOption
-
-	err := options.Error
-	isErrEligible := err != nil &&
-		!workflow.IsContinueAsNewError(err) &&
-		t.CheckError != nil && t.CheckError(err)
-
-	if isErrEligible {
-		opts = append(opts, tracer.WithError(err))
-	}
+	opts := t.OnFinish(options)
 
 	t.Span.Finish(opts...)
 }

--- a/contrib/datadog/tracing/interceptor.go
+++ b/contrib/datadog/tracing/interceptor.go
@@ -46,6 +46,9 @@ type TracerOptions struct {
 
 	// DisableQueryTracing can be set to disable query tracing.
 	DisableQueryTracing bool
+
+	// ErrCheckFn can be set to a custom function to determine if an error should be traced.
+	ErrCheckFn func(err error) bool
 }
 
 // NewTracingInterceptor convenience method that wraps a NeTracer() with a tracing interceptor
@@ -61,6 +64,7 @@ func NewTracer(opts TracerOptions) interceptor.Tracer {
 		opts: TracerOptions{
 			DisableSignalTracing: opts.DisableSignalTracing,
 			DisableQueryTracing:  opts.DisableQueryTracing,
+			ErrCheckFn:           opts.ErrCheckFn,
 		},
 	}
 }
@@ -114,7 +118,7 @@ func (t *tracerImpl) SpanFromContext(ctx context.Context) interceptor.TracerSpan
 	if !ok {
 		return nil
 	}
-	return &tracerSpan{Span: span}
+	return &tracerSpan{ErrCheckFn: t.opts.ErrCheckFn, Span: span}
 }
 
 func (t *tracerImpl) ContextWithSpan(ctx context.Context, span interceptor.TracerSpan) context.Context {
@@ -174,7 +178,7 @@ func (t *tracerImpl) StartSpan(options *interceptor.TracerStartSpanOptions) (int
 
 	// Start and return span
 	s := tracer.StartSpan(t.SpanName(options), startOpts...)
-	return &tracerSpan{Span: s}, nil
+	return &tracerSpan{ErrCheckFn: t.opts.ErrCheckFn, Span: s}, nil
 }
 
 func (t *tracerImpl) GetLogger(logger log.Logger, ref interceptor.TracerSpanRef) log.Logger {
@@ -223,6 +227,7 @@ func (r spanContextReader) ForeachKey(handler func(key string, value string) err
 
 type tracerSpan struct {
 	ddtrace.Span
+	ErrCheckFn func(err error) bool
 }
 type tracerSpanCtx struct {
 	ddtrace.SpanContext
@@ -242,8 +247,21 @@ func (t *tracerSpan) ForeachBaggageItem(handler func(k string, v string) bool) {
 
 func (t *tracerSpan) Finish(options *interceptor.TracerFinishSpanOptions) {
 	var opts []tracer.FinishOption
-	if err := options.Error; err != nil && !workflow.IsContinueAsNewError(err) {
+
+	err := options.Error
+	isErrEligible := err != nil && !workflow.IsContinueAsNewError(err) && t.shouldErrBeTraced(err)
+
+	if isErrEligible {
 		opts = append(opts, tracer.WithError(err))
 	}
+
 	t.Span.Finish(opts...)
+}
+
+func (t *tracerSpan) shouldErrBeTraced(err error) bool {
+	if t.ErrCheckFn == nil {
+		return true
+	}
+
+	return t.ErrCheckFn(err)
 }

--- a/contrib/datadog/tracing/interceptor_test.go
+++ b/contrib/datadog/tracing/interceptor_test.go
@@ -124,7 +124,7 @@ func Test_ErrCheckFn(t *testing.T) {
 		return true
 	}
 
-	impl := NewTracer(TracerOptions{ErrCheckFn: errCheckFn})
+	impl := NewTracer(TracerOptions{CheckError: errCheckFn})
 	trc := testTracer{
 		Tracer: impl,
 		mt:     mt,


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Added an option to datadog tracer that allows to determine whether an error is eligible to be added to the DD span.

Similar functionality in gorm dd instrumentation: [WithErrorCheck](https://github.com/DataDog/dd-trace-go/blob/50ffac63fe850477042ce4c4bad8de9efe15142d/contrib/gorm.io/gorm.v1/option.go#L70-L77)

## Why?
<!-- Tell your future self why have you made these changes -->

Not all errors need to be reported to Datadog (intermediate retry error, validation error, etc).
Users can filter out such errors via specifying a custom function via the option.

## Checklist
<!--- add/delete as needed --->

1. How was this tested:
I've added simple unit tests.

2. Any docs updates needed?
I didn't find docs related to temporal datadog tracer in the repository, but potentially this page can mention the new option: https://docs.temporal.io/dev-guide/go/observability#useful-resources  
