### PR TITLE
Update SDK version

### DIFF
--- a/internal/version.go
+++ b/internal/version.go
@@ -30,7 +30,7 @@ package internal
 const (
 	// SDKVersion is a semver (https://semver.org/) that represents the version of this Temporal GoSDK.
 	// Server validates if SDKVersion fits its supported range and rejects request if it doesn't.
-	SDKVersion = "1.28.0"
+	SDKVersion = "1.28.1"
 
 	// SDKName represents the name of the SDK.
 	SDKName = clientNameHeaderValue

--- a/internal/version.go
+++ b/internal/version.go
@@ -30,7 +30,7 @@ package internal
 const (
 	// SDKVersion is a semver (https://semver.org/) that represents the version of this Temporal GoSDK.
 	// Server validates if SDKVersion fits its supported range and rejects request if it doesn't.
-	SDKVersion = "1.27.0"
+	SDKVersion = "1.28.0"
 
 	// SDKName represents the name of the SDK.
 	SDKName = clientNameHeaderValue


### PR DESCRIPTION
Forgot to bump the version in `version.go` before cutting the `1.28.0` release.