### PR TITLE
Option to redirect devserver stdout/stderr to a file

### DIFF
--- a/testsuite/devserver.go
+++ b/testsuite/devserver.go
@@ -77,8 +77,9 @@ type DevServerOptions struct {
 	LogLevel string
 	// Additional arguments to the dev server.
 	ExtraArgs []string
-	// Where to redirect stdout and stderr, if empty they will be redirected to the current process.
-	StdoutLogFile string
+	// Where to redirect stdout and stderr, if nil they will be redirected to the current process.
+	Stdout io.Writer
+	Stderr io.Writer
 }
 
 // Temporal CLI based DevServer
@@ -112,14 +113,13 @@ func StartDevServer(ctx context.Context, options DevServerOptions) (*DevServer, 
 
 	args := prepareCommand(&options, host, port, clientOptions.Namespace)
 
-	stdout, stderr, err := stdStreams(options.StdoutLogFile)
-	if err != nil {
-		return nil, err
-	}
-
 	cmd := newCmd(exePath, args...)
-	cmd.Stdout = stdout
-	cmd.Stderr = stderr
+	if options.Stdout != nil {
+		cmd.Stdout = options.Stdout
+	}
+	if options.Stderr != nil {
+		cmd.Stderr = options.Stderr
+	}
 
 	clientOptions.Logger.Info("Starting DevServer", "ExePath", exePath, "Args", args)
 	if err := cmd.Start(); err != nil {
@@ -384,17 +384,4 @@ func (s *DevServer) Client() client.Client {
 // FrontendHostPort returns the host:port for this server.
 func (s *DevServer) FrontendHostPort() string {
 	return s.frontendHostPort
-}
-
-func stdStreams(stdoutLogFile string) (io.Writer, io.Writer, error) {
-	if stdoutLogFile == "" {
-		return os.Stdout, os.Stderr, nil
-	}
-
-	file, err := os.OpenFile(stdoutLogFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
-	if err != nil {
-		return nil, nil, fmt.Errorf("open %q: %w", stdoutLogFile, err)
-	}
-
-	return file, file, nil
 }

--- a/testsuite/process_nonwindows.go
+++ b/testsuite/process_nonwindows.go
@@ -33,6 +33,8 @@ import (
 // newCmd creates a new command with the given executable path and arguments.
 func newCmd(exePath string, args ...string) *exec.Cmd {
 	cmd := exec.Command(exePath, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
 	return cmd
 }
 

--- a/testsuite/process_nonwindows.go
+++ b/testsuite/process_nonwindows.go
@@ -33,7 +33,6 @@ import (
 // newCmd creates a new command with the given executable path and arguments.
 func newCmd(exePath string, args ...string) *exec.Cmd {
 	cmd := exec.Command(exePath, args...)
-	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
 	return cmd
 }
 

--- a/testsuite/process_windows.go
+++ b/testsuite/process_windows.go
@@ -37,7 +37,7 @@ func newCmd(exePath string, args ...string) *exec.Cmd {
 		// isolate the process and signals sent to it from the current console
 		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP,
 	}
-	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
+
 	return cmd
 }
 

--- a/testsuite/process_windows.go
+++ b/testsuite/process_windows.go
@@ -37,6 +37,8 @@ func newCmd(exePath string, args ...string) *exec.Cmd {
 		// isolate the process and signals sent to it from the current console
 		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP,
 	}
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
 
 	return cmd
 }


### PR DESCRIPTION
Add a `Stdout` and `Stderr` options to `DevServerOptions` that if it's not `nil` will redirect the spawned server stdout and stderr to them.

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Option to redirect devserver stdout/stderr to different streams.

Add a `Stdout` and `Stderr` options to `DevServerOptions` that if it's not `nil`
will redirect the spawned server stdout and stderr to this file.

## Why?
<!-- Tell your future self why have you made these changes -->
We're embedding the dev server in out app, and when we close it we get huge amount of logs from the underlying dev server.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Ran the current tests.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
Maybe https://docs.temporal.io/dev-guide/go/testing, not sure.
