### PR TITLE
Fix bug in updateWorkflowByID

### DIFF
--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -2539,8 +2539,8 @@ func (env *testWorkflowEnvironmentImpl) updateWorkflowByID(workflowID, name, id 
 		if err != nil {
 			panic(err)
 		}
-		env.postCallback(func() {
-			env.updateHandler(name, id, data, nil, uc)
+		workflowHandle.env.postCallback(func() {
+			workflowHandle.env.updateHandler(name, id, data, nil, uc)
 		}, true)
 		return nil
 	}


### PR DESCRIPTION
`updateWorkflowByID` was not targeting the correct workflow handle. This caused updating a child workflow to fail.
