### PR TITLE
Ensure consistent labels for rpc metrics

### DIFF
--- a/internal/common/metrics/grpc_test.go
+++ b/internal/common/metrics/grpc_test.go
@@ -65,12 +65,12 @@ func TestGRPCInterceptor(t *testing.T) {
 	counters := handler.Counters()
 	require.Len(t, counters, 1)
 	require.Equal(t, metrics.TemporalRequest+"_my_suffix", counters[0].Name)
-	require.Equal(t, map[string]string{metrics.OperationTagName: "Check"}, counters[0].Tags)
+	require.Equal(t, map[string]string{metrics.OperationTagName: "Check", metrics.NamespaceTagName: "_unknown_"}, counters[0].Tags)
 	require.Equal(t, int64(1), counters[0].Value())
 	timers := handler.Timers()
 	require.Len(t, timers, 1)
 	require.Equal(t, metrics.TemporalRequestLatency+"_my_suffix", timers[0].Name)
-	require.Equal(t, map[string]string{metrics.OperationTagName: "Check"}, timers[0].Tags)
+	require.Equal(t, map[string]string{metrics.OperationTagName: "Check", metrics.NamespaceTagName: "_unknown_"}, timers[0].Tags)
 
 	// Now clear the metrics and set a handler with tags and long poll on the
 	// context and make a known failing call
@@ -85,9 +85,9 @@ func TestGRPCInterceptor(t *testing.T) {
 	counters = handler.Counters()
 	require.Len(t, counters, 2)
 	require.Equal(t, metrics.TemporalLongRequest+"_my_suffix", counters[0].Name)
-	require.Equal(t, map[string]string{metrics.OperationTagName: "Check", "roottag": "roottagval"}, counters[0].Tags)
+	require.Equal(t, map[string]string{metrics.OperationTagName: "Check", "roottag": "roottagval", metrics.NamespaceTagName: "_unknown_"}, counters[0].Tags)
 	require.Equal(t, int64(1), counters[0].Value())
 	require.Equal(t, metrics.TemporalLongRequestFailure+"_my_suffix", counters[1].Name)
-	require.Equal(t, map[string]string{metrics.OperationTagName: "Check", "roottag": "roottagval"}, counters[1].Tags)
+	require.Equal(t, map[string]string{metrics.OperationTagName: "Check", "roottag": "roottagval", metrics.NamespaceTagName: "_unknown_"}, counters[1].Tags)
 	require.Equal(t, int64(1), counters[1].Value())
 }


### PR DESCRIPTION
## What was changed
Ensure that all rpc metrics have a `namespace` label, by setting it to `_unknown_` if it can't be derived from the request.

This was mentioned here: https://github.com/temporalio/sdk-go/issues/861#issuecomment-1191524477 and the resolution was to derive the `namespace` label from the request, which is great, but it should be consistent.

## Why?
Many observability systems don't like the same metric to be emitted with different label sets.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
updated unit test

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
