### PR TITLE
Set Temporal-Namespace header on every namespace-specific gRPC request

### DIFF
--- a/internal/grpc_dialer_test.go
+++ b/internal/grpc_dialer_test.go
@@ -133,8 +133,8 @@ func TestHeadersProvider_NotIncludedWhenNil(t *testing.T) {
 }
 
 func TestHeadersProvider_IncludedWithHeadersProvider(t *testing.T) {
-	interceptors := requiredInterceptors(nil,
-		authHeadersProvider{token: "test-auth-token"}, nil, nil, nil)
+	opts := &ClientOptions{HeadersProvider: authHeadersProvider{token: "test-auth-token"}}
+	interceptors := requiredInterceptors(opts, nil)
 	require.Equal(t, 7, len(interceptors))
 }
 

--- a/internal/grpc_dialer_test.go
+++ b/internal/grpc_dialer_test.go
@@ -542,10 +542,10 @@ func TestNamespaceInterceptor(t *testing.T) {
 	})
 	require.NoError(t, err)
 	defer client.Close()
-	// Verify namespace header is set in the context even though getSystemInfo doesn't have it on the request
+	// Verify namespace header is not set in the context
 	require.Equal(
 		t,
-		[]string{"test-namespace"},
+		[]string(nil),
 		metadata.ValueFromIncomingContext(srv.getSystemInfoRequestContext, temporalNamespaceHeaderKey),
 	)
 	// Verify namespace header is set on a request that does have namespace on the request

--- a/internal/grpc_dialer_test.go
+++ b/internal/grpc_dialer_test.go
@@ -129,13 +129,13 @@ func TestHeadersProvider_Error(t *testing.T) {
 
 func TestHeadersProvider_NotIncludedWhenNil(t *testing.T) {
 	interceptors := requiredInterceptors(&ClientOptions{}, nil)
-	require.Equal(t, 5, len(interceptors))
+	require.Equal(t, 6, len(interceptors))
 }
 
 func TestHeadersProvider_IncludedWithHeadersProvider(t *testing.T) {
-	opts := &ClientOptions{HeadersProvider: authHeadersProvider{token: "test-auth-token"}}
-	interceptors := requiredInterceptors(opts, nil)
-	require.Equal(t, 6, len(interceptors))
+	interceptors := requiredInterceptors(nil,
+		authHeadersProvider{token: "test-auth-token"}, nil, nil, nil)
+	require.Equal(t, 7, len(interceptors))
 }
 
 func TestMissingGetServerInfo(t *testing.T) {

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -39,7 +39,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
-	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/durationpb"
 

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -39,6 +39,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/durationpb"
 


### PR DESCRIPTION
Set Temporal-Namespace header on every namespace-specific gRPC request.

closes https://github.com/temporalio/sdk-go/issues/1458