### PR TITLE
Add support for NextRetryDelay for local activities

### DIFF
--- a/internal/error.go
+++ b/internal/error.go
@@ -328,10 +328,11 @@ func NewApplicationError(msg string, errType string, nonRetryable bool, cause er
 
 func NewApplicationErrorWithOptions(msg string, errType string, options ApplicationErrorOptions) error {
 	applicationErr := &ApplicationError{
-		msg:          msg,
-		errType:      errType,
-		cause:        options.Cause,
-		nonRetryable: options.NonRetryable,
+		msg:            msg,
+		errType:        errType,
+		cause:          options.Cause,
+		nonRetryable:   options.NonRetryable,
+		nextRetryDelay: options.NextRetryDelay,
 	}
 	// When return error to user, use EncodedValues as details and data is ready to be decoded by calling Get
 	details := options.Details
@@ -582,6 +583,8 @@ func (e *ApplicationError) Unwrap() error {
 	return e.cause
 }
 
+// NextRetryDelay returns the delay to wait before retrying the activity.
+// a zero value means to use the activities retry policy.
 func (e *ApplicationError) NextRetryDelay() time.Duration { return e.nextRetryDelay }
 
 // Error from error interface

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -1254,7 +1254,7 @@ func (w *workflowExecutionContextImpl) retryLocalActivity(lar *localActivityResu
 		return false
 	}
 
-	retryBackoff := getRetryBackoff(lar, time.Now(), w.wth.dataConverter)
+	retryBackoff := getRetryBackoff(lar, time.Now())
 	if retryBackoff > 0 && retryBackoff <= w.workflowInfo.WorkflowTaskTimeout {
 		// we need a local retry
 		time.AfterFunc(retryBackoff, func() {
@@ -1279,7 +1279,7 @@ func (w *workflowExecutionContextImpl) retryLocalActivity(lar *localActivityResu
 	return false
 }
 
-func getRetryBackoff(lar *localActivityResult, now time.Time, _ converter.DataConverter) time.Duration {
+func getRetryBackoff(lar *localActivityResult, now time.Time) time.Duration {
 	return getRetryBackoffWithNowTime(lar.task.retryPolicy, lar.task.attempt, lar.err, now, lar.task.expireTime)
 }
 
@@ -1300,7 +1300,7 @@ func getRetryBackoffWithNowTime(p *RetryPolicy, attempt int32, err error, now, e
 	}
 	// Calculate next backoff interval if the error did not contain the next backoff interval.
 	// attempt starts from 1
-	if backoffInterval == time.Duration(0) {
+	if backoffInterval == 0 {
 		backoffInterval = time.Duration(float64(p.InitialInterval) * math.Pow(p.BackoffCoefficient, float64(attempt-1)))
 		if backoffInterval <= 0 {
 			// math.Pow() could overflow

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -1306,14 +1306,15 @@ func getRetryBackoffWithNowTime(p *RetryPolicy, attempt int32, err error, now, e
 			// math.Pow() could overflow
 			if p.MaximumInterval > 0 {
 				backoffInterval = p.MaximumInterval
-			} else {
-				return noRetryBackoff
 			}
 		}
 		if p.MaximumInterval > 0 && backoffInterval > p.MaximumInterval {
 			// cap next interval to MaxInterval
 			backoffInterval = p.MaximumInterval
 		}
+	}
+	if backoffInterval <= 0 {
+		return noRetryBackoff
 	}
 
 	nextScheduleTime := now.Add(backoffInterval)

--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -1647,7 +1647,7 @@ func (env *testWorkflowEnvironmentImpl) handleLocalActivityResult(result *localA
 		Attempt: 1,
 	}
 	if result.task.retryPolicy != nil && result.err != nil {
-		lar.Backoff = getRetryBackoff(result, env.Now(), env.dataConverter)
+		lar.Backoff = getRetryBackoff(result, env.Now())
 		lar.Attempt = task.attempt
 	}
 	task.callback(lar)

--- a/test/activity_test.go
+++ b/test/activity_test.go
@@ -86,6 +86,12 @@ func LocalSleep(_ context.Context, delay time.Duration) error {
 	return nil
 }
 
+func ErrorWithNextDelay(_ context.Context, delay time.Duration) error {
+	return temporal.NewApplicationErrorWithOptions("error with next delay", "NextDelay", temporal.ApplicationErrorOptions{
+		NextRetryDelay: delay,
+	})
+}
+
 func (a *Activities) ActivityToBeCanceled(ctx context.Context) (string, error) {
 	a.append("ActivityToBeCanceled")
 	for {

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -465,6 +465,15 @@ func (ts *IntegrationTestSuite) TestDeadlockDetectionViaLocalActivity() {
 	ts.True(strings.Contains(applicationErr.Error(), "Potential deadlock detected"))
 }
 
+func (ts *IntegrationTestSuite) TestLocalActivityNextRetryDelay() {
+	var expected time.Duration
+	wfOpts := ts.startWorkflowOptions("test-local-activity-next-retry-delay")
+	wfOpts.WorkflowTaskTimeout = 5 * time.Second
+	err := ts.executeWorkflowWithOption(wfOpts, ts.workflows.LocalActivityNextRetryDelay, &expected)
+	ts.NoError(err)
+	fmt.Println(expected)
+}
+
 func (ts *IntegrationTestSuite) TestActivityRetryOnError() {
 	var expected []string
 	err := ts.executeWorkflow("test-activity-retry-on-error", ts.workflows.ActivityRetryOnError, &expected)

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -29,6 +29,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"math"
 	"math/rand"
 	"os"
 	"strings"
@@ -466,12 +467,13 @@ func (ts *IntegrationTestSuite) TestDeadlockDetectionViaLocalActivity() {
 }
 
 func (ts *IntegrationTestSuite) TestLocalActivityNextRetryDelay() {
-	var expected time.Duration
+	var activityExecutionTime time.Duration
 	wfOpts := ts.startWorkflowOptions("test-local-activity-next-retry-delay")
 	wfOpts.WorkflowTaskTimeout = 5 * time.Second
-	err := ts.executeWorkflowWithOption(wfOpts, ts.workflows.LocalActivityNextRetryDelay, &expected)
+	err := ts.executeWorkflowWithOption(wfOpts, ts.workflows.LocalActivityNextRetryDelay, &activityExecutionTime)
 	ts.NoError(err)
-	fmt.Println(expected)
+	// Check the activity execution time is around 7 seconds
+	ts.LessOrEqual(math.Abs((activityExecutionTime - 7*time.Second).Seconds()), 1.0)
 }
 
 func (ts *IntegrationTestSuite) TestActivityRetryOnError() {

--- a/test/workflow_test.go
+++ b/test/workflow_test.go
@@ -110,9 +110,7 @@ func (w *Workflows) LocalActivityNextRetryDelay(ctx workflow.Context) (time.Dura
 	})
 
 	t1 := workflow.Now(ctx)
-	workflow.GetLogger(ctx).Info("calling ExecuteLocalActivity")
 	_ = workflow.ExecuteLocalActivity(laCtx, ErrorWithNextDelay, time.Second).Get(laCtx, nil)
-	workflow.GetLogger(ctx).Info("calling ExecuteLocalActivity done")
 	t2 := workflow.Now(ctx)
 	return t2.Sub(t1), nil
 }


### PR DESCRIPTION
Add support for NextRetryDelay for local activities and the test suite

closes https://github.com/temporalio/sdk-go/issues/1454
