### PR TITLE
Add workflow safe Mutex and Semaphore

### DIFF
--- a/internal/internal_workflow.go
+++ b/internal/internal_workflow.go
@@ -1810,6 +1810,6 @@ func (s *semaphoreImpl) TryAcquire(ctx Context, n int64) bool {
 func (s *semaphoreImpl) Release(n int64) {
 	s.cur -= n
 	if s.cur < 0 {
-		panic("Mutex.Release() released more than held")
+		panic("Semaphore.Release() released more than held")
 	}
 }

--- a/internal/internal_workflow.go
+++ b/internal/internal_workflow.go
@@ -1767,6 +1767,7 @@ func (m *mutexImpl) Lock(ctx Context) error {
 }
 
 func (m *mutexImpl) TryLock(ctx Context) bool {
+	assertNotInReadOnlyState(ctx)
 	if m.locked {
 		return false
 	}
@@ -1806,4 +1807,7 @@ func (s *semaphoreImpl) TryAcquire(ctx Context, n int64) bool {
 
 func (s *semaphoreImpl) Release(n int64) {
 	s.count += n
+	if s.count > 0 {
+		panic("Mutex.Release() released more than held")
+	}
 }

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -499,7 +499,7 @@ func NewMutex(ctx Context) Mutex {
 // NewSemaphore creates a new Semaphore instance with an initial weight.
 func NewSemaphore(ctx Context, n int64) Semaphore {
 	assertNotInReadOnlyState(ctx)
-	return &semaphoreImpl{count: n}
+	return &semaphoreImpl{size: n}
 }
 
 // Go creates a new coroutine. It has similar semantic to goroutine in a context of the workflow.

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -1632,7 +1632,7 @@ func (ts *IntegrationTestSuite) TestUpdateWithSemaphore() {
 	ctx := context.Background()
 	wfOptions := ts.startWorkflowOptions("test-update-with-semaphore")
 	run, err := ts.client.ExecuteWorkflow(ctx,
-		wfOptions, ts.workflows.UpdateWitSemaphore)
+		wfOptions, ts.workflows.UpdateWithSemaphore)
 	ts.Nil(err)
 
 	firstUpdate, err := ts.client.UpdateWorkflow(ctx, client.UpdateWorkflowOptions{

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -1562,6 +1562,72 @@ func (ts *IntegrationTestSuite) TestUpdateWorkflowCancelled() {
 	ts.NoError(run.Get(ctx, nil))
 }
 
+func (ts *IntegrationTestSuite) TestUpdateWithMutex() {
+	ctx := context.Background()
+	wfOptions := ts.startWorkflowOptions("test-update-with-mutex")
+	run, err := ts.client.ExecuteWorkflow(ctx,
+		wfOptions, ts.workflows.UpdateWithMutex)
+	ts.Nil(err)
+	// Send a first update to lock the mutex
+	firstUpdate, err := ts.client.UpdateWorkflow(ctx, client.UpdateWorkflowOptions{
+		WorkflowID:   run.GetID(),
+		RunID:        run.GetRunID(),
+		UpdateName:   "update",
+		WaitForStage: client.WorkflowUpdateStageAccepted,
+		Args:         []interface{}{true},
+	})
+	ts.NoError(err)
+	// Send a few updates to the workflow, these should fail because the mutex is locked
+	for i := 0; i < 5; i++ {
+		handle, err := ts.client.UpdateWorkflow(ctx, client.UpdateWorkflowOptions{
+			UpdateID:     fmt.Sprintf("test-update-%d", i),
+			WorkflowID:   run.GetID(),
+			RunID:        run.GetRunID(),
+			UpdateName:   "update",
+			WaitForStage: client.WorkflowUpdateStageAccepted,
+			Args:         []interface{}{true},
+		})
+		ts.NoError(err)
+		err = handle.Get(ctx, nil)
+		ts.Error(err)
+	}
+	// Send an update that will block on the mutex
+	blockedUpdate, err := ts.client.UpdateWorkflow(ctx, client.UpdateWorkflowOptions{
+		WorkflowID:   run.GetID(),
+		RunID:        run.GetRunID(),
+		UpdateName:   "update",
+		WaitForStage: client.WorkflowUpdateStageAccepted,
+		Args:         []interface{}{false},
+	})
+	ts.NoError(err)
+	// Unblock the update to release the mutex
+	ts.NoError(ts.client.SignalWorkflow(ctx, run.GetID(), run.GetRunID(), "unblock", nil))
+	// The first update should now complete
+	ts.NoError(firstUpdate.Get(ctx, nil))
+	// The second update should be blocked on the signal
+	cctx, cancel := context.WithTimeout(ctx, time.Second)
+	defer cancel()
+	ts.Error(blockedUpdate.Get(cctx, nil))
+	// Send another update
+	updateToCancel, err := ts.client.UpdateWorkflow(ctx, client.UpdateWorkflowOptions{
+		WorkflowID:   run.GetID(),
+		RunID:        run.GetRunID(),
+		UpdateName:   "update",
+		WaitForStage: client.WorkflowUpdateStageAccepted,
+		Args:         []interface{}{false},
+	})
+	ts.NoError(err)
+	// Cancel the workflow, this should cancel any update blocking on the mutex
+	ts.NoError(ts.client.CancelWorkflow(ctx, run.GetID(), run.GetRunID()))
+	ts.Error(updateToCancel.Get(ctx, nil))
+	// Unblock the update to release the mutex
+	ts.NoError(ts.client.SignalWorkflow(ctx, run.GetID(), run.GetRunID(), "unblock", nil))
+	ts.NoError(blockedUpdate.Get(ctx, nil))
+	// Signal the workflow to complete it
+	ts.NoError(ts.client.SignalWorkflow(ctx, run.GetID(), run.GetRunID(), "finish", "finished"))
+	ts.NoError(run.Get(ctx, nil))
+}
+
 func (ts *IntegrationTestSuite) TestBasicSession() {
 	var expected []string
 	err := ts.executeWorkflow("test-basic-session", ts.workflows.BasicSession, &expected)

--- a/workflow/deterministic_wrappers.go
+++ b/workflow/deterministic_wrappers.go
@@ -58,6 +58,15 @@ type (
 	// WaitGroup is used to wait for a collection of
 	// coroutines to finish
 	WaitGroup = internal.WaitGroup
+
+	// Mutex is a mutual exclusion lock.
+	// Mutex must be used instead of native go mutex by workflow code.
+	// Use [workflow.NewMutex] method to create a Mutex instance.
+	Mutex = internal.Mutex
+
+	// Semaphore is a counting semaphore.
+	// Use [workflow.NewSemaphore] method to create a Semaphore instance.
+	Semaphore = internal.Semaphore
 )
 
 // Await blocks the calling thread until condition() returns true.
@@ -133,6 +142,21 @@ func NewNamedSelector(ctx Context, name string) Selector {
 // NewWaitGroup creates a new WaitGroup instance.
 func NewWaitGroup(ctx Context) WaitGroup {
 	return internal.NewWaitGroup(ctx)
+}
+
+// NewMutex creates a new Mutex instance. A mutex can be used
+// when you want to ensure only one coroutine in a workflow is executing a
+// critical section of code at a time.
+//
+// Note: In a workflow, only one coroutine is ever executing at a time. So
+// a mutex is not needed to simply protect shared data.
+func NewMutex(ctx Context) Mutex {
+	return internal.NewMutex(ctx)
+}
+
+// NewSemaphore creates a new Semaphore instance.
+func NewSemaphore(ctx Context, n int64) Semaphore {
+	return internal.NewSemaphore(ctx, n)
 }
 
 // Go creates a new coroutine. It has similar semantics to a goroutine, but in the context of the workflow.


### PR DESCRIPTION
Add workflow safe Mutex and Semaphore. Based on Go standard [Mutex](https://pkg.go.dev/sync) and [Semaphore](https://pkg.go.dev/golang.org/x/sync/semaphore). Notable difference for the `Mutex` is our mutex supports cancellation of a lock request. I did this to match `Semaphore` and most other Go SDK primitives.