### PR TITLE
Replace grpc.Dial with grpc.NewClient

### DIFF
--- a/converter/grpc_interceptor_test.go
+++ b/converter/grpc_interceptor_test.go
@@ -74,7 +74,7 @@ func TestPayloadCodecGRPCClientInterceptor(t *testing.T) {
 	)
 	require.NoError(err)
 
-	c, err := grpc.Dial(
+	c, err := grpc.NewClient(
 		server.addr,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithChainUnaryInterceptor(interceptor),
@@ -115,7 +115,7 @@ func TestFailureGRPCClientInterceptor(t *testing.T) {
 	)
 	require.NoError(err)
 
-	c, err := grpc.Dial(
+	c, err := grpc.NewClient(
 		server.addr,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithChainUnaryInterceptor(interceptor),
@@ -181,7 +181,7 @@ func (t *testGRPCServer) waitUntilServing() error {
 	// Try 20 times, waiting 100ms between
 	var lastErr error
 	for i := 0; i < 20; i++ {
-		conn, err := grpc.Dial(t.addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+		conn, err := grpc.NewClient(t.addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 		if err != nil {
 			lastErr = err
 		} else {

--- a/internal/client.go
+++ b/internal/client.go
@@ -405,8 +405,7 @@ type (
 		// will use a registered resolver. By default all hosts returned from the resolver will be used in a round-robin
 		// fashion.
 		//
-		// The "dns" resolver is registered by default. Using a "dns:///" prefixed address will periodically resolve all IPs
-		// for DNS address given and round robin amongst them.
+		// The "dns" resolver is registered by and used by default.
 		//
 		// A custom resolver can be created to provide multiple hosts in other ways. For example, to manually provide
 		// multiple IPs to round-robin across, a google.golang.org/grpc/resolver/manual resolver can be created and

--- a/internal/common/metrics/grpc_test.go
+++ b/internal/common/metrics/grpc_test.go
@@ -50,7 +50,7 @@ func TestGRPCInterceptor(t *testing.T) {
 
 	// Create client with interceptor
 	handler := metrics.NewCapturingHandler()
-	cc, err := grpc.Dial(l.Addr().String(),
+	cc, err := grpc.NewClient(l.Addr().String(),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithUnaryInterceptor(metrics.NewGRPCInterceptor(handler, "_my_suffix", true)))
 	require.NoError(t, err)

--- a/internal/grpc_dialer.go
+++ b/internal/grpc_dialer.go
@@ -141,7 +141,7 @@ func dial(params dialParameters) (*grpc.ClientConn, error) {
 	// Append any user-supplied options
 	opts = append(opts, params.UserConnectionOptions.DialOptions...)
 
-	return grpc.Dial(params.HostPort, opts...)
+	return grpc.NewClient(params.HostPort, opts...)
 }
 
 func requiredInterceptors(

--- a/internal/grpc_dialer_test.go
+++ b/internal/grpc_dialer_test.go
@@ -153,7 +153,7 @@ func TestMissingGetServerInfo(t *testing.T) {
 	var lastErr error
 	for i := 0; i < 20; i++ {
 		lastErr = nil
-		conn, err := grpc.Dial(l.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+		conn, err := grpc.NewClient(l.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 		if err != nil {
 			lastErr = err
 		} else {
@@ -550,7 +550,7 @@ func (t *testGRPCServer) waitUntilServing() error {
 	// Try 20 times, waiting 100ms between
 	var lastErr error
 	for i := 0; i < 20; i++ {
-		conn, err := grpc.Dial(t.addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+		conn, err := grpc.NewClient(t.addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 		if err != nil {
 			lastErr = err
 		} else {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
calls to `grpc.Dial()` have been replaced with `grpc.NewClient()`

## Why?
`grpc.Dial()` is deprecated

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
