### PR TITLE
Add otel Carrier implementation for Temporal headers.

### DIFF
--- a/contrib/opentelemetry/temporal_header_carrier.go
+++ b/contrib/opentelemetry/temporal_header_carrier.go
@@ -1,0 +1,46 @@
+package opentelemetry
+
+import (
+	commonpb "go.temporal.io/api/common/v1"
+	"go.temporal.io/sdk/converter"
+)
+
+// TemporalHeaderCarrier adapts temporal header to satisfy the Carrier interface.
+type TemporalHeaderCarrier map[string]*commonpb.Payload
+
+// Get returns the value associated with the passed key.
+// nolint:fabric_structfunctionordering,fabric_typesordering // https://github.com/anzx/fabric-codestyle/issues/114, https://github.com/anzx/fabric-codestyle/issues/115
+func (h TemporalHeaderCarrier) Get(key string) string {
+	value := ""
+	payload := h[key]
+
+	if err := converter.GetDefaultDataConverter().FromPayload(payload, &value); err != nil {
+		//log.Warn(context.Background(), "error during temporal data conversion from payload", log.Str("error", err.Error()))
+		return ""
+	}
+
+	return value
+}
+
+// Keys lists the keys stored in this carrier.
+// nolint:fabric_structfunctionordering,fabric_typesordering // https://github.com/anzx/fabric-codestyle/issues/114, https://github.com/anzx/fabric-codestyle/issues/115
+func (h TemporalHeaderCarrier) Keys() []string {
+	keys := make([]string, 0, len(h))
+	for k := range h {
+		keys = append(keys, k)
+	}
+
+	return keys
+}
+
+// Set stores the key-value pair.
+// nolint:fabric_structfunctionordering // https://github.com/anzx/fabric-codestyle/issues/114
+func (h TemporalHeaderCarrier) Set(key string, value string) {
+	// Convert value to payload
+	payload, err := converter.GetDefaultDataConverter().ToPayload(value)
+	if err != nil {
+		//log.Warn(context.Background(), "error during temporal data conversion to payload", log.Str("error", err.Error()))
+		return
+	}
+	h[key] = payload
+}

