### PR TITLE
Removing wording saying a signal will ignore start delay

### DIFF
--- a/internal/client.go
+++ b/internal/client.go
@@ -702,8 +702,7 @@ type (
 		EnableEagerStart bool
 
 		// StartDelay - Time to wait before dispatching the first workflow task.
-		// If the workflow gets a signal before the delay, a workflow task will be dispatched and the rest
-		// of the delay will be ignored. A signal from signal with start will not trigger a workflow task.
+		// A signal from signal with start will not trigger a workflow task.
 		// Cannot be set the same time as a CronSchedule.
 		StartDelay time.Duration
 


### PR DESCRIPTION
Removing wording saying a signal will ignore start delay

closes: https://github.com/temporalio/sdk-go/issues/1591