### PR TITLE
Add test environment support for Nexus Operations

### DIFF
--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -2323,7 +2323,7 @@ func (env *testWorkflowEnvironmentImpl) newTestNexusTaskHandler() *nexusTaskHand
 		env.identity,
 		env.workflowInfo.Namespace,
 		env.workflowInfo.TaskQueueName,
-		&testSuiteClientForNexusOperations{env},
+		&testSuiteClientForNexusOperations{env: env},
 		env.dataConverter,
 		env.logger,
 		env.metricsHandler,

--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -29,12 +29,15 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/facebookgo/clock"
 	"github.com/golang/mock/gomock"
+	"github.com/google/uuid"
+	"github.com/nexus-rpc/sdk-go/nexus"
 	"github.com/robfig/cron"
 	"github.com/stretchr/testify/mock"
 	"google.golang.org/grpc"
@@ -44,6 +47,8 @@ import (
 	commandpb "go.temporal.io/api/command/v1"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
+	failurepb "go.temporal.io/api/failure/v1"
+	nexuspb "go.temporal.io/api/nexus/v1"
 	"go.temporal.io/api/serviceerror"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	"go.temporal.io/api/workflowservice/v1"
@@ -95,6 +100,18 @@ type (
 		handled  bool
 		params   *ExecuteWorkflowParams
 		err      error
+	}
+
+	testNexusOperationHandle struct {
+		env             *testWorkflowEnvironmentImpl
+		seq             int64
+		params          executeNexusOperationParams
+		operationID     string
+		cancelRequested bool
+		started         bool
+		done            bool
+		onCompleted     func(*commonpb.Payload, error)
+		onStarted       func(opID string, e error)
 	}
 
 	testCallbackHandle struct {
@@ -149,11 +166,12 @@ type (
 		testTimeout     time.Duration
 		header          *commonpb.Header
 
-		counterID        int64
-		activities       map[string]*testActivityHandle
-		localActivities  map[string]*localActivityTask
-		timers           map[string]*testTimerHandle
-		runningWorkflows map[string]*testWorkflowHandle
+		counterID              int64
+		activities             map[string]*testActivityHandle
+		localActivities        map[string]*localActivityTask
+		timers                 map[string]*testTimerHandle
+		runningWorkflows       map[string]*testWorkflowHandle
+		runningNexusOperations map[int64]*testNexusOperationHandle
 
 		runningCount int
 
@@ -240,6 +258,7 @@ func newTestWorkflowEnvironmentImpl(s *WorkflowTestSuite, parentRegistry *regist
 			activities:                make(map[string]*testActivityHandle),
 			localActivities:           make(map[string]*localActivityTask),
 			runningWorkflows:          make(map[string]*testWorkflowHandle),
+			runningNexusOperations:    make(map[int64]*testNexusOperationHandle),
 			callbackChannel:           make(chan testCallbackHandle, 1000),
 			testTimeout:               3 * time.Second,
 			expectedWorkflowMockCalls: make(map[string]struct{}),
@@ -2121,6 +2140,10 @@ func (env *testWorkflowEnvironmentImpl) RegisterActivityWithOptions(a interface{
 	env.registry.RegisterActivityWithOptions(a, options)
 }
 
+func (env *testWorkflowEnvironmentImpl) RegisterNexusService(s *nexus.Service) {
+	env.registry.RegisterNexusService(s)
+}
+
 func (env *testWorkflowEnvironmentImpl) RegisterCancelHandler(handler func()) {
 	env.workflowCancelHandler = handler
 }
@@ -2279,12 +2302,133 @@ func (env *testWorkflowEnvironmentImpl) executeChildWorkflowWithDelay(delayStart
 	go childEnv.executeWorkflowInternal(delayStart, params.WorkflowType.Name, params.Input)
 }
 
-func (wc *testWorkflowEnvironmentImpl) ExecuteNexusOperation(params executeNexusOperationParams, callback func(*commonpb.Payload, error), startedHandler func(opID string, e error)) int64 {
-	panic("TODO")
+func (env *testWorkflowEnvironmentImpl) newTestNexusTaskHandler() *nexusTaskHandler {
+	if len(env.registry.nexusServices) == 0 {
+		panic(fmt.Errorf("no nexus services registered"))
+	}
+
+	reg := nexus.NewServiceRegistry()
+	for _, service := range env.registry.nexusServices {
+		if err := reg.Register(service); err != nil {
+			panic(fmt.Errorf("failed to register nexus service '%v': %w", service, err))
+		}
+	}
+	handler, err := reg.NewHandler()
+	if err != nil {
+		panic(fmt.Errorf("failed to create nexus handler: %w", err))
+	}
+
+	return newNexusTaskHandler(
+		handler,
+		env.identity,
+		env.workflowInfo.Namespace,
+		env.workflowInfo.TaskQueueName,
+		&testSuiteClientForNexusOperations{env},
+		env.dataConverter,
+		env.logger,
+		env.metricsHandler,
+	)
 }
 
-func (wc *testWorkflowEnvironmentImpl) RequestCancelNexusOperation(seq int64) {
-	panic("TODO")
+func (env *testWorkflowEnvironmentImpl) ExecuteNexusOperation(params executeNexusOperationParams, callback func(*commonpb.Payload, error), startedHandler func(opID string, e error)) int64 {
+	seq := env.nextID()
+	taskHandler := env.newTestNexusTaskHandler()
+	handle := &testNexusOperationHandle{
+		env:         env,
+		seq:         seq,
+		params:      params,
+		onCompleted: callback,
+		onStarted:   startedHandler,
+	}
+	env.runningNexusOperations[seq] = handle
+
+	task := handle.newStartTask()
+	env.runningCount++
+	go func() {
+		response, failure, err := taskHandler.Execute(task)
+		if err != nil {
+			// No retries for operations, fail the operation immediately.
+			failure = taskHandler.fillInFailure(task.TaskToken, nexusHandlerError(nexus.HandlerErrorTypeInternal, err.Error()))
+		}
+		if failure != nil {
+			err := env.failureConverter.FailureToError(nexusOperationFailure(params, "", &failurepb.Failure{
+				Message: failure.GetError().GetFailure().GetMessage(),
+				FailureInfo: &failurepb.Failure_ApplicationFailureInfo{
+					ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{
+						NonRetryable: true,
+					},
+				},
+			}))
+			env.postCallback(func() {
+				handle.startedCallback("", err)
+				handle.completedCallback(nil, err)
+			}, true)
+			return
+		} else {
+			switch v := response.GetResponse().GetStartOperation().GetVariant().(type) {
+			case *nexuspb.StartOperationResponse_SyncSuccess:
+				env.postCallback(func() {
+					handle.startedCallback("", nil)
+					handle.completedCallback(v.SyncSuccess.GetPayload(), nil)
+				}, true)
+			case *nexuspb.StartOperationResponse_AsyncSuccess:
+				env.postCallback(func() {
+					handle.startedCallback(v.AsyncSuccess.GetOperationId(), nil)
+					if handle.cancelRequested {
+						handle.cancel()
+					}
+				}, true)
+			case *nexuspb.StartOperationResponse_OperationError:
+				err := env.failureConverter.FailureToError(
+					nexusOperationFailure(params, "", unsuccessfulOperationErrorToTemporalFailure(v.OperationError)),
+				)
+				env.postCallback(func() {
+					handle.startedCallback("", err)
+					handle.completedCallback(nil, err)
+				}, true)
+			default:
+				panic(fmt.Errorf("unknown response variant: %v", v))
+			}
+		}
+	}()
+	return seq
+}
+
+func (env *testWorkflowEnvironmentImpl) RequestCancelNexusOperation(seq int64) {
+	handle, ok := env.runningNexusOperations[seq]
+	if !ok {
+		panic(fmt.Errorf("no running operation found for sequence: %d", seq))
+	}
+
+	// Avoid duplicate cancelation.
+	if handle.cancelRequested {
+		return
+	}
+
+	// Mark this cancelation request in case the operation hasn't started yet.
+	// Cancel will be called after start.
+	handle.cancelRequested = true
+
+	// Only cancel after started, we need an operation ID.
+	if handle.started {
+		handle.cancel()
+	}
+}
+
+func (env *testWorkflowEnvironmentImpl) resolveNexusOperation(seq int64, result *commonpb.Payload, err error) {
+	env.postCallback(func() {
+		handle, ok := env.runningNexusOperations[seq]
+		if !ok {
+			panic(fmt.Errorf("no running operation found for sequence: %d", seq))
+		}
+		if err != nil {
+			failure := env.failureConverter.ErrorToFailure(err)
+			err = env.failureConverter.FailureToError(nexusOperationFailure(handle.params, handle.operationID, failure.GetCause()))
+			handle.completedCallback(nil, err)
+		} else {
+			handle.completedCallback(result, nil)
+		}
+	}, true)
 }
 
 func (env *testWorkflowEnvironmentImpl) SideEffect(f func() (*commonpb.Payloads, error), callback ResultHandler) {
@@ -2665,3 +2809,92 @@ func mockFnGetVersion(string, Version, Version) Version {
 
 // make sure interface is implemented
 var _ WorkflowEnvironment = (*testWorkflowEnvironmentImpl)(nil)
+
+func (h *testNexusOperationHandle) newStartTask() *workflowservice.PollNexusTaskQueueResponse {
+	return &workflowservice.PollNexusTaskQueueResponse{
+		TaskToken: []byte{},
+		Request: &nexuspb.Request{
+			ScheduledTime: timestamppb.Now(),
+			Header:        h.params.nexusHeader,
+			Variant: &nexuspb.Request_StartOperation{
+				StartOperation: &nexuspb.StartOperationRequest{
+					Service:   h.params.client.Service(),
+					Operation: h.params.operation,
+					RequestId: uuid.NewString(),
+					// This is effectively ignored.
+					Callback: "http://test-env/operations",
+					CallbackHeader: map[string]string{
+						// The test client uses this to call resolveNexusOperation.
+						"operation-sequence": strconv.FormatInt(h.seq, 10),
+					},
+					Payload: h.params.input,
+				},
+			},
+		},
+	}
+}
+
+func (h *testNexusOperationHandle) newCancelTask() *workflowservice.PollNexusTaskQueueResponse {
+	return &workflowservice.PollNexusTaskQueueResponse{
+		TaskToken: []byte{},
+		Request: &nexuspb.Request{
+			ScheduledTime: timestamppb.Now(),
+			Header:        h.params.nexusHeader,
+			Variant: &nexuspb.Request_CancelOperation{
+				CancelOperation: &nexuspb.CancelOperationRequest{
+					Service:     h.params.client.Service(),
+					Operation:   h.params.operation,
+					OperationId: h.operationID,
+				},
+			},
+		},
+	}
+}
+
+// completedCallback is a callback registered to handle operation completion.
+// Must be called in a postCallback block.
+func (h *testNexusOperationHandle) completedCallback(result *commonpb.Payload, err error) {
+	if h.done {
+		// Ignore duplicate completions.
+		return
+	}
+	h.done = true
+	delete(h.env.runningNexusOperations, h.seq)
+	h.onCompleted(result, err)
+}
+
+// startedCallback is a callback registered to handle operation start.
+// Must be called in a postCallback block.
+func (h *testNexusOperationHandle) startedCallback(opID string, e error) {
+	h.operationID = opID
+	h.started = true
+	h.onStarted(opID, e)
+	h.env.runningCount--
+}
+
+func (h *testNexusOperationHandle) cancel() {
+	if h.done {
+		return
+	}
+	if h.started && h.operationID == "" {
+		panic(fmt.Errorf("incomplete operation has no operation ID: (%s, %s, %s)",
+			h.params.client.Endpoint(), h.params.client.Service(), h.params.operation))
+	}
+	h.env.runningCount++
+	task := h.newCancelTask()
+	taskHandler := h.env.newTestNexusTaskHandler()
+
+	go func() {
+		_, failure, err := taskHandler.Execute(task)
+		h.env.postCallback(func() {
+			if err != nil {
+				// No retries in the test env, fail the operation immediately.
+				h.completedCallback(nil, fmt.Errorf("operation cancelation handler failed: %w", err))
+			} else if failure != nil {
+				// No retries in the test env, fail the operation immediately.
+				h.completedCallback(nil, fmt.Errorf("operation cancelation handler failed: %v", failure.GetError().GetFailure().GetMessage()))
+			}
+			h.env.runningCount--
+		}, false)
+	}()
+}

--- a/internal/nexus_operations.go
+++ b/internal/nexus_operations.go
@@ -2,7 +2,18 @@ package internal
 
 import (
 	"context"
+	"fmt"
+	"strconv"
 
+	"github.com/nexus-rpc/sdk-go/nexus"
+	commonpb "go.temporal.io/api/common/v1"
+	"go.temporal.io/api/enums/v1"
+	failurepb "go.temporal.io/api/failure/v1"
+	nexuspb "go.temporal.io/api/nexus/v1"
+	"go.temporal.io/api/operatorservice/v1"
+	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/sdk/converter"
 	"go.temporal.io/sdk/log"
 )
 
@@ -21,3 +32,343 @@ func NexusOperationContextFromGoContext(ctx context.Context) (nctx *NexusOperati
 	nctx, ok = ctx.Value(nexusOperationContextKey).(*NexusOperationContext)
 	return
 }
+
+// nexusOperationFailure is a utility in use by the test environment.
+func nexusOperationFailure(params executeNexusOperationParams, operationID string, cause *failurepb.Failure) *failurepb.Failure {
+	return &failurepb.Failure{
+		Message: "nexus operation completed unsuccessfully",
+		FailureInfo: &failurepb.Failure_NexusOperationExecutionFailureInfo{
+			NexusOperationExecutionFailureInfo: &failurepb.NexusOperationFailureInfo{
+				Endpoint:    params.client.Endpoint(),
+				Service:     params.client.Service(),
+				Operation:   params.operation,
+				OperationId: operationID,
+			},
+		},
+		Cause: cause,
+	}
+}
+
+// unsuccessfulOperationErrorToTemporalFailure is a utility in use by the test environment.
+// copied from the server codebase with a slight adaptation: https://github.com/temporalio/temporal/blob/7635cd7dbdc7dd3219f387e8fc66fa117f585ff6/common/nexus/failure.go#L69-L108
+func unsuccessfulOperationErrorToTemporalFailure(err *nexuspb.UnsuccessfulOperationError) *failurepb.Failure {
+	failure := &failurepb.Failure{
+		Message: err.Failure.Message,
+	}
+	if err.OperationState == string(nexus.OperationStateCanceled) {
+		failure.FailureInfo = &failurepb.Failure_CanceledFailureInfo{
+			CanceledFailureInfo: &failurepb.CanceledFailureInfo{
+				Details: nexusFailureMetadataToPayloads(err.Failure),
+			},
+		}
+	} else {
+		failure.FailureInfo = &failurepb.Failure_ApplicationFailureInfo{
+			ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{
+				// Make up a type here, it's not part of the Nexus Failure spec.
+				Type:         "NexusOperationFailure",
+				Details:      nexusFailureMetadataToPayloads(err.Failure),
+				NonRetryable: true,
+			},
+		}
+	}
+	return failure
+}
+
+// nexusFailureMetadataToPayloads is a utility in use by the test environment.
+// copied from the server codebase with a slight adaptation: https://github.com/temporalio/temporal/blob/7635cd7dbdc7dd3219f387e8fc66fa117f585ff6/common/nexus/failure.go#L69-L108
+func nexusFailureMetadataToPayloads(failure *nexuspb.Failure) *commonpb.Payloads {
+	if len(failure.Metadata) == 0 && len(failure.Details) == 0 {
+		return nil
+	}
+	metadata := make(map[string][]byte, len(failure.Metadata))
+	for k, v := range failure.Metadata {
+		metadata[k] = []byte(v)
+	}
+	return &commonpb.Payloads{
+		Payloads: []*commonpb.Payload{
+			{
+				Metadata: metadata,
+				Data:     failure.Details,
+			},
+		},
+	}
+}
+
+// testSuiteClientForNexusOperations is a partial [Client] implementation for the test workflow environment used to
+// support basic Nexus functionality.
+// Most of its methods are unimplemented, and best effort was made to return errors where possible instead of panicking.
+// More methods can be implemented on demand.
+type testSuiteClientForNexusOperations struct {
+	env *testWorkflowEnvironmentImpl
+}
+
+// CancelWorkflow implements Client.
+func (t *testSuiteClientForNexusOperations) CancelWorkflow(ctx context.Context, workflowID string, runID string) error {
+	doneCh := make(chan error)
+	t.env.cancelWorkflowByID(workflowID, runID, func(result *commonpb.Payloads, err error) {
+		doneCh <- err
+	})
+	return <-doneCh
+}
+
+// CheckHealth implements Client.
+func (t *testSuiteClientForNexusOperations) CheckHealth(ctx context.Context, request *CheckHealthRequest) (*CheckHealthResponse, error) {
+	return &CheckHealthResponse{}, nil
+}
+
+// Close implements Client.
+func (t *testSuiteClientForNexusOperations) Close() {
+	// No op.
+}
+
+// CompleteActivity implements Client.
+func (t *testSuiteClientForNexusOperations) CompleteActivity(ctx context.Context, taskToken []byte, result interface{}, err error) error {
+	return serviceerror.NewUnimplemented("not implemented in the test environment")
+}
+
+// CompleteActivityByID implements Client.
+func (t *testSuiteClientForNexusOperations) CompleteActivityByID(ctx context.Context, namespace string, workflowID string, runID string, activityID string, result interface{}, err error) error {
+	return serviceerror.NewUnimplemented("not implemented in the test environment")
+}
+
+// CountWorkflow implements Client.
+func (t *testSuiteClientForNexusOperations) CountWorkflow(ctx context.Context, request *workflowservice.CountWorkflowExecutionsRequest) (*workflowservice.CountWorkflowExecutionsResponse, error) {
+	return nil, serviceerror.NewUnimplemented("not implemented in the test environment")
+}
+
+// DescribeTaskQueue implements Client.
+func (t *testSuiteClientForNexusOperations) DescribeTaskQueue(ctx context.Context, taskqueue string, taskqueueType enums.TaskQueueType) (*workflowservice.DescribeTaskQueueResponse, error) {
+	return nil, serviceerror.NewUnimplemented("not implemented in the test environment")
+}
+
+// DescribeWorkflowExecution implements Client.
+func (t *testSuiteClientForNexusOperations) DescribeWorkflowExecution(ctx context.Context, workflowID string, runID string) (*workflowservice.DescribeWorkflowExecutionResponse, error) {
+	return nil, serviceerror.NewUnimplemented("not implemented in the test environment")
+}
+
+// ExecuteWorkflow implements Client.
+func (t *testSuiteClientForNexusOperations) ExecuteWorkflow(ctx context.Context, options StartWorkflowOptions, workflow interface{}, args ...interface{}) (WorkflowRun, error) {
+	wfType, input, err := getValidatedWorkflowFunction(workflow, args, t.env.dataConverter, t.env.GetRegistry())
+	if err != nil {
+		return nil, fmt.Errorf("cannot validate workflow function: %w", err)
+	}
+
+	run := &testEnvWorkflowRunForNexusOperations{}
+	doneCh := make(chan error)
+
+	var callback *commonpb.Callback
+
+	if len(options.callbacks) > 0 {
+		callback = options.callbacks[0]
+	}
+
+	t.env.executeChildWorkflowWithDelay(options.StartDelay, ExecuteWorkflowParams{
+		// Not propagating Header as this client does not support context propagation.
+		WorkflowType: wfType,
+		Input:        input,
+		WorkflowOptions: WorkflowOptions{
+			WaitForCancellation:      true,
+			Namespace:                t.env.workflowInfo.Namespace,
+			TaskQueueName:            t.env.workflowInfo.TaskQueueName,
+			WorkflowID:               options.ID,
+			WorkflowExecutionTimeout: options.WorkflowExecutionTimeout,
+			WorkflowRunTimeout:       options.WorkflowRunTimeout,
+			WorkflowTaskTimeout:      options.WorkflowTaskTimeout,
+			DataConverter:            t.env.dataConverter,
+			WorkflowIDReusePolicy:    options.WorkflowIDReusePolicy,
+			ContextPropagators:       t.env.contextPropagators,
+			SearchAttributes:         options.SearchAttributes,
+			TypedSearchAttributes:    options.TypedSearchAttributes,
+			ParentClosePolicy:        enums.PARENT_CLOSE_POLICY_ABANDON,
+			Memo:                     options.Memo,
+			CronSchedule:             options.CronSchedule,
+			RetryPolicy:              convertToPBRetryPolicy(options.RetryPolicy),
+		},
+	}, func(result *commonpb.Payloads, wfErr error) {
+		ncb := callback.GetNexus()
+		if ncb == nil {
+			return
+		}
+		seqStr := ncb.GetHeader()["operation-sequence"]
+		if seqStr == "" {
+			return
+		}
+		seq, err := strconv.ParseInt(seqStr, 10, 64)
+		if err != nil {
+			panic(fmt.Errorf("unexpected operation sequence in callback header: %s: %w", seqStr, err))
+		}
+
+		if wfErr != nil {
+			t.env.resolveNexusOperation(seq, nil, wfErr)
+		} else {
+			var payload *commonpb.Payload
+			if len(result.GetPayloads()) > 0 {
+				payload = result.Payloads[0]
+			}
+			t.env.resolveNexusOperation(seq, payload, nil)
+		}
+	}, func(r WorkflowExecution, err error) {
+		run.WorkflowExecution = r
+		doneCh <- err
+	})
+	err = <-doneCh
+	if err != nil {
+		return nil, err
+	}
+	return run, nil
+}
+
+// GetSearchAttributes implements Client.
+func (t *testSuiteClientForNexusOperations) GetSearchAttributes(ctx context.Context) (*workflowservice.GetSearchAttributesResponse, error) {
+	return nil, serviceerror.NewUnimplemented("not implemented in the test environment")
+}
+
+// GetWorkerBuildIdCompatibility implements Client.
+func (t *testSuiteClientForNexusOperations) GetWorkerBuildIdCompatibility(ctx context.Context, options *GetWorkerBuildIdCompatibilityOptions) (*WorkerBuildIDVersionSets, error) {
+	return nil, serviceerror.NewUnimplemented("not implemented in the test environment")
+}
+
+// GetWorkerTaskReachability implements Client.
+func (t *testSuiteClientForNexusOperations) GetWorkerTaskReachability(ctx context.Context, options *GetWorkerTaskReachabilityOptions) (*WorkerTaskReachability, error) {
+	return nil, serviceerror.NewUnimplemented("not implemented in the test environment")
+}
+
+// GetWorkflow implements Client.
+func (t *testSuiteClientForNexusOperations) GetWorkflow(ctx context.Context, workflowID string, runID string) WorkflowRun {
+	panic("not implemented in the test environment")
+}
+
+// GetWorkflowHistory implements Client.
+func (t *testSuiteClientForNexusOperations) GetWorkflowHistory(ctx context.Context, workflowID string, runID string, isLongPoll bool, filterType enums.HistoryEventFilterType) HistoryEventIterator {
+	panic("not implemented in the test environment")
+}
+
+// GetWorkflowUpdateHandle implements Client.
+func (t *testSuiteClientForNexusOperations) GetWorkflowUpdateHandle(GetWorkflowUpdateHandleOptions) WorkflowUpdateHandle {
+	panic("not implemented in the test environment")
+}
+
+// ListArchivedWorkflow implements Client.
+func (t *testSuiteClientForNexusOperations) ListArchivedWorkflow(ctx context.Context, request *workflowservice.ListArchivedWorkflowExecutionsRequest) (*workflowservice.ListArchivedWorkflowExecutionsResponse, error) {
+	return nil, serviceerror.NewUnimplemented("not implemented in the test environment")
+}
+
+// ListClosedWorkflow implements Client.
+func (t *testSuiteClientForNexusOperations) ListClosedWorkflow(ctx context.Context, request *workflowservice.ListClosedWorkflowExecutionsRequest) (*workflowservice.ListClosedWorkflowExecutionsResponse, error) {
+	return nil, serviceerror.NewUnimplemented("not implemented in the test environment")
+}
+
+// ListOpenWorkflow implements Client.
+func (t *testSuiteClientForNexusOperations) ListOpenWorkflow(ctx context.Context, request *workflowservice.ListOpenWorkflowExecutionsRequest) (*workflowservice.ListOpenWorkflowExecutionsResponse, error) {
+	return nil, serviceerror.NewUnimplemented("not implemented in the test environment")
+}
+
+// ListWorkflow implements Client.
+func (t *testSuiteClientForNexusOperations) ListWorkflow(ctx context.Context, request *workflowservice.ListWorkflowExecutionsRequest) (*workflowservice.ListWorkflowExecutionsResponse, error) {
+	return nil, serviceerror.NewUnimplemented("not implemented in the test environment")
+}
+
+// OperatorService implements Client.
+func (t *testSuiteClientForNexusOperations) OperatorService() operatorservice.OperatorServiceClient {
+	panic("not implemented in the test environment")
+}
+
+// QueryWorkflow implements Client.
+func (t *testSuiteClientForNexusOperations) QueryWorkflow(ctx context.Context, workflowID string, runID string, queryType string, args ...interface{}) (converter.EncodedValue, error) {
+	return t.env.queryWorkflowByID(workflowID, queryType, args)
+}
+
+// QueryWorkflowWithOptions implements Client.
+func (t *testSuiteClientForNexusOperations) QueryWorkflowWithOptions(ctx context.Context, request *QueryWorkflowWithOptionsRequest) (*QueryWorkflowWithOptionsResponse, error) {
+	return nil, serviceerror.NewUnimplemented("not implemented in the test environment")
+}
+
+// RecordActivityHeartbeat implements Client.
+func (t *testSuiteClientForNexusOperations) RecordActivityHeartbeat(ctx context.Context, taskToken []byte, details ...interface{}) error {
+	return serviceerror.NewUnimplemented("not implemented in the test environment")
+}
+
+// RecordActivityHeartbeatByID implements Client.
+func (t *testSuiteClientForNexusOperations) RecordActivityHeartbeatByID(ctx context.Context, namespace string, workflowID string, runID string, activityID string, details ...interface{}) error {
+	return serviceerror.NewUnimplemented("not implemented in the test environment")
+}
+
+// ResetWorkflowExecution implements Client.
+func (t *testSuiteClientForNexusOperations) ResetWorkflowExecution(ctx context.Context, request *workflowservice.ResetWorkflowExecutionRequest) (*workflowservice.ResetWorkflowExecutionResponse, error) {
+	return nil, serviceerror.NewUnimplemented("not implemented in the test environment")
+}
+
+// ScanWorkflow implements Client.
+func (t *testSuiteClientForNexusOperations) ScanWorkflow(ctx context.Context, request *workflowservice.ScanWorkflowExecutionsRequest) (*workflowservice.ScanWorkflowExecutionsResponse, error) {
+	return nil, serviceerror.NewUnimplemented("not implemented in the test environment")
+}
+
+// ScheduleClient implements Client.
+func (t *testSuiteClientForNexusOperations) ScheduleClient() ScheduleClient {
+	panic("not implemented in the test environment")
+}
+
+// SignalWithStartWorkflow implements Client.
+func (t *testSuiteClientForNexusOperations) SignalWithStartWorkflow(ctx context.Context, workflowID string, signalName string, signalArg interface{}, options StartWorkflowOptions, workflow interface{}, workflowArgs ...interface{}) (WorkflowRun, error) {
+	return nil, serviceerror.NewUnimplemented("not implemented in the test environment")
+}
+
+// SignalWorkflow implements Client.
+func (t *testSuiteClientForNexusOperations) SignalWorkflow(ctx context.Context, workflowID string, runID string, signalName string, arg interface{}) error {
+	return t.env.signalWorkflowByID(workflowID, signalName, arg)
+}
+
+// TerminateWorkflow implements Client.
+func (t *testSuiteClientForNexusOperations) TerminateWorkflow(ctx context.Context, workflowID string, runID string, reason string, details ...interface{}) error {
+	return serviceerror.NewUnimplemented("not implemented in the test environment")
+}
+
+// UpdateWorkerBuildIdCompatibility implements Client.
+func (t *testSuiteClientForNexusOperations) UpdateWorkerBuildIdCompatibility(ctx context.Context, options *UpdateWorkerBuildIdCompatibilityOptions) error {
+	return serviceerror.NewUnimplemented("not implemented in the test environment")
+}
+
+// UpdateWorkflow implements Client.
+func (t *testSuiteClientForNexusOperations) UpdateWorkflow(ctx context.Context, workflowID string, workflowRunID string, updateName string, args ...interface{}) (WorkflowUpdateHandle, error) {
+	return nil, serviceerror.NewUnimplemented("not implemented in the test environment")
+}
+
+// UpdateWorkflowWithOptions implements Client.
+func (t *testSuiteClientForNexusOperations) UpdateWorkflowWithOptions(ctx context.Context, request *UpdateWorkflowWithOptionsRequest) (WorkflowUpdateHandle, error) {
+	return nil, serviceerror.NewUnimplemented("not implemented in the test environment")
+}
+
+// WorkflowService implements Client.
+func (t *testSuiteClientForNexusOperations) WorkflowService() workflowservice.WorkflowServiceClient {
+	panic("not implemented in the test environment")
+}
+
+var _ Client = &testSuiteClientForNexusOperations{}
+
+// testEnvWorkflowRunForNexusOperations is a partial [WorkflowRun] implementation for the test workflow environment used
+// to support basic Nexus functionality.
+type testEnvWorkflowRunForNexusOperations struct {
+	WorkflowExecution
+}
+
+// Get implements WorkflowRun.
+func (t *testEnvWorkflowRunForNexusOperations) Get(ctx context.Context, valuePtr interface{}) error {
+	panic("not implemented in the test environment")
+}
+
+// GetID implements WorkflowRun.
+func (t *testEnvWorkflowRunForNexusOperations) GetID() string {
+	return t.ID
+}
+
+// GetRunID implements WorkflowRun.
+func (t *testEnvWorkflowRunForNexusOperations) GetRunID() string {
+	return t.RunID
+}
+
+// GetWithOptions implements WorkflowRun.
+func (t *testEnvWorkflowRunForNexusOperations) GetWithOptions(ctx context.Context, valuePtr interface{}, options WorkflowRunGetOptions) error {
+	panic("not implemented in the test environment")
+}
+
+var _ WorkflowRun = &testEnvWorkflowRunForNexusOperations{}

--- a/internal/workflow_testsuite.go
+++ b/internal/workflow_testsuite.go
@@ -32,6 +32,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nexus-rpc/sdk-go/nexus"
 	"github.com/stretchr/testify/mock"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
@@ -288,6 +289,11 @@ func (e *TestWorkflowEnvironment) RegisterActivityWithOptions(a interface{}, opt
 		panic("RegisterActivity calls cannot follow mock related ones like OnActivity or similar")
 	}
 	e.impl.RegisterActivityWithOptions(a, options)
+}
+
+// RegisterWorkflow registers a Nexus Service with the TestWorkflowEnvironment.
+func (e *TestWorkflowEnvironment) RegisterNexusService(s *nexus.Service) {
+	e.impl.RegisterNexusService(s)
 }
 
 // SetStartTime sets the start time of the workflow. This is optional, default start time will be the wall clock time when

--- a/temporalnexus/operation.go
+++ b/temporalnexus/operation.go
@@ -145,6 +145,9 @@ func MustNewWorkflowRunOperationWithOptions[I, O any](options WorkflowRunOperati
 }
 
 func (*workflowRunOperation[I, O]) Cancel(ctx context.Context, id string, options nexus.CancelOperationOptions) error {
+	// Prevent the test env client from panicking when we try to use it from a workflow run operation.
+	ctx = context.WithValue(ctx, internal.IsWorkflowRunOpContextKey, true)
+
 	nctx, ok := internal.NexusOperationContextFromGoContext(ctx)
 	if !ok {
 		return nexus.HandlerErrorf(nexus.HandlerErrorTypeInternal, "internal error")
@@ -157,6 +160,9 @@ func (o *workflowRunOperation[I, O]) Name() string {
 }
 
 func (o *workflowRunOperation[I, O]) Start(ctx context.Context, input I, options nexus.StartOperationOptions) (nexus.HandlerStartOperationResult[O], error) {
+	// Prevent the test env client from panicking when we try to use it from a workflow run operation.
+	ctx = context.WithValue(ctx, internal.IsWorkflowRunOpContextKey, true)
+
 	if o.options.Handler != nil {
 		handle, err := o.options.Handler(ctx, input, options)
 		if err != nil {


### PR DESCRIPTION
Test environment now supports Nexus Operations.
I've added a partial `Client` implementation for the test env to support what I predict will be the most frequently used methods.
Specifically `WorkflowRunOperation` and `SyncOperation` can use the client to signal and query workflows.

Users can register arbitrary Nexus Operation handlers if they want to mock the operation completely.

This PR is stacked on top of the other two Nexus PRs and completes the basic functionality.