### PR TITLE
Nexus

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,15 @@
 module go.temporal.io/sdk
 
-go 1.20
+go 1.21
+
+toolchain go1.21.1
 
 require (
 	github.com/facebookgo/clock v0.0.0-20150410010913-600d898af40a
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/mock v1.6.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
+	github.com/nexus-rpc/sdk-go v0.0.8-0.20240617225139-cd9d6c50e99d
 	github.com/pborman/uuid v1.2.1
 	github.com/robfig/cron v1.2.0
 	github.com/stretchr/testify v1.9.0
@@ -16,6 +19,8 @@ require (
 	google.golang.org/grpc v1.64.0
 	google.golang.org/protobuf v1.34.1
 )
+
+require github.com/gorilla/mux v1.8.0 // indirect
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -26,11 +26,15 @@ github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.3/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
+github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
+github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 h1:UH//fgunKIs4JdUbpDl1VZCDaL56wXCB/5+wF6uHfaI=
 github.com/grpc-ecosystem/go-grpc-middleware v1.4.0/go.mod h1:g5qyo/la0ALbONm6Vbp88Yd8NsDy6rZz+RcrMPxvld8=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0 h1:bkypFPDjIYGfCYD5mRBvpqxfYX1YCS1PXdKYWi8FsN0=
@@ -40,9 +44,13 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/nexus-rpc/sdk-go v0.0.8-0.20240617225139-cd9d6c50e99d h1:OY7OVvmJgHji2GjQVaY1y4NHTZ5vvYr1GJaZTAjo/SQ=
+github.com/nexus-rpc/sdk-go v0.0.8-0.20240617225139-cd9d6c50e99d/go.mod h1:uBe8fX151zUW9DhXxwHjji19d6YfnNUqJ81tR3JbwHY=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pborman/uuid v1.2.1 h1:+ZZIw58t/ozdjRaXh/3awHfmWRbzYxJoAdNJxe/3pvw=
 github.com/pborman/uuid v1.2.1/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
@@ -53,6 +61,7 @@ github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:
 github.com/robfig/cron v1.2.0 h1:ZjScXvvxeQ63Dbyxy76Fj3AT3Ut0aKsyd2/tl3DTMuQ=
 github.com/robfig/cron v1.2.0/go.mod h1:JGuDeoQd7Z6yL4zQhZ3OPEVHB7fL6Ka6skscFHfmt2k=
 github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
+github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -157,6 +166,7 @@ google.golang.org/protobuf v1.34.1/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHh
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/interceptor/interceptor.go
+++ b/interceptor/interceptor.go
@@ -131,6 +131,11 @@ type HandleQueryInput = internal.HandleQueryInput
 // NOTE: Experimental
 type UpdateInput = internal.UpdateInput
 
+// RequestCancelNexusOperationInput is the input to WorkflowOutboundInterceptor.RequestCancelNexusOperation.
+//
+// NOTE: Experimental
+type RequestCancelNexusOperationInput = internal.RequestCancelNexusOperationInput
+
 // WorkflowOutboundInterceptor is an interface for all workflow calls
 // originating from the SDK.
 //

--- a/internal/client.go
+++ b/internal/client.go
@@ -31,7 +31,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"go.temporal.io/api/common/v1"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/operatorservice/v1"
@@ -662,7 +661,7 @@ type (
 		// request ID. Only settable by the SDK - e.g. [temporalnexus.workflowRunOperation].
 		requestID string
 		// workflow completion callback. Only settable by the SDK - e.g. [temporalnexus.workflowRunOperation].
-		callbacks []*common.Callback
+		callbacks []*commonpb.Callback
 	}
 
 	// RetryPolicy defines the retry policy.
@@ -1017,6 +1016,6 @@ func SetRequestIDOnStartWorkflowOptions(opts *StartWorkflowOptions, requestID st
 
 // SetCallbacksOnStartWorkflowOptions is an internal only method for setting callbacks on StartWorkflowOptions.
 // Callbacks are purposefully not exposed to users for the time being.
-func SetCallbacksOnStartWorkflowOptions(opts *StartWorkflowOptions, callbacks []*common.Callback) {
+func SetCallbacksOnStartWorkflowOptions(opts *StartWorkflowOptions, callbacks []*commonpb.Callback) {
 	opts.callbacks = callbacks
 }

--- a/internal/client.go
+++ b/internal/client.go
@@ -31,6 +31,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"go.temporal.io/api/common/v1"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/operatorservice/v1"
@@ -657,6 +658,11 @@ type (
 		// of the delay will be ignored. A signal from signal with start will not trigger a workflow task.
 		// Cannot be set the same time as a CronSchedule.
 		StartDelay time.Duration
+
+		// request ID. Only settable by the SDK - e.g. [temporalnexus.workflowRunOperation].
+		requestID string
+		// workflow completion callback. Only settable by the SDK - e.g. [temporalnexus.workflowRunOperation].
+		callbacks []*common.Callback
 	}
 
 	// RetryPolicy defines the retry policy.
@@ -1002,3 +1008,15 @@ func (m mTLSCredentials) applyToOptions(opts *ClientOptions) error {
 }
 
 func (mTLSCredentials) gRPCInterceptor() grpc.UnaryClientInterceptor { return nil }
+
+// SetRequestIDOnStartWorkflowOptions is an internal only method for setting a requestID on StartWorkflowOptions.
+// RequestID is purposefully not exposed to users for the time being.
+func SetRequestIDOnStartWorkflowOptions(opts *StartWorkflowOptions, requestID string) {
+	opts.requestID = requestID
+}
+
+// SetCallbacksOnStartWorkflowOptions is an internal only method for setting callbacks on StartWorkflowOptions.
+// Callbacks are purposefully not exposed to users for the time being.
+func SetCallbacksOnStartWorkflowOptions(opts *StartWorkflowOptions, callbacks []*common.Callback) {
+	opts.callbacks = callbacks
+}

--- a/internal/common/metrics/constants.go
+++ b/internal/common/metrics/constants.go
@@ -43,16 +43,11 @@ const (
 	WorkflowTaskNoCompletionCounter     = TemporalMetricsPrefix + "workflow_task_no_completion"
 
 	ActivityPollNoTaskCounter             = TemporalMetricsPrefix + "activity_poll_no_task"
-	NexusPollNoTaskCounter                = TemporalMetricsPrefix + "nexus_poll_no_task"
 	ActivityScheduleToStartLatency        = TemporalMetricsPrefix + "activity_schedule_to_start_latency"
 	ActivityExecutionFailedCounter        = TemporalMetricsPrefix + "activity_execution_failed"
-	NexusTaskScheduleToStartLatency       = TemporalMetricsPrefix + "nexus_task_schedule_to_start_latency"
-	NexusTaskExecutionFailedCounter       = TemporalMetricsPrefix + "nexus_task_execution_failed"
 	UnregisteredActivityInvocationCounter = TemporalMetricsPrefix + "unregistered_activity_invocation"
 	ActivityExecutionLatency              = TemporalMetricsPrefix + "activity_execution_latency"
-	NexusTaskExecutionLatency             = TemporalMetricsPrefix + "nexus_task_execution_latency"
 	ActivitySucceedEndToEndLatency        = TemporalMetricsPrefix + "activity_succeed_endtoend_latency"
-	NexusTaskEndToEndLatency              = TemporalMetricsPrefix + "nexus_task_endtoend_latency"
 	ActivityTaskErrorCounter              = TemporalMetricsPrefix + "activity_task_error"
 
 	LocalActivityTotalCounter             = TemporalMetricsPrefix + "local_activity_total"
@@ -86,6 +81,12 @@ const (
 	StickyCacheSize                = TemporalMetricsPrefix + "sticky_cache_size"
 
 	WorkflowActiveThreadCount = TemporalMetricsPrefix + "workflow_active_thread_count"
+
+	NexusPollNoTaskCounter          = TemporalMetricsPrefix + "nexus_poll_no_task"
+	NexusTaskScheduleToStartLatency = TemporalMetricsPrefix + "nexus_task_schedule_to_start_latency"
+	NexusTaskExecutionFailedCounter = TemporalMetricsPrefix + "nexus_task_execution_failed"
+	NexusTaskExecutionLatency       = TemporalMetricsPrefix + "nexus_task_execution_latency"
+	NexusTaskEndToEndLatency        = TemporalMetricsPrefix + "nexus_task_endtoend_latency"
 )
 
 // Metric tag keys

--- a/internal/common/metrics/constants.go
+++ b/internal/common/metrics/constants.go
@@ -43,11 +43,16 @@ const (
 	WorkflowTaskNoCompletionCounter     = TemporalMetricsPrefix + "workflow_task_no_completion"
 
 	ActivityPollNoTaskCounter             = TemporalMetricsPrefix + "activity_poll_no_task"
+	NexusPollNoTaskCounter                = TemporalMetricsPrefix + "nexus_poll_no_task"
 	ActivityScheduleToStartLatency        = TemporalMetricsPrefix + "activity_schedule_to_start_latency"
 	ActivityExecutionFailedCounter        = TemporalMetricsPrefix + "activity_execution_failed"
+	NexusTaskScheduleToStartLatency       = TemporalMetricsPrefix + "nexus_task_schedule_to_start_latency"
+	NexusTaskExecutionFailedCounter       = TemporalMetricsPrefix + "nexus_task_execution_failed"
 	UnregisteredActivityInvocationCounter = TemporalMetricsPrefix + "unregistered_activity_invocation"
 	ActivityExecutionLatency              = TemporalMetricsPrefix + "activity_execution_latency"
+	NexusTaskExecutionLatency             = TemporalMetricsPrefix + "nexus_task_execution_latency"
 	ActivitySucceedEndToEndLatency        = TemporalMetricsPrefix + "activity_succeed_endtoend_latency"
+	NexusTaskEndToEndLatency              = TemporalMetricsPrefix + "nexus_task_endtoend_latency"
 	ActivityTaskErrorCounter              = TemporalMetricsPrefix + "activity_task_error"
 
 	LocalActivityTotalCounter             = TemporalMetricsPrefix + "local_activity_total"
@@ -91,6 +96,8 @@ const (
 	WorkerTypeTagName         = "worker_type"
 	WorkflowTypeNameTagName   = "workflow_type"
 	ActivityTypeNameTagName   = "activity_type"
+	NexusServiceTagName       = "nexus_service"
+	NexusOperationTagName     = "nexus_operation"
 	TaskQueueTagName          = "task_queue"
 	OperationTagName          = "operation"
 	CauseTagName              = "cause"
@@ -105,4 +112,5 @@ const (
 	PollerTypeWorkflowTask       = "workflow_task"
 	PollerTypeWorkflowStickyTask = "workflow_sticky_task"
 	PollerTypeActivityTask       = "activity_task"
+	PollerTypeNexusTask          = "nexus_task"
 )

--- a/internal/common/metrics/tags.go
+++ b/internal/common/metrics/tags.go
@@ -73,6 +73,15 @@ func LocalActivityTags(workflowType, activityType string) map[string]string {
 	}
 }
 
+// NexusTags returns a set of tags for Nexus Operations.
+func NexusTags(service, operation, taskQueueName string) map[string]string {
+	return map[string]string{
+		NexusServiceTagName:   service,
+		NexusOperationTagName: operation,
+		TaskQueueTagName:      taskQueueName,
+	}
+}
+
 // TaskQueueTags returns a set of tags for a task queue.
 func TaskQueueTags(taskQueue string) map[string]string {
 	return map[string]string{

--- a/internal/error.go
+++ b/internal/error.go
@@ -823,6 +823,7 @@ func (e *ChildWorkflowExecutionError) Unwrap() error {
 	return e.cause
 }
 
+// Error implements the error interface.
 func (e *NexusOperationError) Error() string {
 	msg := fmt.Sprintf(
 		"%s (endpoint: %q, service: %q, operation: %q, operation ID: %q, scheduledEventID: %d)",
@@ -843,6 +844,7 @@ func (e *NexusOperationError) failure() *failurepb.Failure {
 	return e.Failure
 }
 
+// Unwrap returns the Cause associated with this error.
 func (e *NexusOperationError) Unwrap() error {
 	return e.Cause
 }

--- a/internal/error.go
+++ b/internal/error.go
@@ -256,6 +256,28 @@ type (
 		cause            error
 	}
 
+	// NexusOperationError is an error returned when a Nexus Operation has failed.
+	//
+	// NOTE: Experimental
+	NexusOperationError struct {
+		// The raw proto failure object this error was created from.
+		Failure *failurepb.Failure
+		// Error message.
+		Message string
+		// ID of the NexusOperationScheduled event.
+		ScheduledEventID int64
+		// Endpoint name.
+		Endpoint string
+		// Service name.
+		Service string
+		// Operation name.
+		Operation string
+		// Operation ID - may be empty if the operation completed synchronously.
+		OperationID string
+		// Chained cause - typically an ApplicationError or a CanceledError.
+		Cause error
+	}
+
 	// ChildWorkflowExecutionAlreadyStartedError is set as the cause of
 	// ChildWorkflowExecutionError when failure is due the child workflow having
 	// already started.
@@ -799,6 +821,30 @@ func (e *ChildWorkflowExecutionError) message() string {
 
 func (e *ChildWorkflowExecutionError) Unwrap() error {
 	return e.cause
+}
+
+func (e *NexusOperationError) Error() string {
+	msg := fmt.Sprintf(
+		"%s (endpoint: %q, service: %q, operation: %q, operation ID: %q, scheduledEventID: %d)",
+		e.Message, e.Endpoint, e.Service, e.Operation, e.OperationID, e.ScheduledEventID)
+	if e.Cause != nil {
+		msg = fmt.Sprintf("%s: %v", msg, e.Cause)
+	}
+	return msg
+}
+
+// setFailure implements the failureHolder interface for consistency with other failure based errors..
+func (e *NexusOperationError) setFailure(f *failurepb.Failure) {
+	e.Failure = f
+}
+
+// failure implements the failureHolder interface for consistency with other failure based errors.
+func (e *NexusOperationError) failure() *failurepb.Failure {
+	return e.Failure
+}
+
+func (e *NexusOperationError) Unwrap() error {
+	return e.Cause
 }
 
 // Error from error interface

--- a/internal/interceptor.go
+++ b/internal/interceptor.go
@@ -169,6 +169,20 @@ type HandleQueryInput struct {
 	Args      []interface{}
 }
 
+// RequestCancelNexusOperationInput is the input to WorkflowOutboundInterceptor.RequestCancelNexusOperation.
+//
+// NOTE: Experimental
+type RequestCancelNexusOperationInput struct {
+	// Client that was used to start the operation.
+	Client NexusClient
+	// Operation name.
+	Operation any
+	// Operation ID. May be empty if the operation is synchronous or has not started yet.
+	ID string
+	// seq number. For internal use only.
+	seq int64
+}
+
 // WorkflowOutboundInterceptor is an interface for all workflow calls
 // originating from the SDK. See documentation in the interceptor package for
 // more details.
@@ -282,6 +296,15 @@ type WorkflowOutboundInterceptor interface {
 	// NewContinueAsNewError intercepts workflow.NewContinueAsNewError.
 	// interceptor.WorkflowHeader will return a non-nil map for this context.
 	NewContinueAsNewError(ctx Context, wfn interface{}, args ...interface{}) error
+
+	// ExecuteNexusOperation intercepts NexusClient.ExecuteOperation.
+	//
+	// NOTE: Experimental
+	ExecuteNexusOperation(ctx Context, client NexusClient, operation any, input any, options NexusOperationOptions) NexusOperationFuture
+	// RequestCancelNexusOperation intercepts Nexus Operation cancelation via context.
+	//
+	// NOTE: Experimental
+	RequestCancelNexusOperation(ctx Context, input RequestCancelNexusOperationInput)
 
 	mustEmbedWorkflowOutboundInterceptorBase()
 }

--- a/internal/interceptor_base.go
+++ b/internal/interceptor_base.go
@@ -389,6 +389,24 @@ func (w *WorkflowOutboundInterceptorBase) NewContinueAsNewError(
 	return w.Next.NewContinueAsNewError(ctx, wfn, args...)
 }
 
+// ExecuteNexusOperation implements
+// WorkflowOutboundInterceptor.ExecuteNexusOperation.
+func (w *WorkflowOutboundInterceptorBase) ExecuteNexusOperation(
+	ctx Context,
+	client NexusClient,
+	operation any,
+	input any,
+	options NexusOperationOptions,
+) NexusOperationFuture {
+	return w.Next.ExecuteNexusOperation(ctx, client, operation, input, options)
+}
+
+// RequestCancelNexusOperation implements
+// WorkflowOutboundInterceptor.RequestCancelNexusOperation.
+func (w *WorkflowOutboundInterceptorBase) RequestCancelNexusOperation(ctx Context, input RequestCancelNexusOperationInput) {
+	w.Next.RequestCancelNexusOperation(ctx, input)
+}
+
 func (*WorkflowOutboundInterceptorBase) mustEmbedWorkflowOutboundInterceptorBase() {}
 
 // ClientInterceptorBase is a default implementation of ClientInterceptor meant

--- a/internal/internal_logging_tags.go
+++ b/internal/internal_logging_tags.go
@@ -49,6 +49,8 @@ const (
 	tagTaskStartedEventID           = "TaskStartedEventID"
 	tagPreviousStartedEventID       = "PreviousStartedEventID"
 	tagCachedPreviousStartedEventID = "CachedPreviousStartedEventID"
+	tagNexusOperation               = "NexusOperation"
+	tagNexusService                 = "NexusService"
 	tagPanicError                   = "PanicError"
 	tagPanicStack                   = "PanicStack"
 )

--- a/internal/internal_logging_tags.go
+++ b/internal/internal_logging_tags.go
@@ -49,6 +49,7 @@ const (
 	tagTaskStartedEventID           = "TaskStartedEventID"
 	tagPreviousStartedEventID       = "PreviousStartedEventID"
 	tagCachedPreviousStartedEventID = "CachedPreviousStartedEventID"
+	tagNexusEndpoint                = "NexusEndpoint"
 	tagNexusOperation               = "NexusOperation"
 	tagNexusService                 = "NexusService"
 	tagPanicError                   = "PanicError"

--- a/internal/internal_nexus_task_handler.go
+++ b/internal/internal_nexus_task_handler.go
@@ -1,0 +1,353 @@
+package internal
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"reflect"
+	"runtime/debug"
+	"time"
+
+	"github.com/nexus-rpc/sdk-go/nexus"
+	"go.temporal.io/api/common/v1"
+	nexuspb "go.temporal.io/api/nexus/v1"
+	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/sdk/converter"
+	"go.temporal.io/sdk/internal/common/metrics"
+	"go.temporal.io/sdk/log"
+	"google.golang.org/protobuf/proto"
+)
+
+func nexusHandlerError(t nexus.HandlerErrorType, message string) *nexuspb.HandlerError {
+	return &nexuspb.HandlerError{
+		ErrorType: string(t),
+		Failure: &nexuspb.Failure{
+			Message: message,
+		},
+	}
+}
+
+func nexusHandlerErrorToProto(handlerErr *nexus.HandlerError) *nexuspb.HandlerError {
+	pbHandlerErr := &nexuspb.HandlerError{
+		ErrorType: string(handlerErr.Type),
+	}
+	if handlerErr.Failure != nil {
+		pbHandlerErr.Failure = &nexuspb.Failure{
+			Message:  handlerErr.Failure.Message,
+			Metadata: handlerErr.Failure.Metadata,
+			Details:  handlerErr.Failure.Details,
+		}
+	}
+	return pbHandlerErr
+}
+
+type nexusTaskHandler struct {
+	nexusHandler   nexus.Handler
+	taskQueueName  string
+	client         Client
+	dataConverter  converter.DataConverter
+	baseCompletion *workflowservice.RespondNexusTaskCompletedRequest
+	baseFailure    *workflowservice.RespondNexusTaskFailedRequest
+	logger         log.Logger
+	metricsHandler metrics.Handler
+}
+
+func newNexusTaskHandler(
+	nexusHandler nexus.Handler,
+	taskQueueName string,
+	client Client,
+	dataConverter converter.DataConverter,
+	baseCompletion *workflowservice.RespondNexusTaskCompletedRequest,
+	baseFailure *workflowservice.RespondNexusTaskFailedRequest,
+	logger log.Logger,
+	metricsHandler metrics.Handler,
+) *nexusTaskHandler {
+	return &nexusTaskHandler{
+		nexusHandler:   nexusHandler,
+		logger:         logger,
+		dataConverter:  dataConverter,
+		taskQueueName:  taskQueueName,
+		client:         client,
+		metricsHandler: metricsHandler,
+		baseCompletion: baseCompletion,
+		baseFailure:    baseFailure,
+	}
+}
+
+func (h *nexusTaskHandler) Execute(task *workflowservice.PollNexusTaskQueueResponse) (*workflowservice.RespondNexusTaskCompletedRequest, *workflowservice.RespondNexusTaskFailedRequest, error) {
+	res, handlerErr, err := h.execute(task)
+	if err != nil {
+		return nil, nil, err
+	}
+	if handlerErr != nil {
+		return nil, h.fillInFailure(task.TaskToken, handlerErr), nil
+	}
+	return h.fillInCompletion(task.TaskToken, res), nil, nil
+}
+
+func (h *nexusTaskHandler) execute(task *workflowservice.PollNexusTaskQueueResponse) (*nexuspb.Response, *nexuspb.HandlerError, error) {
+	log, handlerErr := h.loggerForTask(task)
+	if handlerErr != nil {
+		return nil, handlerErr, nil
+	}
+	nctx := &NexusOperationContext{
+		Client:    h.client,
+		TaskQueue: h.taskQueueName,
+		Log:       log,
+	}
+	header := nexus.Header(task.GetRequest().GetHeader())
+	if header == nil {
+		header = nexus.Header{}
+	}
+
+	ctx, cancel, handlerErr := h.goContextForTask(nctx, header)
+	if handlerErr != nil {
+		return nil, handlerErr, nil
+	}
+	defer cancel()
+
+	switch req := task.GetRequest().GetVariant().(type) {
+	case *nexuspb.Request_StartOperation:
+		return h.handleStartOperation(ctx, nctx, req.StartOperation, header)
+	case *nexuspb.Request_CancelOperation:
+		return h.handleCancelOperation(ctx, nctx, req.CancelOperation, header)
+	default:
+		return nil, nexusHandlerError(nexus.HandlerErrorTypeNotImplemented, "unknown request type"), nil
+	}
+}
+
+func (h *nexusTaskHandler) handleStartOperation(ctx context.Context, nctx *NexusOperationContext, req *nexuspb.StartOperationRequest, header nexus.Header) (*nexuspb.Response, *nexuspb.HandlerError, error) {
+	serializer := &payloadSerializer{
+		converter: h.dataConverter,
+		payload:   req.GetPayload(),
+	}
+	// Create a fake lazy value, Temporal server already converts Nexus content into payloads.
+	input := nexus.NewLazyValue(
+		serializer,
+		&nexus.Reader{
+			ReadCloser: nopReadCloser,
+		},
+	)
+	// Ensure we don't pass nil values to handlers.
+	callbackHeader := req.GetCallbackHeader()
+	if callbackHeader == nil {
+		callbackHeader = make(map[string]string)
+	}
+	startOptions := nexus.StartOperationOptions{
+		RequestID:      req.RequestId,
+		CallbackURL:    req.Callback,
+		Header:         header,
+		CallbackHeader: callbackHeader,
+	}
+	var opres nexus.HandlerStartOperationResult[any]
+	var err error
+	func() {
+		defer func() {
+			recovered := recover()
+			if recovered != nil {
+				var ok bool
+				err, ok = recovered.(error)
+				if !ok {
+					err = fmt.Errorf("panic: %v", recovered)
+				}
+
+				nctx.Log.Error("Panic captured while handling nexus task", tagStackTrace, string(debug.Stack()), tagError, err)
+			}
+		}()
+		opres, err = h.nexusHandler.StartOperation(ctx, req.GetService(), req.GetOperation(), input, startOptions)
+	}()
+	if ctx.Err() != nil {
+		return nil, nil, ctx.Err()
+	}
+	if err != nil {
+		var unsuccessfulOperationErr *nexus.UnsuccessfulOperationError
+		if errors.As(err, &unsuccessfulOperationErr) {
+			return &nexuspb.Response{
+				Variant: &nexuspb.Response_StartOperation{
+					StartOperation: &nexuspb.StartOperationResponse{
+						Variant: &nexuspb.StartOperationResponse_OperationError{
+							OperationError: &nexuspb.UnsuccessfulOperationError{
+								OperationState: string(unsuccessfulOperationErr.State),
+								Failure: &nexuspb.Failure{
+									Message:  unsuccessfulOperationErr.Failure.Message,
+									Metadata: unsuccessfulOperationErr.Failure.Metadata,
+									Details:  unsuccessfulOperationErr.Failure.Details,
+								},
+							},
+						},
+					},
+				},
+			}, nil, nil
+		}
+		var handlerErr *nexus.HandlerError
+		if errors.As(err, &handlerErr) {
+			return nil, nexusHandlerErrorToProto(handlerErr), nil
+		}
+		// Default to internal error.
+		return nil, h.internalError(err), nil
+	}
+	switch t := opres.(type) {
+	case *nexus.HandlerStartOperationResultAsync:
+		return &nexuspb.Response{
+			Variant: &nexuspb.Response_StartOperation{
+				StartOperation: &nexuspb.StartOperationResponse{
+					Variant: &nexuspb.StartOperationResponse_AsyncSuccess{
+						AsyncSuccess: &nexuspb.StartOperationResponse_Async{OperationId: t.OperationID},
+					},
+				},
+			},
+		}, nil, nil
+	default:
+		// *nexus.HandlerStartOperationResultSync is generic, we can't type switch unfortunately.
+		value := reflect.ValueOf(t).Elem().FieldByName("Value").Interface()
+		payload, err := h.dataConverter.ToPayload(value)
+		if err != nil {
+			return nil, h.internalError(fmt.Errorf("cannot convert nexus sync result: %w", err)), nil
+		}
+		return &nexuspb.Response{
+			Variant: &nexuspb.Response_StartOperation{
+				StartOperation: &nexuspb.StartOperationResponse{
+					Variant: &nexuspb.StartOperationResponse_SyncSuccess{
+						SyncSuccess: &nexuspb.StartOperationResponse_Sync{
+							Payload: payload,
+						},
+					},
+				},
+			},
+		}, nil, nil
+	}
+}
+
+func (h *nexusTaskHandler) handleCancelOperation(ctx context.Context, nctx *NexusOperationContext, req *nexuspb.CancelOperationRequest, header nexus.Header) (*nexuspb.Response, *nexuspb.HandlerError, error) {
+	cancelOptions := nexus.CancelOperationOptions{Header: header}
+	var err error
+	func() {
+		defer func() {
+			recovered := recover()
+			if recovered != nil {
+				var ok bool
+				err, ok = recovered.(error)
+				if !ok {
+					err = fmt.Errorf("panic: %v", recovered)
+				}
+
+				nctx.Log.Error("Panic captured while handling nexus task", tagStackTrace, string(debug.Stack()), tagError, err)
+			}
+		}()
+		err = h.nexusHandler.CancelOperation(ctx, req.GetService(), req.GetOperation(), req.GetOperationId(), cancelOptions)
+	}()
+	if ctx.Err() != nil {
+		return nil, nil, ctx.Err()
+	}
+	if err != nil {
+		var handlerErr *nexus.HandlerError
+		if errors.As(err, &handlerErr) {
+			return nil, nexusHandlerErrorToProto(handlerErr), nil
+		}
+		// Default to internal error.
+		return nil, h.internalError(err), nil
+	}
+
+	return &nexuspb.Response{
+		Variant: &nexuspb.Response_CancelOperation{
+			CancelOperation: &nexuspb.CancelOperationResponse{},
+		},
+	}, nil, nil
+}
+
+func (h *nexusTaskHandler) internalError(err error) *nexuspb.HandlerError {
+	h.logger.Error("error processing nexus task", "error", err)
+	return nexusHandlerError(nexus.HandlerErrorTypeInternal, "internal error")
+}
+
+func (h *nexusTaskHandler) goContextForTask(nctx *NexusOperationContext, header nexus.Header) (context.Context, context.CancelFunc, *nexuspb.HandlerError) {
+	// Associate the NexusOperationContext with the context.Context used to invoke operations.
+	ctx := context.WithValue(context.Background(), nexusOperationContextKey, nctx)
+
+	timeoutStr := header.Get(nexus.HeaderRequestTimeout)
+	if timeoutStr != "" {
+		timeout, err := time.ParseDuration(timeoutStr)
+		if err != nil {
+			return nil, nil, nexusHandlerError(nexus.HandlerErrorTypeBadRequest, "cannot parse request timeout")
+		}
+		ctx, cancel := context.WithTimeout(ctx, timeout)
+		return ctx, cancel, nil
+	}
+
+	return ctx, func() {}, nil
+}
+
+func (h *nexusTaskHandler) loggerForTask(response *workflowservice.PollNexusTaskQueueResponse) (log.Logger, *nexuspb.HandlerError) {
+	var service, operation string
+
+	switch req := response.GetRequest().GetVariant().(type) {
+	case *nexuspb.Request_StartOperation:
+		service = req.StartOperation.Service
+		operation = req.StartOperation.Operation
+	case *nexuspb.Request_CancelOperation:
+		service = req.CancelOperation.Service
+		operation = req.CancelOperation.Operation
+	default:
+		return nil, nexusHandlerError(nexus.HandlerErrorTypeNotImplemented, "unknown request type")
+	}
+
+	return log.With(h.logger,
+		tagNexusService, service,
+		tagNexusOperation, operation,
+	), nil
+}
+
+func (h *nexusTaskHandler) metricsHandlerForTask(response *workflowservice.PollNexusTaskQueueResponse) (metrics.Handler, *nexuspb.HandlerError) {
+	var service, operation string
+
+	switch req := response.GetRequest().GetVariant().(type) {
+	case *nexuspb.Request_StartOperation:
+		service = req.StartOperation.Service
+		operation = req.StartOperation.Operation
+	case *nexuspb.Request_CancelOperation:
+		service = req.CancelOperation.Service
+		operation = req.CancelOperation.Operation
+	default:
+		return nil, &nexuspb.HandlerError{
+			ErrorType: string(nexus.HandlerErrorTypeNotImplemented),
+			Failure: &nexuspb.Failure{
+				Message: "unknown request type",
+			},
+		}
+	}
+
+	return h.metricsHandler.WithTags(metrics.NexusTags(service, operation, h.taskQueueName)), nil
+}
+
+func (h *nexusTaskHandler) fillInCompletion(taskToken []byte, res *nexuspb.Response) *workflowservice.RespondNexusTaskCompletedRequest {
+	r := proto.Clone(h.baseCompletion).(*workflowservice.RespondNexusTaskCompletedRequest)
+	r.TaskToken = taskToken
+	r.Response = res
+	return r
+}
+
+func (h *nexusTaskHandler) fillInFailure(taskToken []byte, err *nexuspb.HandlerError) *workflowservice.RespondNexusTaskFailedRequest {
+	r := proto.Clone(h.baseFailure).(*workflowservice.RespondNexusTaskFailedRequest)
+	r.TaskToken = taskToken
+	r.Error = err
+	return r
+}
+
+// payloadSerializer is a fake nexus Serializer that uses a data converter to read from an embedded payload instead of
+// using the given nexus.Context. Supports only Deserialize.
+type payloadSerializer struct {
+	converter converter.DataConverter
+	payload   *common.Payload
+}
+
+func (p *payloadSerializer) Deserialize(_ *nexus.Content, v any) error {
+	return p.converter.FromPayload(p.payload, v)
+}
+
+func (p *payloadSerializer) Serialize(v any) (*nexus.Content, error) {
+	panic("unimplemented") // not used - operation outputs are directly serialized to payload.
+}
+
+var nopReadCloser = io.NopCloser(bytes.NewReader([]byte{}))

--- a/internal/internal_nexus_task_poller.go
+++ b/internal/internal_nexus_task_poller.go
@@ -126,10 +126,10 @@ func (ntp *nexusTaskPoller) ProcessTask(task interface{}) error {
 		metricsHandler.Counter(metrics.NexusTaskExecutionFailedCounter).Inc(1)
 	}
 
-	// Drop the task, nothing to report back.
+	// Let the poller machinary drop the task, nothing to report back.
 	// This is only expected due to context deadline errors.
 	if err != nil {
-		return nil
+		return err
 	}
 
 	if err := ntp.reportCompletion(res, failure); err != nil {

--- a/internal/internal_nexus_task_poller.go
+++ b/internal/internal_nexus_task_poller.go
@@ -1,0 +1,167 @@
+package internal
+
+import (
+	"context"
+	"time"
+
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	taskqueuepb "go.temporal.io/api/taskqueue/v1"
+	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/sdk/internal/common/metrics"
+	"go.temporal.io/sdk/log"
+)
+
+type nexusTaskPoller struct {
+	basePoller
+	namespace       string
+	taskQueueName   string
+	identity        string
+	service         workflowservice.WorkflowServiceClient
+	taskHandler     *nexusTaskHandler
+	logger          log.Logger
+	numPollerMetric *numPollerMetric
+}
+
+var _ taskPoller = &nexusTaskPoller{}
+
+func newNexusTaskPoller(
+	taskHandler *nexusTaskHandler,
+	service workflowservice.WorkflowServiceClient,
+	params workerExecutionParameters,
+) *nexusTaskPoller {
+	return &nexusTaskPoller{
+		basePoller: basePoller{
+			metricsHandler:       params.MetricsHandler,
+			stopC:                params.WorkerStopChannel,
+			workerBuildID:        params.getBuildID(),
+			useBuildIDVersioning: params.UseBuildIDForVersioning,
+			capabilities:         params.capabilities,
+		},
+		taskHandler:     taskHandler,
+		service:         service,
+		namespace:       params.Namespace,
+		taskQueueName:   params.TaskQueue,
+		identity:        params.Identity,
+		logger:          params.Logger,
+		numPollerMetric: newNumPollerMetric(params.MetricsHandler, metrics.PollerTypeNexusTask),
+	}
+}
+
+// Poll the nexus task queue and update the num_poller metric
+func (ntp *nexusTaskPoller) pollNexusTaskQueue(ctx context.Context, request *workflowservice.PollNexusTaskQueueRequest) (*workflowservice.PollNexusTaskQueueResponse, error) {
+	ntp.numPollerMetric.increment()
+	defer ntp.numPollerMetric.decrement()
+
+	return ntp.service.PollNexusTaskQueue(ctx, request)
+}
+
+func (ntp *nexusTaskPoller) poll(ctx context.Context) (interface{}, error) {
+	traceLog(func() {
+		ntp.logger.Debug("nexusTaskPoller::Poll")
+	})
+	request := &workflowservice.PollNexusTaskQueueRequest{
+		Namespace: ntp.namespace,
+		TaskQueue: &taskqueuepb.TaskQueue{Name: ntp.taskQueueName, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+		Identity:  ntp.identity,
+		WorkerVersionCapabilities: &commonpb.WorkerVersionCapabilities{
+			BuildId:       ntp.workerBuildID,
+			UseVersioning: ntp.useBuildIDVersioning,
+		},
+	}
+
+	response, err := ntp.pollNexusTaskQueue(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+	if response == nil || len(response.TaskToken) == 0 {
+		// No operation info is available on empty poll. Emit using base scope.
+		ntp.metricsHandler.Counter(metrics.NexusPollNoTaskCounter).Inc(1)
+		return nil, nil
+	}
+
+	return response, nil
+}
+
+// PollTask polls a new task
+func (ntp *nexusTaskPoller) PollTask() (any, error) {
+	return ntp.doPoll(ntp.poll)
+}
+
+// ProcessTask processes a new task
+func (ntp *nexusTaskPoller) ProcessTask(task interface{}) error {
+	if ntp.stopping() {
+		return errStop
+	}
+
+	response := task.(*workflowservice.PollNexusTaskQueueResponse)
+	if response.GetRequest() == nil {
+		// We didn't get a request, poll must have timed out.
+		traceLog(func() {
+			ntp.logger.Debug("Empty Nexus poll response")
+		})
+		return nil
+	}
+
+	metricsHandler, handlerErr := ntp.taskHandler.metricsHandlerForTask(response)
+	if handlerErr != nil {
+		// context wasn't propagated to us, use a background context.
+		_, err := ntp.taskHandler.client.WorkflowService().RespondNexusTaskFailed(
+			context.Background(), ntp.taskHandler.fillInFailure(response.TaskToken, handlerErr))
+		return err
+	}
+
+	executionStartTime := time.Now()
+
+	// Schedule-to-start (from the time the request hit the frontend).
+	scheduleToStartLatency := executionStartTime.Sub(response.GetRequest().GetScheduledTime().AsTime())
+	metricsHandler.Timer(metrics.NexusTaskScheduleToStartLatency).Record(scheduleToStartLatency)
+
+	// Process the nexus task.
+	res, failure, err := ntp.taskHandler.Execute(response)
+
+	// Execution latency (in-SDK processing time).
+	metricsHandler.Timer(metrics.NexusTaskExecutionLatency).Record(time.Since(executionStartTime))
+	if err != nil || failure != nil {
+		metricsHandler.Counter(metrics.NexusTaskExecutionFailedCounter).Inc(1)
+	}
+
+	// Drop the task, nothing to report back.
+	// This is only expected due to context deadline errors.
+	if err != nil {
+		return nil
+	}
+
+	if err := ntp.reportCompletion(res, failure); err != nil {
+		traceLog(func() {
+			ntp.logger.Debug("reportActivityComplete failed", tagError, err)
+		})
+		return err
+	}
+
+	// E2E latency, from frontend until we finished reporting completion.
+	metricsHandler.
+		Timer(metrics.NexusTaskEndToEndLatency).
+		Record(time.Since(response.GetRequest().GetScheduledTime().AsTime()))
+	return nil
+}
+
+func (ntp *nexusTaskPoller) reportCompletion(
+	completion *workflowservice.RespondNexusTaskCompletedRequest,
+	failure *workflowservice.RespondNexusTaskFailedRequest,
+) error {
+	ctx := context.Background()
+	// No workflow or activity tags to report.
+	// Task queue expected to be empty for Respond*Task... requests.
+	rpcMetricsHandler := ntp.metricsHandler.WithTags(metrics.RPCTags(metrics.NoneTagValue, metrics.NoneTagValue, metrics.NoneTagValue))
+	ctx, cancel := newGRPCContext(ctx, grpcMetricsHandler(rpcMetricsHandler),
+		defaultGrpcRetryParameters(ctx))
+	defer cancel()
+
+	if failure != nil {
+		_, err := ntp.taskHandler.client.WorkflowService().RespondNexusTaskFailed(ctx, failure)
+		return err
+	}
+	_, err := ntp.taskHandler.client.WorkflowService().RespondNexusTaskCompleted(ctx, completion)
+	return err
+}

--- a/internal/internal_nexus_task_poller.go
+++ b/internal/internal_nexus_task_poller.go
@@ -134,7 +134,7 @@ func (ntp *nexusTaskPoller) ProcessTask(task interface{}) error {
 
 	if err := ntp.reportCompletion(res, failure); err != nil {
 		traceLog(func() {
-			ntp.logger.Debug("reportActivityComplete failed", tagError, err)
+			ntp.logger.Debug("reportNexusTaskComplete failed", tagError, err)
 		})
 		return err
 	}

--- a/internal/internal_nexus_worker.go
+++ b/internal/internal_nexus_worker.go
@@ -27,17 +27,11 @@ func newNexusWorker(opts nexusWorkerOptions) (*nexusWorker, error) {
 	poller := newNexusTaskPoller(
 		newNexusTaskHandler(
 			opts.handler,
+			opts.executionParameters.Namespace,
+			opts.executionParameters.Identity,
 			opts.executionParameters.TaskQueue,
 			opts.client,
 			opts.executionParameters.DataConverter,
-			&workflowservice.RespondNexusTaskCompletedRequest{
-				Namespace: opts.executionParameters.Namespace,
-				Identity:  opts.executionParameters.Identity,
-			},
-			&workflowservice.RespondNexusTaskFailedRequest{
-				Namespace: opts.executionParameters.Namespace,
-				Identity:  opts.executionParameters.Identity,
-			},
 			opts.executionParameters.Logger,
 			opts.executionParameters.MetricsHandler,
 		),

--- a/internal/internal_nexus_worker.go
+++ b/internal/internal_nexus_worker.go
@@ -27,8 +27,8 @@ func newNexusWorker(opts nexusWorkerOptions) (*nexusWorker, error) {
 	poller := newNexusTaskPoller(
 		newNexusTaskHandler(
 			opts.handler,
-			opts.executionParameters.Namespace,
 			opts.executionParameters.Identity,
+			opts.executionParameters.Namespace,
 			opts.executionParameters.TaskQueue,
 			opts.client,
 			opts.executionParameters.DataConverter,

--- a/internal/internal_nexus_worker.go
+++ b/internal/internal_nexus_worker.go
@@ -1,0 +1,86 @@
+package internal
+
+import (
+	"github.com/nexus-rpc/sdk-go/nexus"
+	"go.temporal.io/api/workflowservice/v1"
+)
+
+type nexusWorkerOptions struct {
+	executionParameters workerExecutionParameters
+	client              Client
+	workflowService     workflowservice.WorkflowServiceClient
+	handler             nexus.Handler
+}
+
+type nexusWorker struct {
+	executionParameters workerExecutionParameters
+	workflowService     workflowservice.WorkflowServiceClient
+	worker              *baseWorker
+	stopC               chan struct{}
+}
+
+func newNexusWorker(opts nexusWorkerOptions) (*nexusWorker, error) {
+	workerStopChannel := make(chan struct{})
+	params := opts.executionParameters
+	params.WorkerStopChannel = getReadOnlyChannel(workerStopChannel)
+	ensureRequiredParams(&params)
+	poller := newNexusTaskPoller(
+		newNexusTaskHandler(
+			opts.handler,
+			opts.executionParameters.TaskQueue,
+			opts.client,
+			opts.executionParameters.DataConverter,
+			&workflowservice.RespondNexusTaskCompletedRequest{
+				Namespace: opts.executionParameters.Namespace,
+				Identity:  opts.executionParameters.Identity,
+			},
+			&workflowservice.RespondNexusTaskFailedRequest{
+				Namespace: opts.executionParameters.Namespace,
+				Identity:  opts.executionParameters.Identity,
+			},
+			opts.executionParameters.Logger,
+			opts.executionParameters.MetricsHandler,
+		),
+		opts.workflowService,
+		params,
+	)
+
+	baseWorker := newBaseWorker(baseWorkerOptions{
+		pollerCount:       params.MaxConcurrentNexusTaskQueuePollers,
+		pollerRate:        defaultPollerRate,
+		maxConcurrentTask: params.ConcurrentNexusTaskExecutionSize,
+		maxTaskPerSecond:  defaultWorkerTaskExecutionRate,
+		taskWorker:        poller,
+		identity:          params.Identity,
+		workerType:        "NexusWorker",
+		stopTimeout:       params.WorkerStopTimeout,
+		fatalErrCb:        params.WorkerFatalErrorCallback,
+	},
+		params.Logger,
+		params.MetricsHandler,
+		nil,
+	)
+
+	return &nexusWorker{
+		executionParameters: opts.executionParameters,
+		workflowService:     opts.workflowService,
+		worker:              baseWorker,
+		stopC:               workerStopChannel,
+	}, nil
+}
+
+// Start the worker.
+func (w *nexusWorker) Start() error {
+	err := verifyNamespaceExist(w.workflowService, w.executionParameters.MetricsHandler, w.executionParameters.Namespace, w.worker.logger)
+	if err != nil {
+		return err
+	}
+	w.worker.Start()
+	return nil
+}
+
+// Stop the worker.
+func (w *nexusWorker) Stop() {
+	close(w.stopC)
+	w.worker.Stop()
+}

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -1719,14 +1719,18 @@ func isCommandMatchEvent(d *commandpb.Command, e *historypb.HistoryEvent, obes [
 		eventAttributes := e.GetNexusOperationScheduledEventAttributes()
 		commandAttributes := d.GetScheduleNexusOperationCommandAttributes()
 
-		if eventAttributes.GetService() != commandAttributes.GetService() || eventAttributes.GetOperation() != commandAttributes.GetOperation() {
+		return eventAttributes.GetService() == commandAttributes.GetService() &&
+			eventAttributes.GetOperation() == commandAttributes.GetOperation()
+
+	case enumspb.COMMAND_TYPE_REQUEST_CANCEL_NEXUS_OPERATION:
+		if e.GetEventType() != enumspb.EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUESTED {
 			return false
 		}
 
-		return true
+		eventAttributes := e.GetNexusOperationCancelRequestedEventAttributes()
+		commandAttributes := d.GetRequestCancelNexusOperationCommandAttributes()
 
-	case enumspb.COMMAND_TYPE_REQUEST_CANCEL_NEXUS_OPERATION:
-		return e.GetEventType() == enumspb.EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUESTED
+		return eventAttributes.GetScheduledEventId() == commandAttributes.GetScheduledEventId()
 	}
 
 	return false

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -340,7 +340,9 @@ func isCommandEvent(eventType enumspb.EventType) bool {
 		enumspb.EVENT_TYPE_WORKFLOW_PROPERTIES_MODIFIED,
 		enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_ACCEPTED,
 		enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_COMPLETED,
-		enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_REJECTED:
+		enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_REJECTED,
+		enumspb.EVENT_TYPE_NEXUS_OPERATION_SCHEDULED,
+		enumspb.EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUESTED:
 		return true
 	default:
 		return false
@@ -1709,6 +1711,22 @@ func isCommandMatchEvent(d *commandpb.Command, e *historypb.HistoryEvent, obes [
 			return false
 		}
 		return true
+
+	case enumspb.COMMAND_TYPE_SCHEDULE_NEXUS_OPERATION:
+		if e.GetEventType() != enumspb.EVENT_TYPE_NEXUS_OPERATION_SCHEDULED {
+			return false
+		}
+		eventAttributes := e.GetNexusOperationScheduledEventAttributes()
+		commandAttributes := d.GetScheduleNexusOperationCommandAttributes()
+
+		if eventAttributes.GetService() != commandAttributes.GetService() || eventAttributes.GetOperation() != commandAttributes.GetOperation() {
+			return false
+		}
+
+		return true
+
+	case enumspb.COMMAND_TYPE_REQUEST_CANCEL_NEXUS_OPERATION:
+		return e.GetEventType() == enumspb.EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUESTED
 	}
 
 	return false

--- a/internal/internal_worker_base.go
+++ b/internal/internal_worker_base.go
@@ -77,6 +77,14 @@ type (
 		Backoff time.Duration
 	}
 
+	executeNexusOperationParams struct {
+		client      NexusClient
+		operation   string
+		input       *commonpb.Payload
+		options     NexusOperationOptions
+		nexusHeader map[string]string
+	}
+
 	// WorkflowEnvironment Represents the environment for workflow.
 	// Should only be used within the scope of workflow definition.
 	WorkflowEnvironment interface {
@@ -92,6 +100,8 @@ type (
 		RequestCancelChildWorkflow(namespace, workflowID string)
 		RequestCancelExternalWorkflow(namespace, workflowID, runID string, callback ResultHandler)
 		ExecuteChildWorkflow(params ExecuteWorkflowParams, callback ResultHandler, startedHandler func(r WorkflowExecution, e error))
+		ExecuteNexusOperation(params executeNexusOperationParams, callback func(*commonpb.Payload, error), startedHandler func(opID string, e error)) int64
+		RequestCancelNexusOperation(seq int64)
 		GetLogger() log.Logger
 		GetMetricsHandler() metrics.Handler
 		// Must be called before WorkflowDefinition.Execute returns

--- a/internal/internal_workflow.go
+++ b/internal/internal_workflow.go
@@ -230,6 +230,11 @@ type (
 		executionFuture   *futureImpl // for child workflow execution future
 	}
 
+	nexusOperationFutureImpl struct {
+		*decodeFutureImpl             // for the result
+		executionFuture   *futureImpl // for the NexusOperationExecution
+	}
+
 	asyncFuture interface {
 		Future
 		// Used by selectorImpl
@@ -465,6 +470,10 @@ func (f *childWorkflowFutureImpl) SignalChildWorkflow(ctx Context, signalName st
 	// Put header on context before executing
 	ctx = workflowContextWithNewHeader(ctx)
 	return i.SignalChildWorkflow(ctx, childExec.ID, signalName, data)
+}
+
+func (f *nexusOperationFutureImpl) GetNexusOperationExecution() Future {
+	return f.executionFuture
 }
 
 func newWorkflowContext(

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -1563,7 +1563,6 @@ func (w *workflowClientInterceptor) ExecuteWorkflow(
 	// run propagators to extract information about tracing and other stuff, store in headers field
 	startRequest := &workflowservice.StartWorkflowExecutionRequest{
 		Namespace:                w.client.namespace,
-		RequestId:                uuid.New(),
 		WorkflowId:               workflowID,
 		WorkflowType:             &commonpb.WorkflowType{Name: in.WorkflowType},
 		TaskQueue:                &taskqueuepb.TaskQueue{Name: in.Options.TaskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
@@ -1578,6 +1577,13 @@ func (w *workflowClientInterceptor) ExecuteWorkflow(
 		Memo:                     memo,
 		SearchAttributes:         searchAttr,
 		Header:                   header,
+		CompletionCallbacks:      in.Options.callbacks,
+	}
+
+	if in.Options.requestID != "" {
+		startRequest.RequestId = in.Options.requestID
+	} else {
+		startRequest.RequestId = uuid.New()
 	}
 
 	var eagerExecutor *eagerWorkflowExecutor

--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -2335,7 +2335,7 @@ func (env *testWorkflowEnvironmentImpl) newTestNexusTaskHandler() *nexusTaskHand
 		env.identity,
 		env.workflowInfo.Namespace,
 		env.workflowInfo.TaskQueueName,
-		&testSuiteClientForNexusOperations{env},
+		&testSuiteClientForNexusOperations{env: env},
 		env.dataConverter,
 		env.logger,
 		env.metricsHandler,

--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -2291,6 +2291,14 @@ func (env *testWorkflowEnvironmentImpl) executeChildWorkflowWithDelay(delayStart
 	go childEnv.executeWorkflowInternal(delayStart, params.WorkflowType.Name, params.Input)
 }
 
+func (wc *testWorkflowEnvironmentImpl) ExecuteNexusOperation(params executeNexusOperationParams, callback func(*commonpb.Payload, error), startedHandler func(opID string, e error)) int64 {
+	panic("TODO")
+}
+
+func (wc *testWorkflowEnvironmentImpl) RequestCancelNexusOperation(seq int64) {
+	panic("TODO")
+}
+
 func (env *testWorkflowEnvironmentImpl) SideEffect(f func() (*commonpb.Payloads, error), callback ResultHandler) {
 	callback(f())
 }

--- a/internal/nexus_operations.go
+++ b/internal/nexus_operations.go
@@ -2,7 +2,18 @@ package internal
 
 import (
 	"context"
+	"fmt"
+	"strconv"
 
+	"github.com/nexus-rpc/sdk-go/nexus"
+	commonpb "go.temporal.io/api/common/v1"
+	"go.temporal.io/api/enums/v1"
+	failurepb "go.temporal.io/api/failure/v1"
+	nexuspb "go.temporal.io/api/nexus/v1"
+	"go.temporal.io/api/operatorservice/v1"
+	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/sdk/converter"
 	"go.temporal.io/sdk/log"
 )
 
@@ -21,3 +32,343 @@ func NexusOperationContextFromGoContext(ctx context.Context) (nctx *NexusOperati
 	nctx, ok = ctx.Value(nexusOperationContextKey).(*NexusOperationContext)
 	return
 }
+
+// nexusOperationFailure is a utility in use by the test environment.
+func nexusOperationFailure(params executeNexusOperationParams, operationID string, cause *failurepb.Failure) *failurepb.Failure {
+	return &failurepb.Failure{
+		Message: "nexus operation completed unsuccessfully",
+		FailureInfo: &failurepb.Failure_NexusOperationExecutionFailureInfo{
+			NexusOperationExecutionFailureInfo: &failurepb.NexusOperationFailureInfo{
+				Endpoint:    params.client.Endpoint(),
+				Service:     params.client.Service(),
+				Operation:   params.operation,
+				OperationId: operationID,
+			},
+		},
+		Cause: cause,
+	}
+}
+
+// unsuccessfulOperationErrorToTemporalFailure is a utility in use by the test environment.
+// copied from the server codebase with a slight adaptation: https://github.com/temporalio/temporal/blob/7635cd7dbdc7dd3219f387e8fc66fa117f585ff6/common/nexus/failure.go#L69-L108
+func unsuccessfulOperationErrorToTemporalFailure(err *nexuspb.UnsuccessfulOperationError) *failurepb.Failure {
+	failure := &failurepb.Failure{
+		Message: err.Failure.Message,
+	}
+	if err.OperationState == string(nexus.OperationStateCanceled) {
+		failure.FailureInfo = &failurepb.Failure_CanceledFailureInfo{
+			CanceledFailureInfo: &failurepb.CanceledFailureInfo{
+				Details: nexusFailureMetadataToPayloads(err.Failure),
+			},
+		}
+	} else {
+		failure.FailureInfo = &failurepb.Failure_ApplicationFailureInfo{
+			ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{
+				// Make up a type here, it's not part of the Nexus Failure spec.
+				Type:         "NexusOperationFailure",
+				Details:      nexusFailureMetadataToPayloads(err.Failure),
+				NonRetryable: true,
+			},
+		}
+	}
+	return failure
+}
+
+// nexusFailureMetadataToPayloads is a utility in use by the test environment.
+// copied from the server codebase with a slight adaptation: https://github.com/temporalio/temporal/blob/7635cd7dbdc7dd3219f387e8fc66fa117f585ff6/common/nexus/failure.go#L69-L108
+func nexusFailureMetadataToPayloads(failure *nexuspb.Failure) *commonpb.Payloads {
+	if len(failure.Metadata) == 0 && len(failure.Details) == 0 {
+		return nil
+	}
+	metadata := make(map[string][]byte, len(failure.Metadata))
+	for k, v := range failure.Metadata {
+		metadata[k] = []byte(v)
+	}
+	return &commonpb.Payloads{
+		Payloads: []*commonpb.Payload{
+			{
+				Metadata: metadata,
+				Data:     failure.Details,
+			},
+		},
+	}
+}
+
+// testSuiteClientForNexusOperations is a partial [Client] implementation for the test workflow environment used to
+// support basic Nexus functionality.
+// Most of its methods are unimplemented, and best effort was made to return errors where possible instead of panicking.
+// More methods can be implemented on demand.
+type testSuiteClientForNexusOperations struct {
+	env *testWorkflowEnvironmentImpl
+}
+
+// CancelWorkflow implements Client.
+func (t *testSuiteClientForNexusOperations) CancelWorkflow(ctx context.Context, workflowID string, runID string) error {
+	doneCh := make(chan error)
+	t.env.cancelWorkflowByID(workflowID, runID, func(result *commonpb.Payloads, err error) {
+		doneCh <- err
+	})
+	return <-doneCh
+}
+
+// CheckHealth implements Client.
+func (t *testSuiteClientForNexusOperations) CheckHealth(ctx context.Context, request *CheckHealthRequest) (*CheckHealthResponse, error) {
+	return &CheckHealthResponse{}, nil
+}
+
+// Close implements Client.
+func (t *testSuiteClientForNexusOperations) Close() {
+	// No op.
+}
+
+// CompleteActivity implements Client.
+func (t *testSuiteClientForNexusOperations) CompleteActivity(ctx context.Context, taskToken []byte, result interface{}, err error) error {
+	return serviceerror.NewUnimplemented("not implemented in the test environment")
+}
+
+// CompleteActivityByID implements Client.
+func (t *testSuiteClientForNexusOperations) CompleteActivityByID(ctx context.Context, namespace string, workflowID string, runID string, activityID string, result interface{}, err error) error {
+	return serviceerror.NewUnimplemented("not implemented in the test environment")
+}
+
+// CountWorkflow implements Client.
+func (t *testSuiteClientForNexusOperations) CountWorkflow(ctx context.Context, request *workflowservice.CountWorkflowExecutionsRequest) (*workflowservice.CountWorkflowExecutionsResponse, error) {
+	return nil, serviceerror.NewUnimplemented("not implemented in the test environment")
+}
+
+// DescribeTaskQueue implements Client.
+func (t *testSuiteClientForNexusOperations) DescribeTaskQueue(ctx context.Context, taskqueue string, taskqueueType enums.TaskQueueType) (*workflowservice.DescribeTaskQueueResponse, error) {
+	return nil, serviceerror.NewUnimplemented("not implemented in the test environment")
+}
+
+// DescribeWorkflowExecution implements Client.
+func (t *testSuiteClientForNexusOperations) DescribeWorkflowExecution(ctx context.Context, workflowID string, runID string) (*workflowservice.DescribeWorkflowExecutionResponse, error) {
+	return nil, serviceerror.NewUnimplemented("not implemented in the test environment")
+}
+
+// ExecuteWorkflow implements Client.
+func (t *testSuiteClientForNexusOperations) ExecuteWorkflow(ctx context.Context, options StartWorkflowOptions, workflow interface{}, args ...interface{}) (WorkflowRun, error) {
+	wfType, input, err := getValidatedWorkflowFunction(workflow, args, t.env.dataConverter, t.env.GetRegistry())
+	if err != nil {
+		return nil, fmt.Errorf("cannot validate workflow function: %w", err)
+	}
+
+	run := &testEnvWorkflowRunForNexusOperations{}
+	doneCh := make(chan error)
+
+	var callback *commonpb.Callback
+
+	if len(options.callbacks) > 0 {
+		callback = options.callbacks[0]
+	}
+
+	t.env.executeChildWorkflowWithDelay(options.StartDelay, ExecuteWorkflowParams{
+		// Not propagating Header as this client does not support context propagation.
+		WorkflowType: wfType,
+		Input:        input,
+		WorkflowOptions: WorkflowOptions{
+			WaitForCancellation:      true,
+			Namespace:                t.env.workflowInfo.Namespace,
+			TaskQueueName:            t.env.workflowInfo.TaskQueueName,
+			WorkflowID:               options.ID,
+			WorkflowExecutionTimeout: options.WorkflowExecutionTimeout,
+			WorkflowRunTimeout:       options.WorkflowRunTimeout,
+			WorkflowTaskTimeout:      options.WorkflowTaskTimeout,
+			DataConverter:            t.env.dataConverter,
+			WorkflowIDReusePolicy:    options.WorkflowIDReusePolicy,
+			ContextPropagators:       t.env.contextPropagators,
+			SearchAttributes:         options.SearchAttributes,
+			TypedSearchAttributes:    options.TypedSearchAttributes,
+			ParentClosePolicy:        enums.PARENT_CLOSE_POLICY_ABANDON,
+			Memo:                     options.Memo,
+			CronSchedule:             options.CronSchedule,
+			RetryPolicy:              convertToPBRetryPolicy(options.RetryPolicy),
+		},
+	}, func(result *commonpb.Payloads, wfErr error) {
+		ncb := callback.GetNexus()
+		if ncb == nil {
+			return
+		}
+		seqStr := ncb.GetHeader()["operation-sequence"]
+		if seqStr == "" {
+			return
+		}
+		seq, err := strconv.ParseInt(seqStr, 10, 64)
+		if err != nil {
+			panic(fmt.Errorf("unexpected operation sequence in callback header: %s: %w", seqStr, err))
+		}
+
+		if wfErr != nil {
+			t.env.resolveNexusOperation(seq, nil, wfErr)
+		} else {
+			var payload *commonpb.Payload
+			if len(result.GetPayloads()) > 0 {
+				payload = result.Payloads[0]
+			}
+			t.env.resolveNexusOperation(seq, payload, nil)
+		}
+	}, func(r WorkflowExecution, err error) {
+		run.WorkflowExecution = r
+		doneCh <- err
+	})
+	err = <-doneCh
+	if err != nil {
+		return nil, err
+	}
+	return run, nil
+}
+
+// GetSearchAttributes implements Client.
+func (t *testSuiteClientForNexusOperations) GetSearchAttributes(ctx context.Context) (*workflowservice.GetSearchAttributesResponse, error) {
+	return nil, serviceerror.NewUnimplemented("not implemented in the test environment")
+}
+
+// GetWorkerBuildIdCompatibility implements Client.
+func (t *testSuiteClientForNexusOperations) GetWorkerBuildIdCompatibility(ctx context.Context, options *GetWorkerBuildIdCompatibilityOptions) (*WorkerBuildIDVersionSets, error) {
+	return nil, serviceerror.NewUnimplemented("not implemented in the test environment")
+}
+
+// GetWorkerTaskReachability implements Client.
+func (t *testSuiteClientForNexusOperations) GetWorkerTaskReachability(ctx context.Context, options *GetWorkerTaskReachabilityOptions) (*WorkerTaskReachability, error) {
+	return nil, serviceerror.NewUnimplemented("not implemented in the test environment")
+}
+
+// GetWorkflow implements Client.
+func (t *testSuiteClientForNexusOperations) GetWorkflow(ctx context.Context, workflowID string, runID string) WorkflowRun {
+	panic("not implemented in the test environment")
+}
+
+// GetWorkflowHistory implements Client.
+func (t *testSuiteClientForNexusOperations) GetWorkflowHistory(ctx context.Context, workflowID string, runID string, isLongPoll bool, filterType enums.HistoryEventFilterType) HistoryEventIterator {
+	panic("not implemented in the test environment")
+}
+
+// GetWorkflowUpdateHandle implements Client.
+func (t *testSuiteClientForNexusOperations) GetWorkflowUpdateHandle(GetWorkflowUpdateHandleOptions) WorkflowUpdateHandle {
+	panic("not implemented in the test environment")
+}
+
+// ListArchivedWorkflow implements Client.
+func (t *testSuiteClientForNexusOperations) ListArchivedWorkflow(ctx context.Context, request *workflowservice.ListArchivedWorkflowExecutionsRequest) (*workflowservice.ListArchivedWorkflowExecutionsResponse, error) {
+	return nil, serviceerror.NewUnimplemented("not implemented in the test environment")
+}
+
+// ListClosedWorkflow implements Client.
+func (t *testSuiteClientForNexusOperations) ListClosedWorkflow(ctx context.Context, request *workflowservice.ListClosedWorkflowExecutionsRequest) (*workflowservice.ListClosedWorkflowExecutionsResponse, error) {
+	return nil, serviceerror.NewUnimplemented("not implemented in the test environment")
+}
+
+// ListOpenWorkflow implements Client.
+func (t *testSuiteClientForNexusOperations) ListOpenWorkflow(ctx context.Context, request *workflowservice.ListOpenWorkflowExecutionsRequest) (*workflowservice.ListOpenWorkflowExecutionsResponse, error) {
+	return nil, serviceerror.NewUnimplemented("not implemented in the test environment")
+}
+
+// ListWorkflow implements Client.
+func (t *testSuiteClientForNexusOperations) ListWorkflow(ctx context.Context, request *workflowservice.ListWorkflowExecutionsRequest) (*workflowservice.ListWorkflowExecutionsResponse, error) {
+	return nil, serviceerror.NewUnimplemented("not implemented in the test environment")
+}
+
+// OperatorService implements Client.
+func (t *testSuiteClientForNexusOperations) OperatorService() operatorservice.OperatorServiceClient {
+	panic("not implemented in the test environment")
+}
+
+// QueryWorkflow implements Client.
+func (t *testSuiteClientForNexusOperations) QueryWorkflow(ctx context.Context, workflowID string, runID string, queryType string, args ...interface{}) (converter.EncodedValue, error) {
+	return t.env.queryWorkflowByID(workflowID, queryType, args)
+}
+
+// QueryWorkflowWithOptions implements Client.
+func (t *testSuiteClientForNexusOperations) QueryWorkflowWithOptions(ctx context.Context, request *QueryWorkflowWithOptionsRequest) (*QueryWorkflowWithOptionsResponse, error) {
+	return nil, serviceerror.NewUnimplemented("not implemented in the test environment")
+}
+
+// RecordActivityHeartbeat implements Client.
+func (t *testSuiteClientForNexusOperations) RecordActivityHeartbeat(ctx context.Context, taskToken []byte, details ...interface{}) error {
+	return serviceerror.NewUnimplemented("not implemented in the test environment")
+}
+
+// RecordActivityHeartbeatByID implements Client.
+func (t *testSuiteClientForNexusOperations) RecordActivityHeartbeatByID(ctx context.Context, namespace string, workflowID string, runID string, activityID string, details ...interface{}) error {
+	return serviceerror.NewUnimplemented("not implemented in the test environment")
+}
+
+// ResetWorkflowExecution implements Client.
+func (t *testSuiteClientForNexusOperations) ResetWorkflowExecution(ctx context.Context, request *workflowservice.ResetWorkflowExecutionRequest) (*workflowservice.ResetWorkflowExecutionResponse, error) {
+	return nil, serviceerror.NewUnimplemented("not implemented in the test environment")
+}
+
+// ScanWorkflow implements Client.
+func (t *testSuiteClientForNexusOperations) ScanWorkflow(ctx context.Context, request *workflowservice.ScanWorkflowExecutionsRequest) (*workflowservice.ScanWorkflowExecutionsResponse, error) {
+	return nil, serviceerror.NewUnimplemented("not implemented in the test environment")
+}
+
+// ScheduleClient implements Client.
+func (t *testSuiteClientForNexusOperations) ScheduleClient() ScheduleClient {
+	panic("not implemented in the test environment")
+}
+
+// SignalWithStartWorkflow implements Client.
+func (t *testSuiteClientForNexusOperations) SignalWithStartWorkflow(ctx context.Context, workflowID string, signalName string, signalArg interface{}, options StartWorkflowOptions, workflow interface{}, workflowArgs ...interface{}) (WorkflowRun, error) {
+	return nil, serviceerror.NewUnimplemented("not implemented in the test environment")
+}
+
+// SignalWorkflow implements Client.
+func (t *testSuiteClientForNexusOperations) SignalWorkflow(ctx context.Context, workflowID string, runID string, signalName string, arg interface{}) error {
+	return t.env.signalWorkflowByID(workflowID, signalName, arg)
+}
+
+// TerminateWorkflow implements Client.
+func (t *testSuiteClientForNexusOperations) TerminateWorkflow(ctx context.Context, workflowID string, runID string, reason string, details ...interface{}) error {
+	return serviceerror.NewUnimplemented("not implemented in the test environment")
+}
+
+// UpdateWorkerBuildIdCompatibility implements Client.
+func (t *testSuiteClientForNexusOperations) UpdateWorkerBuildIdCompatibility(ctx context.Context, options *UpdateWorkerBuildIdCompatibilityOptions) error {
+	return serviceerror.NewUnimplemented("not implemented in the test environment")
+}
+
+// UpdateWorkflow implements Client.
+func (t *testSuiteClientForNexusOperations) UpdateWorkflow(ctx context.Context, workflowID string, workflowRunID string, updateName string, args ...interface{}) (WorkflowUpdateHandle, error) {
+	return nil, serviceerror.NewUnimplemented("not implemented in the test environment")
+}
+
+// UpdateWorkflowWithOptions implements Client.
+func (t *testSuiteClientForNexusOperations) UpdateWorkflowWithOptions(ctx context.Context, request *UpdateWorkflowWithOptionsRequest) (WorkflowUpdateHandle, error) {
+	return nil, serviceerror.NewUnimplemented("not implemented in the test environment")
+}
+
+// WorkflowService implements Client.
+func (t *testSuiteClientForNexusOperations) WorkflowService() workflowservice.WorkflowServiceClient {
+	panic("not implemented in the test environment")
+}
+
+var _ Client = &testSuiteClientForNexusOperations{}
+
+// testEnvWorkflowRunForNexusOperations is a partial [WorkflowRun] implementation for the test workflow environment used
+// to support basic Nexus functionality.
+type testEnvWorkflowRunForNexusOperations struct {
+	WorkflowExecution
+}
+
+// Get implements WorkflowRun.
+func (t *testEnvWorkflowRunForNexusOperations) Get(ctx context.Context, valuePtr interface{}) error {
+	panic("not implemented in the test environment")
+}
+
+// GetID implements WorkflowRun.
+func (t *testEnvWorkflowRunForNexusOperations) GetID() string {
+	return t.ID
+}
+
+// GetRunID implements WorkflowRun.
+func (t *testEnvWorkflowRunForNexusOperations) GetRunID() string {
+	return t.RunID
+}
+
+// GetWithOptions implements WorkflowRun.
+func (t *testEnvWorkflowRunForNexusOperations) GetWithOptions(ctx context.Context, valuePtr interface{}, options WorkflowRunGetOptions) error {
+	panic("not implemented in the test environment")
+}
+
+var _ WorkflowRun = &testEnvWorkflowRunForNexusOperations{}

--- a/internal/nexus_operations.go
+++ b/internal/nexus_operations.go
@@ -1,0 +1,23 @@
+package internal
+
+import (
+	"context"
+
+	"go.temporal.io/sdk/log"
+)
+
+// NexusOperationContext is an internal only struct that holds fields used by the temporalnexus functions.
+type NexusOperationContext struct {
+	Client    Client
+	TaskQueue string
+	Log       log.Logger
+}
+
+// nexusOperationContextKey is a key for associating a [NexusOperationContext] with a [context.Context].
+var nexusOperationContextKey = struct{}{}
+
+// NexusOperationContextFromGoContext gets the [NexusOperationContext] associated with the given [context.Context].
+func NexusOperationContextFromGoContext(ctx context.Context) (nctx *NexusOperationContext, ok bool) {
+	nctx, ok = ctx.Value(nexusOperationContextKey).(*NexusOperationContext)
+	return
+}

--- a/internal/nexus_operations.go
+++ b/internal/nexus_operations.go
@@ -151,6 +151,11 @@ func (t *testSuiteClientForNexusOperations) DescribeTaskQueue(ctx context.Contex
 	panic("not implemented in the test environment")
 }
 
+// DescribeTaskQueueEnhanced implements Client.
+func (t *testSuiteClientForNexusOperations) DescribeTaskQueueEnhanced(ctx context.Context, options DescribeTaskQueueEnhancedOptions) (TaskQueueDescription, error) {
+	panic("unimplemented in the test environment")
+}
+
 // DescribeWorkflowExecution implements Client.
 func (t *testSuiteClientForNexusOperations) DescribeWorkflowExecution(ctx context.Context, workflowID string, runID string) (*workflowservice.DescribeWorkflowExecutionResponse, error) {
 	panic("not implemented in the test environment")
@@ -246,6 +251,11 @@ func (t *testSuiteClientForNexusOperations) GetWorkerTaskReachability(ctx contex
 	panic("not implemented in the test environment")
 }
 
+// GetWorkerVersioningRules implements Client.
+func (t *testSuiteClientForNexusOperations) GetWorkerVersioningRules(ctx context.Context, options GetWorkerVersioningOptions) (*WorkerVersioningRules, error) {
+	panic("unimplemented in the test environment")
+}
+
 // GetWorkflow implements Client.
 func (t *testSuiteClientForNexusOperations) GetWorkflow(ctx context.Context, workflowID string, runID string) WorkflowRun {
 	panic("not implemented in the test environment")
@@ -336,19 +346,19 @@ func (t *testSuiteClientForNexusOperations) TerminateWorkflow(ctx context.Contex
 	panic("not implemented in the test environment")
 }
 
+// UpdateWorkflow implements Client.
+func (t *testSuiteClientForNexusOperations) UpdateWorkflow(ctx context.Context, options UpdateWorkflowOptions) (WorkflowUpdateHandle, error) {
+	panic("unimplemented in the test environment")
+}
+
 // UpdateWorkerBuildIdCompatibility implements Client.
 func (t *testSuiteClientForNexusOperations) UpdateWorkerBuildIdCompatibility(ctx context.Context, options *UpdateWorkerBuildIdCompatibilityOptions) error {
 	panic("not implemented in the test environment")
 }
 
-// UpdateWorkflow implements Client.
-func (t *testSuiteClientForNexusOperations) UpdateWorkflow(ctx context.Context, workflowID string, workflowRunID string, updateName string, args ...interface{}) (WorkflowUpdateHandle, error) {
-	panic("not implemented in the test environment")
-}
-
-// UpdateWorkflowWithOptions implements Client.
-func (t *testSuiteClientForNexusOperations) UpdateWorkflowWithOptions(ctx context.Context, request *UpdateWorkflowWithOptionsRequest) (WorkflowUpdateHandle, error) {
-	panic("not implemented in the test environment")
+// UpdateWorkerVersioningRules implements Client.
+func (t *testSuiteClientForNexusOperations) UpdateWorkerVersioningRules(ctx context.Context, options UpdateWorkerVersioningRulesOptions) (*WorkerVersioningRules, error) {
+	panic("unimplemented in the test environment")
 }
 
 // WorkflowService implements Client.

--- a/internal/worker.go
+++ b/internal/worker.go
@@ -95,6 +95,17 @@ type (
 		// default: 2
 		MaxConcurrentWorkflowTaskPollers int
 
+		// Optional: Sets the maximum concurrent nexus task executions this worker can have.
+		// The zero value of this uses the default value.
+		// default: defaultMaxConcurrentTaskExecutionSize(1k)
+		MaxConcurrentNexusTaskExecutionSize int
+
+		// Optional: Sets the maximum number of goroutines that will concurrently poll the
+		// temporal-server to retrieve nexus tasks. Changing this value will affect the
+		// rate at which the worker is able to consume tasks from a task queue.
+		// default: 2
+		MaxConcurrentNexusTaskPollers int
+
 		// Optional: Enable logging in replay.
 		// In the workflow code you can use workflow.GetLogger(ctx) to write logs. By default, the logger will skip log
 		// entry during replay mode so you won't see duplicate logs. This option will enable the logging in replay mode.

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -2122,3 +2122,160 @@ func DeterministicKeysFunc[K comparable, V any](m map[K]V, cmp func(a K, b K) in
 	slices.SortStableFunc(r, cmp)
 	return r
 }
+
+// NexusOperationOptions are options for starting a Nexus Operation from a Workflow.
+type NexusOperationOptions struct {
+	ScheduleToCloseTimeout time.Duration
+}
+
+// NexusOperationExecution is the result of [NexusOperationFuture.GetNexusOperationExecution].
+type NexusOperationExecution struct {
+	OperationID string
+}
+
+// NexusOperationFuture represents the result of a Nexus Operation.
+type NexusOperationFuture interface {
+	Future
+	// GetNexusOperationExecution returns a future that is resolved when the operation reaches the STARTED state.
+	// For synchronous operations, this will be resolved at the same as the containing [NexusOperationFuture]. For
+	// asynchronous operations, this future is resolved independently.
+	// If the operation is unsuccessful, this future will contain the same error as the [NexusOperationFuture].
+	// Use this method to extract the Operation ID of an asynchronous operation. OperationID will be empty for
+	// synchronous operations.
+	//
+	// NOTE: Experimental
+	GetNexusOperationExecution() Future
+}
+
+// NexusClient is a client for executing Nexus Operations from a workflow.
+type NexusClient interface {
+	// The endpoint name this client uses.
+	//
+	// NOTE: Experimental
+	Endpoint() string
+	// The service name this client uses.
+	//
+	// NOTE: Experimental
+	Service() string
+
+	// ExecuteOperation executes a Nexus Operation.
+	// The operation argument can be a string, a [nexus.Operation] or a [nexus.OperationReference].
+	//
+	// NOTE: Experimental
+	ExecuteOperation(ctx Context, operation any, input any, options NexusOperationOptions) NexusOperationFuture
+}
+
+type nexusClient struct {
+	endpoint, service string
+}
+
+// Create a [NexusClient] from an endpoint name and a service name.
+//
+// NOTE: Experimental
+func NewNexusClient(endpoint, service string) NexusClient {
+	return nexusClient{endpoint, service}
+}
+
+func (c nexusClient) Endpoint() string {
+	return c.endpoint
+}
+
+func (c nexusClient) Service() string {
+	return c.service
+}
+
+func (c nexusClient) ExecuteOperation(ctx Context, operation any, input any, options NexusOperationOptions) NexusOperationFuture {
+	assertNotInReadOnlyState(ctx)
+	i := getWorkflowOutboundInterceptor(ctx)
+	return i.ExecuteNexusOperation(ctx, c, operation, input, options)
+}
+
+func (wc *workflowEnvironmentInterceptor) prepareNexusOperationParams(ctx Context, client NexusClient, operation any, input any, options NexusOperationOptions) (executeNexusOperationParams, error) {
+	dc := WithWorkflowContext(ctx, wc.env.GetDataConverter())
+
+	var ok bool
+	var operationName string
+	if operationName, ok = operation.(string); ok {
+	} else if regOp, ok := operation.(interface{ Name() string }); ok {
+		operationName = regOp.Name()
+	} else {
+		return executeNexusOperationParams{}, fmt.Errorf("invalid 'operation' parameter, must be an OperationReference or a string")
+	}
+	// TODO(bergundy): Validate operation types against input once there's a good way to extract the generic types from
+	// OperationReference in the Nexus Go SDK.
+
+	payload, err := dc.ToPayload(input)
+	if err != nil {
+		return executeNexusOperationParams{}, err
+	}
+
+	return executeNexusOperationParams{
+		client:    client,
+		operation: operationName,
+		input:     payload,
+		options:   options,
+	}, nil
+}
+
+func (wc *workflowEnvironmentInterceptor) ExecuteNexusOperation(ctx Context, client NexusClient, operation any, input any, options NexusOperationOptions) NexusOperationFuture {
+	mainFuture, mainSettable := newDecodeFuture(ctx, nil /* this param is never used */)
+	executionFuture, executionSettable := NewFuture(ctx)
+	result := &nexusOperationFutureImpl{
+		decodeFutureImpl: mainFuture.(*decodeFutureImpl),
+		executionFuture:  executionFuture.(*futureImpl),
+	}
+
+	// Immediately return if the context has an error without spawning the child workflow
+	if ctx.Err() != nil {
+		executionSettable.Set(nil, ctx.Err())
+		mainSettable.Set(nil, ctx.Err())
+		return result
+	}
+
+	ctxDone, cancellable := ctx.Done().(*channelImpl)
+	cancellationCallback := &receiveCallback{}
+	params, err := wc.prepareNexusOperationParams(ctx, client, operation, input, options)
+	if err != nil {
+		executionSettable.Set(nil, err)
+		mainSettable.Set(nil, err)
+		return result
+	}
+
+	var operationID string
+	seq := wc.env.ExecuteNexusOperation(params, func(r *commonpb.Payload, e error) {
+		mainSettable.Set(&commonpb.Payloads{Payloads: []*commonpb.Payload{r}}, e)
+		if cancellable {
+			// future is done, we don't need cancellation anymore
+			ctxDone.removeReceiveCallback(cancellationCallback)
+		}
+	}, func(opID string, e error) {
+		operationID = opID
+		executionSettable.Set(NexusOperationExecution{opID}, e)
+	})
+
+	if cancellable {
+		cancellationCallback.fn = func(v any, _ bool) bool {
+			assertNotInReadOnlyStateCancellation(ctx)
+			if ctx.Err() == ErrCanceled && !mainFuture.IsReady() {
+				// Go back to the top of the interception chain.
+				getWorkflowOutboundInterceptor(ctx).RequestCancelNexusOperation(ctx, RequestCancelNexusOperationInput{
+					Client:    client,
+					Operation: operation,
+					ID:        operationID,
+					seq:       seq,
+				})
+			}
+			return false
+		}
+		_, ok, more := ctxDone.receiveAsyncImpl(cancellationCallback)
+		if ok || !more {
+			cancellationCallback.fn(nil, more)
+		}
+	}
+
+	return result
+}
+
+func (wc *workflowEnvironmentInterceptor) RequestCancelNexusOperation(ctx Context, input RequestCancelNexusOperationInput) {
+	wc.env.RequestCancelNexusOperation(input.seq)
+}

--- a/internal/workflow_testsuite.go
+++ b/internal/workflow_testsuite.go
@@ -32,6 +32,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nexus-rpc/sdk-go/nexus"
 	"github.com/stretchr/testify/mock"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
@@ -294,6 +295,11 @@ func (e *TestWorkflowEnvironment) RegisterActivityWithOptions(a interface{}, opt
 		panic("RegisterActivity calls cannot follow mock related ones like OnActivity or similar")
 	}
 	e.impl.RegisterActivityWithOptions(a, options)
+}
+
+// RegisterWorkflow registers a Nexus Service with the TestWorkflowEnvironment.
+func (e *TestWorkflowEnvironment) RegisterNexusService(s *nexus.Service) {
+	e.impl.RegisterNexusService(s)
 }
 
 // SetStartTime sets the start time of the workflow. This is optional, default start time will be the wall clock time when

--- a/temporal/error.go
+++ b/temporal/error.go
@@ -131,6 +131,11 @@ type (
 	// ChildWorkflowExecutionError returned from workflow when child workflow returned an error.
 	ChildWorkflowExecutionError = internal.ChildWorkflowExecutionError
 
+	// NexusOperationError is an error returned when a Nexus Operation has failed.
+	//
+	// NOTE: Experimental
+	NexusOperationError = internal.NexusOperationError
+
 	// ChildWorkflowExecutionAlreadyStartedError is set as the cause of
 	// ChildWorkflowExecutionError when failure is due the child workflow having
 	// already started.

--- a/temporalnexus/example_test.go
+++ b/temporalnexus/example_test.go
@@ -1,0 +1,125 @@
+package temporalnexus_test
+
+import (
+	"context"
+
+	"github.com/nexus-rpc/sdk-go/nexus"
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/temporalnexus"
+	"go.temporal.io/sdk/worker"
+	"go.temporal.io/sdk/workflow"
+)
+
+type MyWorkflowInput struct {
+}
+
+type MyOutput struct {
+}
+
+type MyInput struct {
+	ID string
+}
+
+type MyQueryOutput struct {
+}
+
+func MyHandlerWorkflow(workflow.Context, MyInput) (MyOutput, error) {
+	return MyOutput{}, nil
+}
+
+func MyHandlerWorkflowWithAlternativeInput(workflow.Context, MyWorkflowInput) (MyOutput, error) {
+	return MyOutput{}, nil
+}
+
+func ExampleNewWorkflowRunOperation() {
+	op := temporalnexus.NewWorkflowRunOperation(
+		"my-async-operation",
+		MyHandlerWorkflow,
+		func(ctx context.Context, input MyInput, opts nexus.StartOperationOptions) (client.StartWorkflowOptions, error) {
+			return client.StartWorkflowOptions{
+				// Workflow ID is required and must be deterministically generated from the input in order
+				// for the operation to be idempotent as the request to start the operation may be retried.
+				ID: input.ID,
+			}, nil
+		})
+
+	service := nexus.NewService("my-service")
+	_ = service.Register(op)
+
+	c, _ := client.Dial(client.Options{
+		HostPort:  "localhost:7233",
+		Namespace: "my-namespace",
+	})
+	w := worker.New(c, "my-task-queue", worker.Options{})
+	w.RegisterWorkflow(MyHandlerWorkflow)
+	w.RegisterNexusService(service)
+}
+
+func ExampleNewWorkflowRunOperationWithOptions() {
+	// Alternative 1 - long form version of NewWorkflowRunOperation.
+	opAlt1, _ := temporalnexus.NewWorkflowRunOperationWithOptions(
+		temporalnexus.WorkflowRunOperationOptions[MyInput, MyOutput]{
+			Name:     "my-async-op-1",
+			Workflow: MyHandlerWorkflow,
+			GetOptions: func(ctx context.Context, input MyInput, opts nexus.StartOperationOptions) (client.StartWorkflowOptions, error) {
+				return client.StartWorkflowOptions{
+					// Workflow ID is required and must be deterministically generated from the input in order
+					// for the operation to be idempotent as the request to start the operation may be retried.
+					ID: input.ID,
+				}, nil
+			},
+		})
+
+	// Alternative 2 - start a workflow with alternative inputs.
+	opAlt2, _ := temporalnexus.NewWorkflowRunOperationWithOptions(
+		temporalnexus.WorkflowRunOperationOptions[MyInput, MyOutput]{
+			Name: "my-async-op-2",
+			Handler: func(ctx context.Context, input MyInput, opts nexus.StartOperationOptions) (temporalnexus.WorkflowHandle[MyOutput], error) {
+				// Workflows started with this API must take a single input and return single output.
+				// To start workflows with different signatures, use ExecuteUntypedWorkflow.
+				return temporalnexus.ExecuteWorkflow(ctx, opts, client.StartWorkflowOptions{
+					// Workflow ID is required and must be deterministically generated from the input in order
+					// for the operation to be idempotent as the request to start the operation may be retried.
+					ID: input.ID,
+				}, MyHandlerWorkflowWithAlternativeInput, MyWorkflowInput{})
+			},
+		})
+
+	service := nexus.NewService("my-service")
+	_ = service.Register(opAlt1, opAlt2)
+
+	c, _ := client.Dial(client.Options{
+		HostPort:  "localhost:7233",
+		Namespace: "my-namespace",
+	})
+	w := worker.New(c, "my-task-queue", worker.Options{})
+	w.RegisterWorkflow(MyHandlerWorkflow)
+	w.RegisterWorkflow(MyHandlerWorkflowWithAlternativeInput)
+	w.RegisterNexusService(service)
+}
+
+func ExampleNewSyncOperation() {
+	opRead := temporalnexus.NewSyncOperation("my-read-only-operation", func(ctx context.Context, c client.Client, input MyInput, opts nexus.StartOperationOptions) (MyQueryOutput, error) {
+		var ret MyQueryOutput
+		res, err := c.QueryWorkflow(ctx, input.ID, "", "some-query", nil)
+		if err != nil {
+			return ret, err
+		}
+		return ret, res.Get(&ret)
+	})
+
+	// Operations don't have to return values.
+	opWrite := temporalnexus.NewSyncOperation("my-write-operation", func(ctx context.Context, c client.Client, input MyInput, opts nexus.StartOperationOptions) (nexus.NoValue, error) {
+		return nil, c.SignalWorkflow(ctx, input.ID, "", "some-signal", nil)
+	})
+
+	service := nexus.NewService("my-service")
+	_ = service.Register(opRead, opWrite)
+
+	c, _ := client.Dial(client.Options{
+		HostPort:  "localhost:7233",
+		Namespace: "my-namespace",
+	})
+	w := worker.New(c, "my-task-queue", worker.Options{})
+	w.RegisterNexusService(service)
+}

--- a/temporalnexus/operation.go
+++ b/temporalnexus/operation.go
@@ -1,0 +1,264 @@
+// Package temporalnexus provides utilities for exposing Temporal constructs as Nexus Operations.
+//
+// Nexus RPC is a modern open-source service framework for arbitrary-length operations whose lifetime may extend beyond
+// a traditional RPC. Nexus was designed with durable execution in mind, as an underpinning to connect durable
+// executions within and across namespaces, clusters and regions – with a clean API contract to streamline multi-team
+// collaboration. Any service can be exposed as a set of sync or async Nexus operations – the latter provides an
+// operation identity and a uniform interface to get the status of an operation or its result, receive a completion
+// callback, or cancel the operation.
+//
+// Temporal leverages the Nexus RPC protocol to facilitate calling across namespace and cluster and boundaries.
+//
+// See also:
+//
+// Nexus over HTTP Spec: https://github.com/nexus-rpc/api/blob/main/SPEC.md
+//
+// Nexus Go SDK: https://github.com/nexus-rpc/sdk-go
+package temporalnexus
+
+import (
+	"context"
+	"errors"
+
+	"github.com/nexus-rpc/sdk-go/nexus"
+	"go.temporal.io/api/common/v1"
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/internal"
+	"go.temporal.io/sdk/workflow"
+)
+
+type syncOperation[I, O any] struct {
+	nexus.UnimplementedOperation[I, O]
+
+	name    string
+	handler func(context.Context, client.Client, I, nexus.StartOperationOptions) (O, error)
+}
+
+// NewSyncOperation is a helper for creating a synchronous-only [nexus.Operation] from a given name and handler
+// function. The handler is passed the client that the worker was created with.
+// Sync operations are useful for exposing short-lived Temporal client requests, such as signals, queries, sync update,
+// list workflows, etc...
+//
+// NOTE: Experimental
+func NewSyncOperation[I any, O any](
+	name string,
+	handler func(context.Context, client.Client, I, nexus.StartOperationOptions) (O, error),
+) nexus.Operation[I, O] {
+	return &syncOperation[I, O]{
+		name:    name,
+		handler: handler,
+	}
+}
+
+func (o *syncOperation[I, O]) Name() string {
+	return o.name
+}
+
+func (o *syncOperation[I, O]) Start(ctx context.Context, input I, options nexus.StartOperationOptions) (nexus.HandlerStartOperationResult[O], error) {
+	nctx, ok := internal.NexusOperationContextFromGoContext(ctx)
+	if !ok {
+		return nil, nexus.HandlerErrorf(nexus.HandlerErrorTypeInternal, "internal error")
+	}
+	out, err := o.handler(ctx, nctx.Client, input, options)
+	if err != nil {
+		return nil, err
+	}
+	return &nexus.HandlerStartOperationResultSync[O]{Value: out}, err
+}
+
+// WorkflowRunOperationOptions are options for [NewWorkflowRunOperationWithOptions].
+//
+// NOTE: Experimental
+type WorkflowRunOperationOptions[I, O any] struct {
+	// Operation name.
+	Name string
+	// Workflow function to map this operation to. The operation input maps directly to workflow input.
+	// The workflow name is resolved as it would when using this function in client.ExecuteOperation.
+	// GetOptions must be provided when setting this option. Mutually exclusive with Handler.
+	Workflow func(workflow.Context, I) (O, error)
+	// Options for starting the workflow. Must be set if Workflow is set. Mutually exclusive with Handler.
+	// The options returned must include a workflow ID that is deterministically generated from the input in order
+	// for the operation to be idempotent as the request to start the operation may be retried.
+	// TaskQueue is optional and defaults to the current worker's task queue.
+	GetOptions func(context.Context, I, nexus.StartOperationOptions) (client.StartWorkflowOptions, error)
+	// Handler for starting a workflow with a different input than the operation. Mutually exclusive with Workflow
+	// and GetOptions.
+	Handler func(context.Context, I, nexus.StartOperationOptions) (WorkflowHandle[O], error)
+}
+
+// NOTE: not implementing GetInfo and GetResult just yet, they're not part of the supported methods in Temporal.
+type workflowRunOperation[I, O any] struct {
+	nexus.UnimplementedOperation[I, O]
+
+	options WorkflowRunOperationOptions[I, O]
+}
+
+// NewWorkflowRunOperation maps an operation to a workflow run.
+//
+// NOTE: Experimental
+func NewWorkflowRunOperation[I, O any](
+	name string,
+	workflow func(workflow.Context, I) (O, error),
+	getOptions func(context.Context, I, nexus.StartOperationOptions) (client.StartWorkflowOptions, error),
+) nexus.Operation[I, O] {
+	return &workflowRunOperation[I, O]{
+		options: WorkflowRunOperationOptions[I, O]{
+			Name:       name,
+			Workflow:   workflow,
+			GetOptions: getOptions,
+		},
+	}
+}
+
+// NewWorkflowRunOperation map an operation to a workflow run with the given options.
+// Returns an error if invalid options are provided.
+//
+// NOTE: Experimental
+func NewWorkflowRunOperationWithOptions[I, O any](options WorkflowRunOperationOptions[I, O]) (nexus.Operation[I, O], error) {
+	if options.Name == "" {
+		return nil, errors.New("invalid options: Name is required")
+	}
+	if options.Workflow == nil && options.GetOptions == nil && options.Handler == nil {
+		return nil, errors.New("invalid options: either GetOptions and Workflow, or Handler are required")
+	}
+	if options.Workflow != nil && options.GetOptions == nil || options.Workflow == nil && options.GetOptions != nil {
+		return nil, errors.New("invalid options: must provide both Workflow and GetOptions")
+	}
+	if options.Handler != nil && options.Workflow != nil || options.Handler == nil && options.Workflow == nil {
+		return nil, errors.New("invalid options: Workflow is mutually exclusive with Handler")
+	}
+	return &workflowRunOperation[I, O]{
+		options: options,
+	}, nil
+}
+
+// MustNewWorkflowRunOperation map an operation to a workflow run with the given options.
+// Panics if invalid options are provided.
+//
+// NOTE: Experimental
+func MustNewWorkflowRunOperationWithOptions[I, O any](options WorkflowRunOperationOptions[I, O]) nexus.Operation[I, O] {
+	op, err := NewWorkflowRunOperationWithOptions[I, O](options)
+	if err != nil {
+		panic(err)
+	}
+	return op
+}
+
+func (*workflowRunOperation[I, O]) Cancel(ctx context.Context, id string, options nexus.CancelOperationOptions) error {
+	nctx, ok := internal.NexusOperationContextFromGoContext(ctx)
+	if !ok {
+		return nexus.HandlerErrorf(nexus.HandlerErrorTypeInternal, "internal error")
+	}
+	return nctx.Client.CancelWorkflow(ctx, id, "")
+}
+
+func (o *workflowRunOperation[I, O]) Name() string {
+	return o.options.Name
+}
+
+func (o *workflowRunOperation[I, O]) Start(ctx context.Context, input I, options nexus.StartOperationOptions) (nexus.HandlerStartOperationResult[O], error) {
+	if o.options.Handler != nil {
+		handle, err := o.options.Handler(ctx, input, options)
+		if err != nil {
+			return nil, err
+		}
+		return &nexus.HandlerStartOperationResultAsync{OperationID: handle.ID()}, nil
+	}
+
+	wfOpts, err := o.options.GetOptions(ctx, input, options)
+	if err != nil {
+		return nil, err
+	}
+
+	handle, err := ExecuteWorkflow(ctx, options, wfOpts, o.options.Workflow, input)
+	if err != nil {
+		return nil, err
+	}
+	return &nexus.HandlerStartOperationResultAsync{OperationID: handle.ID()}, nil
+}
+
+// WorkflowHandle is a readonly representation of a workflow run backing a Nexus operation.
+// It's created via the [ExecuteWorkflow] and [ExecuteUntypedWorkflow] methods.
+//
+// NOTE: Experimental
+type WorkflowHandle[T any] interface {
+	// ID is the workflow's ID.
+	ID() string
+	// ID is the workflow's run ID.
+	RunID() string
+}
+
+type workflowHandle[T any] struct {
+	id    string
+	runID string
+}
+
+func (h workflowHandle[T]) ID() string {
+	return h.id
+}
+
+func (h workflowHandle[T]) RunID() string {
+	return h.runID
+}
+
+// ExecuteWorkflow starts a workflow run for a [WorkflowRunOperationOptions] Handler, linking the execution chain to a
+// Nexus operation (subsequent runs started from continue-as-new and retries).
+// Automatically propagates the callback and request ID from the nexus options to the workflow.
+//
+// NOTE: Experimental
+func ExecuteWorkflow[I, O any, WF func(workflow.Context, I) (O, error)](
+	ctx context.Context,
+	nexusOptions nexus.StartOperationOptions,
+	startWorkflowOptions client.StartWorkflowOptions,
+	workflow WF,
+	arg I,
+) (WorkflowHandle[O], error) {
+	return ExecuteUntypedWorkflow[O](ctx, nexusOptions, startWorkflowOptions, workflow, arg)
+}
+
+// ExecuteUntypedWorkflow starts a workflow with by function reference or string name, linking the execution chain to a
+// Nexus operation.
+// Useful for invoking workflows that don't follow the single argument - single return type signature.
+// See [ExecuteWorkflow] for more information.
+//
+// NOTE: Experimental
+func ExecuteUntypedWorkflow[R any](
+	ctx context.Context,
+	nexusOptions nexus.StartOperationOptions,
+	startWorkflowOptions client.StartWorkflowOptions,
+	workflow any,
+	args ...any,
+) (WorkflowHandle[R], error) {
+	nctx, ok := internal.NexusOperationContextFromGoContext(ctx)
+	if !ok {
+		return nil, nexus.HandlerErrorf(nexus.HandlerErrorTypeInternal, "internal error")
+	}
+	if startWorkflowOptions.TaskQueue == "" {
+		startWorkflowOptions.TaskQueue = nctx.TaskQueue
+	}
+
+	if nexusOptions.RequestID != "" {
+		internal.SetRequestIDOnStartWorkflowOptions(&startWorkflowOptions, nexusOptions.RequestID)
+	}
+
+	if nexusOptions.CallbackURL != "" {
+		internal.SetCallbacksOnStartWorkflowOptions(&startWorkflowOptions, []*common.Callback{
+			{
+				Variant: &common.Callback_Nexus_{
+					Nexus: &common.Callback_Nexus{
+						Url:    nexusOptions.CallbackURL,
+						Header: nexusOptions.CallbackHeader,
+					},
+				},
+			},
+		})
+	}
+	run, err := nctx.Client.ExecuteWorkflow(ctx, startWorkflowOptions, workflow, args...)
+	if err != nil {
+		return nil, err
+	}
+	return workflowHandle[R]{
+		id:    run.GetID(),
+		runID: run.GetRunID(),
+	}, nil
+}

--- a/temporalnexus/operation.go
+++ b/temporalnexus/operation.go
@@ -145,6 +145,9 @@ func MustNewWorkflowRunOperationWithOptions[I, O any](options WorkflowRunOperati
 }
 
 func (*workflowRunOperation[I, O]) Cancel(ctx context.Context, id string, options nexus.CancelOperationOptions) error {
+	// Prevent the test env client from panicking when we try to use it from a workflow run operation.
+	ctx = context.WithValue(ctx, internal.IsWorkflowRunOpContextKey, true)
+
 	nctx, ok := internal.NexusOperationContextFromGoContext(ctx)
 	if !ok {
 		return nexus.HandlerErrorf(nexus.HandlerErrorTypeInternal, "internal error")
@@ -157,6 +160,9 @@ func (o *workflowRunOperation[I, O]) Name() string {
 }
 
 func (o *workflowRunOperation[I, O]) Start(ctx context.Context, input I, options nexus.StartOperationOptions) (nexus.HandlerStartOperationResult[O], error) {
+	// Prevent the test env client from panicking when we try to use it from a workflow run operation.
+	ctx = context.WithValue(ctx, internal.IsWorkflowRunOpContextKey, true)
+
 	if o.options.Handler != nil {
 		handle, err := o.options.Handler(ctx, input, options)
 		if err != nil {

--- a/temporalnexus/operation_test.go
+++ b/temporalnexus/operation_test.go
@@ -1,0 +1,71 @@
+package temporalnexus_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/nexus-rpc/sdk-go/nexus"
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/temporalnexus"
+	"go.temporal.io/sdk/workflow"
+)
+
+func TestNewWorkflowRunOperationWithOptions(t *testing.T) {
+	_, err := temporalnexus.NewWorkflowRunOperationWithOptions(temporalnexus.WorkflowRunOperationOptions[string, string]{})
+	require.ErrorContains(t, err, "Name is required")
+
+	_, err = temporalnexus.NewWorkflowRunOperationWithOptions(temporalnexus.WorkflowRunOperationOptions[string, string]{
+		Name: "test",
+	})
+	require.ErrorContains(t, err, "either GetOptions and Workflow, or Handler are required")
+
+	_, err = temporalnexus.NewWorkflowRunOperationWithOptions(temporalnexus.WorkflowRunOperationOptions[string, string]{
+		Name: "test",
+		Workflow: func(workflow.Context, string) (string, error) {
+			return "", nil
+		},
+	})
+	require.ErrorContains(t, err, "must provide both Workflow and GetOptions")
+
+	_, err = temporalnexus.NewWorkflowRunOperationWithOptions(temporalnexus.WorkflowRunOperationOptions[string, string]{
+		Name: "test",
+		GetOptions: func(ctx context.Context, s string, soo nexus.StartOperationOptions) (client.StartWorkflowOptions, error) {
+			return client.StartWorkflowOptions{}, nil
+		},
+	})
+	require.ErrorContains(t, err, "must provide both Workflow and GetOptions")
+
+	_, err = temporalnexus.NewWorkflowRunOperationWithOptions(temporalnexus.WorkflowRunOperationOptions[string, string]{
+		Name: "test",
+		Workflow: func(workflow.Context, string) (string, error) {
+			return "", nil
+		},
+		GetOptions: func(ctx context.Context, s string, soo nexus.StartOperationOptions) (client.StartWorkflowOptions, error) {
+			return client.StartWorkflowOptions{}, nil
+		},
+		Handler: func(ctx context.Context, s string, soo nexus.StartOperationOptions) (temporalnexus.WorkflowHandle[string], error) {
+			return nil, nil
+		},
+	})
+	require.ErrorContains(t, err, "Workflow is mutually exclusive with Handler")
+
+	_, err = temporalnexus.NewWorkflowRunOperationWithOptions(temporalnexus.WorkflowRunOperationOptions[string, string]{
+		Name: "test",
+		Workflow: func(workflow.Context, string) (string, error) {
+			return "", nil
+		},
+		GetOptions: func(ctx context.Context, s string, soo nexus.StartOperationOptions) (client.StartWorkflowOptions, error) {
+			return client.StartWorkflowOptions{}, nil
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = temporalnexus.NewWorkflowRunOperationWithOptions(temporalnexus.WorkflowRunOperationOptions[string, string]{
+		Name: "test",
+		Handler: func(ctx context.Context, s string, soo nexus.StartOperationOptions) (temporalnexus.WorkflowHandle[string], error) {
+			return nil, nil
+		},
+	})
+	require.NoError(t, err)
+}

--- a/test/go.mod
+++ b/test/go.mod
@@ -2,9 +2,12 @@ module go.temporal.io/sdk/test
 
 go 1.21
 
+toolchain go1.21.1
+
 require (
 	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.6.0
+	github.com/nexus-rpc/sdk-go v0.0.8-0.20240617225139-cd9d6c50e99d
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/pborman/uuid v1.2.1
 	github.com/stretchr/testify v1.9.0
@@ -28,6 +31,7 @@ require (
 	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/test/go.sum
+++ b/test/go.sum
@@ -68,6 +68,8 @@ github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
+github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 h1:UH//fgunKIs4JdUbpDl1VZCDaL56wXCB/5+wF6uHfaI=
 github.com/grpc-ecosystem/go-grpc-middleware v1.4.0/go.mod h1:g5qyo/la0ALbONm6Vbp88Yd8NsDy6rZz+RcrMPxvld8=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0 h1:bkypFPDjIYGfCYD5mRBvpqxfYX1YCS1PXdKYWi8FsN0=
@@ -97,6 +99,8 @@ github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lN
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
+github.com/nexus-rpc/sdk-go v0.0.8-0.20240617225139-cd9d6c50e99d h1:OY7OVvmJgHji2GjQVaY1y4NHTZ5vvYr1GJaZTAjo/SQ=
+github.com/nexus-rpc/sdk-go v0.0.8-0.20240617225139-cd9d6c50e99d/go.mod h1:uBe8fX151zUW9DhXxwHjji19d6YfnNUqJ81tR3JbwHY=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=

--- a/test/nexus_test.go
+++ b/test/nexus_test.go
@@ -1,0 +1,272 @@
+// The MIT License
+//
+// Copyright (c) 2024 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package test_test
+
+import (
+	"context"
+	"net/http"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/nexus-rpc/sdk-go/nexus"
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/api/common/v1"
+	nexuspb "go.temporal.io/api/nexus/v1"
+	"go.temporal.io/api/operatorservice/v1"
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/internal/common/metrics"
+	ilog "go.temporal.io/sdk/internal/log"
+	"go.temporal.io/sdk/temporalnexus"
+	"go.temporal.io/sdk/worker"
+	"go.temporal.io/sdk/workflow"
+)
+
+var syncOp = temporalnexus.NewSyncOperation("sync-op", func(ctx context.Context, c client.Client, s string, o nexus.StartOperationOptions) (string, error) {
+	switch s {
+	case "ok":
+		// Verify options are properly propagated.
+		if _, ok := ctx.Deadline(); !ok {
+			return "", nexus.HandlerErrorf(nexus.HandlerErrorTypeBadRequest, "expected context deadline to be set")
+		}
+		if o.RequestID != "test-request-id" {
+			return "", nexus.HandlerErrorf(nexus.HandlerErrorTypeBadRequest, "invalid request ID, got: %v", o.RequestID)
+		}
+		if o.Header.Get("test") != "ok" {
+			return "", nexus.HandlerErrorf(nexus.HandlerErrorTypeBadRequest, "invalid test header, got: %v", o.Header.Get("test"))
+		}
+		if o.CallbackURL != "http://localhost/test" {
+			return "", nexus.HandlerErrorf(nexus.HandlerErrorTypeBadRequest, "invalid test callback URL, got: %v", o.CallbackURL)
+		}
+		if o.CallbackHeader.Get("test") != "ok" {
+			return "", nexus.HandlerErrorf(nexus.HandlerErrorTypeBadRequest, "invalid test callback header, got: %v", o.CallbackHeader.Get("test"))
+		}
+		return s, nil
+	case "fail":
+		return "", &nexus.UnsuccessfulOperationError{
+			State: nexus.OperationStateFailed,
+			Failure: nexus.Failure{
+				Message: "fail",
+			},
+		}
+	case "handlererror":
+		return "", nexus.HandlerErrorf(nexus.HandlerErrorTypeBadRequest, s)
+	case "panic":
+		panic("panic")
+	}
+	return "", nil
+})
+
+func waitForCancelWorkflow(ctx workflow.Context, ownID string) (string, error) {
+	return "", workflow.Await(ctx, func() bool { return false })
+}
+
+var workflowOp = temporalnexus.NewWorkflowRunOperation(
+	"workflow-op",
+	waitForCancelWorkflow,
+	func(ctx context.Context, id string, soo nexus.StartOperationOptions) (client.StartWorkflowOptions, error) {
+		return client.StartWorkflowOptions{ID: id}, nil
+	},
+)
+
+func TestNexusSyncOperation(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+	config := NewConfig()
+	require.NoError(t, WaitForTCP(time.Minute, config.ServiceAddr))
+
+	metricsHandler := metrics.NewCapturingHandler()
+	c, err := client.DialContext(ctx, client.Options{
+		HostPort:          config.ServiceAddr,
+		Namespace:         config.Namespace,
+		Logger:            ilog.NewDefaultLogger(),
+		ConnectionOptions: client.ConnectionOptions{TLS: config.TLS},
+		MetricsHandler:    metricsHandler,
+	})
+	require.NoError(t, err)
+
+	taskQueue := "nexus-test" + uuid.NewString()
+
+	w := worker.New(c, taskQueue, worker.Options{})
+
+	service := nexus.NewService("test")
+	require.NoError(t, service.Register(syncOp, workflowOp))
+	w.RegisterNexusService(service)
+	w.RegisterWorkflow(waitForCancelWorkflow)
+	require.NoError(t, w.Start())
+	t.Cleanup(w.Stop)
+
+	res, err := c.OperatorService().CreateNexusEndpoint(ctx, &operatorservice.CreateNexusEndpointRequest{
+		Spec: &nexuspb.EndpointSpec{
+			Name: "sdk-go-test-" + uuid.NewString(),
+			Target: &nexuspb.EndpointTarget{
+				Variant: &nexuspb.EndpointTarget_Worker_{
+					Worker: &nexuspb.EndpointTarget_Worker{
+						Namespace: config.Namespace,
+						TaskQueue: taskQueue,
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	nc, err := nexus.NewClient(nexus.ClientOptions{
+		BaseURL: "http://" + config.ServiceHTTPAddr + res.Endpoint.UrlPrefix,
+		Service: service.Name,
+	})
+	require.NoError(t, err)
+
+	t.Run("ok", func(t *testing.T) {
+		metricsHandler.Clear()
+		result, err := nexus.ExecuteOperation(ctx, nc, syncOp, "ok", nexus.ExecuteOperationOptions{
+			RequestID:      "test-request-id",
+			Header:         nexus.Header{"test": "ok"},
+			CallbackURL:    "http://localhost/test",
+			CallbackHeader: nexus.Header{"test": "ok"},
+		})
+		require.NoError(t, err)
+		require.Equal(t, "ok", result)
+		requireTimer(t, metricsHandler, metrics.NexusTaskEndToEndLatency, service.Name, syncOp.Name())
+		requireTimer(t, metricsHandler, metrics.NexusTaskScheduleToStartLatency, service.Name, syncOp.Name())
+		requireTimer(t, metricsHandler, metrics.NexusTaskExecutionLatency, service.Name, syncOp.Name())
+	})
+
+	t.Run("fail", func(t *testing.T) {
+		metricsHandler.Clear()
+		_, err := nexus.ExecuteOperation(ctx, nc, syncOp, "fail", nexus.ExecuteOperationOptions{})
+		var unsuccessfulOperationErr *nexus.UnsuccessfulOperationError
+		require.ErrorAs(t, err, &unsuccessfulOperationErr)
+		require.Equal(t, nexus.OperationStateFailed, unsuccessfulOperationErr.State)
+		require.Equal(t, "fail", unsuccessfulOperationErr.Failure.Message)
+
+		requireTimer(t, metricsHandler, metrics.NexusTaskEndToEndLatency, service.Name, syncOp.Name())
+		requireTimer(t, metricsHandler, metrics.NexusTaskScheduleToStartLatency, service.Name, syncOp.Name())
+		requireTimer(t, metricsHandler, metrics.NexusTaskExecutionLatency, service.Name, syncOp.Name())
+		requireCounter(t, metricsHandler, metrics.NexusTaskExecutionFailedCounter, service.Name, syncOp.Name())
+	})
+
+	t.Run("handlererror", func(t *testing.T) {
+		_, err := nexus.ExecuteOperation(ctx, nc, syncOp, "handlererror", nexus.ExecuteOperationOptions{})
+		var unexpectedResponseErr *nexus.UnexpectedResponseError
+		require.ErrorAs(t, err, &unexpectedResponseErr)
+		require.Equal(t, http.StatusBadRequest, unexpectedResponseErr.Response.StatusCode)
+		require.Contains(t, unexpectedResponseErr.Message, `"400 Bad Request": handlererror`)
+	})
+
+	t.Run("panic", func(t *testing.T) {
+		_, err := nexus.ExecuteOperation(ctx, nc, syncOp, "panic", nexus.ExecuteOperationOptions{})
+		var unexpectedResponseErr *nexus.UnexpectedResponseError
+		require.ErrorAs(t, err, &unexpectedResponseErr)
+		// TODO(bergundy): Eventually we'll get rid of this special status and propagate error from worker.
+		// At that point this test will need to be modified.
+		require.Equal(t, 520, unexpectedResponseErr.Response.StatusCode)
+		require.Contains(t, unexpectedResponseErr.Message, "internal error")
+	})
+}
+
+func TestNexusWorkflowRunOperation(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+	config := NewConfig()
+	require.NoError(t, WaitForTCP(time.Minute, config.ServiceAddr))
+
+	c, err := client.DialContext(ctx, client.Options{
+		HostPort:          config.ServiceAddr,
+		Namespace:         config.Namespace,
+		Logger:            ilog.NewDefaultLogger(),
+		ConnectionOptions: client.ConnectionOptions{TLS: config.TLS},
+	})
+	require.NoError(t, err)
+
+	taskQueue := "nexus-test" + uuid.NewString()
+
+	w := worker.New(c, taskQueue, worker.Options{})
+
+	service := nexus.NewService("test")
+	require.NoError(t, service.Register(syncOp, workflowOp))
+	w.RegisterNexusService(service)
+	w.RegisterWorkflow(waitForCancelWorkflow)
+	require.NoError(t, w.Start())
+	t.Cleanup(w.Stop)
+
+	res, err := c.OperatorService().CreateNexusEndpoint(ctx, &operatorservice.CreateNexusEndpointRequest{
+		Spec: &nexuspb.EndpointSpec{
+			Name: "sdk-go-test-" + uuid.NewString(),
+			Target: &nexuspb.EndpointTarget{
+				Variant: &nexuspb.EndpointTarget_Worker_{
+					Worker: &nexuspb.EndpointTarget_Worker{
+						Namespace: config.Namespace,
+						TaskQueue: taskQueue,
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	nc, err := nexus.NewClient(nexus.ClientOptions{
+		BaseURL: "http://" + config.ServiceHTTPAddr + res.Endpoint.UrlPrefix,
+		Service: service.Name,
+	})
+	require.NoError(t, err)
+
+	workflowID := "nexus-handler-workflow-" + uuid.NewString()
+	result, err := nexus.StartOperation(ctx, nc, workflowOp, workflowID, nexus.StartOperationOptions{
+		CallbackURL:    "http://localhost/test",
+		CallbackHeader: nexus.Header{"test": "ok"},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result.Pending)
+	handle := result.Pending
+	require.Equal(t, workflowID, handle.ID)
+	desc, err := c.DescribeWorkflowExecution(ctx, workflowID, "")
+	require.NoError(t, err)
+
+	require.Equal(t, 1, len(desc.Callbacks))
+	callback, ok := desc.Callbacks[0].Callback.Variant.(*common.Callback_Nexus_)
+	require.True(t, ok)
+	require.Equal(t, "http://localhost/test", callback.Nexus.Url)
+	require.Equal(t, map[string]string{"test": "ok"}, callback.Nexus.Header)
+
+	run := c.GetWorkflow(ctx, workflowID, "")
+	require.NoError(t, handle.Cancel(ctx, nexus.CancelOperationOptions{}))
+	require.ErrorContains(t, run.Get(ctx, nil), "canceled")
+}
+
+func requireTimer(t *testing.T, metricsHandler *metrics.CapturingHandler, metric, service, operation string) {
+	require.True(t, slices.ContainsFunc(metricsHandler.Timers(), func(ct *metrics.CapturedTimer) bool {
+		return ct.Name == metric &&
+			ct.Tags[metrics.NexusServiceTagName] == service &&
+			ct.Tags[metrics.NexusOperationTagName] == operation
+	}))
+}
+
+func requireCounter(t *testing.T, metricsHandler *metrics.CapturingHandler, metric, service, operation string) {
+	require.True(t, slices.ContainsFunc(metricsHandler.Counters(), func(ct *metrics.CapturedCounter) bool {
+		return ct.Name == metric &&
+			ct.Tags[metrics.NexusServiceTagName] == service &&
+			ct.Tags[metrics.NexusOperationTagName] == operation
+	}))
+}

--- a/test/nexus_test.go
+++ b/test/nexus_test.go
@@ -574,7 +574,7 @@ func TestAsyncOperationFromWorkflow(t *testing.T) {
 }
 
 func TestReplay(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
 	tc := newTestContext(t, ctx)
 

--- a/test/test_utils_test.go
+++ b/test/test_utils_test.go
@@ -52,6 +52,7 @@ type (
 	// Config contains the integration test configuration
 	Config struct {
 		ServiceAddr             string
+		ServiceHTTPAddr         string
 		maxWorkflowCacheSize    int
 		Debug                   bool
 		Namespace               string
@@ -73,12 +74,16 @@ var taskQueuePrefix = "tq-" + uuid.New()
 func NewConfig() Config {
 	cfg := Config{
 		ServiceAddr:             client.DefaultHostPort,
+		ServiceHTTPAddr:         "localhost:7243",
 		maxWorkflowCacheSize:    10000,
 		Namespace:               "integration-test-namespace",
 		ShouldRegisterNamespace: true,
 	}
 	if addr := getEnvServiceAddr(); addr != "" {
 		cfg.ServiceAddr = addr
+	}
+	if addr := strings.TrimSpace(os.Getenv("SERVICE_HTTP_ADDR")); addr != "" {
+		cfg.ServiceHTTPAddr = addr
 	}
 	if siz := getEnvCacheSize(); siz != "" {
 		asInt, err := strconv.Atoi(siz)

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -28,6 +28,7 @@ package worker
 import (
 	"context"
 
+	"github.com/nexus-rpc/sdk-go/nexus"
 	historypb "go.temporal.io/api/history/v1"
 	"go.temporal.io/api/workflowservice/v1"
 
@@ -73,6 +74,7 @@ type (
 	Registry interface {
 		WorkflowRegistry
 		ActivityRegistry
+		NexusServiceRegistry
 	}
 
 	// WorkflowRegistry exposes workflow registration functions to consumers.
@@ -148,6 +150,14 @@ type (
 		// which might be useful for integration tests.
 		// worker.RegisterActivityWithOptions(barActivity, RegisterActivityOptions{DisableAlreadyRegisteredCheck: true})
 		RegisterActivityWithOptions(a interface{}, options activity.RegisterOptions)
+	}
+
+	// NexusServiceRegistry exposes Nexus Service registration functions.
+	NexusServiceRegistry interface {
+		// RegisterNexusService registers a service with a worker. Panics if a service with the same name has
+		// already been registered on this worker or if the worker has already been started. A worker will only
+		// poll for Nexus tasks if any services are registered on it.
+		RegisterNexusService(*nexus.Service)
 	}
 
 	// WorkflowReplayer supports replaying a workflow from its event history.

--- a/workflow/nexus_example_test.go
+++ b/workflow/nexus_example_test.go
@@ -1,0 +1,50 @@
+package workflow_test
+
+import (
+	"context"
+	"time"
+
+	"github.com/nexus-rpc/sdk-go/nexus"
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/temporalnexus"
+	"go.temporal.io/sdk/workflow"
+)
+
+type MyInput struct{}
+type MyOutput struct{}
+
+var myOperationRef = nexus.NewOperationReference[MyInput, MyOutput]("my-operation")
+
+var myOperation = temporalnexus.NewSyncOperation("my-operation", func(ctx context.Context, c client.Client, mi MyInput, soo nexus.StartOperationOptions) (MyOutput, error) {
+	return MyOutput{}, nil
+})
+
+func ExampleNexusClient() {
+	myWorkflow := func(ctx workflow.Context) (MyOutput, error) {
+		client := workflow.NewNexusClient("my-endpoint", "my-service")
+		// Execute an operation using an operation name.
+		fut := client.ExecuteOperation(ctx, "my-operation", MyInput{}, workflow.NexusOperationOptions{
+			ScheduleToCloseTimeout: time.Hour,
+		})
+		// Or using an OperationReference.
+		fut = client.ExecuteOperation(ctx, myOperationRef, MyInput{}, workflow.NexusOperationOptions{
+			ScheduleToCloseTimeout: time.Hour,
+		})
+		// Or using a defined operation (which is also an OperationReference).
+		fut = client.ExecuteOperation(ctx, myOperation, MyInput{}, workflow.NexusOperationOptions{
+			ScheduleToCloseTimeout: time.Hour,
+		})
+
+		var exec workflow.NexusOperationExecution
+		// Optionally wait for the operation to be started.
+		_ = fut.GetNexusOperationExecution().Get(ctx, &exec)
+		// OperationID will be empty if the operation completed synchronously.
+		workflow.GetLogger(ctx).Info("operation started", "operationID", exec.OperationID)
+
+		// Get the result of the operation.
+		var output MyOutput
+		return output, fut.Get(ctx, &output)
+	}
+
+	_ = myWorkflow
+}

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -72,10 +72,25 @@ type (
 
 	UpdateHandlerOptions = internal.UpdateHandlerOptions
 
+	// NOTE to maintainers, this interface definition is duplicated in the internal package to provide a better UX.
+
 	// NexusClient is a client for executing Nexus Operations from a workflow.
-	//
-	// NOTE: Experimental
-	NexusClient = internal.NexusClient
+	NexusClient interface {
+		// The endpoint name this client uses.
+		//
+		// NOTE: Experimental
+		Endpoint() string
+		// The service name this client uses.
+		//
+		// NOTE: Experimental
+		Service() string
+
+		// ExecuteOperation executes a Nexus Operation.
+		// The operation argument can be a string, a [nexus.Operation] or a [nexus.OperationReference].
+		//
+		// NOTE: Experimental
+		ExecuteOperation(ctx Context, operation any, input any, options NexusOperationOptions) NexusOperationFuture
+	}
 
 	// NexusOperationOptions are options for starting a Nexus Operation from a Workflow.
 	//

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -71,6 +71,26 @@ type (
 	ContinueAsNewErrorOptions = internal.ContinueAsNewErrorOptions
 
 	UpdateHandlerOptions = internal.UpdateHandlerOptions
+
+	// NexusClient is a client for executing Nexus Operations from a workflow.
+	//
+	// NOTE: Experimental
+	NexusClient = internal.NexusClient
+
+	// NexusOperationOptions are options for starting a Nexus Operation from a Workflow.
+	//
+	// NOTE: Experimental
+	NexusOperationOptions = internal.NexusOperationOptions
+
+	// NexusOperationFuture represents the result of a Nexus Operation.
+	//
+	// NOTE: Experimental
+	NexusOperationFuture = internal.NexusOperationFuture
+
+	// NexusOperationExecution is the result of [NexusOperationFuture.GetNexusOperationExecution].
+	//
+	// NOTE: Experimental
+	NexusOperationExecution = internal.NexusOperationExecution
 )
 
 // ExecuteActivity requests activity execution in the context of a workflow.
@@ -691,4 +711,9 @@ func DeterministicKeys[K constraints.Ordered, V any](m map[K]V) []K {
 // To be used in for loops in workflows for deterministic iteration.
 func DeterministicKeysFunc[K comparable, V any](m map[K]V, cmp func(K, K) int) []K {
 	return internal.DeterministicKeysFunc(m, cmp)
+}
+
+// Create a [NexusClient] from an endpoint name and a service name.
+func NewNexusClient(endpoint, service string) NexusClient {
+	return internal.NewNexusClient(endpoint, service)
 }


### PR DESCRIPTION
## What was changed

**EDIT**: Merged #1473 and #1475 into this PR, it now included the entire Nexus implementation for the SDK.

Added the `temporalnexus` package and implemented the handler side for Nexus, including registering and dispatching Nexus Operations.

Tests only pass with server `main`, so this PR should not be merged until the server is released.
A future PR will complete the nexus work allowing invoking Nexus Operations from a workflow.

See the [proposal](https://github.com/temporalio/proposals/blob/6db78a083ec8fe397527a3f0d7146c77c8204e96/nexus/sdk-go.md) for more information.

Also now memoizing `worker.Start()` to return consistent errors to callers and avoid rerunning the function unnecessarily.

Merge Checklist:

- [ ] Release Server
- [ ] Depend on tagged Nexus SDK