### PR TITLE
Update some docs around grpc Dial options

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -940,8 +940,7 @@ func NewClientFromExistingWithContext(ctx context.Context, existingClient Client
 // NewNamespaceClient creates an instance of a namespace client, to manage
 // lifecycle of namespaces. This will not attempt to connect to the server
 // eagerly and therefore may not fail for an unreachable server until a call is
-// made. grpc.WithBlock can be passed as a gRPC dial option to connection
-// options to eagerly connect.
+// made.
 func NewNamespaceClient(options Options) (NamespaceClient, error) {
 	return internal.NewNamespaceClient(options)
 }

--- a/internal/client.go
+++ b/internal/client.go
@@ -538,7 +538,8 @@ type (
 		MaxPayloadSize int
 
 		// Advanced dial options for gRPC connections. These are applied after the internal default dial options are
-		// applied. Therefore any dial options here may override internal ones.
+		// applied. Therefore any dial options here may override internal ones. Dial options WithBlock, WithTimeout,
+		// WithReturnConnectionError, and FailOnNonTempDialError are ignored.
 		//
 		// For gRPC interceptors, internal interceptors such as error handling, metrics, and retrying are done via
 		// grpc.WithChainUnaryInterceptor. Therefore to add inner interceptors that are wrapped by those, a

--- a/internal/client.go
+++ b/internal/client.go
@@ -539,7 +539,7 @@ type (
 
 		// Advanced dial options for gRPC connections. These are applied after the internal default dial options are
 		// applied. Therefore any dial options here may override internal ones. Dial options WithBlock, WithTimeout,
-		// WithReturnConnectionError, and FailOnNonTempDialError are ignored.
+		// WithReturnConnectionError, and FailOnNonTempDialError are ignored since [grpc.NewClient] is used.
 		//
 		// For gRPC interceptors, internal interceptors such as error handling, metrics, and retrying are done via
 		// grpc.WithChainUnaryInterceptor. Therefore to add inner interceptors that are wrapped by those, a


### PR DESCRIPTION
Update some docs around grpc Dial options because `grpc-go` deprecated `grpc.Dial` so we switched to `grpc.NewClient` that doesn't support some of these dial options because they are anti patterns not recommended by the gRPC team.

https://github.com/grpc/grpc-go/blob/master/Documentation/anti-patterns.md 

Another thing we could do is add a flag to use the old deprecated client options to help who did rely on these options.
