### PR TITLE
Add new VersioningIntent options

### DIFF
--- a/internal/worker_version_sets.go
+++ b/internal/worker_version_sets.go
@@ -45,10 +45,20 @@ const (
 	// VersioningIntentCompatible indicates that the command should run on a worker with compatible
 	// version if possible. It may not be possible if the target task queue does not also have
 	// knowledge of the current worker's build ID.
+	// Deprecated. This has the same effect as VersioningIntentInheritBuildId, use that instead.
 	VersioningIntentCompatible
 	// VersioningIntentDefault indicates that the command should run on the target task queue's
 	// current overall-default build ID.
+	// Deprecated. This has the same effect as VersioningIntentUseAssignmentRules, use that instead.
 	VersioningIntentDefault
+	// VersioningIntentInheritBuildId indicates the command should inherit the current Build ID of the
+	// Workflow triggering it, and not use Assignment Rules. (Redirect Rules are still applicable)
+	// This is the default behavior for commands running on the same Task Queue as the current worker.
+	VersioningIntentInheritBuildId
+	// VersioningIntentUseAssignmentRules indicates the command should use the latest Assignment Rules
+	// to select a Build ID independently of the workflow triggering it.
+	// This is the default behavior for commands not running on the same Task Queue as the current worker.
+	VersioningIntentUseAssignmentRules
 )
 
 // TaskReachability specifies which category of tasks may reach a worker on a versioned task queue.
