### PR TITLE
Add TraceFlags to otel tracing interceptor

### DIFF
--- a/contrib/opentelemetry/tracing_interceptor.go
+++ b/contrib/opentelemetry/tracing_interceptor.go
@@ -26,6 +26,7 @@ package opentelemetry
 import (
 	"context"
 	"fmt"
+
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/baggage"
@@ -237,6 +238,7 @@ func (t *tracer) GetLogger(logger log.Logger, ref interceptor.TracerSpanRef) log
 	logger = log.With(logger,
 		"TraceID", span.SpanContext().TraceID(),
 		"SpanID", span.SpanContext().SpanID(),
+		"TraceFlags", span.SpanContext().TraceFlags(),
 	)
 
 	return logger

--- a/contrib/opentelemetry/tracing_interceptor_logger_test.go
+++ b/contrib/opentelemetry/tracing_interceptor_logger_test.go
@@ -81,9 +81,7 @@ func TestLogFields(t *testing.T) {
 	span := rec.Ended()[0]
 	assert.Contains(t, buf.String(), "TraceID="+span.Parent().TraceID().String())
 	assert.Contains(t, buf.String(), "SpanID="+span.Parent().SpanID().String())
-
-	assert.Contains(t, buf.String(), "TraceID="+span.Parent().TraceID().String())
-	assert.Contains(t, buf.String(), "SpanID="+span.Parent().SpanID().String())
+	assert.Contains(t, buf.String(), "TraceFlags="+span.Parent().TraceFlags().String())
 }
 
 func testWorkflow(ctx workflow.Context) error {


### PR DESCRIPTION
According to the otel log datamodel, there needs to be a `TraceFlags` byte field, which currently defines only the `SAMPLED` flag:
https://opentelemetry.io/docs/specs/otel/logs/data-model/#field-traceflags

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Added the `TraceFlags` field to otel tracing interceptor

## Why?
To conform to otel's log data model, the `TraceFlags` field has to appear and define the `SAMPLED` flag.

## Checklist

1. How was this tested:

Added a TraceFlags assert to the current logger test