--- a/contrib/opentelemetry/temporal_header_carrier.go
+++ b/contrib/opentelemetry/temporal_header_carrier.go
@@ -9,7 +9,6 @@ import (
 type TemporalHeaderCarrier map[string]*commonpb.Payload
 
 // Get returns the value associated with the passed key.
-// nolint:fabric_structfunctionordering,fabric_typesordering // https://github.com/anzx/fabric-codestyle/issues/114, https://github.com/anzx/fabric-codestyle/issues/115
 func (h TemporalHeaderCarrier) Get(key string) string {
 	value := ""
 	payload := h[key]
@@ -23,7 +22,6 @@ func (h TemporalHeaderCarrier) Get(key string) string {
 }
 
 // Keys lists the keys stored in this carrier.
-// nolint:fabric_structfunctionordering,fabric_typesordering // https://github.com/anzx/fabric-codestyle/issues/114, https://github.com/anzx/fabric-codestyle/issues/115
 func (h TemporalHeaderCarrier) Keys() []string {
 	keys := make([]string, 0, len(h))
 	for k := range h {
@@ -34,7 +32,6 @@ func (h TemporalHeaderCarrier) Keys() []string {
 }
 
 // Set stores the key-value pair.
-// nolint:fabric_structfunctionordering // https://github.com/anzx/fabric-codestyle/issues/114
 func (h TemporalHeaderCarrier) Set(key string, value string) {
 	// Convert value to payload
 	payload, err := converter.GetDefaultDataConverter().ToPayload(value)

--- a/contrib/opentelemetry/temporal_header_carrier.go
+++ b/contrib/opentelemetry/temporal_header_carrier.go
@@ -14,7 +14,6 @@ func (h TemporalHeaderCarrier) Get(key string) string {
 	payload := h[key]
 
 	if err := converter.GetDefaultDataConverter().FromPayload(payload, &value); err != nil {
-		//log.Warn(context.Background(), "error during temporal data conversion from payload", log.Str("error", err.Error()))
 		return ""
 	}
 
@@ -36,7 +35,6 @@ func (h TemporalHeaderCarrier) Set(key string, value string) {
 	// Convert value to payload
 	payload, err := converter.GetDefaultDataConverter().ToPayload(value)
 	if err != nil {
-		//log.Warn(context.Background(), "error during temporal data conversion to payload", log.Str("error", err.Error()))
 		return
 	}
 	h[key] = payload

--- a/contrib/opentelemetry/temporal_header_carrier_test.go
+++ b/contrib/opentelemetry/temporal_header_carrier_test.go
@@ -1,0 +1,90 @@
+package opentelemetry
+
+import (
+	"github.com/stretchr/testify/assert"
+	commonpb "go.temporal.io/api/common/v1"
+	"go.temporal.io/sdk/converter"
+	"testing"
+)
+
+func TestTemporalHeaderCarrier_Get(t *testing.T) {
+	tests := []struct {
+		name      string
+		carrier   TemporalHeaderCarrier
+		wantValue string
+	}{
+		{
+			name:      "empty metadata",
+			carrier:   TemporalHeaderCarrier(map[string]*commonpb.Payload{}),
+			wantValue: "",
+		},
+		{
+			name: "with no matching key",
+			carrier: TemporalHeaderCarrier(map[string]*commonpb.Payload{
+				"other_key": encodeString(t, "value"),
+			}),
+			wantValue: "",
+		},
+		{
+			name: "with matching key",
+			carrier: TemporalHeaderCarrier(map[string]*commonpb.Payload{
+				"key": encodeString(t, "value1"),
+			}),
+			wantValue: "value1",
+		},
+	}
+
+	for _, test := range tests {
+		tt := test
+		t.Run(tt.name, func(t *testing.T) {
+			val := tt.carrier.Get("key")
+			assert.Equal(t, tt.wantValue, val)
+		})
+	}
+}
+
+func TestTemporalHeaderCarrier_Keys(t *testing.T) {
+	tests := []struct {
+		name         string
+		carrier      TemporalHeaderCarrier
+		expectedKeys []string
+	}{
+		{
+			name:         "empty metadata",
+			carrier:      TemporalHeaderCarrier(map[string]*commonpb.Payload{}),
+			expectedKeys: []string{},
+		},
+		{
+			name: "metadata with keys",
+			carrier: TemporalHeaderCarrier(map[string]*commonpb.Payload{
+				"key1": encodeString(t, "value1"),
+				"key2": encodeString(t, "value2"),
+			}),
+			expectedKeys: []string{"key1", "key2"},
+		},
+	}
+
+	for _, test := range tests {
+		tt := test
+		t.Run(tt.name, func(t *testing.T) {
+			val := tt.carrier.Keys()
+			assert.ElementsMatch(t, tt.expectedKeys, val)
+		})
+	}
+}
+
+func TestTemporalHeaderCarrier_Set(t *testing.T) {
+	m := map[string]*commonpb.Payload{}
+	carrier := TemporalHeaderCarrier(m)
+
+	carrier.Set("test", "value")
+
+	assert.Equal(t, "value", carrier.Get("test"))
+	assert.Equal(t, encodeString(t, "value"), m["test"])
+}
+
+func encodeString(t *testing.T, s string) *commonpb.Payload {
+	p, err := converter.GetDefaultDataConverter().ToPayload(s)
+	assert.NoError(t, err)
+	return p
+}


### PR DESCRIPTION
## What was changed
Adds a Opentelemetry 'Carrier' implementation for Temporal Headers. This can be used by third party libraries to propagate Opentelemetry data via the Temporal headers. For example to propagate trace ID from the starter to workers.

Similar to implementations for other protocols here https://github.com/open-telemetry/opentelemetry-go/blob/0485de287ec48767a58e9fc2eda30b3dc1836668/propagation/propagation.go#L104 and here  https://github.com/open-telemetry/opentelemetry-go-contrib/blob/main/instrumentation/google.golang.org/grpc/otelgrpc/metadata_supplier.go#L21.

## Why?
I have made these changes in order for external libraries to be able to add Opentelemetry trace info to the Temporal Headers. Specifically my use case is a custom temporal interceptor that we have written.

Example usage:

```
import  (
    "go.opentelemetry.io/otel/propagation"
    "go.temporal.io/sdk/interceptor"
)

carrier := temporal_propagator.TemporalHeaderCarrier(interceptor.WorkflowHeader(ctx)

// In order to copy otel TextMap data from context into Temporal Headers
propagation.TextMapPropagator.Inject(ctx, carrier)

// In order to copy the otel TextMap data from Temporal Headers into context
propagation.TextMapPropagator.Extract(ctx, carrier)
```

## Checklist

1. Closes <!-- add issue number here -->

2. How was this tested:
Unit test
I was unable to figure out where in the temporal interceptor code the trace ID is copied into the temporal headers, but perhaps that could be updated to use this and then it will be covered by an integration test? Appreciate any pointers on that.

3. Any docs updates needed?
not sure?
