### PR TITLE
Add the missing failure_reason tag.

### DIFF
--- a/internal/internal_event_handlers.go
+++ b/internal/internal_event_handlers.go
@@ -54,6 +54,7 @@ import (
 const (
 	queryResultSizeLimit             = 2000000 // 2MB
 	changeVersionSearchAttrSizeLimit = 2048
+	failureReasonPanic               = "Panic"
 )
 
 // Assert that structs do indeed implement the interfaces
@@ -1105,7 +1106,7 @@ func (weh *workflowExecutionEventHandlerImpl) ProcessEvent(
 	}
 	defer func() {
 		if p := recover(); p != nil {
-			weh.metricsHandler.Counter(metrics.WorkflowTaskExecutionFailureCounter).Inc(1)
+			weh.metricsHandler.WithTags(metrics.WorkflowTaskFailedTags(failureReasonPanic)).Counter(metrics.WorkflowTaskExecutionFailureCounter).Inc(1)
 			topLine := fmt.Sprintf("process event for %s [panic]:", weh.workflowInfo.TaskQueueName)
 			st := getStackTraceRaw(topLine, 7, 0)
 			weh.Complete(nil, newWorkflowPanicError(p, st))
@@ -1295,7 +1296,7 @@ func (weh *workflowExecutionEventHandlerImpl) ProcessMessage(
 ) error {
 	defer func() {
 		if p := recover(); p != nil {
-			weh.metricsHandler.Counter(metrics.WorkflowTaskExecutionFailureCounter).Inc(1)
+			weh.metricsHandler.WithTags(metrics.WorkflowTaskFailedTags(failureReasonPanic)).Counter(metrics.WorkflowTaskExecutionFailureCounter).Inc(1)
 			topLine := fmt.Sprintf("process message for %s [panic]:", weh.workflowInfo.TaskQueueName)
 			st := getStackTraceRaw(topLine, 7, 0)
 			weh.Complete(nil, newWorkflowPanicError(p, st))


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
When omitting the metric "WorkflowTaskExecutionFailureCounter", there are two other occasions that don't specify
the additional "failure_reason" tag. See [here](https://github.com/temporalio/sdk-go/blob/master/internal/internal_task_pollers.go#L421) that omits the same metric with additional tag.

## Why?
When using [prometheus](https://prometheus.io/) as a client backend, it enforces the same metric be consistent with the
same tags. If not, it will generate an error, and no metric is reported.

## Checklist

1. Closes: simple change, no issue is created.

2. How was this tested:
Implementing a new `metrics.Handler` that is backed by Prometheus, executing an intentional failing activity or workflow, no metrics for the errors are reported.

3. Any docs updates needed?
N/A.
