### PR TITLE
Always run all the versioning tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,8 +88,6 @@ jobs:
         if: ${{ matrix.testDockerCompose }}
         run: go run . integration-test
         working-directory: ./internal/cmd/build
-        env:
-          RUN_VERSIONING_V2_TESTS: "true"
 
   cloud-test:
     strategy:

--- a/client/client.go
+++ b/client/client.go
@@ -742,6 +742,7 @@ type (
 		// When not supported by the server, it returns an empty [TaskQueueDescription] if there is no information
 		// about the task queue, or an error when the response identifies an unsupported server.
 		// Note that using a sticky queue as target is not supported.
+		// Also, workflow reachability status is eventually consistent, and it could take a few minutes to update.
 		// WARNING: Worker versioning is currently experimental, and requires server 1.24+
 		DescribeTaskQueueEnhanced(ctx context.Context, options DescribeTaskQueueEnhancedOptions) (TaskQueueDescription, error)
 

--- a/internal/client.go
+++ b/internal/client.go
@@ -359,6 +359,7 @@ type (
 		// When not supported by the server, it returns an empty [TaskQueueDescription] if there is no information
 		// about the task queue, or an error when the response identifies an unsupported server.
 		// Note that using a sticky queue as target is not supported.
+		// Also, workflow reachability status is eventually consistent, and it could take a few minutes to update.
 		// WARNING: Worker versioning is currently experimental, and requires server 1.24+
 		DescribeTaskQueueEnhanced(ctx context.Context, options DescribeTaskQueueEnhancedOptions) (TaskQueueDescription, error)
 

--- a/test/worker_versioning_test.go
+++ b/test/worker_versioning_test.go
@@ -24,7 +24,6 @@ package test_test
 
 import (
 	"context"
-	"os"
 	"testing"
 	"time"
 
@@ -38,13 +37,6 @@ import (
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/worker"
 )
-
-var runNewVersioningTests bool
-
-func init() {
-	run, ok := os.LookupEnv("RUN_VERSIONING_V2_TESTS")
-	runNewVersioningTests = ok && run != ""
-}
 
 type WorkerVersioningTestSuite struct {
 	*require.Assertions
@@ -111,10 +103,6 @@ func (ts *WorkerVersioningTestSuite) TestManipulateVersionSets() {
 }
 
 func (ts *WorkerVersioningTestSuite) TestManipulateRules() {
-	if !runNewVersioningTests {
-		ts.T().Skip("temporal cli devserver does not support new versioning API yet.")
-	}
-
 	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
 	defer cancel()
 
@@ -181,10 +169,6 @@ func (ts *WorkerVersioningTestSuite) TestManipulateRules() {
 }
 
 func (ts *WorkerVersioningTestSuite) TestReplaceDeleteRules() {
-	if !runNewVersioningTests {
-		ts.T().Skip("temporal cli devserver does not support new versioning API yet.")
-	}
-
 	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
 	defer cancel()
 
@@ -277,10 +261,6 @@ func (ts *WorkerVersioningTestSuite) TestReplaceDeleteRules() {
 }
 
 func (ts *WorkerVersioningTestSuite) TestCommitRules() {
-	if !runNewVersioningTests {
-		ts.T().Skip("temporal cli devserver does not support new versioning API yet.")
-	}
-
 	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
 	defer cancel()
 
@@ -354,10 +334,6 @@ func (ts *WorkerVersioningTestSuite) TestCommitRules() {
 }
 
 func (ts *WorkerVersioningTestSuite) TestConflictTokens() {
-	if !runNewVersioningTests {
-		ts.T().Skip("temporal cli devserver does not support new versioning API yet.")
-	}
-
 	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
 	defer cancel()
 
@@ -467,10 +443,6 @@ func (ts *WorkerVersioningTestSuite) TestTwoWorkersGetDifferentTasks() {
 }
 
 func (ts *WorkerVersioningTestSuite) TestTwoWorkersGetDifferentTasksWithRules() {
-	if !runNewVersioningTests {
-		ts.T().Skip("temporal cli devserver does not support new versioning API yet.")
-	}
-
 	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
 	defer cancel()
 
@@ -558,10 +530,6 @@ func (ts *WorkerVersioningTestSuite) TestReachabilityUnreachable() {
 }
 
 func (ts *WorkerVersioningTestSuite) TestReachabilityUnreachableWithRules() {
-	if !runNewVersioningTests {
-		ts.T().Skip("temporal cli devserver does not support new versioning API yet.")
-	}
-
 	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
 	defer cancel()
 
@@ -624,10 +592,6 @@ func (ts *WorkerVersioningTestSuite) TestReachabilityUnversionedWorker() {
 }
 
 func (ts *WorkerVersioningTestSuite) TestReachabilityUnversionedWorkerWithRules() {
-	if !runNewVersioningTests {
-		ts.T().Skip("temporal cli devserver does not support new versioning API yet.")
-	}
-
 	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
 	defer cancel()
 
@@ -745,10 +709,6 @@ func (ts *WorkerVersioningTestSuite) TestReachabilityVersions() {
 }
 
 func (ts *WorkerVersioningTestSuite) TestReachabilityVersionsWithRules() {
-	if !runNewVersioningTests {
-		ts.T().Skip("temporal cli devserver does not support new versioning API yet.")
-	}
-
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
@@ -913,10 +873,6 @@ func (ts *WorkerVersioningTestSuite) TestBuildIDChangesOverWorkflowLifetime() {
 }
 
 func (ts *WorkerVersioningTestSuite) TestBuildIDChangesOverWorkflowLifetimeWithRules() {
-	if !runNewVersioningTests {
-		ts.T().Skip("temporal cli devserver does not support new versioning API yet.")
-	}
-
 	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
 	defer cancel()
 


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->
Delete the checks that made some versioning tests run only against a docker ubuntu image.

## Why?
<!-- Tell your future self why have you made these changes -->
CLI 0.13 has just been released and it provides a server with versioning support.
