### PR TITLE
Workflow update client API refactor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
         working-directory: test
 
   features-test:
-    uses: temporalio/features/.github/workflows/go.yaml@main
+    uses: temporalio/features/.github/workflows/go.yaml@go-sdk-update-refactor
     with:
       go-repo-path: ${{github.event.pull_request.head.repo.full_name}}
       version: ${{github.event.pull_request.head.ref}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,4 +119,5 @@ jobs:
     with:
       go-repo-path: ${{github.event.pull_request.head.repo.full_name}}
       version: ${{github.event.pull_request.head.ref}}
+      features-repo-ref: go-sdk-update-refactor
       version-is-repo-ref: true

--- a/client/client.go
+++ b/client/client.go
@@ -215,10 +215,10 @@ type (
 	// ScheduleBackfillOptions configure the parameters for backfilling a schedule.
 	ScheduleBackfillOptions = internal.ScheduleBackfillOptions
 
-	// UpdateWorkflowOptionsRequest encapsulates the parameters for
+	// UpdateWorkflowOptions encapsulates the parameters for
 	// sending an update to a workflow execution.
 	// NOTE: Experimental
-	UpdateWorkflowOptionsRequest = internal.UpdateWorkflowOptionsRequest
+	UpdateWorkflowOptions = internal.UpdateWorkflowOptions
 
 	// WorkflowUpdateHandle represents a running or completed workflow
 	// execution update and gives the holder access to the outcome of the same.
@@ -591,10 +591,10 @@ type (
 		// from the server will be exposed through the return value of
 		// WorkflowUpdateHandle.Get(). Errors that occur before the
 		// update is requested (e.g. if the required workflow ID field is
-		// missing from the UpdateWorkflowOptionsRequest) are returned
+		// missing from the UpdateWorkflowOptions) are returned
 		// directly from this function call.
 		// NOTE: Experimental
-		UpdateWorkflow(ctx context.Context, request *UpdateWorkflowOptionsRequest) (WorkflowUpdateHandle, error)
+		UpdateWorkflow(ctx context.Context, options UpdateWorkflowOptions) (WorkflowUpdateHandle, error)
 
 		// GetWorkflowUpdateHandle creates a handle to the referenced update
 		// which can be polled for an outcome. Note that runID is optional and

--- a/client/client.go
+++ b/client/client.go
@@ -215,10 +215,10 @@ type (
 	// ScheduleBackfillOptions configure the parameters for backfilling a schedule.
 	ScheduleBackfillOptions = internal.ScheduleBackfillOptions
 
-	// UpdateWorkflowWithOptionsRequest encapsulates the parameters for
+	// UpdateWorkflowOptionsRequest encapsulates the parameters for
 	// sending an update to a workflow execution.
 	// NOTE: Experimental
-	UpdateWorkflowWithOptionsRequest = internal.UpdateWorkflowWithOptionsRequest
+	UpdateWorkflowOptionsRequest = internal.UpdateWorkflowOptionsRequest
 
 	// WorkflowUpdateHandle represents a running or completed workflow
 	// execution update and gives the holder access to the outcome of the same.
@@ -585,24 +585,16 @@ type (
 		// API. If the check fails, an error is returned.
 		CheckHealth(ctx context.Context, request *CheckHealthRequest) (*CheckHealthResponse, error)
 
-		// UpdateWorkflow issues an update request to the specified
-		// workflow execution and returns the result synchronously. Calling this
-		// function is equivalent to calling UpdateWorkflowWithOptions with
-		// the same arguments and indicating that the RPC call should wait for
-		// completion of the update process.
-		// NOTE: Experimental
-		UpdateWorkflow(ctx context.Context, workflowID string, workflowRunID string, updateName string, args ...interface{}) (WorkflowUpdateHandle, error)
-
-		// UpdateWorkflowWithOptions issues an update request to the
+		// UpdateWorkflow issues an update request to the
 		// specified workflow execution and returns a handle to the update that
 		// is running in in parallel with the calling thread. Errors returned
 		// from the server will be exposed through the return value of
 		// WorkflowUpdateHandle.Get(). Errors that occur before the
 		// update is requested (e.g. if the required workflow ID field is
-		// missing from the UpdateWorkflowWithOptionsRequest) are returned
+		// missing from the UpdateWorkflowOptionsRequest) are returned
 		// directly from this function call.
 		// NOTE: Experimental
-		UpdateWorkflowWithOptions(ctx context.Context, request *UpdateWorkflowWithOptionsRequest) (WorkflowUpdateHandle, error)
+		UpdateWorkflow(ctx context.Context, request *UpdateWorkflowOptionsRequest) (WorkflowUpdateHandle, error)
 
 		// GetWorkflowUpdateHandle creates a handle to the referenced update
 		// which can be polled for an outcome. Note that runID is optional and

--- a/client/client.go
+++ b/client/client.go
@@ -64,23 +64,23 @@ const (
 	TaskReachabilityClosedWorkflows = internal.TaskReachabilityClosedWorkflows
 )
 
-// UpdateLifeCycleStage indicates the stage of an update request.
+// WorkflowUpdateLifeCycleStage indicates the stage of an update request.
 // NOTE: Experimental
-type UpdateLifeCycleStage = internal.UpdateLifeCycleStage
+type WorkflowUpdateLifeCycleStage = internal.WorkflowUpdateLifeCycleStage
 
 const (
-	// UpdateLifeCycleStageUnspecified indicates the wait stage was not specified
+	// WorkflowUpdateLifeCycleStageUnspecified indicates the wait stage was not specified
 	// NOTE: Experimental
-	UpdateLifeCycleStageUnspecified = internal.UpdateLifeCycleStageUnspecified
-	// UpdateLifeCycleStageAdmitted indicates the update is admitted
+	WorkflowUpdateLifeCycleStageUnspecified = internal.WorkflowUpdateLifeCycleStageUnspecified
+	// WorkflowUpdateLifeCycleStageAdmitted indicates the update is admitted
 	// NOTE: Experimental
-	UpdateLifeCycleStageAdmitted = internal.UpdateLifeCycleStageAdmitted
-	// UpdateLifeCycleStageAccepted indicates the update is accepted
+	WorkflowUpdateLifeCycleStageAdmitted = internal.WorkflowUpdateLifeCycleStageAdmitted
+	// WorkflowUpdateLifeCycleStageAccepted indicates the update is accepted
 	// NOTE: Experimental
-	UpdateLifeCycleStageAccepted = internal.UpdateLifeCycleStageAccepted
-	// UpdateLifeCycleStageCompleted indicates the update is completed
+	WorkflowUpdateLifeCycleStageAccepted = internal.WorkflowUpdateLifeCycleStageAccepted
+	// WorkflowUpdateLifeCycleStageCompleted indicates the update is completed
 	// NOTE: Experimental
-	UpdateLifeCycleStageCompleted = internal.UpdateLifeCycleStageCompleted
+	WorkflowUpdateLifeCycleStageCompleted = internal.WorkflowUpdateLifeCycleStageCompleted
 )
 
 const (

--- a/client/client.go
+++ b/client/client.go
@@ -64,23 +64,23 @@ const (
 	TaskReachabilityClosedWorkflows = internal.TaskReachabilityClosedWorkflows
 )
 
-// WorkflowUpdateLifeCycleStage indicates the stage of an update request.
+// WorkflowUpdateStage indicates the stage of an update request.
 // NOTE: Experimental
-type WorkflowUpdateLifeCycleStage = internal.WorkflowUpdateLifeCycleStage
+type WorkflowUpdateStage = internal.WorkflowUpdateStage
 
 const (
-	// WorkflowUpdateLifeCycleStageUnspecified indicates the wait stage was not specified
+	// WorkflowUpdateStageUnspecified indicates the wait stage was not specified
 	// NOTE: Experimental
-	WorkflowUpdateLifeCycleStageUnspecified = internal.WorkflowUpdateLifeCycleStageUnspecified
-	// WorkflowUpdateLifeCycleStageAdmitted indicates the update is admitted
+	WorkflowUpdateStageUnspecified = internal.WorkflowUpdateStageUnspecified
+	// WorkflowUpdateStageAdmitted indicates the update is admitted
 	// NOTE: Experimental
-	WorkflowUpdateLifeCycleStageAdmitted = internal.WorkflowUpdateLifeCycleStageAdmitted
-	// WorkflowUpdateLifeCycleStageAccepted indicates the update is accepted
+	WorkflowUpdateStageAdmitted = internal.WorkflowUpdateStageAdmitted
+	// WorkflowUpdateStageAccepted indicates the update is accepted
 	// NOTE: Experimental
-	WorkflowUpdateLifeCycleStageAccepted = internal.WorkflowUpdateLifeCycleStageAccepted
-	// WorkflowUpdateLifeCycleStageCompleted indicates the update is completed
+	WorkflowUpdateStageAccepted = internal.WorkflowUpdateStageAccepted
+	// WorkflowUpdateStageCompleted indicates the update is completed
 	// NOTE: Experimental
-	WorkflowUpdateLifeCycleStageCompleted = internal.WorkflowUpdateLifeCycleStageCompleted
+	WorkflowUpdateStageCompleted = internal.WorkflowUpdateStageCompleted
 )
 
 const (

--- a/client/client.go
+++ b/client/client.go
@@ -64,6 +64,25 @@ const (
 	TaskReachabilityClosedWorkflows = internal.TaskReachabilityClosedWorkflows
 )
 
+// UpdateLifeCycleStage indicates the stage of an update request.
+// NOTE: Experimental
+type UpdateLifeCycleStage = internal.UpdateLifeCycleStage
+
+const (
+	// UpdateLifeCycleStageUnspecified indicates the wait stage was not specified
+	// NOTE: Experimental
+	UpdateLifeCycleStageUnspecified = internal.UpdateLifeCycleStageUnspecified
+	// UpdateLifeCycleStageAdmitted indicates the update is admitted
+	// NOTE: Experimental
+	UpdateLifeCycleStageAdmitted = internal.UpdateLifeCycleStageAdmitted
+	// UpdateLifeCycleStageAccepted indicates the update is accepted
+	// NOTE: Experimental
+	UpdateLifeCycleStageAccepted = internal.UpdateLifeCycleStageAccepted
+	// UpdateLifeCycleStageCompleted indicates the update is completed
+	// NOTE: Experimental
+	UpdateLifeCycleStageCompleted = internal.UpdateLifeCycleStageCompleted
+)
+
 const (
 	// DefaultHostPort is the host:port which is used if not passed with options.
 	DefaultHostPort = internal.LocalHostPort
@@ -198,7 +217,7 @@ type (
 
 	// UpdateWorkflowWithOptionsRequest encapsulates the parameters for
 	// sending an update to a workflow execution.
-	// WARNING: Worker versioning is currently experimental
+	// NOTE: Experimental
 	UpdateWorkflowWithOptionsRequest = internal.UpdateWorkflowWithOptionsRequest
 
 	// WorkflowUpdateHandle represents a running or completed workflow

--- a/internal/client.go
+++ b/internal/client.go
@@ -362,10 +362,10 @@ type (
 		// from the server will be exposed through the return value of
 		// WorkflowExecutionUpdateHandle.Get(). Errors that occur before the
 		// update is requested (e.g. if the required workflow ID field is
-		// missing from the UpdateWorkflowOptionsRequest) are returned
+		// missing from the UpdateWorkflowOptions) are returned
 		// directly from this function call.
 		// NOTE: Experimental
-		UpdateWorkflow(ctx context.Context, request *UpdateWorkflowOptionsRequest) (WorkflowUpdateHandle, error)
+		UpdateWorkflow(ctx context.Context, options UpdateWorkflowOptions) (WorkflowUpdateHandle, error)
 
 		// GetWorkflowUpdateHandle creates a handle to the referenced update
 		// which can be polled for an outcome. Note that runID is optional and

--- a/internal/client.go
+++ b/internal/client.go
@@ -356,24 +356,16 @@ type (
 		// API. If the check fails, an error is returned.
 		CheckHealth(ctx context.Context, request *CheckHealthRequest) (*CheckHealthResponse, error)
 
-		// UpdateWorkflow issues an update request to the specified
-		// workflow execution and returns the result synchronously. Calling this
-		// function is equivalent to calling UpdateWorkflowWithOptions with
-		// the same arguments and indicating that the RPC call should wait for
-		// completion of the update process.
-		// NOTE: Experimental
-		UpdateWorkflow(ctx context.Context, workflowID string, workflowRunID string, updateName string, args ...interface{}) (WorkflowUpdateHandle, error)
-
-		// UpdateWorkflowWithOptions issues an update request to the
+		// UpdateWorkflow issues an update request to the
 		// specified workflow execution and returns a handle to the update that
 		// is running in in parallel with the calling thread. Errors returned
 		// from the server will be exposed through the return value of
 		// WorkflowExecutionUpdateHandle.Get(). Errors that occur before the
 		// update is requested (e.g. if the required workflow ID field is
-		// missing from the UpdateWorkflowWithOptionsRequest) are returned
+		// missing from the UpdateWorkflowOptionsRequest) are returned
 		// directly from this function call.
 		// NOTE: Experimental
-		UpdateWorkflowWithOptions(ctx context.Context, request *UpdateWorkflowWithOptionsRequest) (WorkflowUpdateHandle, error)
+		UpdateWorkflow(ctx context.Context, request *UpdateWorkflowOptionsRequest) (WorkflowUpdateHandle, error)
 
 		// GetWorkflowUpdateHandle creates a handle to the referenced update
 		// which can be polled for an outcome. Note that runID is optional and

--- a/internal/interceptor.go
+++ b/internal/interceptor.go
@@ -351,7 +351,7 @@ type ClientUpdateWorkflowInput struct {
 	Args                []interface{}
 	RunID               string
 	FirstExecutionRunID string
-	WaitForStage        WorkflowUpdateLifeCycleStage
+	WaitForStage        WorkflowUpdateStage
 }
 
 // ClientPollWorkflowUpdateInput is the input to

--- a/internal/interceptor.go
+++ b/internal/interceptor.go
@@ -351,7 +351,7 @@ type ClientUpdateWorkflowInput struct {
 	Args                []interface{}
 	RunID               string
 	FirstExecutionRunID string
-	WaitPolicy          *updatepb.WaitPolicy
+	LifeCycleWaitStage  UpdateLifeCycleStage
 }
 
 // ClientPollWorkflowUpdateInput is the input to

--- a/internal/interceptor.go
+++ b/internal/interceptor.go
@@ -335,7 +335,7 @@ type ClientOutboundInterceptor interface {
 	// server.
 	//
 	// NOTE: Experimental
-	PollWorkflowUpdate(context.Context, *ClientPollWorkflowUpdateInput) (converter.EncodedValue, error)
+	PollWorkflowUpdate(context.Context, *ClientPollWorkflowUpdateInput) (*ClientPollWorkflowUpdateOutput, error)
 
 	mustEmbedClientOutboundInterceptorBase()
 }
@@ -358,6 +358,15 @@ type ClientUpdateWorkflowInput struct {
 // ClientOutboundInterceptor.PollWorkflowUpdate.
 type ClientPollWorkflowUpdateInput struct {
 	UpdateRef *updatepb.UpdateRef
+}
+
+// ClientPollWorkflowUpdateOutput is the output to
+// ClientOutboundInterceptor.PollWorkflowUpdate.
+type ClientPollWorkflowUpdateOutput struct {
+	// Result is the result of the update, if it has completed successfully.
+	Result converter.EncodedValue
+	// Error is the result of a failed update.
+	Error error
 }
 
 // ScheduleClientCreateInput is the input to

--- a/internal/interceptor.go
+++ b/internal/interceptor.go
@@ -351,7 +351,7 @@ type ClientUpdateWorkflowInput struct {
 	Args                []interface{}
 	RunID               string
 	FirstExecutionRunID string
-	LifeCycleWaitStage  UpdateLifeCycleStage
+	WaitForStage        WorkflowUpdateLifeCycleStage
 }
 
 // ClientPollWorkflowUpdateInput is the input to

--- a/internal/interceptor_base.go
+++ b/internal/interceptor_base.go
@@ -425,7 +425,7 @@ func (c *ClientOutboundInterceptorBase) UpdateWorkflow(
 func (c *ClientOutboundInterceptorBase) PollWorkflowUpdate(
 	ctx context.Context,
 	in *ClientPollWorkflowUpdateInput,
-) (converter.EncodedValue, error) {
+) (*ClientPollWorkflowUpdateOutput, error) {
 	return c.Next.PollWorkflowUpdate(ctx, in)
 }
 

--- a/internal/internal_update.go
+++ b/internal/internal_update.go
@@ -30,6 +30,7 @@ import (
 	"reflect"
 
 	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
 	historypb "go.temporal.io/api/history/v1"
 	protocolpb "go.temporal.io/api/protocol/v1"
 	updatepb "go.temporal.io/api/update/v1"
@@ -38,6 +39,20 @@ import (
 )
 
 type updateState string
+
+// UpdateLifeCycleStage indicates the stage of an update request.
+type UpdateLifeCycleStage int
+
+const (
+	// UpdateLifeCycleStageUnspecified indicates the wait stage was not specified
+	UpdateLifeCycleStageUnspecified UpdateLifeCycleStage = iota
+	// UpdateLifeCycleStageAdmitted indicates the update is admitted
+	UpdateLifeCycleStageAdmitted
+	// UpdateLifeCycleStageAccepted indicates the update is accepted
+	UpdateLifeCycleStageAccepted
+	// UpdateLifeCycleStageCompleted indicates the update is completed
+	UpdateLifeCycleStageCompleted
+)
 
 const (
 	updateStateNew              updateState = "New"
@@ -452,4 +467,19 @@ func validateUpdateHandlerFn(fn interface{}) error {
 			"error or a serializable result and error (i.e. (ResultType, error))")
 	}
 	return nil
+}
+
+func updateLifeCycleStageToProto(l UpdateLifeCycleStage) enumspb.UpdateWorkflowExecutionLifecycleStage {
+	switch l {
+	case UpdateLifeCycleStageUnspecified:
+		return enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_UNSPECIFIED
+	case UpdateLifeCycleStageAdmitted:
+		return enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ADMITTED
+	case UpdateLifeCycleStageAccepted:
+		return enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED
+	case UpdateLifeCycleStageCompleted:
+		return enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED
+	default:
+		panic("unknown update lifecycle stage")
+	}
 }

--- a/internal/internal_update.go
+++ b/internal/internal_update.go
@@ -40,18 +40,18 @@ import (
 
 type updateState string
 
-// UpdateLifeCycleStage indicates the stage of an update request.
-type UpdateLifeCycleStage int
+// WorkflowUpdateLifeCycleStage indicates the stage of an update request.
+type WorkflowUpdateLifeCycleStage int
 
 const (
-	// UpdateLifeCycleStageUnspecified indicates the wait stage was not specified
-	UpdateLifeCycleStageUnspecified UpdateLifeCycleStage = iota
-	// UpdateLifeCycleStageAdmitted indicates the update is admitted
-	UpdateLifeCycleStageAdmitted
-	// UpdateLifeCycleStageAccepted indicates the update is accepted
-	UpdateLifeCycleStageAccepted
-	// UpdateLifeCycleStageCompleted indicates the update is completed
-	UpdateLifeCycleStageCompleted
+	// WorkflowUpdateLifeCycleStageUnspecified indicates the wait stage was not specified
+	WorkflowUpdateLifeCycleStageUnspecified WorkflowUpdateLifeCycleStage = iota
+	// WorkflowUpdateLifeCycleStageAdmitted indicates the update is admitted
+	WorkflowUpdateLifeCycleStageAdmitted
+	// WorkflowUpdateLifeCycleStageAccepted indicates the update is accepted
+	WorkflowUpdateLifeCycleStageAccepted
+	// WorkflowUpdateLifeCycleStageCompleted indicates the update is completed
+	WorkflowUpdateLifeCycleStageCompleted
 )
 
 const (
@@ -469,15 +469,15 @@ func validateUpdateHandlerFn(fn interface{}) error {
 	return nil
 }
 
-func updateLifeCycleStageToProto(l UpdateLifeCycleStage) enumspb.UpdateWorkflowExecutionLifecycleStage {
+func updateLifeCycleStageToProto(l WorkflowUpdateLifeCycleStage) enumspb.UpdateWorkflowExecutionLifecycleStage {
 	switch l {
-	case UpdateLifeCycleStageUnspecified:
+	case WorkflowUpdateLifeCycleStageUnspecified:
 		return enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_UNSPECIFIED
-	case UpdateLifeCycleStageAdmitted:
+	case WorkflowUpdateLifeCycleStageAdmitted:
 		return enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ADMITTED
-	case UpdateLifeCycleStageAccepted:
+	case WorkflowUpdateLifeCycleStageAccepted:
 		return enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED
-	case UpdateLifeCycleStageCompleted:
+	case WorkflowUpdateLifeCycleStageCompleted:
 		return enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED
 	default:
 		panic("unknown update lifecycle stage")

--- a/internal/internal_update.go
+++ b/internal/internal_update.go
@@ -40,18 +40,18 @@ import (
 
 type updateState string
 
-// WorkflowUpdateLifeCycleStage indicates the stage of an update request.
-type WorkflowUpdateLifeCycleStage int
+// WorkflowUpdateStage indicates the stage of an update request.
+type WorkflowUpdateStage int
 
 const (
-	// WorkflowUpdateLifeCycleStageUnspecified indicates the wait stage was not specified
-	WorkflowUpdateLifeCycleStageUnspecified WorkflowUpdateLifeCycleStage = iota
-	// WorkflowUpdateLifeCycleStageAdmitted indicates the update is admitted
-	WorkflowUpdateLifeCycleStageAdmitted
-	// WorkflowUpdateLifeCycleStageAccepted indicates the update is accepted
-	WorkflowUpdateLifeCycleStageAccepted
-	// WorkflowUpdateLifeCycleStageCompleted indicates the update is completed
-	WorkflowUpdateLifeCycleStageCompleted
+	// WorkflowUpdateStageUnspecified indicates the wait stage was not specified
+	WorkflowUpdateStageUnspecified WorkflowUpdateStage = iota
+	// WorkflowUpdateStageAdmitted indicates the update is admitted
+	WorkflowUpdateStageAdmitted
+	// WorkflowUpdateStageAccepted indicates the update is accepted
+	WorkflowUpdateStageAccepted
+	// WorkflowUpdateStageCompleted indicates the update is completed
+	WorkflowUpdateStageCompleted
 )
 
 const (
@@ -469,15 +469,15 @@ func validateUpdateHandlerFn(fn interface{}) error {
 	return nil
 }
 
-func updateLifeCycleStageToProto(l WorkflowUpdateLifeCycleStage) enumspb.UpdateWorkflowExecutionLifecycleStage {
+func updateLifeCycleStageToProto(l WorkflowUpdateStage) enumspb.UpdateWorkflowExecutionLifecycleStage {
 	switch l {
-	case WorkflowUpdateLifeCycleStageUnspecified:
+	case WorkflowUpdateStageUnspecified:
 		return enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_UNSPECIFIED
-	case WorkflowUpdateLifeCycleStageAdmitted:
+	case WorkflowUpdateStageAdmitted:
 		return enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ADMITTED
-	case WorkflowUpdateLifeCycleStageAccepted:
+	case WorkflowUpdateStageAccepted:
 		return enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED
-	case WorkflowUpdateLifeCycleStageCompleted:
+	case WorkflowUpdateStageCompleted:
 		return enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED
 	default:
 		panic("unknown update lifecycle stage")

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -782,7 +782,7 @@ type UpdateWorkflowWithOptionsRequest struct {
 	FirstExecutionRunID string
 
 	// How this RPC should block on the server before returning.
-	WaitPolicy *updatepb.WaitPolicy
+	LifeCycleWaitStage UpdateLifeCycleStage
 }
 
 // WorkflowUpdateHandle is a handle to a workflow execution update process. The
@@ -1058,7 +1058,7 @@ func (wc *WorkflowClient) UpdateWorkflowWithOptions(
 		Args:                req.Args,
 		RunID:               req.RunID,
 		FirstExecutionRunID: req.FirstExecutionRunID,
-		WaitPolicy:          req.WaitPolicy,
+		LifeCycleWaitStage:  req.LifeCycleWaitStage,
 	})
 }
 
@@ -1799,7 +1799,9 @@ func (w *workflowClientInterceptor) UpdateWorkflow(
 		RunId:      in.RunID,
 	}
 	resp, err := w.client.workflowService.UpdateWorkflowExecution(grpcCtx, &workflowservice.UpdateWorkflowExecutionRequest{
-		WaitPolicy:          in.WaitPolicy,
+		WaitPolicy: &updatepb.WaitPolicy{
+			LifecycleStage: updateLifeCycleStageToProto(in.LifeCycleWaitStage),
+		},
 		Namespace:           w.client.namespace,
 		WorkflowExecution:   wfexec,
 		FirstExecutionRunId: in.FirstExecutionRunID,

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -783,8 +783,8 @@ type UpdateWorkflowWithOptionsRequest struct {
 
 	// How this RPC should block on the server before returning.
 	// By default will block until the update is completed.
-	// NOTE: Specifying WorkflowUpdateLifeCycleStageAdmitted is not supported.
-	WaitForStage WorkflowUpdateLifeCycleStage
+	// NOTE: Specifying WorkflowUpdateStageAdmitted is not supported.
+	WaitForStage WorkflowUpdateStage
 }
 
 // WorkflowUpdateHandle is a handle to a workflow execution update process. The

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -782,7 +782,7 @@ type UpdateWorkflowWithOptionsRequest struct {
 	FirstExecutionRunID string
 
 	// How this RPC should block on the server before returning.
-	LifeCycleWaitStage UpdateLifeCycleStage
+	WaitForStage WorkflowUpdateLifeCycleStage
 }
 
 // WorkflowUpdateHandle is a handle to a workflow execution update process. The
@@ -1058,7 +1058,7 @@ func (wc *WorkflowClient) UpdateWorkflowWithOptions(
 		Args:                req.Args,
 		RunID:               req.RunID,
 		FirstExecutionRunID: req.FirstExecutionRunID,
-		LifeCycleWaitStage:  req.LifeCycleWaitStage,
+		WaitForStage:        req.WaitForStage,
 	})
 }
 
@@ -1800,7 +1800,7 @@ func (w *workflowClientInterceptor) UpdateWorkflow(
 	}
 	resp, err := w.client.workflowService.UpdateWorkflowExecution(grpcCtx, &workflowservice.UpdateWorkflowExecutionRequest{
 		WaitPolicy: &updatepb.WaitPolicy{
-			LifecycleStage: updateLifeCycleStageToProto(in.LifeCycleWaitStage),
+			LifecycleStage: updateLifeCycleStageToProto(in.WaitForStage),
 		},
 		Namespace:           w.client.namespace,
 		WorkflowExecution:   wfexec,

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -37,9 +37,7 @@ import (
 
 	"github.com/pborman/uuid"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
-	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/durationpb"
 
 	commonpb "go.temporal.io/api/common/v1"
@@ -753,8 +751,8 @@ func (wc *WorkflowClient) QueryWorkflow(ctx context.Context, workflowID string, 
 	})
 }
 
-// UpdateWorkflowWithOptionsRequest is the request to UpdateWorkflowWithOptions
-type UpdateWorkflowWithOptionsRequest struct {
+// UpdateWorkflowOptionsRequest is the request to UpdateWorkflow
+type UpdateWorkflowOptionsRequest struct {
 	// UpdateID is an application-layer identifier for the requested update. It
 	// must be unique within the scope of a Namespace+WorkflowID+RunID.
 	UpdateID string
@@ -776,15 +774,15 @@ type UpdateWorkflowWithOptionsRequest struct {
 	// update.
 	Args []interface{}
 
+	// WaitForStage is a required field which specifies which stage to wait until returning.
+	// See https://docs.temporal.io/workflows#update for more details.
+	// NOTE: Specifying WorkflowUpdateStageAdmitted is not supported.
+	WaitForStage WorkflowUpdateStage
+
 	// FirstExecutionRunID specifies the RunID expected to identify the first
 	// run in the workflow execution chain. If this expectation does not match
 	// then the server will reject the update request with an error.
 	FirstExecutionRunID string
-
-	// How this RPC should block on the server before returning.
-	// By default will block until the update is completed.
-	// NOTE: Specifying WorkflowUpdateStageAdmitted is not supported.
-	WaitForStage WorkflowUpdateStage
 }
 
 // WorkflowUpdateHandle is a handle to a workflow execution update process. The
@@ -1038,32 +1036,6 @@ func (wc *WorkflowClient) GetWorkerTaskReachability(ctx context.Context, options
 	return converted, nil
 }
 
-func (wc *WorkflowClient) UpdateWorkflowWithOptions(
-	ctx context.Context,
-	req *UpdateWorkflowWithOptionsRequest,
-) (WorkflowUpdateHandle, error) {
-	if err := wc.ensureInitialized(ctx); err != nil {
-		return nil, err
-	}
-	// Default update ID
-	updateID := req.UpdateID
-	if updateID == "" {
-		updateID = uuid.New()
-	}
-
-	ctx = contextWithNewHeader(ctx)
-
-	return wc.interceptor.UpdateWorkflow(ctx, &ClientUpdateWorkflowInput{
-		UpdateID:            updateID,
-		WorkflowID:          req.WorkflowID,
-		UpdateName:          req.UpdateName,
-		Args:                req.Args,
-		RunID:               req.RunID,
-		FirstExecutionRunID: req.FirstExecutionRunID,
-		WaitForStage:        req.WaitForStage,
-	})
-}
-
 func (wc *WorkflowClient) GetWorkflowUpdateHandle(ref GetWorkflowUpdateHandleOptions) WorkflowUpdateHandle {
 	return &lazyUpdateHandle{
 		client: wc,
@@ -1084,7 +1056,7 @@ func (wc *WorkflowClient) GetWorkflowUpdateHandle(ref GetWorkflowUpdateHandleOpt
 func (wc *WorkflowClient) PollWorkflowUpdate(
 	ctx context.Context,
 	ref *updatepb.UpdateRef,
-) (converter.EncodedValue, error) {
+) (*ClientPollWorkflowUpdateOutput, error) {
 	if err := wc.ensureInitialized(ctx); err != nil {
 		return nil, err
 	}
@@ -1096,22 +1068,35 @@ func (wc *WorkflowClient) PollWorkflowUpdate(
 
 func (wc *WorkflowClient) UpdateWorkflow(
 	ctx context.Context,
-	workflowID string,
-	workflowRunID string,
-	updateName string,
-	args ...interface{},
+	req *UpdateWorkflowOptionsRequest,
 ) (WorkflowUpdateHandle, error) {
 	if err := wc.ensureInitialized(ctx); err != nil {
 		return nil, err
+	}
+	// Default update ID
+	updateID := req.UpdateID
+	if updateID == "" {
+		updateID = uuid.New()
+	}
+
+	if req.WaitForStage == WorkflowUpdateStageUnspecified {
+		return nil, errors.New("WaitForStage must be specified")
+	}
+
+	if req.WaitForStage == WorkflowUpdateStageAdmitted {
+		return nil, errors.New("WaitForStage WorkflowUpdateStageAdmitted is not supported")
 	}
 
 	ctx = contextWithNewHeader(ctx)
 
 	return wc.interceptor.UpdateWorkflow(ctx, &ClientUpdateWorkflowInput{
-		WorkflowID: workflowID,
-		UpdateName: updateName,
-		UpdateID:   uuid.New(),
-		Args:       args,
+		UpdateID:            updateID,
+		WorkflowID:          req.WorkflowID,
+		UpdateName:          req.UpdateName,
+		Args:                req.Args,
+		RunID:               req.RunID,
+		FirstExecutionRunID: req.FirstExecutionRunID,
+		WaitForStage:        req.WaitForStage,
 	})
 }
 
@@ -1794,33 +1779,69 @@ func (w *workflowClientInterceptor) UpdateWorkflow(
 	if err != nil {
 		return nil, err
 	}
-	grpcCtx, cancel := newGRPCContext(ctx, grpcTimeout(pollUpdateTimeout), grpcLongPoll(true), defaultGrpcRetryParameters(ctx))
-	defer cancel()
-	wfexec := &commonpb.WorkflowExecution{
-		WorkflowId: in.WorkflowID,
-		RunId:      in.RunID,
+	desiredLifecycleStage := updateLifeCycleStageToProto(in.WaitForStage)
+	var resp *workflowservice.UpdateWorkflowExecutionResponse
+	for ctx.Err() == nil {
+		var err error
+		resp, err = func() (*workflowservice.UpdateWorkflowExecutionResponse, error) {
+			grpcCtx, cancel := newGRPCContext(ctx, grpcTimeout(pollUpdateTimeout), grpcLongPoll(true), defaultGrpcRetryParameters(ctx))
+			defer cancel()
+			wfexec := &commonpb.WorkflowExecution{
+				WorkflowId: in.WorkflowID,
+				RunId:      in.RunID,
+			}
+			return w.client.workflowService.UpdateWorkflowExecution(grpcCtx, &workflowservice.UpdateWorkflowExecutionRequest{
+				WaitPolicy:          &updatepb.WaitPolicy{LifecycleStage: desiredLifecycleStage},
+				Namespace:           w.client.namespace,
+				WorkflowExecution:   wfexec,
+				FirstExecutionRunId: in.FirstExecutionRunID,
+				Request: &updatepb.Request{
+					Meta: &updatepb.Meta{
+						UpdateId: in.UpdateID,
+						Identity: w.client.identity,
+					},
+					Input: &updatepb.Input{
+						Header: header,
+						Name:   in.UpdateName,
+						Args:   argPayloads,
+					},
+				},
+			})
+		}()
+		if err != nil {
+			return nil, err
+		}
+		// Once the update is past admitted we know it is durable
+		// Note: old server version may return UNSPECIFIED if the update request
+		// did not reach the desired lifecycle stage.
+		if resp.GetStage() != enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ADMITTED &&
+			resp.GetStage() != enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_UNSPECIFIED {
+			break
+		}
 	}
-	resp, err := w.client.workflowService.UpdateWorkflowExecution(grpcCtx, &workflowservice.UpdateWorkflowExecutionRequest{
-		WaitPolicy: &updatepb.WaitPolicy{
-			LifecycleStage: updateLifeCycleStageToProto(in.WaitForStage),
-		},
-		Namespace:           w.client.namespace,
-		WorkflowExecution:   wfexec,
-		FirstExecutionRunId: in.FirstExecutionRunID,
-		Request: &updatepb.Request{
-			Meta: &updatepb.Meta{
-				UpdateId: in.UpdateID,
-				Identity: w.client.identity,
-			},
-			Input: &updatepb.Input{
-				Header: header,
-				Name:   in.UpdateName,
-				Args:   argPayloads,
-			},
-		},
-	})
-	if err != nil {
-		return nil, err
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
+	// Here we know the update is at least accepted
+	if desiredLifecycleStage == enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED &&
+		resp.GetStage() != enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED {
+		// TODO(https://github.com/temporalio/features/issues/428) replace with handle wait for stage once implemented
+		pollResp, err := w.client.PollWorkflowUpdate(ctx, resp.GetUpdateRef())
+		if err != nil {
+			return nil, err
+		}
+		if pollResp.Error != nil {
+			return &completedUpdateHandle{
+				err:              pollResp.Error,
+				baseUpdateHandle: baseUpdateHandle{ref: resp.GetUpdateRef()},
+			}, nil
+		} else {
+			return &completedUpdateHandle{
+				value:            pollResp.Result,
+				baseUpdateHandle: baseUpdateHandle{ref: resp.GetUpdateRef()},
+			}, nil
+		}
 	}
 	switch v := resp.GetOutcome().GetValue().(type) {
 	case nil:
@@ -1845,7 +1866,7 @@ func (w *workflowClientInterceptor) UpdateWorkflow(
 func (w *workflowClientInterceptor) PollWorkflowUpdate(
 	parentCtx context.Context,
 	in *ClientPollWorkflowUpdateInput,
-) (converter.EncodedValue, error) {
+) (*ClientPollWorkflowUpdateOutput, error) {
 	// header, _ = headerPropagated(ctx, w.client.contextPropagators)
 	// todo header not in PollWorkflowUpdate
 
@@ -1870,9 +1891,7 @@ func (w *workflowClientInterceptor) PollWorkflowUpdate(
 		)
 		resp, err := w.client.workflowService.PollWorkflowExecutionUpdate(ctx, &pollReq)
 		cancel()
-		if err == context.DeadlineExceeded ||
-			status.Code(err) == codes.DeadlineExceeded ||
-			(err == nil && resp.GetOutcome() == nil) {
+		if err == nil && resp.GetOutcome() == nil {
 			continue
 		}
 		if err != nil {
@@ -1880,9 +1899,13 @@ func (w *workflowClientInterceptor) PollWorkflowUpdate(
 		}
 		switch v := resp.GetOutcome().GetValue().(type) {
 		case *updatepb.Outcome_Failure:
-			return nil, w.client.failureConverter.FailureToError(v.Failure)
+			return &ClientPollWorkflowUpdateOutput{
+				Error: w.client.failureConverter.FailureToError(v.Failure),
+			}, nil
 		case *updatepb.Outcome_Success:
-			return newEncodedValue(v.Success, w.client.dataConverter), nil
+			return &ClientPollWorkflowUpdateOutput{
+				Result: newEncodedValue(v.Success, w.client.dataConverter),
+			}, nil
 		default:
 			return nil, fmt.Errorf("unsupported outcome type %T", v)
 		}
@@ -1916,11 +1939,14 @@ func (ch *completedUpdateHandle) Get(ctx context.Context, valuePtr interface{}) 
 }
 
 func (luh *lazyUpdateHandle) Get(ctx context.Context, valuePtr interface{}) error {
-	enc, err := luh.client.PollWorkflowUpdate(ctx, luh.ref)
-	if err != nil || valuePtr == nil {
+	resp, err := luh.client.PollWorkflowUpdate(ctx, luh.ref)
+	if err != nil {
 		return err
 	}
-	return enc.Get(valuePtr)
+	if resp.Error != nil || valuePtr == nil {
+		return resp.Error
+	}
+	return resp.Result.Get(valuePtr)
 }
 
 func (q *queryRejectedError) Error() string {

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -782,6 +782,8 @@ type UpdateWorkflowWithOptionsRequest struct {
 	FirstExecutionRunID string
 
 	// How this RPC should block on the server before returning.
+	// By default will block until the update is completed.
+	// NOTE: Specifying WorkflowUpdateLifeCycleStageAdmitted is not supported.
 	WaitForStage WorkflowUpdateLifeCycleStage
 }
 

--- a/internal/internal_workflow_client_test.go
+++ b/internal/internal_workflow_client_test.go
@@ -1719,21 +1719,21 @@ func TestUpdate(t *testing.T) {
 	}
 
 	const (
-		sync  = enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED
-		async = enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED
+		sync  = UpdateLifeCycleStageCompleted
+		async = UpdateLifeCycleStageAccepted
 	)
 
 	newRequest := func(
 		t *testing.T,
-		stage enumspb.UpdateWorkflowExecutionLifecycleStage,
+		stage UpdateLifeCycleStage,
 	) *UpdateWorkflowWithOptionsRequest {
 		t.Helper()
 		return &UpdateWorkflowWithOptionsRequest{
-			UpdateID:   fmt.Sprintf("%v-update_id", t.Name()),
-			WorkflowID: fmt.Sprintf("%v-workflow_id", t.Name()),
-			RunID:      fmt.Sprintf("%v-run_id", t.Name()),
-			UpdateName: fmt.Sprintf("%v-update_name", t.Name()),
-			WaitPolicy: &updatepb.WaitPolicy{LifecycleStage: stage},
+			UpdateID:           fmt.Sprintf("%v-update_id", t.Name()),
+			WorkflowID:         fmt.Sprintf("%v-workflow_id", t.Name()),
+			RunID:              fmt.Sprintf("%v-run_id", t.Name()),
+			UpdateName:         fmt.Sprintf("%v-update_name", t.Name()),
+			LifeCycleWaitStage: stage,
 		}
 	}
 

--- a/internal/internal_workflow_client_test.go
+++ b/internal/internal_workflow_client_test.go
@@ -1724,9 +1724,9 @@ func TestUpdate(t *testing.T) {
 	newRequest := func(
 		t *testing.T,
 		stage WorkflowUpdateStage,
-	) *UpdateWorkflowOptionsRequest {
+	) UpdateWorkflowOptions {
 		t.Helper()
-		return &UpdateWorkflowOptionsRequest{
+		return UpdateWorkflowOptions{
 			UpdateID:     fmt.Sprintf("%v-update_id", t.Name()),
 			WorkflowID:   fmt.Sprintf("%v-workflow_id", t.Name()),
 			RunID:        fmt.Sprintf("%v-run_id", t.Name()),
@@ -1735,13 +1735,13 @@ func TestUpdate(t *testing.T) {
 		}
 	}
 
-	refFromRequest := func(req *UpdateWorkflowOptionsRequest) *updatepb.UpdateRef {
+	refFromRequest := func(opt UpdateWorkflowOptions) *updatepb.UpdateRef {
 		return &updatepb.UpdateRef{
 			WorkflowExecution: &commonpb.WorkflowExecution{
-				WorkflowId: req.WorkflowID,
-				RunId:      req.RunID,
+				WorkflowId: opt.WorkflowID,
+				RunId:      opt.RunID,
 			},
-			UpdateId: req.UpdateName,
+			UpdateId: opt.UpdateName,
 		}
 	}
 

--- a/internal/internal_workflow_client_test.go
+++ b/internal/internal_workflow_client_test.go
@@ -1719,21 +1719,21 @@ func TestUpdate(t *testing.T) {
 	}
 
 	const (
-		sync  = UpdateLifeCycleStageCompleted
-		async = UpdateLifeCycleStageAccepted
+		sync  = WorkflowUpdateLifeCycleStageCompleted
+		async = WorkflowUpdateLifeCycleStageAccepted
 	)
 
 	newRequest := func(
 		t *testing.T,
-		stage UpdateLifeCycleStage,
+		stage WorkflowUpdateLifeCycleStage,
 	) *UpdateWorkflowWithOptionsRequest {
 		t.Helper()
 		return &UpdateWorkflowWithOptionsRequest{
-			UpdateID:           fmt.Sprintf("%v-update_id", t.Name()),
-			WorkflowID:         fmt.Sprintf("%v-workflow_id", t.Name()),
-			RunID:              fmt.Sprintf("%v-run_id", t.Name()),
-			UpdateName:         fmt.Sprintf("%v-update_name", t.Name()),
-			LifeCycleWaitStage: stage,
+			UpdateID:     fmt.Sprintf("%v-update_id", t.Name()),
+			WorkflowID:   fmt.Sprintf("%v-workflow_id", t.Name()),
+			RunID:        fmt.Sprintf("%v-run_id", t.Name()),
+			UpdateName:   fmt.Sprintf("%v-update_name", t.Name()),
+			WaitForStage: stage,
 		}
 	}
 

--- a/internal/internal_workflow_client_test.go
+++ b/internal/internal_workflow_client_test.go
@@ -1719,13 +1719,13 @@ func TestUpdate(t *testing.T) {
 	}
 
 	const (
-		sync  = WorkflowUpdateLifeCycleStageCompleted
-		async = WorkflowUpdateLifeCycleStageAccepted
+		sync  = WorkflowUpdateStageCompleted
+		async = WorkflowUpdateStageAccepted
 	)
 
 	newRequest := func(
 		t *testing.T,
-		stage WorkflowUpdateLifeCycleStage,
+		stage WorkflowUpdateStage,
 	) *UpdateWorkflowWithOptionsRequest {
 		t.Helper()
 		return &UpdateWorkflowWithOptionsRequest{

--- a/mocks/Client.go
+++ b/mocks/Client.go
@@ -30,6 +30,7 @@ package mocks
 
 import (
 	"context"
+
 	"go.temporal.io/sdk/client"
 
 	"go.temporal.io/api/enums/v1"
@@ -824,12 +825,9 @@ func (_m *Client) UpdateWorkerBuildIdCompatibility(ctx context.Context, options 
 	return r0
 }
 
-// UpdateWorkflow provides a mock function with given fields: ctx, workflowID, workflowRunID, updateName, args
-func (_m *Client) UpdateWorkflow(ctx context.Context, workflowID string, workflowRunID string, updateName string, args ...interface{}) (client.WorkflowUpdateHandle, error) {
-	var _ca []interface{}
-	_ca = append(_ca, ctx, workflowID, workflowRunID, updateName)
-	_ca = append(_ca, args...)
-	ret := _m.Called(_ca...)
+// UpdateWorkflow provides a mock function with given fields: ctx, request
+func (_m *Client) UpdateWorkflow(ctx context.Context, request *client.UpdateWorkflowOptionsRequest) (client.WorkflowUpdateHandle, error) {
+	ret := _m.Called(ctx, request)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpdateWorkflow")
@@ -837,40 +835,10 @@ func (_m *Client) UpdateWorkflow(ctx context.Context, workflowID string, workflo
 
 	var r0 client.WorkflowUpdateHandle
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, ...interface{}) (client.WorkflowUpdateHandle, error)); ok {
-		return rf(ctx, workflowID, workflowRunID, updateName, args...)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, ...interface{}) client.WorkflowUpdateHandle); ok {
-		r0 = rf(ctx, workflowID, workflowRunID, updateName, args...)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(client.WorkflowUpdateHandle)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(context.Context, string, string, string, ...interface{}) error); ok {
-		r1 = rf(ctx, workflowID, workflowRunID, updateName, args...)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// UpdateWorkflowWithOptions provides a mock function with given fields: ctx, request
-func (_m *Client) UpdateWorkflowWithOptions(ctx context.Context, request *client.UpdateWorkflowWithOptionsRequest) (client.WorkflowUpdateHandle, error) {
-	ret := _m.Called(ctx, request)
-
-	if len(ret) == 0 {
-		panic("no return value specified for UpdateWorkflowWithOptions")
-	}
-
-	var r0 client.WorkflowUpdateHandle
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, *client.UpdateWorkflowWithOptionsRequest) (client.WorkflowUpdateHandle, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, *client.UpdateWorkflowOptionsRequest) (client.WorkflowUpdateHandle, error)); ok {
 		return rf(ctx, request)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, *client.UpdateWorkflowWithOptionsRequest) client.WorkflowUpdateHandle); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, *client.UpdateWorkflowOptionsRequest) client.WorkflowUpdateHandle); ok {
 		r0 = rf(ctx, request)
 	} else {
 		if ret.Get(0) != nil {
@@ -878,7 +846,7 @@ func (_m *Client) UpdateWorkflowWithOptions(ctx context.Context, request *client
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, *client.UpdateWorkflowWithOptionsRequest) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, *client.UpdateWorkflowOptionsRequest) error); ok {
 		r1 = rf(ctx, request)
 	} else {
 		r1 = ret.Error(1)

--- a/mocks/Client.go
+++ b/mocks/Client.go
@@ -825,9 +825,9 @@ func (_m *Client) UpdateWorkerBuildIdCompatibility(ctx context.Context, options 
 	return r0
 }
 
-// UpdateWorkflow provides a mock function with given fields: ctx, request
-func (_m *Client) UpdateWorkflow(ctx context.Context, request *client.UpdateWorkflowOptionsRequest) (client.WorkflowUpdateHandle, error) {
-	ret := _m.Called(ctx, request)
+// UpdateWorkflow provides a mock function with given fields: ctx, options
+func (_m *Client) UpdateWorkflow(ctx context.Context, options client.UpdateWorkflowOptions) (client.WorkflowUpdateHandle, error) {
+	ret := _m.Called(ctx, options)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpdateWorkflow")
@@ -835,19 +835,19 @@ func (_m *Client) UpdateWorkflow(ctx context.Context, request *client.UpdateWork
 
 	var r0 client.WorkflowUpdateHandle
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, *client.UpdateWorkflowOptionsRequest) (client.WorkflowUpdateHandle, error)); ok {
-		return rf(ctx, request)
+	if rf, ok := ret.Get(0).(func(context.Context, client.UpdateWorkflowOptions) (client.WorkflowUpdateHandle, error)); ok {
+		return rf(ctx, options)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, *client.UpdateWorkflowOptionsRequest) client.WorkflowUpdateHandle); ok {
-		r0 = rf(ctx, request)
+	if rf, ok := ret.Get(0).(func(context.Context, client.UpdateWorkflowOptions) client.WorkflowUpdateHandle); ok {
+		r0 = rf(ctx, options)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(client.WorkflowUpdateHandle)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, *client.UpdateWorkflowOptionsRequest) error); ok {
-		r1 = rf(ctx, request)
+	if rf, ok := ret.Get(1).(func(context.Context, client.UpdateWorkflowOptions) error); ok {
+		r1 = rf(ctx, options)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -1392,7 +1392,7 @@ func (ts *IntegrationTestSuite) TestMutatingUpdateValidator() {
 		ts.startWorkflowOptions("test-mutating-update-validator"), ts.workflows.MutatingUpdateValidatorWorkflow)
 	ts.Nil(err)
 	go func() {
-		_, err = ts.client.UpdateWorkflow(ctx, &client.UpdateWorkflowOptionsRequest{
+		_, err = ts.client.UpdateWorkflow(ctx, client.UpdateWorkflowOptions{
 			WorkflowID:   "test-mutating-update-validator",
 			RunID:        run.GetRunID(),
 			UpdateName:   "mutating_update",
@@ -1454,7 +1454,7 @@ func (ts *IntegrationTestSuite) TestUpdateInfo() {
 		ts.startWorkflowOptions("test-update-info"), ts.workflows.UpdateInfoWorkflow)
 	ts.Nil(err)
 	// Send an update request with a know update ID
-	handler, err := ts.client.UpdateWorkflow(ctx, &client.UpdateWorkflowOptionsRequest{
+	handler, err := ts.client.UpdateWorkflow(ctx, client.UpdateWorkflowOptions{
 		UpdateID:     "testID",
 		WorkflowID:   run.GetID(),
 		RunID:        run.GetRunID(),
@@ -1467,7 +1467,7 @@ func (ts *IntegrationTestSuite) TestUpdateInfo() {
 	ts.NoError(handler.Get(ctx, &result))
 	ts.Equal("testID", result)
 	// Test the update validator can also use the update info
-	handler, err = ts.client.UpdateWorkflow(ctx, &client.UpdateWorkflowOptionsRequest{
+	handler, err = ts.client.UpdateWorkflow(ctx, client.UpdateWorkflowOptions{
 		UpdateID:     "notTestID",
 		WorkflowID:   run.GetID(),
 		RunID:        run.GetRunID(),
@@ -1491,7 +1491,7 @@ func (ts *IntegrationTestSuite) TestUpdateValidatorRejectedFirstWFT() {
 		wfOptions, ts.workflows.UpdateWithValidatorWorkflow)
 	ts.Nil(err)
 	// Send a bad update request that will get rejected
-	handler, err := ts.client.UpdateWorkflow(ctx, &client.UpdateWorkflowOptionsRequest{
+	handler, err := ts.client.UpdateWorkflow(ctx, client.UpdateWorkflowOptions{
 		WorkflowID:   run.GetID(),
 		RunID:        run.GetRunID(),
 		UpdateName:   "update",
@@ -1514,7 +1514,7 @@ func (ts *IntegrationTestSuite) TestUpdateValidatorRejected() {
 	_, err = ts.client.QueryWorkflow(ctx, run.GetID(), run.GetRunID(), client.QueryTypeStackTrace)
 	ts.NoError(err)
 	// Send a bad update request that will get rejected
-	handler, err := ts.client.UpdateWorkflow(ctx, &client.UpdateWorkflowOptionsRequest{
+	handler, err := ts.client.UpdateWorkflow(ctx, client.UpdateWorkflowOptions{
 		WorkflowID:   run.GetID(),
 		RunID:        run.GetRunID(),
 		UpdateName:   "update",
@@ -1538,7 +1538,7 @@ func (ts *IntegrationTestSuite) TestUpdateWorkflowCancelled() {
 	// Send a few updates to the workflow
 	handles := make([]client.WorkflowUpdateHandle, 0, 5)
 	for i := 0; i < 5; i++ {
-		handler, err := ts.client.UpdateWorkflow(ctx, &client.UpdateWorkflowOptionsRequest{
+		handler, err := ts.client.UpdateWorkflow(ctx, client.UpdateWorkflowOptions{
 			UpdateID:     fmt.Sprintf("test-update-%d", i),
 			WorkflowID:   run.GetID(),
 			RunID:        run.GetRunID(),
@@ -2779,7 +2779,7 @@ func (ts *IntegrationTestSuite) TestUpdateBasic() {
 	ts.Nil(err)
 	// Send an update request
 	ts.Run("ShortUpdate", func() {
-		handler, err := ts.client.UpdateWorkflow(ctx, &client.UpdateWorkflowOptionsRequest{
+		handler, err := ts.client.UpdateWorkflow(ctx, client.UpdateWorkflowOptions{
 			WorkflowID:   run.GetID(),
 			RunID:        run.GetRunID(),
 			UpdateName:   "update",
@@ -2791,7 +2791,7 @@ func (ts *IntegrationTestSuite) TestUpdateBasic() {
 	})
 	// Send an update request
 	ts.Run("ShortUpdateWaitOnCompleted", func() {
-		handler, err := ts.client.UpdateWorkflow(ctx, &client.UpdateWorkflowOptionsRequest{
+		handler, err := ts.client.UpdateWorkflow(ctx, client.UpdateWorkflowOptions{
 			WorkflowID:   run.GetID(),
 			RunID:        run.GetRunID(),
 			UpdateName:   "update",
@@ -2804,7 +2804,7 @@ func (ts *IntegrationTestSuite) TestUpdateBasic() {
 	})
 	// Send an update request
 	ts.Run("LongUpdateWaitOnAccepted", func() {
-		handler, err := ts.client.UpdateWorkflow(ctx, &client.UpdateWorkflowOptionsRequest{
+		handler, err := ts.client.UpdateWorkflow(ctx, client.UpdateWorkflowOptions{
 			WorkflowID:   run.GetID(),
 			RunID:        run.GetRunID(),
 			UpdateName:   "update",
@@ -2831,7 +2831,7 @@ func (ts *IntegrationTestSuite) TestLongUpdateWaitOnCompleted() {
 	// Send an update request
 	tctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
-	_, err = ts.client.UpdateWorkflow(tctx, &client.UpdateWorkflowOptionsRequest{
+	_, err = ts.client.UpdateWorkflow(tctx, client.UpdateWorkflowOptions{
 		WorkflowID:   run.GetID(),
 		RunID:        run.GetRunID(),
 		UpdateName:   "update",
@@ -2857,7 +2857,7 @@ func (ts *IntegrationTestSuite) TestUpdateAdmittedNoWorker() {
 	// Send an update request
 	tctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
-	_, err = ts.client.UpdateWorkflow(tctx, &client.UpdateWorkflowOptionsRequest{
+	_, err = ts.client.UpdateWorkflow(tctx, client.UpdateWorkflowOptions{
 		WorkflowID:   run.GetID(),
 		RunID:        run.GetRunID(),
 		UpdateName:   "update",
@@ -2880,7 +2880,7 @@ func (ts *IntegrationTestSuite) TestUpdateWithNoHandlerRejected() {
 		ts.workflows.Basic)
 	ts.NoError(err)
 	// Send an update that we know has no handle
-	handle, err := ts.client.UpdateWorkflow(ctx, &client.UpdateWorkflowOptionsRequest{
+	handle, err := ts.client.UpdateWorkflow(ctx, client.UpdateWorkflowOptions{
 		WorkflowID:   run.GetID(),
 		RunID:        run.GetRunID(),
 		UpdateName:   "bad update",
@@ -2903,7 +2903,7 @@ func (ts *IntegrationTestSuite) TestUpdateWithWrongHandleRejected() {
 		ts.workflows.WaitOnUpdate)
 	ts.NoError(err)
 	// Send an update before the first workflow task
-	updateHandle, err := ts.client.UpdateWorkflow(ctx, &client.UpdateWorkflowOptionsRequest{
+	updateHandle, err := ts.client.UpdateWorkflow(ctx, client.UpdateWorkflowOptions{
 		WorkflowID:   run.GetID(),
 		RunID:        run.GetRunID(),
 		UpdateName:   "bad update",
@@ -2927,7 +2927,7 @@ func (ts *IntegrationTestSuite) TestWaitOnUpdate() {
 		ts.workflows.WaitOnUpdate)
 	ts.NoError(err)
 	// Send an update before the first workflow task
-	updateHandle, err := ts.client.UpdateWorkflow(ctx, &client.UpdateWorkflowOptionsRequest{
+	updateHandle, err := ts.client.UpdateWorkflow(ctx, client.UpdateWorkflowOptions{
 		WorkflowID:   run.GetID(),
 		RunID:        run.GetRunID(),
 		UpdateName:   "echo",
@@ -2952,7 +2952,7 @@ func (ts *IntegrationTestSuite) TestUpdateHandlerRegisteredLate() {
 	// Wait for the workflow to be blocked
 	ts.waitForQueryTrue(run, "state", 0)
 	// Send an update before the handler is registered
-	updateHandle, err := ts.client.UpdateWorkflow(ctx, &client.UpdateWorkflowOptionsRequest{
+	updateHandle, err := ts.client.UpdateWorkflow(ctx, client.UpdateWorkflowOptions{
 		WorkflowID:   run.GetID(),
 		RunID:        run.GetRunID(),
 		UpdateName:   "update",
@@ -2963,7 +2963,7 @@ func (ts *IntegrationTestSuite) TestUpdateHandlerRegisteredLate() {
 	// Unblock the workflow so it can register the handler
 	ts.client.SignalWorkflow(ctx, run.GetID(), run.GetRunID(), "unblock", nil)
 	// Send an update after the handler is registered
-	updateHandle, err = ts.client.UpdateWorkflow(ctx, &client.UpdateWorkflowOptionsRequest{
+	updateHandle, err = ts.client.UpdateWorkflow(ctx, client.UpdateWorkflowOptions{
 		WorkflowID:   run.GetID(),
 		RunID:        run.GetRunID(),
 		UpdateName:   "update",
@@ -2992,7 +2992,7 @@ func (ts *IntegrationTestSuite) TestUpdateSDKFlag() {
 	// Unblock the workflow so it can register the handler
 	ts.client.SignalWorkflow(ctx, run.GetID(), run.GetRunID(), "unblock", nil)
 	// Send an update after the handler is registered
-	updateHandle, err := ts.client.UpdateWorkflow(ctx, &client.UpdateWorkflowOptionsRequest{
+	updateHandle, err := ts.client.UpdateWorkflow(ctx, client.UpdateWorkflowOptions{
 		WorkflowID:   run.GetID(),
 		RunID:        run.GetRunID(),
 		UpdateName:   "update",
@@ -3034,7 +3034,7 @@ func (ts *IntegrationTestSuite) TestUpdateOrdering() {
 		ts.workflows.UpdateOrdering)
 	ts.NoError(err)
 	// Send an update before the first workflow task
-	updateHandle, err := ts.client.UpdateWorkflow(ctx, &client.UpdateWorkflowOptionsRequest{
+	updateHandle, err := ts.client.UpdateWorkflow(ctx, client.UpdateWorkflowOptions{
 		WorkflowID:   run.GetID(),
 		RunID:        run.GetRunID(),
 		UpdateName:   "update",
@@ -3043,7 +3043,7 @@ func (ts *IntegrationTestSuite) TestUpdateOrdering() {
 	ts.NoError(err)
 	ts.NoError(updateHandle.Get(ctx, nil))
 	// Send an update after the first workflow task
-	updateHandle, err = ts.client.UpdateWorkflow(ctx, &client.UpdateWorkflowOptionsRequest{
+	updateHandle, err = ts.client.UpdateWorkflow(ctx, client.UpdateWorkflowOptions{
 		WorkflowID:   run.GetID(),
 		RunID:        run.GetRunID(),
 		UpdateName:   "update",
@@ -3087,7 +3087,7 @@ func (ts *IntegrationTestSuite) testUpdateOrderingCancel(cancelWf bool) {
 		go func() {
 			defer wf.Done()
 			handle := updateHandles[rand.Intn(3)]
-			updateHandle, err := ts.client.UpdateWorkflow(ctx, &client.UpdateWorkflowOptionsRequest{
+			updateHandle, err := ts.client.UpdateWorkflow(ctx, client.UpdateWorkflowOptions{
 				WorkflowID:   run.GetID(),
 				RunID:        run.GetRunID(),
 				UpdateName:   handle,
@@ -3127,7 +3127,7 @@ func (ts *IntegrationTestSuite) TestUpdateAlwaysHandled() {
 	run, err := ts.client.ExecuteWorkflow(ctx, options, ts.workflows.UpdateSetHandlerOnly)
 	ts.NoError(err)
 	// Send an update before the first workflow task
-	_, err = ts.client.UpdateWorkflow(ctx, &client.UpdateWorkflowOptionsRequest{
+	_, err = ts.client.UpdateWorkflow(ctx, client.UpdateWorkflowOptions{
 		WorkflowID:   run.GetID(),
 		RunID:        run.GetRunID(),
 		UpdateName:   "update",
@@ -3147,7 +3147,7 @@ func (ts *IntegrationTestSuite) TestUpdateRejected() {
 	run, err := ts.client.ExecuteWorkflow(ctx, options, ts.workflows.UpdateRejectedWithOtherGoRoutine)
 	ts.NoError(err)
 	// Send an update we expect to be rejected before the first workflow task
-	handle, err := ts.client.UpdateWorkflow(ctx, &client.UpdateWorkflowOptionsRequest{
+	handle, err := ts.client.UpdateWorkflow(ctx, client.UpdateWorkflowOptions{
 		WorkflowID:   run.GetID(),
 		RunID:        run.GetRunID(),
 		UpdateName:   "update",
@@ -3166,7 +3166,7 @@ func (ts *IntegrationTestSuite) TestUpdateSettingHandlerInGoroutine() {
 	run, err := ts.client.ExecuteWorkflow(ctx, options, ts.workflows.UpdateSettingHandlerInGoroutine)
 	ts.NoError(err)
 	// Send an update handler in a workflow goroutine, this should be accepted
-	handle, err := ts.client.UpdateWorkflow(ctx, &client.UpdateWorkflowOptionsRequest{
+	handle, err := ts.client.UpdateWorkflow(ctx, client.UpdateWorkflowOptions{
 		WorkflowID:   run.GetID(),
 		RunID:        run.GetRunID(),
 		UpdateName:   "update",
@@ -3185,7 +3185,7 @@ func (ts *IntegrationTestSuite) TestUpdateSettingHandlerInHandler() {
 	run, err := ts.client.ExecuteWorkflow(ctx, options, ts.workflows.UpdateSettingHandlerInHandler)
 	ts.NoError(err)
 	// Expect this to fail because the handler is not set yet
-	handle, err := ts.client.UpdateWorkflow(ctx, &client.UpdateWorkflowOptionsRequest{
+	handle, err := ts.client.UpdateWorkflow(ctx, client.UpdateWorkflowOptions{
 		WorkflowID:   run.GetID(),
 		RunID:        run.GetRunID(),
 		UpdateName:   "inner update",
@@ -3194,7 +3194,7 @@ func (ts *IntegrationTestSuite) TestUpdateSettingHandlerInHandler() {
 	ts.NoError(err)
 	ts.Error(handle.Get(ctx, nil))
 	// Send an update that should register a new handler for "inner update"
-	handle, err = ts.client.UpdateWorkflow(ctx, &client.UpdateWorkflowOptionsRequest{
+	handle, err = ts.client.UpdateWorkflow(ctx, client.UpdateWorkflowOptions{
 		WorkflowID:   run.GetID(),
 		RunID:        run.GetRunID(),
 		UpdateName:   "update",
@@ -3203,7 +3203,7 @@ func (ts *IntegrationTestSuite) TestUpdateSettingHandlerInHandler() {
 	ts.NoError(err)
 	ts.NoError(handle.Get(ctx, nil))
 	// Expect this to succeed because the handler is set now
-	handle, err = ts.client.UpdateWorkflow(ctx, &client.UpdateWorkflowOptionsRequest{
+	handle, err = ts.client.UpdateWorkflow(ctx, client.UpdateWorkflowOptions{
 		WorkflowID:   run.GetID(),
 		RunID:        run.GetRunID(),
 		UpdateName:   "inner update",

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -1526,7 +1526,7 @@ func (ts *IntegrationTestSuite) TestUpdateWorkflowCancelled() {
 			WorkflowID:   run.GetID(),
 			RunID:        run.GetRunID(),
 			UpdateName:   "update",
-			WaitForStage: client.WorkflowUpdateLifeCycleStageAccepted,
+			WaitForStage: client.WorkflowUpdateStageAccepted,
 		})
 		ts.NoError(err)
 		handles = append(handles, handler)

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -1522,11 +1522,11 @@ func (ts *IntegrationTestSuite) TestUpdateWorkflowCancelled() {
 	handles := make([]client.WorkflowUpdateHandle, 0, 5)
 	for i := 0; i < 5; i++ {
 		handler, err := ts.client.UpdateWorkflowWithOptions(ctx, &client.UpdateWorkflowWithOptionsRequest{
-			UpdateID:           fmt.Sprintf("test-update-%d", i),
-			WorkflowID:         run.GetID(),
-			RunID:              run.GetRunID(),
-			UpdateName:         "update",
-			LifeCycleWaitStage: client.UpdateLifeCycleStageAccepted,
+			UpdateID:     fmt.Sprintf("test-update-%d", i),
+			WorkflowID:   run.GetID(),
+			RunID:        run.GetRunID(),
+			UpdateName:   "update",
+			WaitForStage: client.WorkflowUpdateLifeCycleStageAccepted,
 		})
 		ts.NoError(err)
 		handles = append(handles, handler)

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -52,7 +52,6 @@ import (
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
-	updatepb "go.temporal.io/api/update/v1"
 	workflowpb "go.temporal.io/api/workflow/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.uber.org/goleak"
@@ -1523,13 +1522,11 @@ func (ts *IntegrationTestSuite) TestUpdateWorkflowCancelled() {
 	handles := make([]client.WorkflowUpdateHandle, 0, 5)
 	for i := 0; i < 5; i++ {
 		handler, err := ts.client.UpdateWorkflowWithOptions(ctx, &client.UpdateWorkflowWithOptionsRequest{
-			UpdateID:   fmt.Sprintf("test-update-%d", i),
-			WorkflowID: run.GetID(),
-			RunID:      run.GetRunID(),
-			UpdateName: "update",
-			WaitPolicy: &updatepb.WaitPolicy{
-				LifecycleStage: enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED,
-			},
+			UpdateID:           fmt.Sprintf("test-update-%d", i),
+			WorkflowID:         run.GetID(),
+			RunID:              run.GetRunID(),
+			UpdateName:         "update",
+			LifeCycleWaitStage: client.UpdateLifeCycleStageAccepted,
 		})
 		ts.NoError(err)
 		handles = append(handles, handler)

--- a/test/workflow_test.go
+++ b/test/workflow_test.go
@@ -326,6 +326,21 @@ func (w *Workflows) ActivityRetryOnHBTimeout(ctx workflow.Context) ([]string, er
 	return []string{"heartbeatAndSleep", "heartbeatAndSleep", "heartbeatAndSleep"}, nil
 }
 
+func (w *Workflows) UpdateBasicWorkflow(ctx workflow.Context) error {
+	err := workflow.SetUpdateHandler(ctx, "update", func(ctx workflow.Context, t time.Duration) (string, error) {
+		err := workflow.Sleep(ctx, t)
+		if err != nil {
+			return "", err
+		}
+		return "test", nil
+	})
+	if err != nil {
+		return errors.New("failed to register update handler")
+	}
+	workflow.GetSignalChannel(ctx, "finish").Receive(ctx, nil)
+	return nil
+}
+
 func (w *Workflows) UpdateCancelableWorkflow(ctx workflow.Context) error {
 	err := workflow.SetUpdateHandler(ctx, "update", func(ctx workflow.Context) error {
 		return workflow.Sleep(ctx, time.Hour)
@@ -3058,6 +3073,7 @@ func (w *Workflows) register(worker worker.Worker) {
 	worker.RegisterWorkflow(w.UpdateSettingHandlerInHandler)
 	worker.RegisterWorkflow(w.UpdateCancelableWorkflow)
 	worker.RegisterWorkflow(w.UpdateHandlerRegisteredLate)
+	worker.RegisterWorkflow(w.UpdateBasicWorkflow)
 	worker.RegisterWorkflow(w.LocalActivityNextRetryDelay)
 	worker.RegisterWorkflow(w.QueryTestWorkflow)
 


### PR DESCRIPTION
This PR makes multiple changes to the client experience around update:
* Merge `UpdateWorkflowWithOptions` and `UpdateWorkflow` to a single api 
* Makes `WaitForStage` a required parameter in update
* Create a Go SDK enum for update lifecyle
*  Updated start update polling to poll until stage reached or ACCEPTED. If more polling needed, switches to result polling.


closes https://github.com/temporalio/sdk-go/issues/1414
closes https://github.com/temporalio/sdk-go/issues/1449
closes https://github.com/temporalio/sdk-go/issues/1411

since this has multiple breaking changes feature tests are expected to fail until I make a separate branch
