### PR TITLE
Add request failure code label to metrics

### DIFF
--- a/internal/client.go
+++ b/internal/client.go
@@ -472,7 +472,7 @@ type (
 		// interceptor should not be set here and in worker options.
 		Interceptors []ClientInterceptor
 
-		/// If set true, error code labels will not be included on request failure metrics.
+		// If set true, error code labels will not be included on request failure metrics.
 		DisableErrorCodeMetricTags bool
 	}
 

--- a/internal/client.go
+++ b/internal/client.go
@@ -471,6 +471,9 @@ type (
 		// worker options, the ones here wrap the ones in worker options. The same
 		// interceptor should not be set here and in worker options.
 		Interceptors []ClientInterceptor
+
+		/// If set true, error code labels will not be included on request failure metrics.
+		DisableErrorCodeMetricTags bool
 	}
 
 	// HeadersProvider returns a map of gRPC headers that should be used on every request.
@@ -813,14 +816,8 @@ func newDialParameters(options *ClientOptions, excludeInternalFromRetry *atomic.
 	return dialParameters{
 		UserConnectionOptions: options.ConnectionOptions,
 		HostPort:              options.HostPort,
-		RequiredInterceptors: requiredInterceptors(
-			options.MetricsHandler,
-			options.HeadersProvider,
-			options.TrafficController,
-			excludeInternalFromRetry,
-			options.Credentials,
-		),
-		DefaultServiceConfig: defaultServiceConfig,
+		RequiredInterceptors:  requiredInterceptors(options, excludeInternalFromRetry),
+		DefaultServiceConfig:  defaultServiceConfig,
 	}
 }
 

--- a/internal/common/metrics/constants.go
+++ b/internal/common/metrics/constants.go
@@ -95,6 +95,7 @@ const (
 	OperationTagName          = "operation"
 	CauseTagName              = "cause"
 	WorkflowTaskFailureReason = "failure_reason"
+	RequestFailureCode        = "status_code"
 )
 
 // Metric tag values

--- a/internal/common/metrics/grpc_test.go
+++ b/internal/common/metrics/grpc_test.go
@@ -52,7 +52,7 @@ func TestGRPCInterceptor(t *testing.T) {
 	handler := metrics.NewCapturingHandler()
 	cc, err := grpc.Dial(l.Addr().String(),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithUnaryInterceptor(metrics.NewGRPCInterceptor(handler, "_my_suffix")))
+		grpc.WithUnaryInterceptor(metrics.NewGRPCInterceptor(handler, "_my_suffix", true)))
 	require.NoError(t, err)
 	defer func() { _ = cc.Close() }()
 	client := grpc_health_v1.NewHealthClient(cc)

--- a/internal/common/metrics/tags.go
+++ b/internal/common/metrics/tags.go
@@ -22,6 +22,12 @@
 
 package metrics
 
