### PR TITLE
expose mock Calls for testing activity order

### DIFF
--- a/internal/workflow_testsuite.go
+++ b/internal/workflow_testsuite.go
@@ -955,3 +955,7 @@ func (e *TestWorkflowEnvironment) AssertNotCalled(t mock.TestingT, methodName st
 func (e *TestWorkflowEnvironment) AssertNumberOfCalls(t mock.TestingT, methodName string, expectedCalls int) bool {
 	return e.mock.AssertNumberOfCalls(t, methodName, expectedCalls)
 }
+
+func (e *TestWorkflowEnvironment) Calls() []mock.Call {
+	return e.mock.Calls
+}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

## Why?
<!-- Tell your future self why have you made these changes -->
I would like to test the order of activity execution in the workflow unit tests. Looks like it’s lack of the feature.
Exposing the Calls of mock would be one solution.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
