### PR TITLE
Remove DisableStickyExecution

### DIFF
--- a/internal/worker.go
+++ b/internal/worker.go
@@ -102,21 +102,16 @@ type (
 		// default: false
 		EnableLoggingInReplay bool
 
-		// Optional: Disable sticky execution.
+		// Optional: Sticky schedule to start timeout.
+		// The resolution is seconds.
+		//
 		// Sticky Execution is to run the workflow tasks for one workflow execution on same worker host. This is an
 		// optimization for workflow execution. When sticky execution is enabled, worker keeps the workflow state in
 		// memory. New workflow task contains the new history events will be dispatched to the same worker. If this
 		// worker crashes, the sticky workflow task will timeout after StickyScheduleToStartTimeout, and temporal server
 		// will clear the stickiness for that workflow execution and automatically reschedule a new workflow task that
 		// is available for any worker to pick up and resume the progress.
-		// default: false
 		//
-		// Deprecated: DisableStickyExecution harms performance. It will be removed soon. See SetStickyWorkflowCacheSize
-		// instead.
-		DisableStickyExecution bool
-
-		// Optional: Sticky schedule to start timeout.
-		// The resolution is seconds. See details about StickyExecution on the comments for DisableStickyExecution.
 		// default: 5s
 		StickyScheduleToStartTimeout time.Duration
 

--- a/test/bindings_test.go
+++ b/test/bindings_test.go
@@ -60,10 +60,7 @@ func (ts *AsyncBindingsTestSuite) TearDownSuite() {
 
 func (ts *AsyncBindingsTestSuite) SetupTest() {
 	ts.taskQueueName = taskQueuePrefix + "-" + ts.T().Name()
-	options := worker.Options{
-		DisableStickyExecution: ts.config.maxWorkflowCacheSize <= 0,
-	}
-	ts.worker = worker.New(ts.client, ts.taskQueueName, options)
+	ts.worker = worker.New(ts.client, ts.taskQueueName, worker.Options{})
 	ts.worker.RegisterWorkflow(SimplestWorkflow)
 }
 

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -1596,7 +1596,7 @@ func (ts *IntegrationTestSuite) TestSessionStateFailedWorkerFailed() {
 
 	// Now create a new worker on that same task queue to resume the work of the
 	// workflow
-	nextWorker := worker.New(ts.client, ts.taskQueueName, worker.Options{DisableStickyExecution: true})
+	nextWorker := worker.New(ts.client, ts.taskQueueName, worker.Options{})
 	ts.registerWorkflowsAndActivities(nextWorker)
 	ts.NoError(nextWorker.Start())
 	defer nextWorker.Stop()
@@ -3017,7 +3017,7 @@ func (ts *IntegrationTestSuite) TestSessionOnWorkerFailure() {
 
 	// Now create a new worker on that same task queue to resume the work of the
 	// workflow
-	nextWorker := worker.New(ts.client, ts.taskQueueName, worker.Options{DisableStickyExecution: true})
+	nextWorker := worker.New(ts.client, ts.taskQueueName, worker.Options{})
 	ts.registerWorkflowsAndActivities(nextWorker)
 	ts.NoError(nextWorker.Start())
 	defer nextWorker.Stop()
@@ -3229,7 +3229,7 @@ func (ts *IntegrationTestSuite) testNonDeterminismFailureCause(historyMismatch b
 	// Now, stop the worker and start a new one
 	ts.worker.Stop()
 	ts.workerStopped = true
-	nextWorker := worker.New(ts.client, ts.taskQueueName, worker.Options{DisableStickyExecution: true})
+	nextWorker := worker.New(ts.client, ts.taskQueueName, worker.Options{})
 	ts.registerWorkflowsAndActivities(nextWorker)
 	ts.NoError(nextWorker.Start())
 	defer nextWorker.Stop()


### PR DESCRIPTION
Remove DisableStickyExecution, this flag has done nothing for 4 years and is time to remove since it causes confusion.
