### PR TITLE
Only record activity_succeed_endtoend_latency on success

### DIFF
--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -1023,9 +1023,11 @@ func (atp *activityTaskPoller) ProcessTask(task interface{}) error {
 		return reportErr
 	}
 
-	activityMetricsHandler.
-		Timer(metrics.ActivitySucceedEndToEndLatency).
-		Record(time.Since(activityTask.task.GetScheduledTime().AsTime()))
+	if _, ok := request.(*workflowservice.RespondActivityTaskCompletedRequest); ok {
+		activityMetricsHandler.
+			Timer(metrics.ActivitySucceedEndToEndLatency).
+			Record(time.Since(activityTask.task.GetScheduledTime().AsTime()))
+	}
 	return nil
 }
 


### PR DESCRIPTION
closes https://github.com/temporalio/sdk-go/issues/1465