### PR TITLE
get-free-port: prevent duplicate ports on Linux

### DIFF
--- a/testsuite/freeport.go
+++ b/testsuite/freeport.go
@@ -1,3 +1,25 @@
+// The MIT License
+//
+// Copyright (c) 2022 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package testsuite
 
 import (

--- a/testsuite/freeport.go
+++ b/testsuite/freeport.go
@@ -7,7 +7,7 @@ import (
 )
 
 // Copied and adapted from
-// https://github.com/mjameswh/temporalio-cli/blob/6b5a708e51da89dbdfd4fda7b7219ae12bcd8ffb/temporalcli/devserver/freeport.go
+// https://github.com/temporalio/cli/blob/350cb2f9dca55e5063b39ffbdaa2739fdeab4399/temporalcli/devserver/freeport.go
 
 // Returns a TCP port that is available to listen on, for the given (local) host.
 //

--- a/testsuite/freeport.go
+++ b/testsuite/freeport.go
@@ -28,7 +28,7 @@ func getFreePort(host string) (string, int, error) {
 	if err != nil {
 		return "", 0, fmt.Errorf("failed to assign a free port: %v", err)
 	}
-	defer l.Close()
+	defer func() { _ = l.Close() }()
 	port := l.Addr().(*net.TCPAddr).Port
 
 	// On Linux and some BSD variants, ephemeral ports are randomized, and may
@@ -56,8 +56,8 @@ func getFreePort(host string) (string, int, error) {
 			return "", 0, fmt.Errorf("failed to assign a free port: %v", err)
 		}
 		// Closing the socket from the server side
-		c.Close()
-		defer r.Close()
+		_ = c.Close()
+		defer func() { _ = r.Close() }()
 	}
 
 	return host, port, nil

--- a/testsuite/freeport.go
+++ b/testsuite/freeport.go
@@ -48,7 +48,7 @@ import (
 func getFreePort(host string) (string, int, error) {
 	l, err := net.Listen("tcp", host+":0")
 	if err != nil {
-		return "", 0, fmt.Errorf("failed to assign a free port: %v", err)
+		return "", 0, fmt.Errorf("failed to assign a free port: %w", err)
 	}
 	defer func() { _ = l.Close() }()
 	port := l.Addr().(*net.TCPAddr).Port
@@ -71,11 +71,11 @@ func getFreePort(host string) (string, int, error) {
 	if runtime.GOOS != "darwin" && runtime.GOOS != "windows" {
 		r, err := net.DialTCP("tcp", nil, l.Addr().(*net.TCPAddr))
 		if err != nil {
-			return "", 0, fmt.Errorf("failed to assign a free port: %v", err)
+			return "", 0, fmt.Errorf("failed to assign a free port: %w", err)
 		}
 		c, err := l.Accept()
 		if err != nil {
-			return "", 0, fmt.Errorf("failed to assign a free port: %v", err)
+			return "", 0, fmt.Errorf("failed to assign a free port: %w", err)
 		}
 		// Closing the socket from the server side
 		_ = c.Close()

--- a/testsuite/freeport.go
+++ b/testsuite/freeport.go
@@ -1,81 +1,75 @@
-// The MIT License
-//
-// Copyright (c) 2022 Temporal Technologies Inc.  All rights reserved.
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
-
 package testsuite
 
 import (
 	"fmt"
 	"net"
+	"runtime"
 )
 
-// Modified from Temporalite which itself modified from
-// https://github.com/phayes/freeport/blob/95f893ade6f232a5f1511d61735d89b1ae2df543/freeport.go
+// Copied and adapted from
+// https://github.com/mjameswh/temporalio-cli/blob/6b5a708e51da89dbdfd4fda7b7219ae12bcd8ffb/temporalcli/devserver/freeport.go
 
-func newPortProvider() *portProvider {
-	return &portProvider{}
-}
-
-type portProvider struct {
-	listeners []*net.TCPListener
-}
-
-// GetFreePort asks the kernel for a free open port that is ready to use.
-// Returns the interface's IP and the free port.
-func (p *portProvider) GetFreePort() (string, int, error) {
-	addr, err := net.ResolveTCPAddr("tcp", "127.0.0.1:0")
+// Returns a TCP port that is available to listen on, for the given (local) host.
+//
+// This works by binding a new TCP socket on port 0, which requests the OS to
+// allocate a free port. There is no strict guarantee that the port will remain
+// available after this function returns, but it should be safe to assume that
+// a given port will not be allocated again to any process on this machine
+// within a few seconds.
+//
+// On Unix-based systems, binding to the port returned by this function requires
+// setting the `SO_REUSEADDR` socket option (Go already does that by default,
+// but other languages may not); otherwise, the OS may fail with a message such
+// as "address already in use". Windows default behavior is already appropriate
+// in this regard; on that platform, `SO_REUSEADDR` has a different meaning and
+// should not be set (setting it may have unpredictable consequences).
+func getFreePort(host string) (string, int, error) {
+	l, err := net.Listen("tcp", host+":0")
 	if err != nil {
-		if addr, err = net.ResolveTCPAddr("tcp6", "[::1]:0"); err != nil {
-			return "", 0, fmt.Errorf("failed to get free port: %w", err)
+		return "", 0, fmt.Errorf("failed to assign a free port: %v", err)
+	}
+	defer l.Close()
+	port := l.Addr().(*net.TCPAddr).Port
+
+	// On Linux and some BSD variants, ephemeral ports are randomized, and may
+	// consequently repeat within a short time frame after the listenning end
+	// has been closed. To avoid this, we make a connection to the port, then
+	// close that connection from the server's side (this is very important),
+	// which puts the connection in TIME_WAIT state for some time (by default,
+	// 60s on Linux). While it remains in that state, the OS will not reallocate
+	// that port number for bind(:0) syscalls, yet we are not prevented from
+	// explicitly binding to it (thanks to SO_REUSEADDR).
+	//
+	// On macOS and Windows, the above technique is not necessary, as the OS
+	// allocates ephemeral ports sequentially, meaning a port number will only
+	// be reused after the entire range has been exhausted. Quite the opposite,
+	// given that these OSes use a significantly smaller range for ephemeral
+	// ports, making an extra connection just to reserve a port might actually
+	// be harmful (by hastening ephemeral port exhaustion).
+	if runtime.GOOS != "darwin" && runtime.GOOS != "windows" {
+		r, err := net.DialTCP("tcp", nil, l.Addr().(*net.TCPAddr))
+		if err != nil {
+			return "", 0, fmt.Errorf("failed to assign a free port: %v", err)
 		}
-	}
-
-	l, err := net.ListenTCP("tcp", addr)
-	if err != nil {
-		return "", 0, err
-	}
-
-	p.listeners = append(p.listeners, l)
-	tcpAddr := l.Addr().(*net.TCPAddr)
-
-	return tcpAddr.IP.String(), tcpAddr.Port, nil
-}
-
-func (p *portProvider) Close() error {
-	for _, l := range p.listeners {
-		if err := l.Close(); err != nil {
-			return err
+		c, err := l.Accept()
+		if err != nil {
+			return "", 0, fmt.Errorf("failed to assign a free port: %v", err)
 		}
+		// Closing the socket from the server side
+		c.Close()
+		defer r.Close()
 	}
-	return nil
+
+	return host, port, nil
 }
 
 func getFreeHostPort() (string, error) {
-	pp := newPortProvider()
-	host, port, err := pp.GetFreePort()
-	closeErr := pp.Close()
+	host, port, err := getFreePort("127.0.0.1")
 	if err != nil {
-		return "", err
-	} else if closeErr != nil {
-		return "", fmt.Errorf("failed to close TCP listener: %w", closeErr)
+		host, port, err = getFreePort("[::1]")
+		if err != nil {
+			return "", err
+		}
 	}
 	return fmt.Sprintf("%v:%v", host, port), nil
 }


### PR DESCRIPTION
## What changed

- When assigning ephemeral ports for use by the Temporal Server, on all platforms except MacOS and Windows, immediately open a connection to that port, and force the connection into `TIME_WAIT` state. This avoids various race conditions that could happen due to the port being reallocated between the moment the port is obtained and the moment the server actually binds to that port. See temporalio/cli#564 for details.