### PR TITLE
Improve error message for missing body

### DIFF
--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -1042,7 +1042,7 @@ ProcessEvents:
 				}
 				// At this point, all update messages should have a body
 				if historyMessages[i].Body == nil {
-					return nil, errors.New("missing body for accepted message")
+					return nil, fmt.Errorf("missing body in message for update ID %v", msg.GetProtocolInstanceId())
 				}
 			}
 			msgs = indexMessagesByEventID(historyMessages)


### PR DESCRIPTION
Improve error message for missing body in update message, without the ID it would be very annoying to debug if this ever does happen.