@@ -320,15 +330,15 @@ func (v *BuildIDOpPromoteIDWithinSet) targetedBuildId() string      { return v.B
 // Helper to determine if how the `InheritBuildId` flag for a command should be set based on
 // the user's intent and whether the target task queue matches this worker's task queue.
 func determineInheritBuildIdFlagForCommand(intent VersioningIntent, workerTq, TargetTq string) bool {
-	useCompat := true
-	if intent == VersioningIntentDefault {
-		useCompat = false
+	inheritBuildId := true
+	if intent == VersioningIntentDefault || intent == VersioningIntentUseAssignmentRules {
+		inheritBuildId = false
 	} else if intent == VersioningIntentUnspecified {
 		// If the target task queue doesn't match ours, use the default version. Empty target counts
 		// as matching.
 		if TargetTq != "" && workerTq != TargetTq {
-			useCompat = false
+			inheritBuildId = false
 		}
 	}
-	return useCompat
+	return inheritBuildId
 }

--- a/internal/worker_version_sets.go
+++ b/internal/worker_version_sets.go
@@ -45,16 +45,16 @@ const (
 	// VersioningIntentCompatible indicates that the command should run on a worker with compatible
 	// version if possible. It may not be possible if the target task queue does not also have
 	// knowledge of the current worker's build ID.
-	// Deprecated. This has the same effect as VersioningIntentInheritBuildId, use that instead.
+	// Deprecated. This has the same effect as VersioningIntentInheritBuildID, use that instead.
 	VersioningIntentCompatible
 	// VersioningIntentDefault indicates that the command should run on the target task queue's
 	// current overall-default build ID.
 	// Deprecated. This has the same effect as VersioningIntentUseAssignmentRules, use that instead.
 	VersioningIntentDefault
-	// VersioningIntentInheritBuildId indicates the command should inherit the current Build ID of the
+	// VersioningIntentInheritBuildID indicates the command should inherit the current Build ID of the
 	// Workflow triggering it, and not use Assignment Rules. (Redirect Rules are still applicable)
 	// This is the default behavior for commands running on the same Task Queue as the current worker.
-	VersioningIntentInheritBuildId
+	VersioningIntentInheritBuildID
 	// VersioningIntentUseAssignmentRules indicates the command should use the latest Assignment Rules
 	// to select a Build ID independently of the workflow triggering it.
 	// This is the default behavior for commands not running on the same Task Queue as the current worker.

--- a/internal/worker_version_sets_test.go
+++ b/internal/worker_version_sets_test.go
@@ -64,7 +64,7 @@ func Test_WorkerVersionSets_fromProtoResponse(t *testing.T) {
 	}
 }
 
-func Test_VersioningIntent(t *testing.T) {
+func Test_VersioningIntentOld(t *testing.T) {
 	tests := []struct {
 		name                string
 		intent              VersioningIntent

--- a/internal/worker_versioning_rules_test.go
+++ b/internal/worker_versioning_rules_test.go
@@ -83,11 +83,10 @@ func Test_WorkerVersioningRules_fromProtoGetResponse(t *testing.T) {
 	}
 }
 
-
 func Test_VersioningIntent(t *testing.T) {
 	tests := []struct {
-		name                string
-		intent              VersioningIntent
+		name          string
+		intent        VersioningIntent
 		tqSame        bool
 		shouldInherit bool
 	}{

--- a/internal/worker_versioning_rules_test.go
+++ b/internal/worker_versioning_rules_test.go
@@ -82,3 +82,61 @@ func Test_WorkerVersioningRules_fromProtoGetResponse(t *testing.T) {
 		})
 	}
 }
+
+
+func Test_VersioningIntent(t *testing.T) {
+	tests := []struct {
+		name                string
+		intent              VersioningIntent
+		tqSame        bool
+		shouldInherit bool
+	}{
+		{
+			name:          "Unspecified same TQ",
+			intent:        VersioningIntentUnspecified,
+			tqSame:        true,
+			shouldInherit: true,
+		},
+		{
+			name:          "Unspecified different TQ",
+			intent:        VersioningIntentUnspecified,
+			tqSame:        false,
+			shouldInherit: false,
+		},
+		{
+			name:          "UseAssignmentRules same TQ",
+			intent:        VersioningIntentUseAssignmentRules,
+			tqSame:        true,
+			shouldInherit: false,
+		},
+		{
+			name:          "UseAssignmentRules different TQ",
+			intent:        VersioningIntentUseAssignmentRules,
+			tqSame:        false,
+			shouldInherit: false,
+		},
+		{
+			name:          "InheritBuildId same TQ",
+			intent:        VersioningIntentInheritBuildId,
+			tqSame:        true,
+			shouldInherit: true,
+		},
+		{
+			name:          "InheritBuildId different TQ",
+			intent:        VersioningIntentInheritBuildId,
+			tqSame:        false,
+			shouldInherit: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tqA := "a"
+			tqB := "b"
+			if tt.tqSame {
+				tqB = tqA
+			}
+			assert.Equal(t,
+				tt.shouldInherit, determineInheritBuildIdFlagForCommand(tt.intent, tqA, tqB))
+		})
+	}
+}

--- a/internal/worker_versioning_rules_test.go
+++ b/internal/worker_versioning_rules_test.go
@@ -116,14 +116,14 @@ func Test_VersioningIntent(t *testing.T) {
 			shouldInherit: false,
 		},
 		{
-			name:          "InheritBuildId same TQ",
-			intent:        VersioningIntentInheritBuildId,
+			name:          "InheritBuildID same TQ",
+			intent:        VersioningIntentInheritBuildID,
 			tqSame:        true,
 			shouldInherit: true,
 		},
 		{
-			name:          "InheritBuildId different TQ",
-			intent:        VersioningIntentInheritBuildId,
+			name:          "InheritBuildID different TQ",
+			intent:        VersioningIntentInheritBuildID,
 			tqSame:        false,
 			shouldInherit: true,
 		},

--- a/temporal/build_id_versioning.go
+++ b/temporal/build_id_versioning.go
@@ -49,9 +49,9 @@ const (
 	// VersioningIntentInheritBuildID indicates the command should inherit the current Build ID of the
 	// Workflow triggering it, and not use Assignment Rules. (Redirect Rules are still applicable)
 	// This is the default behavior for commands running on the same Task Queue as the current worker.
-	VersioningIntentInheritBuildID= internal.VersioningIntentInheritBuildID
+	VersioningIntentInheritBuildID = internal.VersioningIntentInheritBuildID
 	// VersioningIntentUseAssignmentRules indicates the command should use the latest Assignment Rules
 	// to select a Build ID independently of the workflow triggering it.
 	// This is the default behavior for commands not running on the same Task Queue as the current worker.
-	VersioningIntentUseAssignmentRules= internal.VersioningIntentUseAssignmentRules
+	VersioningIntentUseAssignmentRules = internal.VersioningIntentUseAssignmentRules
 )

--- a/temporal/build_id_versioning.go
+++ b/temporal/build_id_versioning.go
@@ -39,17 +39,17 @@ const (
 	// version if possible. It may not be possible if the target task queue does not also have
 	// knowledge of the current worker's build ID.
 	// WARNING: Worker versioning is currently experimental
-	// Deprecated. This has the same effect as VersioningIntentInheritBuildId, use that instead.
+	// Deprecated. This has the same effect as VersioningIntentInheritBuildID, use that instead.
 	VersioningIntentCompatible = internal.VersioningIntentCompatible
 	// VersioningIntentDefault indicates that the command should run on the target task queue's
 	// current overall-default build ID.
 	// WARNING: Worker versioning is currently experimental
 	// Deprecated. This has the same effect as VersioningIntentUseAssignmentRules, use that instead.
 	VersioningIntentDefault = internal.VersioningIntentDefault
-	// VersioningIntentInheritBuildId indicates the command should inherit the current Build ID of the
+	// VersioningIntentInheritBuildID indicates the command should inherit the current Build ID of the
 	// Workflow triggering it, and not use Assignment Rules. (Redirect Rules are still applicable)
 	// This is the default behavior for commands running on the same Task Queue as the current worker.
-	VersioningIntentInheritBuildId= internal.VersioningIntentInheritBuildId
+	VersioningIntentInheritBuildID= internal.VersioningIntentInheritBuildID
 	// VersioningIntentUseAssignmentRules indicates the command should use the latest Assignment Rules
 	// to select a Build ID independently of the workflow triggering it.
 	// This is the default behavior for commands not running on the same Task Queue as the current worker.

--- a/temporal/build_id_versioning.go
+++ b/temporal/build_id_versioning.go
@@ -39,9 +39,19 @@ const (
 	// version if possible. It may not be possible if the target task queue does not also have
 	// knowledge of the current worker's build ID.
 	// WARNING: Worker versioning is currently experimental
+	// Deprecated. This has the same effect as VersioningIntentInheritBuildId, use that instead.
 	VersioningIntentCompatible = internal.VersioningIntentCompatible
 	// VersioningIntentDefault indicates that the command should run on the target task queue's
 	// current overall-default build ID.
 	// WARNING: Worker versioning is currently experimental
+	// Deprecated. This has the same effect as VersioningIntentUseAssignmentRules, use that instead.
 	VersioningIntentDefault = internal.VersioningIntentDefault
+	// VersioningIntentInheritBuildId indicates the command should inherit the current Build ID of the
+	// Workflow triggering it, and not use Assignment Rules. (Redirect Rules are still applicable)
+	// This is the default behavior for commands running on the same Task Queue as the current worker.
+	VersioningIntentInheritBuildId= internal.VersioningIntentInheritBuildId
+	// VersioningIntentUseAssignmentRules indicates the command should use the latest Assignment Rules
+	// to select a Build ID independently of the workflow triggering it.
+	// This is the default behavior for commands not running on the same Task Queue as the current worker.
+	VersioningIntentUseAssignmentRules= internal.VersioningIntentUseAssignmentRules
 )


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Added `InheritBuildID` and `UseAssignmentRules` to `VersioningIntent` enum, replacing (now deprecated) `Default` and `Compatible` options, respectively.

## Why?
<!-- Tell your future self why have you made these changes -->
New options follow new versioning terminology and are more to-the-point. The old option can be confusing when used with new versioning rule concepts:
- `Compatible` could be seen as to have to do with using/not-using `CompatibleRedirectRule`s, while this option is not about redirect rules and solely means keep the same build ID as the parent/previous wf instead of selecting an independent build ID.
- `Default` is not clear because there is no more a "default version set" concept that this could refer to, instead the build ID has to be chosen based on the assignment rules. Moreover, the existence of the concept of "default build ID" (as use in enhanced DescribeTaskQueue API) which is a different (but related) concept will cause additional confusion if we were to keep this option name.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Unit test added.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
Not yet.