### PR TITLE
testsuite.StartDevServer: Respect timeout during dial

### DIFF
--- a/testsuite/devserver_internal_test.go
+++ b/testsuite/devserver_internal_test.go
@@ -1,0 +1,62 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package testsuite
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/internal/log"
+)
+
+func TestWaitServerReady_respectsTimeout(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancel()
+
+	hostPort, err := getFreeHostPort()
+	require.NoError(t, err, "get free host port")
+
+	startTime := time.Now()
+	_, err = waitServerReady(ctx, client.Options{
+		HostPort:  hostPort,
+		Namespace: "default",
+		Logger:    log.NewNopLogger(),
+	})
+	require.Error(t, err, "Dial should fail")
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.WithinDuration(t,
+		startTime.Add(time.Millisecond),
+		time.Now(),
+		5*time.Millisecond,
+		// Even though the timeout is only a millisecond,
+		// we'll allow for a slack of up to 5 milliseconds
+		// to account for slow CI machines.
+		// Anything smaller than 1 second is fine to use here.
+	)
+}


### PR DESCRIPTION
## What was changed

**Background:**
testsuite.StartDevServer accepts a context.Context
meant to indicate how long the caller is willing to wait for the result.
This context is used when downloading the Temporal CLI,
but is not considered when trying to dial to the server in
`waitServerReady`.

**Change:**
This changes `waitServerReady` to respect the timeout configured in the
context--checking in on it after each attempt, and returning early
if the context has expired.
Similarly, the `Dial` attempt now uses `DialContext` so that if the context
expires, the dial operation also returns early if it can.

## Why?

Without this, if an attempt to start the server failed
(e.g. because of an invalid `--log-format` argument),
`waitServerReady` will block the test for 1 minute
before giving up and returning an error.
This is a pretty long time to wait for a test to fail,
when the caller is expecting, say, 5 seconds at most.

## Checklist

1. How was this tested:
   A unit test was added for the new functionality,
   and run with `go test -run WaitServerReady -count 1000`
   to verify that it's not flaky.

3. Any docs updates needed?
   I don't think so.
