### PR TITLE
Execute nexus operation from a workflow

### DIFF
--- a/interceptor/interceptor.go
+++ b/interceptor/interceptor.go
@@ -131,6 +131,11 @@ type HandleQueryInput = internal.HandleQueryInput
 // NOTE: Experimental
 type UpdateInput = internal.UpdateInput
 
+// RequestCancelNexusOperationInput is the input to WorkflowOutboundInterceptor.RequestCancelNexusOperation.
+//
+// NOTE: Experimental
+type RequestCancelNexusOperationInput = internal.RequestCancelNexusOperationInput
+
 // WorkflowOutboundInterceptor is an interface for all workflow calls
 // originating from the SDK.
 //

--- a/internal/client.go
+++ b/internal/client.go
@@ -31,7 +31,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"go.temporal.io/api/common/v1"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/operatorservice/v1"
@@ -649,7 +648,7 @@ type (
 		// request ID. Only settable by the SDK - e.g. [temporalnexus.workflowRunOperation].
 		requestID string
 		// workflow completion callback. Only settable by the SDK - e.g. [temporalnexus.workflowRunOperation].
-		callbacks []*common.Callback
+		callbacks []*commonpb.Callback
 	}
 
 	// RetryPolicy defines the retry policy.
@@ -1004,6 +1003,6 @@ func SetRequestIDOnStartWorkflowOptions(opts *StartWorkflowOptions, requestID st
 
 // SetCallbacksOnStartWorkflowOptions is an internal only method for setting callbacks on StartWorkflowOptions.
 // Callbacks are purposefully not exposed to users for the time being.
-func SetCallbacksOnStartWorkflowOptions(opts *StartWorkflowOptions, callbacks []*common.Callback) {
+func SetCallbacksOnStartWorkflowOptions(opts *StartWorkflowOptions, callbacks []*commonpb.Callback) {
 	opts.callbacks = callbacks
 }

--- a/internal/error.go
+++ b/internal/error.go
@@ -822,6 +822,7 @@ func (e *ChildWorkflowExecutionError) Unwrap() error {
 	return e.cause
 }
 
+// Error implements the error interface.
 func (e *NexusOperationError) Error() string {
 	msg := fmt.Sprintf(
 		"%s (endpoint: %q, service: %q, operation: %q, operation ID: %q, scheduledEventID: %d)",
@@ -842,6 +843,7 @@ func (e *NexusOperationError) failure() *failurepb.Failure {
 	return e.Failure
 }
 
+// Unwrap returns the Cause associated with this error.
 func (e *NexusOperationError) Unwrap() error {
 	return e.Cause
 }

--- a/internal/interceptor.go
+++ b/internal/interceptor.go
@@ -169,6 +169,20 @@ type HandleQueryInput struct {
 	Args      []interface{}
 }
 
+// RequestCancelNexusOperationInput is the input to WorkflowOutboundInterceptor.RequestCancelNexusOperation.
+//
+// NOTE: Experimental
+type RequestCancelNexusOperationInput struct {
+	// Client that was used to start the operation.
+	Client NexusClient
+	// Operation name.
+	Operation any
+	// Operation ID. May be empty if the operation is synchronous or has not started yet.
+	ID string
+	// seq number. For internal use only.
+	seq int64
+}
+
 // WorkflowOutboundInterceptor is an interface for all workflow calls
 // originating from the SDK. See documentation in the interceptor package for
 // more details.
@@ -282,6 +296,15 @@ type WorkflowOutboundInterceptor interface {
 	// NewContinueAsNewError intercepts workflow.NewContinueAsNewError.
 	// interceptor.WorkflowHeader will return a non-nil map for this context.
 	NewContinueAsNewError(ctx Context, wfn interface{}, args ...interface{}) error
+
+	// ExecuteNexusOperation intercepts NexusClient.ExecuteOperation.
+	//
+	// NOTE: Experimental
+	ExecuteNexusOperation(ctx Context, client NexusClient, operation any, input any, options NexusOperationOptions) NexusOperationFuture
+	// RequestCancelNexusOperation intercepts Nexus Operation cancelation via context.
+	//
+	// NOTE: Experimental
+	RequestCancelNexusOperation(ctx Context, input RequestCancelNexusOperationInput)
 
 	mustEmbedWorkflowOutboundInterceptorBase()
 }

--- a/internal/interceptor_base.go
+++ b/internal/interceptor_base.go
@@ -389,6 +389,24 @@ func (w *WorkflowOutboundInterceptorBase) NewContinueAsNewError(
 	return w.Next.NewContinueAsNewError(ctx, wfn, args...)
 }
 
+// ExecuteNexusOperation implements
+// WorkflowOutboundInterceptor.ExecuteNexusOperation.
+func (w *WorkflowOutboundInterceptorBase) ExecuteNexusOperation(
+	ctx Context,
+	client NexusClient,
+	operation any,
+	input any,
+	options NexusOperationOptions,
+) NexusOperationFuture {
+	return w.Next.ExecuteNexusOperation(ctx, client, operation, input, options)
+}
+
+// RequestCancelNexusOperation implements
+// WorkflowOutboundInterceptor.RequestCancelNexusOperation.
+func (w *WorkflowOutboundInterceptorBase) RequestCancelNexusOperation(ctx Context, input RequestCancelNexusOperationInput) {
+	w.Next.RequestCancelNexusOperation(ctx, input)
+}
+
 func (*WorkflowOutboundInterceptorBase) mustEmbedWorkflowOutboundInterceptorBase() {}
 
 // ClientInterceptorBase is a default implementation of ClientInterceptor meant

--- a/internal/internal_logging_tags.go
+++ b/internal/internal_logging_tags.go
@@ -49,6 +49,7 @@ const (
 	tagTaskStartedEventID           = "TaskStartedEventID"
 	tagPreviousStartedEventID       = "PreviousStartedEventID"
 	tagCachedPreviousStartedEventID = "CachedPreviousStartedEventID"
+	tagNexusEndpoint                = "NexusEndpoint"
 	tagNexusOperation               = "NexusOperation"
 	tagNexusService                 = "NexusService"
 	tagPanicError                   = "PanicError"

--- a/internal/internal_nexus_task_poller.go
+++ b/internal/internal_nexus_task_poller.go
@@ -134,7 +134,7 @@ func (ntp *nexusTaskPoller) ProcessTask(task interface{}) error {
 
 	if err := ntp.reportCompletion(res, failure); err != nil {
 		traceLog(func() {
-			ntp.logger.Debug("reportActivityComplete failed", tagError, err)
+			ntp.logger.Debug("reportNexusTaskComplete failed", tagError, err)
 		})
 		return err
 	}

--- a/internal/internal_nexus_worker.go
+++ b/internal/internal_nexus_worker.go
@@ -27,8 +27,8 @@ func newNexusWorker(opts nexusWorkerOptions) (*nexusWorker, error) {
 	poller := newNexusTaskPoller(
 		newNexusTaskHandler(
 			opts.handler,
-			opts.executionParameters.Namespace,
 			opts.executionParameters.Identity,
+			opts.executionParameters.Namespace,
 			opts.executionParameters.TaskQueue,
 			opts.client,
 			opts.executionParameters.DataConverter,

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -1697,14 +1697,18 @@ func isCommandMatchEvent(d *commandpb.Command, e *historypb.HistoryEvent, obes [
 		eventAttributes := e.GetNexusOperationScheduledEventAttributes()
 		commandAttributes := d.GetScheduleNexusOperationCommandAttributes()
 
-		if eventAttributes.GetService() != commandAttributes.GetService() || eventAttributes.GetOperation() != commandAttributes.GetOperation() {
+		return eventAttributes.GetService() == commandAttributes.GetService() &&
+			eventAttributes.GetOperation() == commandAttributes.GetOperation()
+
+	case enumspb.COMMAND_TYPE_REQUEST_CANCEL_NEXUS_OPERATION:
+		if e.GetEventType() != enumspb.EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUESTED {
 			return false
 		}
 
-		return true
+		eventAttributes := e.GetNexusOperationCancelRequestedEventAttributes()
+		commandAttributes := d.GetRequestCancelNexusOperationCommandAttributes()
 
-	case enumspb.COMMAND_TYPE_REQUEST_CANCEL_NEXUS_OPERATION:
-		return e.GetEventType() == enumspb.EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUESTED
+		return eventAttributes.GetScheduledEventId() == commandAttributes.GetScheduledEventId()
 	}
 
 	return false

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -336,7 +336,9 @@ func isCommandEvent(eventType enumspb.EventType) bool {
 		enumspb.EVENT_TYPE_WORKFLOW_PROPERTIES_MODIFIED,
 		enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_ACCEPTED,
 		enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_COMPLETED,
-		enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_REJECTED:
+		enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_REJECTED,
+		enumspb.EVENT_TYPE_NEXUS_OPERATION_SCHEDULED,
+		enumspb.EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUESTED:
 		return true
 	default:
 		return false
@@ -1687,6 +1689,22 @@ func isCommandMatchEvent(d *commandpb.Command, e *historypb.HistoryEvent, obes [
 			return false
 		}
 		return true
+
+	case enumspb.COMMAND_TYPE_SCHEDULE_NEXUS_OPERATION:
+		if e.GetEventType() != enumspb.EVENT_TYPE_NEXUS_OPERATION_SCHEDULED {
+			return false
+		}
+		eventAttributes := e.GetNexusOperationScheduledEventAttributes()
+		commandAttributes := d.GetScheduleNexusOperationCommandAttributes()
+
+		if eventAttributes.GetService() != commandAttributes.GetService() || eventAttributes.GetOperation() != commandAttributes.GetOperation() {
+			return false
+		}
+
+		return true
+
+	case enumspb.COMMAND_TYPE_REQUEST_CANCEL_NEXUS_OPERATION:
+		return e.GetEventType() == enumspb.EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUESTED
 	}
 
 	return false

--- a/internal/internal_worker_base.go
+++ b/internal/internal_worker_base.go
@@ -77,6 +77,14 @@ type (
 		Backoff time.Duration
 	}
 
+	executeNexusOperationParams struct {
+		client      NexusClient
+		operation   string
+		input       *commonpb.Payload
+		options     NexusOperationOptions
+		nexusHeader map[string]string
+	}
+
 	// WorkflowEnvironment Represents the environment for workflow.
 	// Should only be used within the scope of workflow definition.
 	WorkflowEnvironment interface {
@@ -92,6 +100,8 @@ type (
 		RequestCancelChildWorkflow(namespace, workflowID string)
 		RequestCancelExternalWorkflow(namespace, workflowID, runID string, callback ResultHandler)
 		ExecuteChildWorkflow(params ExecuteWorkflowParams, callback ResultHandler, startedHandler func(r WorkflowExecution, e error))
+		ExecuteNexusOperation(params executeNexusOperationParams, callback func(*commonpb.Payload, error), startedHandler func(opID string, e error)) int64
+		RequestCancelNexusOperation(seq int64)
 		GetLogger() log.Logger
 		GetMetricsHandler() metrics.Handler
 		// Must be called before WorkflowDefinition.Execute returns

--- a/internal/internal_workflow.go
+++ b/internal/internal_workflow.go
@@ -230,6 +230,11 @@ type (
 		executionFuture   *futureImpl // for child workflow execution future
 	}
 
+	nexusOperationFutureImpl struct {
+		*decodeFutureImpl             // for the result
+		executionFuture   *futureImpl // for the NexusOperationExecution
+	}
+
 	asyncFuture interface {
 		Future
 		// Used by selectorImpl
@@ -465,6 +470,10 @@ func (f *childWorkflowFutureImpl) SignalChildWorkflow(ctx Context, signalName st
 	// Put header on context before executing
 	ctx = workflowContextWithNewHeader(ctx)
 	return i.SignalChildWorkflow(ctx, childExec.ID, signalName, data)
+}
+
+func (f *nexusOperationFutureImpl) GetNexusOperationExecution() Future {
+	return f.executionFuture
 }
 
 func newWorkflowContext(

--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -29,12 +29,15 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/facebookgo/clock"
 	"github.com/golang/mock/gomock"
+	"github.com/google/uuid"
+	"github.com/nexus-rpc/sdk-go/nexus"
 	"github.com/robfig/cron"
 	"github.com/stretchr/testify/mock"
 	"google.golang.org/grpc"
@@ -44,6 +47,8 @@ import (
 	commandpb "go.temporal.io/api/command/v1"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
+	failurepb "go.temporal.io/api/failure/v1"
+	nexuspb "go.temporal.io/api/nexus/v1"
 	"go.temporal.io/api/serviceerror"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	"go.temporal.io/api/workflowservice/v1"
@@ -95,6 +100,18 @@ type (
 		handled  bool
 		params   *ExecuteWorkflowParams
 		err      error
+	}
+
+	testNexusOperationHandle struct {
+		env             *testWorkflowEnvironmentImpl
+		seq             int64
+		params          executeNexusOperationParams
+		operationID     string
+		cancelRequested bool
+		started         bool
+		done            bool
+		onCompleted     func(*commonpb.Payload, error)
+		onStarted       func(opID string, e error)
 	}
 
 	testCallbackHandle struct {
@@ -149,11 +166,12 @@ type (
 		testTimeout     time.Duration
 		header          *commonpb.Header
 
-		counterID        int64
-		activities       map[string]*testActivityHandle
-		localActivities  map[string]*localActivityTask
-		timers           map[string]*testTimerHandle
-		runningWorkflows map[string]*testWorkflowHandle
+		counterID              int64
+		activities             map[string]*testActivityHandle
+		localActivities        map[string]*localActivityTask
+		timers                 map[string]*testTimerHandle
+		runningWorkflows       map[string]*testWorkflowHandle
+		runningNexusOperations map[int64]*testNexusOperationHandle
 
 		runningCount int
 
@@ -240,6 +258,7 @@ func newTestWorkflowEnvironmentImpl(s *WorkflowTestSuite, parentRegistry *regist
 			activities:                make(map[string]*testActivityHandle),
 			localActivities:           make(map[string]*localActivityTask),
 			runningWorkflows:          make(map[string]*testWorkflowHandle),
+			runningNexusOperations:    make(map[int64]*testNexusOperationHandle),
 			callbackChannel:           make(chan testCallbackHandle, 1000),
 			testTimeout:               3 * time.Second,
 			expectedWorkflowMockCalls: make(map[string]struct{}),
@@ -2121,6 +2140,10 @@ func (env *testWorkflowEnvironmentImpl) RegisterActivityWithOptions(a interface{
 	env.registry.RegisterActivityWithOptions(a, options)
 }
 
+func (env *testWorkflowEnvironmentImpl) RegisterNexusService(s *nexus.Service) {
+	env.registry.RegisterNexusService(s)
+}
+
 func (env *testWorkflowEnvironmentImpl) RegisterCancelHandler(handler func()) {
 	env.workflowCancelHandler = handler
 }
@@ -2279,12 +2302,133 @@ func (env *testWorkflowEnvironmentImpl) executeChildWorkflowWithDelay(delayStart
 	go childEnv.executeWorkflowInternal(delayStart, params.WorkflowType.Name, params.Input)
 }
 
-func (wc *testWorkflowEnvironmentImpl) ExecuteNexusOperation(params executeNexusOperationParams, callback func(*commonpb.Payload, error), startedHandler func(opID string, e error)) int64 {
-	panic("TODO")
+func (env *testWorkflowEnvironmentImpl) newTestNexusTaskHandler() *nexusTaskHandler {
+	if len(env.registry.nexusServices) == 0 {
+		panic(fmt.Errorf("no nexus services registered"))
+	}
+
+	reg := nexus.NewServiceRegistry()
+	for _, service := range env.registry.nexusServices {
+		if err := reg.Register(service); err != nil {
+			panic(fmt.Errorf("failed to register nexus service '%v': %w", service, err))
+		}
+	}
+	handler, err := reg.NewHandler()
+	if err != nil {
+		panic(fmt.Errorf("failed to create nexus handler: %w", err))
+	}
+
+	return newNexusTaskHandler(
+		handler,
+		env.identity,
+		env.workflowInfo.Namespace,
+		env.workflowInfo.TaskQueueName,
+		&testSuiteClientForNexusOperations{env: env},
+		env.dataConverter,
+		env.logger,
+		env.metricsHandler,
+	)
 }
 
-func (wc *testWorkflowEnvironmentImpl) RequestCancelNexusOperation(seq int64) {
-	panic("TODO")
+func (env *testWorkflowEnvironmentImpl) ExecuteNexusOperation(params executeNexusOperationParams, callback func(*commonpb.Payload, error), startedHandler func(opID string, e error)) int64 {
+	seq := env.nextID()
+	taskHandler := env.newTestNexusTaskHandler()
+	handle := &testNexusOperationHandle{
+		env:         env,
+		seq:         seq,
+		params:      params,
+		onCompleted: callback,
+		onStarted:   startedHandler,
+	}
+	env.runningNexusOperations[seq] = handle
+
+	task := handle.newStartTask()
+	env.runningCount++
+	go func() {
+		response, failure, err := taskHandler.Execute(task)
+		if err != nil {
+			// No retries for operations, fail the operation immediately.
+			failure = taskHandler.fillInFailure(task.TaskToken, nexusHandlerError(nexus.HandlerErrorTypeInternal, err.Error()))
+		}
+		if failure != nil {
+			err := env.failureConverter.FailureToError(nexusOperationFailure(params, "", &failurepb.Failure{
+				Message: failure.GetError().GetFailure().GetMessage(),
+				FailureInfo: &failurepb.Failure_ApplicationFailureInfo{
+					ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{
+						NonRetryable: true,
+					},
+				},
+			}))
+			env.postCallback(func() {
+				handle.startedCallback("", err)
+				handle.completedCallback(nil, err)
+			}, true)
+			return
+		} else {
+			switch v := response.GetResponse().GetStartOperation().GetVariant().(type) {
+			case *nexuspb.StartOperationResponse_SyncSuccess:
+				env.postCallback(func() {
+					handle.startedCallback("", nil)
+					handle.completedCallback(v.SyncSuccess.GetPayload(), nil)
+				}, true)
+			case *nexuspb.StartOperationResponse_AsyncSuccess:
+				env.postCallback(func() {
+					handle.startedCallback(v.AsyncSuccess.GetOperationId(), nil)
+					if handle.cancelRequested {
+						handle.cancel()
+					}
+				}, true)
+			case *nexuspb.StartOperationResponse_OperationError:
+				err := env.failureConverter.FailureToError(
+					nexusOperationFailure(params, "", unsuccessfulOperationErrorToTemporalFailure(v.OperationError)),
+				)
+				env.postCallback(func() {
+					handle.startedCallback("", err)
+					handle.completedCallback(nil, err)
+				}, true)
+			default:
+				panic(fmt.Errorf("unknown response variant: %v", v))
+			}
+		}
+	}()
+	return seq
+}
+
+func (env *testWorkflowEnvironmentImpl) RequestCancelNexusOperation(seq int64) {
+	handle, ok := env.runningNexusOperations[seq]
+	if !ok {
+		panic(fmt.Errorf("no running operation found for sequence: %d", seq))
+	}
+
+	// Avoid duplicate cancelation.
+	if handle.cancelRequested {
+		return
+	}
+
+	// Mark this cancelation request in case the operation hasn't started yet.
+	// Cancel will be called after start.
+	handle.cancelRequested = true
+
+	// Only cancel after started, we need an operation ID.
+	if handle.started {
+		handle.cancel()
+	}
+}
+
+func (env *testWorkflowEnvironmentImpl) resolveNexusOperation(seq int64, result *commonpb.Payload, err error) {
+	env.postCallback(func() {
+		handle, ok := env.runningNexusOperations[seq]
+		if !ok {
+			panic(fmt.Errorf("no running operation found for sequence: %d", seq))
+		}
+		if err != nil {
+			failure := env.failureConverter.ErrorToFailure(err)
+			err = env.failureConverter.FailureToError(nexusOperationFailure(handle.params, handle.operationID, failure.GetCause()))
+			handle.completedCallback(nil, err)
+		} else {
+			handle.completedCallback(result, nil)
+		}
+	}, true)
 }
 
 func (env *testWorkflowEnvironmentImpl) SideEffect(f func() (*commonpb.Payloads, error), callback ResultHandler) {
@@ -2665,3 +2809,92 @@ func mockFnGetVersion(string, Version, Version) Version {
 
 // make sure interface is implemented
 var _ WorkflowEnvironment = (*testWorkflowEnvironmentImpl)(nil)
+
+func (h *testNexusOperationHandle) newStartTask() *workflowservice.PollNexusTaskQueueResponse {
+	return &workflowservice.PollNexusTaskQueueResponse{
+		TaskToken: []byte{},
+		Request: &nexuspb.Request{
+			ScheduledTime: timestamppb.Now(),
+			Header:        h.params.nexusHeader,
+			Variant: &nexuspb.Request_StartOperation{
+				StartOperation: &nexuspb.StartOperationRequest{
+					Service:   h.params.client.Service(),
+					Operation: h.params.operation,
+					RequestId: uuid.NewString(),
+					// This is effectively ignored.
+					Callback: "http://test-env/operations",
+					CallbackHeader: map[string]string{
+						// The test client uses this to call resolveNexusOperation.
+						"operation-sequence": strconv.FormatInt(h.seq, 10),
+					},
+					Payload: h.params.input,
+				},
+			},
+		},
+	}
+}
+
+func (h *testNexusOperationHandle) newCancelTask() *workflowservice.PollNexusTaskQueueResponse {
+	return &workflowservice.PollNexusTaskQueueResponse{
+		TaskToken: []byte{},
+		Request: &nexuspb.Request{
+			ScheduledTime: timestamppb.Now(),
+			Header:        h.params.nexusHeader,
+			Variant: &nexuspb.Request_CancelOperation{
+				CancelOperation: &nexuspb.CancelOperationRequest{
+					Service:     h.params.client.Service(),
+					Operation:   h.params.operation,
+					OperationId: h.operationID,
+				},
+			},
+		},
+	}
+}
+
+// completedCallback is a callback registered to handle operation completion.
+// Must be called in a postCallback block.
+func (h *testNexusOperationHandle) completedCallback(result *commonpb.Payload, err error) {
+	if h.done {
+		// Ignore duplicate completions.
+		return
+	}
+	h.done = true
+	delete(h.env.runningNexusOperations, h.seq)
+	h.onCompleted(result, err)
+}
+
+// startedCallback is a callback registered to handle operation start.
+// Must be called in a postCallback block.
+func (h *testNexusOperationHandle) startedCallback(opID string, e error) {
+	h.operationID = opID
+	h.started = true
+	h.onStarted(opID, e)
+	h.env.runningCount--
+}
+
+func (h *testNexusOperationHandle) cancel() {
+	if h.done {
+		return
+	}
+	if h.started && h.operationID == "" {
+		panic(fmt.Errorf("incomplete operation has no operation ID: (%s, %s, %s)",
+			h.params.client.Endpoint(), h.params.client.Service(), h.params.operation))
+	}
+	h.env.runningCount++
+	task := h.newCancelTask()
+	taskHandler := h.env.newTestNexusTaskHandler()
+
+	go func() {
+		_, failure, err := taskHandler.Execute(task)
+		h.env.postCallback(func() {
+			if err != nil {
+				// No retries in the test env, fail the operation immediately.
+				h.completedCallback(nil, fmt.Errorf("operation cancelation handler failed: %w", err))
+			} else if failure != nil {
+				// No retries in the test env, fail the operation immediately.
+				h.completedCallback(nil, fmt.Errorf("operation cancelation handler failed: %v", failure.GetError().GetFailure().GetMessage()))
+			}
+			h.env.runningCount--
+		}, false)
+	}()
+}

--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -2279,6 +2279,14 @@ func (env *testWorkflowEnvironmentImpl) executeChildWorkflowWithDelay(delayStart
 	go childEnv.executeWorkflowInternal(delayStart, params.WorkflowType.Name, params.Input)
 }
 
+func (wc *testWorkflowEnvironmentImpl) ExecuteNexusOperation(params executeNexusOperationParams, callback func(*commonpb.Payload, error), startedHandler func(opID string, e error)) int64 {
+	panic("TODO")
+}
+
+func (wc *testWorkflowEnvironmentImpl) RequestCancelNexusOperation(seq int64) {
+	panic("TODO")
+}
+
 func (env *testWorkflowEnvironmentImpl) SideEffect(f func() (*commonpb.Payloads, error), callback ResultHandler) {
 	callback(f())
 }

--- a/internal/nexus_operations.go
+++ b/internal/nexus_operations.go
@@ -2,7 +2,17 @@ package internal
 
 import (
 	"context"
+	"fmt"
+	"strconv"
 
+	"github.com/nexus-rpc/sdk-go/nexus"
+	commonpb "go.temporal.io/api/common/v1"
+	"go.temporal.io/api/enums/v1"
+	failurepb "go.temporal.io/api/failure/v1"
+	nexuspb "go.temporal.io/api/nexus/v1"
+	"go.temporal.io/api/operatorservice/v1"
+	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/sdk/converter"
 	"go.temporal.io/sdk/log"
 )
 
@@ -13,11 +23,365 @@ type NexusOperationContext struct {
 	Log       log.Logger
 }
 
+type nexusOperationContextKeyType struct{}
+
 // nexusOperationContextKey is a key for associating a [NexusOperationContext] with a [context.Context].
-var nexusOperationContextKey = struct{}{}
+var nexusOperationContextKey = nexusOperationContextKeyType{}
+
+type isWorkflowRunOpContextKeyType struct{}
+
+// IsWorkflowRunOpContextKey is a key to mark that the current context is used within a workflow run operation.
+// The fake test env client verifies this key is set on the context to decide whether it should execute a method or
+// panic as we don't want to expose a partial client to sync operations.
+var IsWorkflowRunOpContextKey = isWorkflowRunOpContextKeyType{}
 
 // NexusOperationContextFromGoContext gets the [NexusOperationContext] associated with the given [context.Context].
 func NexusOperationContextFromGoContext(ctx context.Context) (nctx *NexusOperationContext, ok bool) {
 	nctx, ok = ctx.Value(nexusOperationContextKey).(*NexusOperationContext)
 	return
 }
+
+// nexusOperationFailure is a utility in use by the test environment.
+func nexusOperationFailure(params executeNexusOperationParams, operationID string, cause *failurepb.Failure) *failurepb.Failure {
+	return &failurepb.Failure{
+		Message: "nexus operation completed unsuccessfully",
+		FailureInfo: &failurepb.Failure_NexusOperationExecutionFailureInfo{
+			NexusOperationExecutionFailureInfo: &failurepb.NexusOperationFailureInfo{
+				Endpoint:    params.client.Endpoint(),
+				Service:     params.client.Service(),
+				Operation:   params.operation,
+				OperationId: operationID,
+			},
+		},
+		Cause: cause,
+	}
+}
+
+// unsuccessfulOperationErrorToTemporalFailure is a utility in use by the test environment.
+// copied from the server codebase with a slight adaptation: https://github.com/temporalio/temporal/blob/7635cd7dbdc7dd3219f387e8fc66fa117f585ff6/common/nexus/failure.go#L69-L108
+func unsuccessfulOperationErrorToTemporalFailure(err *nexuspb.UnsuccessfulOperationError) *failurepb.Failure {
+	failure := &failurepb.Failure{
+		Message: err.Failure.Message,
+	}
+	if err.OperationState == string(nexus.OperationStateCanceled) {
+		failure.FailureInfo = &failurepb.Failure_CanceledFailureInfo{
+			CanceledFailureInfo: &failurepb.CanceledFailureInfo{
+				Details: nexusFailureMetadataToPayloads(err.Failure),
+			},
+		}
+	} else {
+		failure.FailureInfo = &failurepb.Failure_ApplicationFailureInfo{
+			ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{
+				// Make up a type here, it's not part of the Nexus Failure spec.
+				Type:         "NexusOperationFailure",
+				Details:      nexusFailureMetadataToPayloads(err.Failure),
+				NonRetryable: true,
+			},
+		}
+	}
+	return failure
+}
+
+// nexusFailureMetadataToPayloads is a utility in use by the test environment.
+// copied from the server codebase with a slight adaptation: https://github.com/temporalio/temporal/blob/7635cd7dbdc7dd3219f387e8fc66fa117f585ff6/common/nexus/failure.go#L69-L108
+func nexusFailureMetadataToPayloads(failure *nexuspb.Failure) *commonpb.Payloads {
+	if len(failure.Metadata) == 0 && len(failure.Details) == 0 {
+		return nil
+	}
+	metadata := make(map[string][]byte, len(failure.Metadata))
+	for k, v := range failure.Metadata {
+		metadata[k] = []byte(v)
+	}
+	return &commonpb.Payloads{
+		Payloads: []*commonpb.Payload{
+			{
+				Metadata: metadata,
+				Data:     failure.Details,
+			},
+		},
+	}
+}
+
+// testSuiteClientForNexusOperations is a partial [Client] implementation for the test workflow environment used to
+// support running the workflow run operation - and only this operation, all methods will panic when this client is
+// passed to sync operations.
+type testSuiteClientForNexusOperations struct {
+	env *testWorkflowEnvironmentImpl
+}
+
+// CancelWorkflow implements Client.
+func (t *testSuiteClientForNexusOperations) CancelWorkflow(ctx context.Context, workflowID string, runID string) error {
+	if set, ok := ctx.Value(IsWorkflowRunOpContextKey).(bool); !ok || !set {
+		panic("not implemented in the test environment")
+	}
+	doneCh := make(chan error)
+	t.env.cancelWorkflowByID(workflowID, runID, func(result *commonpb.Payloads, err error) {
+		doneCh <- err
+	})
+	return <-doneCh
+}
+
+// CheckHealth implements Client.
+func (t *testSuiteClientForNexusOperations) CheckHealth(ctx context.Context, request *CheckHealthRequest) (*CheckHealthResponse, error) {
+	return &CheckHealthResponse{}, nil
+}
+
+// Close implements Client.
+func (t *testSuiteClientForNexusOperations) Close() {
+	// No op.
+}
+
+// CompleteActivity implements Client.
+func (t *testSuiteClientForNexusOperations) CompleteActivity(ctx context.Context, taskToken []byte, result interface{}, err error) error {
+	panic("not implemented in the test environment")
+}
+
+// CompleteActivityByID implements Client.
+func (t *testSuiteClientForNexusOperations) CompleteActivityByID(ctx context.Context, namespace string, workflowID string, runID string, activityID string, result interface{}, err error) error {
+	panic("not implemented in the test environment")
+}
+
+// CountWorkflow implements Client.
+func (t *testSuiteClientForNexusOperations) CountWorkflow(ctx context.Context, request *workflowservice.CountWorkflowExecutionsRequest) (*workflowservice.CountWorkflowExecutionsResponse, error) {
+	panic("not implemented in the test environment")
+}
+
+// DescribeTaskQueue implements Client.
+func (t *testSuiteClientForNexusOperations) DescribeTaskQueue(ctx context.Context, taskqueue string, taskqueueType enums.TaskQueueType) (*workflowservice.DescribeTaskQueueResponse, error) {
+	panic("not implemented in the test environment")
+}
+
+// DescribeWorkflowExecution implements Client.
+func (t *testSuiteClientForNexusOperations) DescribeWorkflowExecution(ctx context.Context, workflowID string, runID string) (*workflowservice.DescribeWorkflowExecutionResponse, error) {
+	panic("not implemented in the test environment")
+}
+
+// ExecuteWorkflow implements Client.
+func (t *testSuiteClientForNexusOperations) ExecuteWorkflow(ctx context.Context, options StartWorkflowOptions, workflow interface{}, args ...interface{}) (WorkflowRun, error) {
+	if set, ok := ctx.Value(IsWorkflowRunOpContextKey).(bool); !ok || !set {
+		panic("not implemented in the test environment")
+	}
+	wfType, input, err := getValidatedWorkflowFunction(workflow, args, t.env.dataConverter, t.env.GetRegistry())
+	if err != nil {
+		return nil, fmt.Errorf("cannot validate workflow function: %w", err)
+	}
+
+	run := &testEnvWorkflowRunForNexusOperations{}
+	doneCh := make(chan error)
+
+	var callback *commonpb.Callback
+
+	if len(options.callbacks) > 0 {
+		callback = options.callbacks[0]
+	}
+
+	t.env.executeChildWorkflowWithDelay(options.StartDelay, ExecuteWorkflowParams{
+		// Not propagating Header as this client does not support context propagation.
+		WorkflowType: wfType,
+		Input:        input,
+		WorkflowOptions: WorkflowOptions{
+			WaitForCancellation:      true,
+			Namespace:                t.env.workflowInfo.Namespace,
+			TaskQueueName:            t.env.workflowInfo.TaskQueueName,
+			WorkflowID:               options.ID,
+			WorkflowExecutionTimeout: options.WorkflowExecutionTimeout,
+			WorkflowRunTimeout:       options.WorkflowRunTimeout,
+			WorkflowTaskTimeout:      options.WorkflowTaskTimeout,
+			DataConverter:            t.env.dataConverter,
+			WorkflowIDReusePolicy:    options.WorkflowIDReusePolicy,
+			ContextPropagators:       t.env.contextPropagators,
+			SearchAttributes:         options.SearchAttributes,
+			TypedSearchAttributes:    options.TypedSearchAttributes,
+			ParentClosePolicy:        enums.PARENT_CLOSE_POLICY_ABANDON,
+			Memo:                     options.Memo,
+			CronSchedule:             options.CronSchedule,
+			RetryPolicy:              convertToPBRetryPolicy(options.RetryPolicy),
+		},
+	}, func(result *commonpb.Payloads, wfErr error) {
+		ncb := callback.GetNexus()
+		if ncb == nil {
+			return
+		}
+		seqStr := ncb.GetHeader()["operation-sequence"]
+		if seqStr == "" {
+			return
+		}
+		seq, err := strconv.ParseInt(seqStr, 10, 64)
+		if err != nil {
+			panic(fmt.Errorf("unexpected operation sequence in callback header: %s: %w", seqStr, err))
+		}
+
+		if wfErr != nil {
+			t.env.resolveNexusOperation(seq, nil, wfErr)
+		} else {
+			var payload *commonpb.Payload
+			if len(result.GetPayloads()) > 0 {
+				payload = result.Payloads[0]
+			}
+			t.env.resolveNexusOperation(seq, payload, nil)
+		}
+	}, func(r WorkflowExecution, err error) {
+		run.WorkflowExecution = r
+		doneCh <- err
+	})
+	err = <-doneCh
+	if err != nil {
+		return nil, err
+	}
+	return run, nil
+}
+
+// GetSearchAttributes implements Client.
+func (t *testSuiteClientForNexusOperations) GetSearchAttributes(ctx context.Context) (*workflowservice.GetSearchAttributesResponse, error) {
+	panic("not implemented in the test environment")
+}
+
+// GetWorkerBuildIdCompatibility implements Client.
+func (t *testSuiteClientForNexusOperations) GetWorkerBuildIdCompatibility(ctx context.Context, options *GetWorkerBuildIdCompatibilityOptions) (*WorkerBuildIDVersionSets, error) {
+	panic("not implemented in the test environment")
+}
+
+// GetWorkerTaskReachability implements Client.
+func (t *testSuiteClientForNexusOperations) GetWorkerTaskReachability(ctx context.Context, options *GetWorkerTaskReachabilityOptions) (*WorkerTaskReachability, error) {
+	panic("not implemented in the test environment")
+}
+
+// GetWorkflow implements Client.
+func (t *testSuiteClientForNexusOperations) GetWorkflow(ctx context.Context, workflowID string, runID string) WorkflowRun {
+	panic("not implemented in the test environment")
+}
+
+// GetWorkflowHistory implements Client.
+func (t *testSuiteClientForNexusOperations) GetWorkflowHistory(ctx context.Context, workflowID string, runID string, isLongPoll bool, filterType enums.HistoryEventFilterType) HistoryEventIterator {
+	panic("not implemented in the test environment")
+}
+
+// GetWorkflowUpdateHandle implements Client.
+func (t *testSuiteClientForNexusOperations) GetWorkflowUpdateHandle(GetWorkflowUpdateHandleOptions) WorkflowUpdateHandle {
+	panic("not implemented in the test environment")
+}
+
+// ListArchivedWorkflow implements Client.
+func (t *testSuiteClientForNexusOperations) ListArchivedWorkflow(ctx context.Context, request *workflowservice.ListArchivedWorkflowExecutionsRequest) (*workflowservice.ListArchivedWorkflowExecutionsResponse, error) {
+	panic("not implemented in the test environment")
+}
+
+// ListClosedWorkflow implements Client.
+func (t *testSuiteClientForNexusOperations) ListClosedWorkflow(ctx context.Context, request *workflowservice.ListClosedWorkflowExecutionsRequest) (*workflowservice.ListClosedWorkflowExecutionsResponse, error) {
+	panic("not implemented in the test environment")
+}
+
+// ListOpenWorkflow implements Client.
+func (t *testSuiteClientForNexusOperations) ListOpenWorkflow(ctx context.Context, request *workflowservice.ListOpenWorkflowExecutionsRequest) (*workflowservice.ListOpenWorkflowExecutionsResponse, error) {
+	panic("not implemented in the test environment")
+}
+
+// ListWorkflow implements Client.
+func (t *testSuiteClientForNexusOperations) ListWorkflow(ctx context.Context, request *workflowservice.ListWorkflowExecutionsRequest) (*workflowservice.ListWorkflowExecutionsResponse, error) {
+	panic("not implemented in the test environment")
+}
+
+// OperatorService implements Client.
+func (t *testSuiteClientForNexusOperations) OperatorService() operatorservice.OperatorServiceClient {
+	panic("not implemented in the test environment")
+}
+
+// QueryWorkflow implements Client.
+func (t *testSuiteClientForNexusOperations) QueryWorkflow(ctx context.Context, workflowID string, runID string, queryType string, args ...interface{}) (converter.EncodedValue, error) {
+	panic("not implemented in the test environment")
+}
+
+// QueryWorkflowWithOptions implements Client.
+func (t *testSuiteClientForNexusOperations) QueryWorkflowWithOptions(ctx context.Context, request *QueryWorkflowWithOptionsRequest) (*QueryWorkflowWithOptionsResponse, error) {
+	panic("not implemented in the test environment")
+}
+
+// RecordActivityHeartbeat implements Client.
+func (t *testSuiteClientForNexusOperations) RecordActivityHeartbeat(ctx context.Context, taskToken []byte, details ...interface{}) error {
+	panic("not implemented in the test environment")
+}
+
+// RecordActivityHeartbeatByID implements Client.
+func (t *testSuiteClientForNexusOperations) RecordActivityHeartbeatByID(ctx context.Context, namespace string, workflowID string, runID string, activityID string, details ...interface{}) error {
+	panic("not implemented in the test environment")
+}
+
+// ResetWorkflowExecution implements Client.
+func (t *testSuiteClientForNexusOperations) ResetWorkflowExecution(ctx context.Context, request *workflowservice.ResetWorkflowExecutionRequest) (*workflowservice.ResetWorkflowExecutionResponse, error) {
+	panic("not implemented in the test environment")
+}
+
+// ScanWorkflow implements Client.
+func (t *testSuiteClientForNexusOperations) ScanWorkflow(ctx context.Context, request *workflowservice.ScanWorkflowExecutionsRequest) (*workflowservice.ScanWorkflowExecutionsResponse, error) {
+	panic("not implemented in the test environment")
+}
+
+// ScheduleClient implements Client.
+func (t *testSuiteClientForNexusOperations) ScheduleClient() ScheduleClient {
+	panic("not implemented in the test environment")
+}
+
+// SignalWithStartWorkflow implements Client.
+func (t *testSuiteClientForNexusOperations) SignalWithStartWorkflow(ctx context.Context, workflowID string, signalName string, signalArg interface{}, options StartWorkflowOptions, workflow interface{}, workflowArgs ...interface{}) (WorkflowRun, error) {
+	panic("not implemented in the test environment")
+}
+
+// SignalWorkflow implements Client.
+func (t *testSuiteClientForNexusOperations) SignalWorkflow(ctx context.Context, workflowID string, runID string, signalName string, arg interface{}) error {
+	panic("not implemented in the test environment")
+}
+
+// TerminateWorkflow implements Client.
+func (t *testSuiteClientForNexusOperations) TerminateWorkflow(ctx context.Context, workflowID string, runID string, reason string, details ...interface{}) error {
+	panic("not implemented in the test environment")
+}
+
+// UpdateWorkerBuildIdCompatibility implements Client.
+func (t *testSuiteClientForNexusOperations) UpdateWorkerBuildIdCompatibility(ctx context.Context, options *UpdateWorkerBuildIdCompatibilityOptions) error {
+	panic("not implemented in the test environment")
+}
+
+// UpdateWorkflow implements Client.
+func (t *testSuiteClientForNexusOperations) UpdateWorkflow(ctx context.Context, workflowID string, workflowRunID string, updateName string, args ...interface{}) (WorkflowUpdateHandle, error) {
+	panic("not implemented in the test environment")
+}
+
+// UpdateWorkflowWithOptions implements Client.
+func (t *testSuiteClientForNexusOperations) UpdateWorkflowWithOptions(ctx context.Context, request *UpdateWorkflowWithOptionsRequest) (WorkflowUpdateHandle, error) {
+	panic("not implemented in the test environment")
+}
+
+// WorkflowService implements Client.
+func (t *testSuiteClientForNexusOperations) WorkflowService() workflowservice.WorkflowServiceClient {
+	panic("not implemented in the test environment")
+}
+
+var _ Client = &testSuiteClientForNexusOperations{}
+
+// testEnvWorkflowRunForNexusOperations is a partial [WorkflowRun] implementation for the test workflow environment used
+// to support basic Nexus functionality.
+type testEnvWorkflowRunForNexusOperations struct {
+	WorkflowExecution
+}
+
+// Get implements WorkflowRun.
+func (t *testEnvWorkflowRunForNexusOperations) Get(ctx context.Context, valuePtr interface{}) error {
+	panic("not implemented in the test environment")
+}
+
+// GetID implements WorkflowRun.
+func (t *testEnvWorkflowRunForNexusOperations) GetID() string {
+	return t.ID
+}
+
+// GetRunID implements WorkflowRun.
+func (t *testEnvWorkflowRunForNexusOperations) GetRunID() string {
+	return t.RunID
+}
+
+// GetWithOptions implements WorkflowRun.
+func (t *testEnvWorkflowRunForNexusOperations) GetWithOptions(ctx context.Context, valuePtr interface{}, options WorkflowRunGetOptions) error {
+	panic("not implemented in the test environment")
+}
+
+var _ WorkflowRun = &testEnvWorkflowRunForNexusOperations{}

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -2125,8 +2125,10 @@ type NexusOperationOptions struct {
 	ScheduleToCloseTimeout time.Duration
 }
 
-// NexusOperationExecution is the result of [NexusOperationFuture.GetNexusOperationExecution].
+// NexusOperationExecution is the result of NexusOperationFuture.GetNexusOperationExecution.
 type NexusOperationExecution struct {
+	// Operation ID as set by the Operation's handler. May be empty if the operation hasn't started yet or completed
+	// synchronously.
 	OperationID string
 }
 
@@ -2141,10 +2143,17 @@ type NexusOperationFuture interface {
 	// synchronous operations.
 	//
 	// NOTE: Experimental
+	//
+	//  fut := nexusClient.ExecuteOperation(ctx, op, ...)
+	//  var exec workflow.NexusOperationExecution
+	//  if err := fut.GetNexusOperationExecution().Get(ctx, &exec); err == nil {
+	//      // Nexus Operation started, OperationID is optionally set.
+	//  }
 	GetNexusOperationExecution() Future
 }
 
 // NexusClient is a client for executing Nexus Operations from a workflow.
+// NOTE to maintainers, this interface definition is duplicated in the workflow package to provide a better UX.
 type NexusClient interface {
 	// The endpoint name this client uses.
 	//
@@ -2240,7 +2249,11 @@ func (wc *workflowEnvironmentInterceptor) ExecuteNexusOperation(ctx Context, cli
 
 	var operationID string
 	seq := wc.env.ExecuteNexusOperation(params, func(r *commonpb.Payload, e error) {
-		mainSettable.Set(&commonpb.Payloads{Payloads: []*commonpb.Payload{r}}, e)
+		var payloads *commonpb.Payloads
+		if r != nil {
+			payloads = &commonpb.Payloads{Payloads: []*commonpb.Payload{r}}
+		}
+		mainSettable.Set(payloads, e)
 		if cancellable {
 			// future is done, we don't need cancellation anymore
 			ctxDone.removeReceiveCallback(cancellationCallback)

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -2119,3 +2119,160 @@ func DeterministicKeysFunc[K comparable, V any](m map[K]V, cmp func(a K, b K) in
 	slices.SortStableFunc(r, cmp)
 	return r
 }
+
+// NexusOperationOptions are options for starting a Nexus Operation from a Workflow.
+type NexusOperationOptions struct {
+	ScheduleToCloseTimeout time.Duration
+}
+
+// NexusOperationExecution is the result of [NexusOperationFuture.GetNexusOperationExecution].
+type NexusOperationExecution struct {
+	OperationID string
+}
+
+// NexusOperationFuture represents the result of a Nexus Operation.
+type NexusOperationFuture interface {
+	Future
+	// GetNexusOperationExecution returns a future that is resolved when the operation reaches the STARTED state.
+	// For synchronous operations, this will be resolved at the same as the containing [NexusOperationFuture]. For
+	// asynchronous operations, this future is resolved independently.
+	// If the operation is unsuccessful, this future will contain the same error as the [NexusOperationFuture].
+	// Use this method to extract the Operation ID of an asynchronous operation. OperationID will be empty for
+	// synchronous operations.
+	//
+	// NOTE: Experimental
+	GetNexusOperationExecution() Future
+}
+
+// NexusClient is a client for executing Nexus Operations from a workflow.
+type NexusClient interface {
+	// The endpoint name this client uses.
+	//
+	// NOTE: Experimental
+	Endpoint() string
+	// The service name this client uses.
+	//
+	// NOTE: Experimental
+	Service() string
+
+	// ExecuteOperation executes a Nexus Operation.
+	// The operation argument can be a string, a [nexus.Operation] or a [nexus.OperationReference].
+	//
+	// NOTE: Experimental
+	ExecuteOperation(ctx Context, operation any, input any, options NexusOperationOptions) NexusOperationFuture
+}
+
+type nexusClient struct {
+	endpoint, service string
+}
+
+// Create a [NexusClient] from an endpoint name and a service name.
+//
+// NOTE: Experimental
+func NewNexusClient(endpoint, service string) NexusClient {
+	return nexusClient{endpoint, service}
+}
+
+func (c nexusClient) Endpoint() string {
+	return c.endpoint
+}
+
+func (c nexusClient) Service() string {
+	return c.service
+}
+
+func (c nexusClient) ExecuteOperation(ctx Context, operation any, input any, options NexusOperationOptions) NexusOperationFuture {
+	assertNotInReadOnlyState(ctx)
+	i := getWorkflowOutboundInterceptor(ctx)
+	return i.ExecuteNexusOperation(ctx, c, operation, input, options)
+}
+
+func (wc *workflowEnvironmentInterceptor) prepareNexusOperationParams(ctx Context, client NexusClient, operation any, input any, options NexusOperationOptions) (executeNexusOperationParams, error) {
+	dc := WithWorkflowContext(ctx, wc.env.GetDataConverter())
+
+	var ok bool
+	var operationName string
+	if operationName, ok = operation.(string); ok {
+	} else if regOp, ok := operation.(interface{ Name() string }); ok {
+		operationName = regOp.Name()
+	} else {
+		return executeNexusOperationParams{}, fmt.Errorf("invalid 'operation' parameter, must be an OperationReference or a string")
+	}
+	// TODO(bergundy): Validate operation types against input once there's a good way to extract the generic types from
+	// OperationReference in the Nexus Go SDK.
+
+	payload, err := dc.ToPayload(input)
+	if err != nil {
+		return executeNexusOperationParams{}, err
+	}
+
+	return executeNexusOperationParams{
+		client:    client,
+		operation: operationName,
+		input:     payload,
+		options:   options,
+	}, nil
+}
+
+func (wc *workflowEnvironmentInterceptor) ExecuteNexusOperation(ctx Context, client NexusClient, operation any, input any, options NexusOperationOptions) NexusOperationFuture {
+	mainFuture, mainSettable := newDecodeFuture(ctx, nil /* this param is never used */)
+	executionFuture, executionSettable := NewFuture(ctx)
+	result := &nexusOperationFutureImpl{
+		decodeFutureImpl: mainFuture.(*decodeFutureImpl),
+		executionFuture:  executionFuture.(*futureImpl),
+	}
+
+	// Immediately return if the context has an error without spawning the child workflow
+	if ctx.Err() != nil {
+		executionSettable.Set(nil, ctx.Err())
+		mainSettable.Set(nil, ctx.Err())
+		return result
+	}
+
+	ctxDone, cancellable := ctx.Done().(*channelImpl)
+	cancellationCallback := &receiveCallback{}
+	params, err := wc.prepareNexusOperationParams(ctx, client, operation, input, options)
+	if err != nil {
+		executionSettable.Set(nil, err)
+		mainSettable.Set(nil, err)
+		return result
+	}
+
+	var operationID string
+	seq := wc.env.ExecuteNexusOperation(params, func(r *commonpb.Payload, e error) {
+		mainSettable.Set(&commonpb.Payloads{Payloads: []*commonpb.Payload{r}}, e)
+		if cancellable {
+			// future is done, we don't need cancellation anymore
+			ctxDone.removeReceiveCallback(cancellationCallback)
+		}
+	}, func(opID string, e error) {
+		operationID = opID
+		executionSettable.Set(NexusOperationExecution{opID}, e)
+	})
+
+	if cancellable {
+		cancellationCallback.fn = func(v any, _ bool) bool {
+			assertNotInReadOnlyStateCancellation(ctx)
+			if ctx.Err() == ErrCanceled && !mainFuture.IsReady() {
+				// Go back to the top of the interception chain.
+				getWorkflowOutboundInterceptor(ctx).RequestCancelNexusOperation(ctx, RequestCancelNexusOperationInput{
+					Client:    client,
+					Operation: operation,
+					ID:        operationID,
+					seq:       seq,
+				})
+			}
+			return false
+		}
+		_, ok, more := ctxDone.receiveAsyncImpl(cancellationCallback)
+		if ok || !more {
+			cancellationCallback.fn(nil, more)
+		}
+	}
+
+	return result
+}
+
+func (wc *workflowEnvironmentInterceptor) RequestCancelNexusOperation(ctx Context, input RequestCancelNexusOperationInput) {
+	wc.env.RequestCancelNexusOperation(input.seq)
+}

--- a/internal/workflow_testsuite.go
+++ b/internal/workflow_testsuite.go
@@ -32,6 +32,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nexus-rpc/sdk-go/nexus"
 	"github.com/stretchr/testify/mock"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
@@ -288,6 +289,11 @@ func (e *TestWorkflowEnvironment) RegisterActivityWithOptions(a interface{}, opt
 		panic("RegisterActivity calls cannot follow mock related ones like OnActivity or similar")
 	}
 	e.impl.RegisterActivityWithOptions(a, options)
+}
+
+// RegisterWorkflow registers a Nexus Service with the TestWorkflowEnvironment.
+func (e *TestWorkflowEnvironment) RegisterNexusService(s *nexus.Service) {
+	e.impl.RegisterNexusService(s)
 }
 
 // SetStartTime sets the start time of the workflow. This is optional, default start time will be the wall clock time when

--- a/temporal/error.go
+++ b/temporal/error.go
@@ -131,6 +131,11 @@ type (
 	// ChildWorkflowExecutionError returned from workflow when child workflow returned an error.
 	ChildWorkflowExecutionError = internal.ChildWorkflowExecutionError
 
+	// NexusOperationError is an error returned when a Nexus Operation has failed.
+	//
+	// NOTE: Experimental
+	NexusOperationError = internal.NexusOperationError
+
 	// ChildWorkflowExecutionAlreadyStartedError is set as the cause of
 	// ChildWorkflowExecutionError when failure is due the child workflow having
 	// already started.

--- a/temporalnexus/operation.go
+++ b/temporalnexus/operation.go
@@ -145,6 +145,9 @@ func MustNewWorkflowRunOperationWithOptions[I, O any](options WorkflowRunOperati
 }
 
 func (*workflowRunOperation[I, O]) Cancel(ctx context.Context, id string, options nexus.CancelOperationOptions) error {
+	// Prevent the test env client from panicking when we try to use it from a workflow run operation.
+	ctx = context.WithValue(ctx, internal.IsWorkflowRunOpContextKey, true)
+
 	nctx, ok := internal.NexusOperationContextFromGoContext(ctx)
 	if !ok {
 		return nexus.HandlerErrorf(nexus.HandlerErrorTypeInternal, "internal error")
@@ -157,6 +160,9 @@ func (o *workflowRunOperation[I, O]) Name() string {
 }
 
 func (o *workflowRunOperation[I, O]) Start(ctx context.Context, input I, options nexus.StartOperationOptions) (nexus.HandlerStartOperationResult[O], error) {
+	// Prevent the test env client from panicking when we try to use it from a workflow run operation.
+	ctx = context.WithValue(ctx, internal.IsWorkflowRunOpContextKey, true)
+
 	if o.options.Handler != nil {
 		handle, err := o.options.Handler(ctx, input, options)
 		if err != nil {

--- a/test/nexus_test.go
+++ b/test/nexus_test.go
@@ -574,7 +574,7 @@ func TestAsyncOperationFromWorkflow(t *testing.T) {
 }
 
 func TestReplay(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
 	tc := newTestContext(t, ctx)
 

--- a/test/nexus_test.go
+++ b/test/nexus_test.go
@@ -24,6 +24,7 @@ package test_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"slices"
@@ -44,6 +45,7 @@ import (
 	ilog "go.temporal.io/sdk/internal/log"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/temporalnexus"
+	"go.temporal.io/sdk/testsuite"
 	"go.temporal.io/sdk/worker"
 	"go.temporal.io/sdk/workflow"
 )
@@ -656,4 +658,252 @@ func TestReplay(t *testing.T) {
 		err = rw.ReplayWorkflowHistory(ilog.NewDefaultLogger(), &historypb.History{Events: events})
 		require.ErrorContains(t, err, "[TMPRL1100]")
 	})
+}
+
+func TestWorkflowTestSuite_NexusSyncOperation(t *testing.T) {
+	op := nexus.NewSyncOperation("op", func(ctx context.Context, outcome string, opts nexus.StartOperationOptions) (string, error) {
+		switch outcome {
+		case "ok":
+			return outcome, nil
+		case "failure":
+			return "", &nexus.UnsuccessfulOperationError{
+				State: nexus.OperationStateFailed,
+				Failure: nexus.Failure{
+					Message: "test operation failed",
+				},
+			}
+		case "handler-error":
+			return "", &nexus.HandlerError{
+				Type: nexus.HandlerErrorTypeBadRequest,
+				Failure: &nexus.Failure{
+					Message: "test operation failed",
+				},
+			}
+		}
+		panic(fmt.Errorf("invalid outcome: %q", outcome))
+	})
+	wf := func(ctx workflow.Context, outcome string) error {
+		client := workflow.NewNexusClient("endpoint", "test")
+		fut := client.ExecuteOperation(ctx, op, outcome, workflow.NexusOperationOptions{})
+		var exec workflow.NexusOperationExecution
+		if err := fut.GetNexusOperationExecution().Get(ctx, &exec); err != nil {
+			return err
+		}
+		var res string
+		if err := fut.Get(ctx, &res); err != nil {
+			return err
+		}
+		if res != "ok" {
+			return fmt.Errorf("unexpected result: %v", res)
+		}
+		return nil
+	}
+
+	service := nexus.NewService("test")
+	service.Register(op)
+
+	t.Run("ok", func(t *testing.T) {
+		suite := testsuite.WorkflowTestSuite{}
+		env := suite.NewTestWorkflowEnvironment()
+		env.RegisterNexusService(service)
+		env.ExecuteWorkflow(wf, "ok")
+		require.True(t, env.IsWorkflowCompleted())
+		require.NoError(t, env.GetWorkflowError())
+	})
+
+	for _, outcome := range []string{"failure", "handler-error"} {
+		outcome := outcome // capture just in case.
+		t.Run(outcome, func(t *testing.T) {
+			suite := testsuite.WorkflowTestSuite{}
+			env := suite.NewTestWorkflowEnvironment()
+			env.RegisterNexusService(service)
+			env.ExecuteWorkflow(wf, "failure")
+			require.True(t, env.IsWorkflowCompleted())
+			var execErr *temporal.WorkflowExecutionError
+			err := env.GetWorkflowError()
+			require.ErrorAs(t, err, &execErr)
+			var opErr *temporal.NexusOperationError
+			err = execErr.Unwrap()
+			require.ErrorAs(t, err, &opErr)
+			require.Equal(t, "endpoint", opErr.Endpoint)
+			require.Equal(t, "test", opErr.Service)
+			require.Equal(t, op.Name(), opErr.Operation)
+			require.Empty(t, opErr.OperationID)
+			require.Equal(t, "nexus operation completed unsuccessfully", opErr.Message)
+			err = opErr.Unwrap()
+			var appErr *temporal.ApplicationError
+			require.ErrorAs(t, err, &appErr)
+			require.Equal(t, "test operation failed", appErr.Message())
+		})
+	}
+}
+
+func TestWorkflowTestSuite_WorkflowRunOperation(t *testing.T) {
+	handlerWF := func(ctx workflow.Context, outcome string) (string, error) {
+		if outcome == "ok" {
+			return "ok", nil
+		}
+		return "", fmt.Errorf("expected failure")
+	}
+
+	op := temporalnexus.NewWorkflowRunOperation(
+		"op",
+		handlerWF,
+		func(ctx context.Context, id string, opts nexus.StartOperationOptions) (client.StartWorkflowOptions, error) {
+			return client.StartWorkflowOptions{ID: opts.RequestID}, nil
+		})
+
+	callerWF := func(ctx workflow.Context, outcome string) error {
+		client := workflow.NewNexusClient("endpoint", "test")
+		fut := client.ExecuteOperation(ctx, op, outcome, workflow.NexusOperationOptions{})
+		var exec workflow.NexusOperationExecution
+		if err := fut.GetNexusOperationExecution().Get(ctx, &exec); err != nil {
+			return err
+		}
+		if exec.OperationID == "" {
+			return errors.New("got empty operation ID")
+		}
+
+		var result string
+		if err := fut.Get(ctx, &result); err != nil {
+			return err
+		}
+		if result != "ok" {
+			return fmt.Errorf("expected result to be 'ok', got: %s", result)
+		}
+		return nil
+	}
+
+	service := nexus.NewService("test")
+	service.Register(op)
+
+	t.Run("ok", func(t *testing.T) {
+		suite := testsuite.WorkflowTestSuite{}
+		env := suite.NewTestWorkflowEnvironment()
+		env.RegisterWorkflow(handlerWF)
+		env.RegisterNexusService(service)
+
+		env.ExecuteWorkflow(callerWF, "ok")
+		require.True(t, env.IsWorkflowCompleted())
+		require.NoError(t, env.GetWorkflowError())
+	})
+
+	t.Run("fail", func(t *testing.T) {
+		suite := testsuite.WorkflowTestSuite{}
+		env := suite.NewTestWorkflowEnvironment()
+		env.RegisterWorkflow(handlerWF)
+		env.RegisterNexusService(service)
+
+		env.ExecuteWorkflow(callerWF, "fail")
+		require.True(t, env.IsWorkflowCompleted())
+
+		var execErr *temporal.WorkflowExecutionError
+		err := env.GetWorkflowError()
+		require.ErrorAs(t, err, &execErr)
+		var opErr *temporal.NexusOperationError
+		err = execErr.Unwrap()
+		require.ErrorAs(t, err, &opErr)
+		require.Equal(t, "endpoint", opErr.Endpoint)
+		require.Equal(t, "test", opErr.Service)
+		require.Equal(t, op.Name(), opErr.Operation)
+		require.Empty(t, opErr.OperationID)
+		require.Equal(t, "nexus operation completed unsuccessfully", opErr.Message)
+		err = opErr.Unwrap()
+		var appErr *temporal.ApplicationError
+		require.ErrorAs(t, err, &appErr)
+		require.Equal(t, "expected failure", appErr.Message())
+	})
+}
+
+func TestWorkflowTestSuite_WorkflowRunOperation_WithCancel(t *testing.T) {
+	wf := func(ctx workflow.Context, cancelBeforeStarted bool) error {
+		childCtx, cancel := workflow.WithCancel(ctx)
+		defer cancel()
+
+		client := workflow.NewNexusClient("endpoint", "test")
+		fut := client.ExecuteOperation(childCtx, workflowOp, "op-id", workflow.NexusOperationOptions{})
+		if cancelBeforeStarted {
+			cancel()
+		}
+		var exec workflow.NexusOperationExecution
+		if err := fut.GetNexusOperationExecution().Get(ctx, &exec); err != nil {
+			return err
+		}
+		if exec.OperationID != "op-id" {
+			return fmt.Errorf("unexpected operation ID: %q", exec.OperationID)
+		}
+
+		if !cancelBeforeStarted {
+			cancel()
+		}
+		err := fut.Get(ctx, nil)
+		return err
+	}
+
+	service := nexus.NewService("test")
+	service.Register(workflowOp)
+
+	cases := []struct {
+		cancelBeforeStarted bool
+		name                string
+	}{
+		{false, "AfterStarted"},
+		{true, "BeforeStarted"},
+	}
+	for _, tc := range cases {
+		tc := tc // capture just in case.
+		t.Run(tc.name, func(t *testing.T) {
+			suite := testsuite.WorkflowTestSuite{}
+			env := suite.NewTestWorkflowEnvironment()
+			env.RegisterWorkflow(waitForCancelWorkflow)
+			env.RegisterNexusService(service)
+			env.ExecuteWorkflow(wf, tc.cancelBeforeStarted)
+			require.True(t, env.IsWorkflowCompleted())
+			// Error wrapping is different in the test environment than the server (same as for child workflows).
+			var execErr *temporal.WorkflowExecutionError
+			err := env.GetWorkflowError()
+			require.ErrorAs(t, err, &execErr)
+			var opErr *temporal.NexusOperationError
+			err = execErr.Unwrap()
+			require.ErrorAs(t, err, &opErr)
+			require.Equal(t, "endpoint", opErr.Endpoint)
+			require.Equal(t, "test", opErr.Service)
+			require.Equal(t, workflowOp.Name(), opErr.Operation)
+			require.Equal(t, "op-id", opErr.OperationID)
+			require.Equal(t, "nexus operation completed unsuccessfully", opErr.Message)
+			err = opErr.Unwrap()
+			var canceledError *temporal.CanceledError
+			require.ErrorAs(t, err, &canceledError)
+		})
+	}
+}
+
+func TestWorkflowTestSuite_NexusSyncOperation_ClientMethods_Panic(t *testing.T) {
+	var panicReason any
+	op := temporalnexus.NewSyncOperation("signal-op", func(ctx context.Context, c client.Client, _ nexus.NoValue, opts nexus.StartOperationOptions) (nexus.NoValue, error) {
+		func() {
+			defer func() {
+				panicReason = recover()
+			}()
+			c.ExecuteWorkflow(ctx, client.StartWorkflowOptions{}, "test", "", "get-secret")
+		}()
+		return nil, nil
+	})
+	wf := func(ctx workflow.Context) error {
+		client := workflow.NewNexusClient("endpoint", "test")
+		fut := client.ExecuteOperation(ctx, op, nil, workflow.NexusOperationOptions{})
+		return fut.Get(ctx, nil)
+	}
+
+	service := nexus.NewService("test")
+	service.Register(op)
+
+	suite := testsuite.WorkflowTestSuite{}
+	env := suite.NewTestWorkflowEnvironment()
+	env.RegisterWorkflow(waitForCancelWorkflow)
+	env.RegisterNexusService(service)
+	env.ExecuteWorkflow(wf)
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+	require.Equal(t, "not implemented in the test environment", panicReason)
 }

--- a/workflow/nexus_example_test.go
+++ b/workflow/nexus_example_test.go
@@ -1,0 +1,50 @@
+package workflow_test
+
+import (
+	"context"
+	"time"
+
+	"github.com/nexus-rpc/sdk-go/nexus"
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/temporalnexus"
+	"go.temporal.io/sdk/workflow"
+)
+
+type MyInput struct{}
+type MyOutput struct{}
+
+var myOperationRef = nexus.NewOperationReference[MyInput, MyOutput]("my-operation")
+
+var myOperation = temporalnexus.NewSyncOperation("my-operation", func(ctx context.Context, c client.Client, mi MyInput, soo nexus.StartOperationOptions) (MyOutput, error) {
+	return MyOutput{}, nil
+})
+
+func ExampleNexusClient() {
+	myWorkflow := func(ctx workflow.Context) (MyOutput, error) {
+		client := workflow.NewNexusClient("my-endpoint", "my-service")
+		// Execute an operation using an operation name.
+		fut := client.ExecuteOperation(ctx, "my-operation", MyInput{}, workflow.NexusOperationOptions{
+			ScheduleToCloseTimeout: time.Hour,
+		})
+		// Or using an OperationReference.
+		fut = client.ExecuteOperation(ctx, myOperationRef, MyInput{}, workflow.NexusOperationOptions{
+			ScheduleToCloseTimeout: time.Hour,
+		})
+		// Or using a defined operation (which is also an OperationReference).
+		fut = client.ExecuteOperation(ctx, myOperation, MyInput{}, workflow.NexusOperationOptions{
+			ScheduleToCloseTimeout: time.Hour,
+		})
+
+		var exec workflow.NexusOperationExecution
+		// Optionally wait for the operation to be started.
+		_ = fut.GetNexusOperationExecution().Get(ctx, &exec)
+		// OperationID will be empty if the operation completed synchronously.
+		workflow.GetLogger(ctx).Info("operation started", "operationID", exec.OperationID)
+
+		// Get the result of the operation.
+		var output MyOutput
+		return output, fut.Get(ctx, &output)
+	}
+
+	_ = myWorkflow
+}

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -72,10 +72,25 @@ type (
 
 	UpdateHandlerOptions = internal.UpdateHandlerOptions
 
+	// NOTE to maintainers, this interface definition is duplicated in the internal package to provide a better UX.
+
 	// NexusClient is a client for executing Nexus Operations from a workflow.
-	//
-	// NOTE: Experimental
-	NexusClient = internal.NexusClient
+	NexusClient interface {
+		// The endpoint name this client uses.
+		//
+		// NOTE: Experimental
+		Endpoint() string
+		// The service name this client uses.
+		//
+		// NOTE: Experimental
+		Service() string
+
+		// ExecuteOperation executes a Nexus Operation.
+		// The operation argument can be a string, a [nexus.Operation] or a [nexus.OperationReference].
+		//
+		// NOTE: Experimental
+		ExecuteOperation(ctx Context, operation any, input any, options NexusOperationOptions) NexusOperationFuture
+	}
 
 	// NexusOperationOptions are options for starting a Nexus Operation from a Workflow.
 	//

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -71,6 +71,26 @@ type (
 	ContinueAsNewErrorOptions = internal.ContinueAsNewErrorOptions
 
 	UpdateHandlerOptions = internal.UpdateHandlerOptions
+
+	// NexusClient is a client for executing Nexus Operations from a workflow.
+	//
+	// NOTE: Experimental
+	NexusClient = internal.NexusClient
+
+	// NexusOperationOptions are options for starting a Nexus Operation from a Workflow.
+	//
+	// NOTE: Experimental
+	NexusOperationOptions = internal.NexusOperationOptions
+
+	// NexusOperationFuture represents the result of a Nexus Operation.
+	//
+	// NOTE: Experimental
+	NexusOperationFuture = internal.NexusOperationFuture
+
+	// NexusOperationExecution is the result of [NexusOperationFuture.GetNexusOperationExecution].
+	//
+	// NOTE: Experimental
+	NexusOperationExecution = internal.NexusOperationExecution
 )
 
 // ExecuteActivity requests activity execution in the context of a workflow.
@@ -687,4 +707,9 @@ func DeterministicKeys[K constraints.Ordered, V any](m map[K]V) []K {
 // To be used in for loops in workflows for deterministic iteration.
 func DeterministicKeysFunc[K comparable, V any](m map[K]V, cmp func(K, K) int) []K {
 	return internal.DeterministicKeysFunc(m, cmp)
+}
+
+// Create a [NexusClient] from an endpoint name and a service name.
+func NewNexusClient(endpoint, service string) NexusClient {
+	return internal.NewNexusClient(endpoint, service)
 }


### PR DESCRIPTION
## What was changed

Added the ability to execute nexus operations from a workflow.
This PR is stacked on top of https://github.com/temporalio/sdk-go/pull/1466.

## Checklist

- [x] [Implement test framework logic](https://github.com/temporalio/sdk-go/pull/1475)