### PR TITLE
Fix some Deprecated go docs

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -48,6 +48,7 @@ import (
 
 // TaskReachability specifies which category of tasks may reach a worker on a versioned task queue.
 // Used both in a reachability query and its response.
+//
 // Deprecated: Use [BuildIDTaskReachability]
 type TaskReachability = internal.TaskReachability
 
@@ -276,50 +277,61 @@ type (
 	GetWorkflowUpdateHandleOptions = internal.GetWorkflowUpdateHandleOptions
 
 	// UpdateWorkerBuildIdCompatibilityOptions is the input to Client.UpdateWorkerBuildIdCompatibility.
+	//
 	// Deprecated: Use [UpdateWorkerVersioningRulesOptions] with the new worker versioning api.
 	UpdateWorkerBuildIdCompatibilityOptions = internal.UpdateWorkerBuildIdCompatibilityOptions
 
 	// GetWorkerBuildIdCompatibilityOptions is the input to Client.GetWorkerBuildIdCompatibility.
+	//
 	// Deprecated: Use [GetWorkerVersioningOptions] with the new worker versioning api.
 	GetWorkerBuildIdCompatibilityOptions = internal.GetWorkerBuildIdCompatibilityOptions
 
 	// WorkerBuildIDVersionSets is the response for Client.GetWorkerBuildIdCompatibility.
+	//
 	// Deprecated: Replaced by the new worker versioning api.
 	WorkerBuildIDVersionSets = internal.WorkerBuildIDVersionSets
 
 	// BuildIDOpAddNewIDInNewDefaultSet is an operation for UpdateWorkerBuildIdCompatibilityOptions
 	// to add a new BuildID in a new default set.
+	//
 	// Deprecated: Replaced by the new worker versioning api.
 	BuildIDOpAddNewIDInNewDefaultSet = internal.BuildIDOpAddNewIDInNewDefaultSet
 
 	// BuildIDOpAddNewCompatibleVersion is an operation for UpdateWorkerBuildIdCompatibilityOptions
 	// to add a new BuildID to an existing compatible set.
+	//
 	// Deprecated: Replaced by the new worker versioning api.
 	BuildIDOpAddNewCompatibleVersion = internal.BuildIDOpAddNewCompatibleVersion
 
 	// BuildIDOpPromoteSet is an operation for UpdateWorkerBuildIdCompatibilityOptions to promote a
 	// set to be the default set by targeting an existing BuildID.
+	//
 	// Deprecated: Replaced by the new worker versioning api.
 	BuildIDOpPromoteSet = internal.BuildIDOpPromoteSet
 
 	// BuildIDOpPromoteIDWithinSet is an operation for UpdateWorkerBuildIdCompatibilityOptions to
 	// promote a BuildID within a set to be the default.
+	//
 	// Deprecated: Replaced by the new worker versioning api.
 	BuildIDOpPromoteIDWithinSet = internal.BuildIDOpPromoteIDWithinSet
 
 	// GetWorkerTaskReachabilityOptions is the input to Client.GetWorkerTaskReachability.
+	//
 	// Deprecated: Use [DescribeTaskQueueEnhancedOptions] with the new worker versioning api.
 	GetWorkerTaskReachabilityOptions = internal.GetWorkerTaskReachabilityOptions
 
 	// WorkerTaskReachability is the response for Client.GetWorkerTaskReachability.
+	//
 	// Deprecated: Replaced by the new worker versioning api.
 	WorkerTaskReachability = internal.WorkerTaskReachability
 
 	// BuildIDReachability describes the reachability of a buildID
+	//
 	// Deprecated: Replaced by the new worker versioning api.
 	BuildIDReachability = internal.BuildIDReachability
 
 	// TaskQueueReachability Describes how the Build ID may be reachable from the task queue.
+	//
 	// Deprecated: Replaced by the new worker versioning api.
 	TaskQueueReachability = internal.TaskQueueReachability
 
@@ -766,16 +778,19 @@ type (
 		// UpdateWorkerBuildIdCompatibility
 		// Allows you to update the worker-build-id based version sets for a particular task queue. This is used in
 		// conjunction with workers who specify their build id and thus opt into the feature.
+		//
 		// Deprecated: Use [UpdateWorkerVersioningRules] with the versioning api.
 		UpdateWorkerBuildIdCompatibility(ctx context.Context, options *UpdateWorkerBuildIdCompatibilityOptions) error
 
 		// GetWorkerBuildIdCompatibility
 		// Returns the worker-build-id based version sets for a particular task queue.
+		//
 		// Deprecated: Use [GetWorkerVersioningRules] with the versioning api.
 		GetWorkerBuildIdCompatibility(ctx context.Context, options *GetWorkerBuildIdCompatibilityOptions) (*WorkerBuildIDVersionSets, error)
 
 		// GetWorkerTaskReachability
 		// Returns which versions are is still in use by open or closed workflows
+		//
 		// Deprecated: Use [DescribeTaskQueueEnhanced] with the versioning api.
 		GetWorkerTaskReachability(ctx context.Context, options *GetWorkerTaskReachabilityOptions) (*WorkerTaskReachability, error)
 

--- a/internal/worker_version_sets.go
+++ b/internal/worker_version_sets.go
@@ -45,10 +45,12 @@ const (
 	// VersioningIntentCompatible indicates that the command should run on a worker with compatible
 	// version if possible. It may not be possible if the target task queue does not also have
 	// knowledge of the current worker's build ID.
+	//
 	// Deprecated: This has the same effect as [VersioningIntentInheritBuildID], use that instead.
 	VersioningIntentCompatible
 	// VersioningIntentDefault indicates that the command should run on the target task queue's
 	// current overall-default build ID.
+	//
 	// Deprecated: This has the same effect as [VersioningIntentUseAssignmentRules], use that instead.
 	VersioningIntentDefault
 	// VersioningIntentInheritBuildID indicates the command should inherit the current Build ID of the

--- a/internal/workflow_testsuite.go
+++ b/internal/workflow_testsuite.go
@@ -513,6 +513,7 @@ func (e *TestWorkflowEnvironment) OnGetVersion(changeID string, minSupported, ma
 // OnUpsertSearchAttributes setup a mock for workflow.UpsertSearchAttributes call.
 // If mock is not setup, the UpsertSearchAttributes call will only validate input attributes.
 // If mock is setup, all UpsertSearchAttributes calls in workflow have to be mocked.
+//
 // Deprecated: use OnUpsertTypedSearchAttributes instead.
 func (e *TestWorkflowEnvironment) OnUpsertSearchAttributes(attributes interface{}) *MockCallWrapper {
 	call := e.workflowMock.On(mockMethodForUpsertSearchAttributes, attributes)
@@ -954,6 +955,7 @@ func (e *TestWorkflowEnvironment) SetMemoOnStart(memo map[string]interface{}) er
 }
 
 // SetSearchAttributesOnStart sets the search attributes when start workflow.
+//
 // Deprecated: Use SetTypedSearchAttributes instead.
 func (e *TestWorkflowEnvironment) SetSearchAttributesOnStart(searchAttributes map[string]interface{}) error {
 	attr, err := serializeUntypedSearchAttributes(searchAttributes)

--- a/mocks/Client.go
+++ b/mocks/Client.go
@@ -321,6 +321,8 @@ func (_m *Client) GetSearchAttributes(ctx context.Context) (*workflowservice.Get
 }
 
 // GetWorkerBuildIdCompatibility provides a mock function with given fields: ctx, options
+//
+//lint:ignore SA1019 ignore for SDK
 func (_m *Client) GetWorkerBuildIdCompatibility(ctx context.Context, options *client.GetWorkerBuildIdCompatibilityOptions) (*client.WorkerBuildIDVersionSets, error) {
 	ret := _m.Called(ctx, options)
 
@@ -328,19 +330,23 @@ func (_m *Client) GetWorkerBuildIdCompatibility(ctx context.Context, options *cl
 		panic("no return value specified for GetWorkerBuildIdCompatibility")
 	}
 
+	//lint:ignore SA1019 ignore for SDK mocks
 	var r0 *client.WorkerBuildIDVersionSets
 	var r1 error
+	//lint:ignore SA1019 ignore for SDK mocks
 	if rf, ok := ret.Get(0).(func(context.Context, *client.GetWorkerBuildIdCompatibilityOptions) (*client.WorkerBuildIDVersionSets, error)); ok {
 		return rf(ctx, options)
 	}
+	//lint:ignore SA1019 ignore for SDK mocks
 	if rf, ok := ret.Get(0).(func(context.Context, *client.GetWorkerBuildIdCompatibilityOptions) *client.WorkerBuildIDVersionSets); ok {
 		r0 = rf(ctx, options)
 	} else {
 		if ret.Get(0) != nil {
+			//lint:ignore SA1019 ignore for SDK mocks
 			r0 = ret.Get(0).(*client.WorkerBuildIDVersionSets)
 		}
 	}
-
+	//lint:ignore SA1019 ignore for SDK
 	if rf, ok := ret.Get(1).(func(context.Context, *client.GetWorkerBuildIdCompatibilityOptions) error); ok {
 		r1 = rf(ctx, options)
 	} else {
@@ -351,26 +357,31 @@ func (_m *Client) GetWorkerBuildIdCompatibility(ctx context.Context, options *cl
 }
 
 // GetWorkerTaskReachability provides a mock function with given fields: ctx, options
+//
+//lint:ignore SA1019 ignore for SDK mocks
 func (_m *Client) GetWorkerTaskReachability(ctx context.Context, options *client.GetWorkerTaskReachabilityOptions) (*client.WorkerTaskReachability, error) {
 	ret := _m.Called(ctx, options)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetWorkerTaskReachability")
 	}
-
+	//lint:ignore SA1019 ignore for SDK mocks
 	var r0 *client.WorkerTaskReachability
 	var r1 error
+	//lint:ignore SA1019 ignore for SDK mocks
 	if rf, ok := ret.Get(0).(func(context.Context, *client.GetWorkerTaskReachabilityOptions) (*client.WorkerTaskReachability, error)); ok {
 		return rf(ctx, options)
 	}
+	//lint:ignore SA1019 ignore for SDK mocks
 	if rf, ok := ret.Get(0).(func(context.Context, *client.GetWorkerTaskReachabilityOptions) *client.WorkerTaskReachability); ok {
 		r0 = rf(ctx, options)
 	} else {
 		if ret.Get(0) != nil {
+			//lint:ignore SA1019 ignore for SDK mocks
 			r0 = ret.Get(0).(*client.WorkerTaskReachability)
 		}
 	}
-
+	//lint:ignore SA1019 ignore for SDK mocks
 	if rf, ok := ret.Get(1).(func(context.Context, *client.GetWorkerTaskReachabilityOptions) error); ok {
 		r1 = rf(ctx, options)
 	} else {
@@ -868,6 +879,8 @@ func (_m *Client) TerminateWorkflow(ctx context.Context, workflowID string, runI
 }
 
 // UpdateWorkerBuildIdCompatibility provides a mock function with given fields: ctx, options
+//
+//lint:ignore SA1019 ignore for SDK mocks
 func (_m *Client) UpdateWorkerBuildIdCompatibility(ctx context.Context, options *client.UpdateWorkerBuildIdCompatibilityOptions) error {
 	ret := _m.Called(ctx, options)
 
@@ -876,6 +889,7 @@ func (_m *Client) UpdateWorkerBuildIdCompatibility(ctx context.Context, options 
 	}
 
 	var r0 error
+	//lint:ignore SA1019 ignore for SDK mocks
 	if rf, ok := ret.Get(0).(func(context.Context, *client.UpdateWorkerBuildIdCompatibilityOptions) error); ok {
 		r0 = rf(ctx, options)
 	} else {

--- a/temporal/build_id_versioning.go
+++ b/temporal/build_id_versioning.go
@@ -38,11 +38,15 @@ const (
 	// VersioningIntentCompatible indicates that the command should run on a worker with compatible
 	// version if possible. It may not be possible if the target task queue does not also have
 	// knowledge of the current worker's build ID.
+	//
 	// Deprecated: This has the same effect as [VersioningIntentInheritBuildID], use that instead.
+	//lint:ignore SA1019 ignore for SDK
 	VersioningIntentCompatible = internal.VersioningIntentCompatible
 	// VersioningIntentDefault indicates that the command should run on the target task queue's
 	// current overall-default build ID.
+	//
 	// Deprecated: This has the same effect as [VersioningIntentUseAssignmentRules], use that instead.
+	//lint:ignore SA1019 ignore for SDK
 	VersioningIntentDefault = internal.VersioningIntentDefault
 	// VersioningIntentInheritBuildID indicates the command should inherit the current Build ID of the
 	// Workflow triggering it, and not use Assignment Rules. (Redirect Rules are still applicable)


### PR DESCRIPTION
Fix some misformatted `Deprecated` go docs comments 