+import (
+	"strconv"
+
+	"google.golang.org/grpc/codes"
+)
+
 // RootTags returns a set of base tags for all metrics.
 func RootTags(namespace string) map[string]string {
 	return map[string]string{
@@ -92,5 +98,55 @@ func PollerTags(pollerType string) map[string]string {
 func WorkflowTaskFailedTags(reason string) map[string]string {
 	return map[string]string{
 		WorkflowTaskFailureReason: reason,
+	}
+}
+
+// RequestFailureCodeTags returns a set of tags for a request failure.
+func RequestFailureCodeTags(statusCode codes.Code) map[string]string {
+	asStr := canonicalString(statusCode)
+	return map[string]string{
+		RequestFailureCode: asStr,
+	}
+}
+
+// Annoyingly gRPC defines this, but does not expose it publicly.
+func canonicalString(c codes.Code) string {
+	switch c {
+	case codes.OK:
+		return "OK"
+	case codes.Canceled:
+		return "CANCELLED"
+	case codes.Unknown:
+		return "UNKNOWN"
+	case codes.InvalidArgument:
+		return "INVALID_ARGUMENT"
+	case codes.DeadlineExceeded:
+		return "DEADLINE_EXCEEDED"
+	case codes.NotFound:
+		return "NOT_FOUND"
+	case codes.AlreadyExists:
+		return "ALREADY_EXISTS"
+	case codes.PermissionDenied:
+		return "PERMISSION_DENIED"
+	case codes.ResourceExhausted:
+		return "RESOURCE_EXHAUSTED"
+	case codes.FailedPrecondition:
+		return "FAILED_PRECONDITION"
+	case codes.Aborted:
+		return "ABORTED"
+	case codes.OutOfRange:
+		return "OUT_OF_RANGE"
+	case codes.Unimplemented:
+		return "UNIMPLEMENTED"
+	case codes.Internal:
+		return "INTERNAL"
+	case codes.Unavailable:
+		return "UNAVAILABLE"
+	case codes.DataLoss:
+		return "DATA_LOSS"
+	case codes.Unauthenticated:
+		return "UNAUTHENTICATED"
+	default:
+		return "CODE(" + strconv.FormatInt(int64(c), 10) + ")"
 	}
 }

--- a/internal/grpc_dialer.go
+++ b/internal/grpc_dialer.go
@@ -145,34 +145,31 @@ func dial(params dialParameters) (*grpc.ClientConn, error) {
 }
 
 func requiredInterceptors(
-	metricsHandler metrics.Handler,
-	headersProvider HeadersProvider,
-	controller TrafficController,
+	clientOptions *ClientOptions,
 	excludeInternalFromRetry *atomic.Bool,
-	credentials Credentials,
 ) []grpc.UnaryClientInterceptor {
 	interceptors := []grpc.UnaryClientInterceptor{
 		errorInterceptor,
 		// Report aggregated metrics for the call, this is done outside of the retry loop.
-		metrics.NewGRPCInterceptor(metricsHandler, ""),
+		metrics.NewGRPCInterceptor(clientOptions.MetricsHandler, "", clientOptions.DisableErrorCodeMetricTags),
 		// By default the grpc retry interceptor *is disabled*, preventing accidental use of retries.
 		// We add call options for retry configuration based on the values present in the context.
 		retry.NewRetryOptionsInterceptor(excludeInternalFromRetry),
 		// Performs retries *IF* retry options are set for the call.
 		grpc_retry.UnaryClientInterceptor(),
 		// Report metrics for every call made to the server.
-		metrics.NewGRPCInterceptor(metricsHandler, attemptSuffix),
+		metrics.NewGRPCInterceptor(clientOptions.MetricsHandler, attemptSuffix, clientOptions.DisableErrorCodeMetricTags),
 	}
-	if headersProvider != nil {
-		interceptors = append(interceptors, headersProviderInterceptor(headersProvider))
+	if clientOptions.HeadersProvider != nil {
+		interceptors = append(interceptors, headersProviderInterceptor(clientOptions.HeadersProvider))
 	}
-	if controller != nil {
-		interceptors = append(interceptors, trafficControllerInterceptor(controller))
+	if clientOptions.TrafficController != nil {
+		interceptors = append(interceptors, trafficControllerInterceptor(clientOptions.TrafficController))
 	}
 	// Add credentials interceptor. This is intentionally added after headers
 	// provider to overwrite anything set there.
-	if credentials != nil {
-		if interceptor := credentials.gRPCInterceptor(); interceptor != nil {
+	if clientOptions.Credentials != nil {
+		if interceptor := clientOptions.Credentials.gRPCInterceptor(); interceptor != nil {
 			interceptors = append(interceptors, interceptor)
 		}
 	}

--- a/internal/grpc_dialer_test.go
+++ b/internal/grpc_dialer_test.go
@@ -128,13 +128,13 @@ func TestHeadersProvider_Error(t *testing.T) {
 }
 
 func TestHeadersProvider_NotIncludedWhenNil(t *testing.T) {
-	interceptors := requiredInterceptors(nil, nil, nil, nil, nil)
+	interceptors := requiredInterceptors(&ClientOptions{}, nil)
 	require.Equal(t, 5, len(interceptors))
 }
 
 func TestHeadersProvider_IncludedWithHeadersProvider(t *testing.T) {
-	interceptors := requiredInterceptors(nil,
-		authHeadersProvider{token: "test-auth-token"}, nil, nil, nil)
+	opts := &ClientOptions{HeadersProvider: authHeadersProvider{token: "test-auth-token"}}
+	interceptors := requiredInterceptors(opts, nil)
 	require.Equal(t, 6, len(interceptors))
 }
 

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -4828,6 +4828,18 @@ func (ts *IntegrationTestSuite) TestNondeterministicUpdateRegistertion() {
 	ts.EqualValues(expected, ts.activities.invoked())
 }
 
+func (ts *IntegrationTestSuite) TestRequestFailureMetric() {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Unset namespace field will cause an invalid argument error
+	_, _ = ts.client.WorkflowService().DescribeNamespace(ctx, &workflowservice.DescribeNamespaceRequest{})
+
+	ts.assertMetricCount(metrics.TemporalRequestFailure, 1,
+		metrics.OperationTagName, "DescribeNamespace",
+		metrics.RequestFailureCode, "INVALID_ARGUMENT")
+}
+
 // executeWorkflow executes a given workflow and waits for the result
 func (ts *IntegrationTestSuite) executeWorkflow(
 	wfID string, wfFunc interface{}, retValPtr interface{}, args ...interface{},


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Added error code labels to request failure metrics w/ an option to disable.

## Why?
Go part of https://github.com/temporalio/features/issues/144

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/features/issues/144

2. How was this tested:
Added IT

3. Any docs updates needed?
For the option
