### PR TITLE
Wrap GRPC::CANCELED and DEADLINE_EXCEEDED in an SDK Timeout exception…

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -453,6 +453,12 @@ type (
 	// WARNING: Worker versioning is currently experimental.
 	WorkerVersioningRules = internal.WorkerVersioningRules
 
+	// WorkflowUpdateRPCTimeoutOrCancelledError is an error that occurs when an update RPC call times out or is cancelled.
+	//
+	// Note, this is not related to any general concept of timing out or cancelling a running update, this is only related to the client call itself.
+	// NOTE: Experimental
+	WorkflowUpdateRPCTimeoutOrCancelledError = internal.WorkflowUpdateRPCTimeoutOrCancelledError
+
 	// Client is the client for starting and getting information about a workflow executions as well as
 	// completing activities asynchronously.
 	Client interface {
@@ -792,6 +798,9 @@ type (
 		// update is requested (e.g. if the required workflow ID field is
 		// missing from the UpdateWorkflowOptions) are returned
 		// directly from this function call.
+		//
+		// The errors it can return:
+		//  - WorkflowUpdateRPCTimeoutOrCancelledError
 		// NOTE: Experimental
 		UpdateWorkflow(ctx context.Context, options UpdateWorkflowOptions) (WorkflowUpdateHandle, error)
 
@@ -1024,4 +1033,9 @@ func NewAPIKeyDynamicCredentials(apiKeyCallback func(context.Context) (string, e
 // these credentials.
 func NewMTLSCredentials(certificate tls.Certificate) Credentials {
 	return internal.NewMTLSCredentials(certificate)
+}
+
+// NewWorkflowUpdateRPCTimeoutOrCancelledError creates a new WorkflowUpdateRPCTimeoutOrCancelledError.
+func NewWorkflowUpdateRPCTimeoutOrCancelledError(err error) *WorkflowUpdateRPCTimeoutOrCancelledError {
+	return internal.NewWorkflowUpdateRPCTimeoutOrCancelledError(err)
 }

--- a/client/client.go
+++ b/client/client.go
@@ -453,11 +453,11 @@ type (
 	// WARNING: Worker versioning is currently experimental.
 	WorkerVersioningRules = internal.WorkerVersioningRules
 
-	// WorkflowUpdateRPCTimeoutOrCancelledError is an error that occurs when an update RPC call times out or is cancelled.
+	// WorkflowUpdateServiceTimeoutOrCanceledError is an error that occurs when an update call times out or is cancelled.
 	//
 	// Note, this is not related to any general concept of timing out or cancelling a running update, this is only related to the client call itself.
 	// NOTE: Experimental
-	WorkflowUpdateRPCTimeoutOrCancelledError = internal.WorkflowUpdateRPCTimeoutOrCancelledError
+	WorkflowUpdateServiceTimeoutOrCanceledError = internal.WorkflowUpdateServiceTimeoutOrCanceledError
 
 	// Client is the client for starting and getting information about a workflow executions as well as
 	// completing activities asynchronously.
@@ -800,7 +800,7 @@ type (
 		// directly from this function call.
 		//
 		// The errors it can return:
-		//  - WorkflowUpdateRPCTimeoutOrCancelledError
+		//  - WorkflowUpdateServiceTimeoutOrCanceledError
 		// NOTE: Experimental
 		UpdateWorkflow(ctx context.Context, options UpdateWorkflowOptions) (WorkflowUpdateHandle, error)
 
@@ -1035,7 +1035,7 @@ func NewMTLSCredentials(certificate tls.Certificate) Credentials {
 	return internal.NewMTLSCredentials(certificate)
 }
 
-// NewWorkflowUpdateRPCTimeoutOrCancelledError creates a new WorkflowUpdateRPCTimeoutOrCancelledError.
-func NewWorkflowUpdateRPCTimeoutOrCancelledError(err error) *WorkflowUpdateRPCTimeoutOrCancelledError {
-	return internal.NewWorkflowUpdateRPCTimeoutOrCancelledError(err)
+// NewWorkflowUpdateServiceTimeoutOrCanceledError creates a new WorkflowUpdateServiceTimeoutOrCanceledError.
+func NewWorkflowUpdateServiceTimeoutOrCanceledError(err error) *WorkflowUpdateServiceTimeoutOrCanceledError {
+	return internal.NewWorkflowUpdateServiceTimeoutOrCanceledError(err)
 }

--- a/internal/client.go
+++ b/internal/client.go
@@ -1003,3 +1003,23 @@ func (m mTLSCredentials) applyToOptions(opts *ClientOptions) error {
 }
 
 func (mTLSCredentials) gRPCInterceptor() grpc.UnaryClientInterceptor { return nil }
+
+// WorkflowUpdateRPCTimeoutOrCancelledError is an error that occurs when an update RPC call times out or is cancelled.
+//
+// Note, this is not related to any general concept of timing out or cancelling a running update, this is only related to the client call itself.
+type WorkflowUpdateRPCTimeoutOrCancelledError struct {
+	cause error
+}
+
+// NewWorkflowUpdateRPCTimeoutOrCancelledError creates a new WorkflowUpdateRPCTimeoutOrCancelledError.
+func NewWorkflowUpdateRPCTimeoutOrCancelledError(err error) *WorkflowUpdateRPCTimeoutOrCancelledError {
+	return &WorkflowUpdateRPCTimeoutOrCancelledError{
+		cause: err,
+	}
+}
+
+func (e *WorkflowUpdateRPCTimeoutOrCancelledError) Error() string {
+	return fmt.Sprintf("Timeout or cancellation waiting for update: %v", e.cause)
+}
+
+func (e *WorkflowUpdateRPCTimeoutOrCancelledError) Unwrap() error { return e.cause }

--- a/internal/client.go
+++ b/internal/client.go
@@ -1004,22 +1004,22 @@ func (m mTLSCredentials) applyToOptions(opts *ClientOptions) error {
 
 func (mTLSCredentials) gRPCInterceptor() grpc.UnaryClientInterceptor { return nil }
 
-// WorkflowUpdateRPCTimeoutOrCancelledError is an error that occurs when an update RPC call times out or is cancelled.
+// WorkflowUpdateServiceTimeoutOrCanceledError is an error that occurs when an update call times out or is cancelled.
 //
 // Note, this is not related to any general concept of timing out or cancelling a running update, this is only related to the client call itself.
-type WorkflowUpdateRPCTimeoutOrCancelledError struct {
+type WorkflowUpdateServiceTimeoutOrCanceledError struct {
 	cause error
 }
 
-// NewWorkflowUpdateRPCTimeoutOrCancelledError creates a new WorkflowUpdateRPCTimeoutOrCancelledError.
-func NewWorkflowUpdateRPCTimeoutOrCancelledError(err error) *WorkflowUpdateRPCTimeoutOrCancelledError {
-	return &WorkflowUpdateRPCTimeoutOrCancelledError{
+// NewWorkflowUpdateServiceTimeoutOrCanceledError creates a new WorkflowUpdateServiceTimeoutOrCanceledError.
+func NewWorkflowUpdateServiceTimeoutOrCanceledError(err error) *WorkflowUpdateServiceTimeoutOrCanceledError {
+	return &WorkflowUpdateServiceTimeoutOrCanceledError{
 		cause: err,
 	}
 }
 
-func (e *WorkflowUpdateRPCTimeoutOrCancelledError) Error() string {
+func (e *WorkflowUpdateServiceTimeoutOrCanceledError) Error() string {
 	return fmt.Sprintf("Timeout or cancellation waiting for update: %v", e.cause)
 }
 
-func (e *WorkflowUpdateRPCTimeoutOrCancelledError) Unwrap() error { return e.cause }
+func (e *WorkflowUpdateServiceTimeoutOrCanceledError) Unwrap() error { return e.cause }

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -1887,10 +1887,10 @@ func (w *workflowClientInterceptor) UpdateWorkflow(
 		}()
 		if err != nil {
 			if ctx.Err() != nil {
-				return nil, NewWorkflowUpdateRPCTimeoutOrCancelledError(err)
+				return nil, NewWorkflowUpdateServiceTimeoutOrCanceledError(err)
 			}
 			if code := status.Code(err); code == codes.Canceled || code == codes.DeadlineExceeded {
-				return nil, NewWorkflowUpdateRPCTimeoutOrCancelledError(err)
+				return nil, NewWorkflowUpdateServiceTimeoutOrCanceledError(err)
 			}
 			return nil, err
 		}
@@ -1975,10 +1975,10 @@ func (w *workflowClientInterceptor) PollWorkflowUpdate(
 		}
 		if err != nil {
 			if ctx.Err() != nil {
-				return nil, NewWorkflowUpdateRPCTimeoutOrCancelledError(err)
+				return nil, NewWorkflowUpdateServiceTimeoutOrCanceledError(err)
 			}
 			if code := status.Code(err); code == codes.Canceled || code == codes.DeadlineExceeded {
-				return nil, NewWorkflowUpdateRPCTimeoutOrCancelledError(err)
+				return nil, NewWorkflowUpdateServiceTimeoutOrCanceledError(err)
 			}
 			return nil, err
 		}

--- a/internal/internal_workflow_client_test.go
+++ b/internal/internal_workflow_client_test.go
@@ -35,7 +35,9 @@ import (
 	updatepb "go.temporal.io/api/update/v1"
 	workflowpb "go.temporal.io/api/workflow/v1"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/status"
 
 	ilog "go.temporal.io/sdk/internal/log"
 
@@ -1967,7 +1969,7 @@ func TestUpdate(t *testing.T) {
 					ctxWillTimeoutIn := time.Until(thisDeadline)
 					sleepCtx(ctx, ctxWillTimeoutIn+3*time.Second)
 					require.ErrorIs(t, ctx.Err(), context.DeadlineExceeded)
-					return nil, ctx.Err()
+					return nil, status.Error(codes.DeadlineExceeded, context.DeadlineExceeded.Error())
 				},
 			)
 		callerCtx, cancel := context.WithDeadline(context.TODO(), callerDeadline)
@@ -1975,7 +1977,30 @@ func TestUpdate(t *testing.T) {
 		var got string
 		err := handle.Get(callerCtx, &got)
 		require.Error(t, err)
-		require.Equal(t, callerCtx.Err(), err)
+		var rpcErr *WorkflowUpdateRPCTimeoutOrCancelledError
+		require.ErrorAs(t, err, &rpcErr)
+	})
+	t.Run("parent ctx cancelled", func(t *testing.T) {
+		svc, client := init(t)
+		handle := client.GetWorkflowUpdateHandle(GetWorkflowUpdateHandleOptions{})
+		svc.EXPECT().PollWorkflowExecutionUpdate(gomock.Any(), gomock.Any()).
+			DoAndReturn(
+				func(
+					ctx context.Context,
+					_ *workflowservice.PollWorkflowExecutionUpdateRequest,
+					_ ...grpc.CallOption,
+				) (*workflowservice.PollWorkflowExecutionUpdateResponse, error) {
+					return nil, status.Error(codes.Canceled, context.Canceled.Error())
+				},
+			)
+		callerCtx, cancel := context.WithCancel(context.TODO())
+		cancel()
+		var got string
+		err := handle.Get(callerCtx, &got)
+		require.Error(t, err)
+		var rpcErr *WorkflowUpdateRPCTimeoutOrCancelledError
+		require.ErrorAs(t, err, &rpcErr)
+		require.Contains(t, err.Error(), "context canceled")
 	})
 	t.Run("sync delayed success", func(t *testing.T) {
 		svc, client := init(t)

--- a/internal/internal_workflow_client_test.go
+++ b/internal/internal_workflow_client_test.go
@@ -1977,7 +1977,7 @@ func TestUpdate(t *testing.T) {
 		var got string
 		err := handle.Get(callerCtx, &got)
 		require.Error(t, err)
-		var rpcErr *WorkflowUpdateRPCTimeoutOrCancelledError
+		var rpcErr *WorkflowUpdateServiceTimeoutOrCanceledError
 		require.ErrorAs(t, err, &rpcErr)
 	})
 	t.Run("parent ctx cancelled", func(t *testing.T) {
@@ -1998,7 +1998,7 @@ func TestUpdate(t *testing.T) {
 		var got string
 		err := handle.Get(callerCtx, &got)
 		require.Error(t, err)
-		var rpcErr *WorkflowUpdateRPCTimeoutOrCancelledError
+		var rpcErr *WorkflowUpdateServiceTimeoutOrCanceledError
 		require.ErrorAs(t, err, &rpcErr)
 		require.Contains(t, err.Error(), "context canceled")
 	})

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -1880,7 +1880,7 @@ func (ts *IntegrationTestSuite) TestWorkflowExecutionUpdateDeadline() {
 		WaitForStage: client.WorkflowUpdateStageCompleted,
 	})
 	ts.Error(err)
-	var rpcErr *client.WorkflowUpdateRPCTimeoutOrCancelledError
+	var rpcErr *client.WorkflowUpdateServiceTimeoutOrCanceledError
 	ts.ErrorAs(err, &rpcErr)
 	ts.Contains(err.Error(), "context deadline exceeded")
 	// Complete workflow
@@ -1904,7 +1904,7 @@ func (ts *IntegrationTestSuite) TestWorkflowExecutionUpdateCancelled() {
 		WaitForStage: client.WorkflowUpdateStageCompleted,
 	})
 	ts.Error(err)
-	var rpcErr *client.WorkflowUpdateRPCTimeoutOrCancelledError
+	var rpcErr *client.WorkflowUpdateServiceTimeoutOrCanceledError
 	ts.ErrorAs(err, &rpcErr)
 	ts.Contains(err.Error(), "context canceled")
 	// Complete workflow


### PR DESCRIPTION
Based on https://github.com/temporalio/features/issues/483#issuecomment-2150832036

Closes https://github.com/temporalio/sdk-go/issues/1479
