### PR TITLE
add Name method to ReceiveChannel and SendChannel interface

### DIFF
--- a/internal/internal_coroutines_test.go
+++ b/internal/internal_coroutines_test.go
@@ -430,6 +430,12 @@ func TestChannelName(t *testing.T) {
 		ch2 := NewNamedChannel(ctx, namedChannel)
 		assert.Equal(t, namedChannel, ch2.Name())
 
+		var receiveChannel ReceiveChannel = ch2
+		assert.Equal(t, namedChannel, receiveChannel.Name())
+
+		var sendChannel SendChannel = ch2
+		assert.Equal(t, namedChannel, sendChannel.Name())
+
 		const signalChannel = "signal-channel"
 		ch3 := GetSignalChannel(ctx, signalChannel)
 		assert.Equal(t, signalChannel, ch3.Name())

--- a/internal/internal_coroutines_test.go
+++ b/internal/internal_coroutines_test.go
@@ -420,6 +420,25 @@ func TestBufferedChannelGet(t *testing.T) {
 	require.EqualValues(t, expected, history)
 }
 
+func TestChannelName(t *testing.T) {
+	d := createNewDispatcher(func(ctx Context) {
+		const namedBufferedChannel = "named-buffered-channel"
+		ch1 := NewNamedBufferedChannel(ctx, namedBufferedChannel, 1)
+		assert.Equal(t, namedBufferedChannel, ch1.Name())
+
+		const namedChannel = "named-channel"
+		ch2 := NewNamedChannel(ctx, namedChannel)
+		assert.Equal(t, namedChannel, ch2.Name())
+
+		const signalChannel = "signal-channel"
+		ch3 := GetSignalChannel(ctx, signalChannel)
+		assert.Equal(t, signalChannel, ch3.Name())
+	})
+	defer d.Close()
+	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked(defaultDeadlockDetectionTimeout))
+	require.True(t, d.IsDone())
+}
+
 func TestNotBlockingSelect(t *testing.T) {
 	var history []string
 	d := createNewDispatcher(func(ctx Context) {

--- a/internal/internal_workflow.go
+++ b/internal/internal_workflow.go
@@ -751,6 +751,10 @@ func getStateIfRunning(ctx Context) *coroutineState {
 	return state
 }
 
+func (c *channelImpl) Name() string {
+	return c.name
+}
+
 func (c *channelImpl) CanReceiveWithoutBlocking() bool {
 	return c.recValue != nil || len(c.buffer) > 0 || len(c.blockedSends) > 0 || c.closed
 }

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -69,6 +69,10 @@ type (
 	// commonChannel contains methods common to both SendChannel and ReceiveChannel
 	commonChannel interface {
 		// Name returns the name of the channel.
+		// If the channel was retrieved from a GetSignalChannel call, Name returns the signal name.
+		//
+		// A Channel created without an explicit name will use a generated name by the SDK and
+		// is not deterministic.
 		Name() string
 	}
 

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -68,8 +68,8 @@ var (
 type (
 	// commonChannel contains methods common to both SendChannel and ReceiveChannel
 	commonChannel interface {
-		// Name returns the name of the channel.
-		// If the channel was retrieved from a GetSignalChannel call, Name returns the signal name.
+		// Name returns the name of the Channel.
+		// If the Channel was retrieved from a GetSignalChannel call, Name returns the signal name.
 		//
 		// A Channel created without an explicit name will use a generated name by the SDK and
 		// is not deterministic.

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -66,8 +66,16 @@ var (
 )
 
 type (
+	// commonChannel contains methods common to both SendChannel and ReceiveChannel
+	commonChannel interface {
+		// Name returns the name of the channel.
+		Name() string
+	}
+
 	// SendChannel is a write only view of the Channel
 	SendChannel interface {
+		commonChannel
+
 		// Send blocks until the data is sent.
 		Send(ctx Context, v interface{})
 
@@ -80,6 +88,8 @@ type (
 
 	// ReceiveChannel is a read only view of the Channel
 	ReceiveChannel interface {
+		commonChannel
+
 		// Receive blocks until it receives a value, and then assigns the received value to the provided pointer.
 		// Returns false when Channel is closed.
 		// Parameter valuePtr is a pointer to the expected data structure to be received. For example:

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -66,19 +66,14 @@ var (
 )
 
 type (
-	// commonChannel contains methods common to both SendChannel and ReceiveChannel
-	commonChannel interface {
+	// SendChannel is a write only view of the Channel
+	SendChannel interface {
 		// Name returns the name of the Channel.
 		// If the Channel was retrieved from a GetSignalChannel call, Name returns the signal name.
 		//
 		// A Channel created without an explicit name will use a generated name by the SDK and
 		// is not deterministic.
 		Name() string
-	}
-
-	// SendChannel is a write only view of the Channel
-	SendChannel interface {
-		commonChannel
 
 		// Send blocks until the data is sent.
 		Send(ctx Context, v interface{})
@@ -92,7 +87,12 @@ type (
 
 	// ReceiveChannel is a read only view of the Channel
 	ReceiveChannel interface {
-		commonChannel
+		// Name returns the name of the Channel.
+		// If the Channel was retrieved from a GetSignalChannel call, Name returns the signal name.
+		//
+		// A Channel created without an explicit name will use a generated name by the SDK and
+		// is not deterministic.
+		Name() string
 
 		// Receive blocks until it receives a value, and then assigns the received value to the provided pointer.
 		// Returns false when Channel is closed.


### PR DESCRIPTION
## What was changed
- Added `Name` method to `SendChannel` and `ReceiveChannel` interface
- Added tests to assert `Name`returns back the same given name.

## Why?

- We have custom wrappers around signalling receive and send calls so that we can attach OpenTelemetry to our signal payload. Since we want our spans to contain the signal name and happen before calling into the underlying `channel.Send` method, ideally we could simplify our API to not require a redundant sending of the channelName again.
  - ie. `telemetrytemporal.ChannelSend[T](ctx workflow.Context, channel workflow.SendChannel, channelName string, payload T)`

## Checklist

Closes #1304

2. How was this tested:
- Added "TestChannelName" in `internal/internal_coroutines_test.go` which creates named channels and asserts that the `Name` method returns back the same name you gave it.

3. Any docs updates needed?
- N/A