### PR TITLE
Disable UTF8-invalid tests when running CLI dev server

### DIFF
--- a/internal/cmd/build/main.go
+++ b/internal/cmd/build/main.go
@@ -166,6 +166,9 @@ func (b *builder) integrationTest() error {
 	if *coverageFileFlag != "" {
 		args = append(args, "-coverprofile="+filepath.Join(b.rootDir, coverageDir, *coverageFileFlag), "-coverpkg=./...")
 	}
+	if *devServerFlag {
+		args = append(args, "-using-cli-dev-server")
+	}
 	args = append(args, "./...")
 	// Must run in test dir
 	cmd := b.cmdFromRoot(args...)


### PR DESCRIPTION
## What was changed

When doing tests with the about-to-be-released CLI, we discovered that the dev server there disallows invalid UTF8 but the traditional server still allows it. We want to disallow it in the CLI dev server, so, we are just disabling tests that confirm invalid UTF8 is ok when using the dev server.