### PR TITLE
Fix non-deterministic error when resetting a parent workflow with a child workflow

### DIFF
--- a/internal/internal_event_handlers.go
+++ b/internal/internal_event_handlers.go
@@ -553,7 +553,11 @@ func (wc *workflowEnvironmentImpl) ExecuteChildWorkflow(
 	params ExecuteWorkflowParams, callback ResultHandler, startedHandler func(r WorkflowExecution, e error),
 ) {
 	if params.WorkflowID == "" {
-		params.WorkflowID = wc.workflowInfo.WorkflowExecution.RunID + "_" + wc.GenerateSequenceID()
+		if wc.workflowInfo.OriginalRunID != "" {
+			params.WorkflowID = wc.workflowInfo.OriginalRunID + "_" + wc.GenerateSequenceID()
+		} else {
+			params.WorkflowID = wc.workflowInfo.WorkflowExecution.RunID + "_" + wc.GenerateSequenceID()
+		}
 	}
 	memo, err := getWorkflowMemo(params.Memo, wc.dataConverter)
 	if err != nil {


### PR DESCRIPTION

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Fix non-deterministic error when resetting a parent workflow with a child workflow

## Why?
<!-- Tell your future self why have you made these changes -->
Includes the following change from cadence: https://github.com/uber-go/cadence-client/pull/1118

## Checklist
<!--- add/delete as needed --->

1. Closes 
2. https://github.com/temporalio/sdk-go/issues/723

3. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
unit tests manual tests

4. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
