### PR TITLE
Add DisableLogging option to otel tracing interceptor

### DIFF
--- a/contrib/opentelemetry/tracing_interceptor.go
+++ b/contrib/opentelemetry/tracing_interceptor.go
@@ -26,6 +26,7 @@ package opentelemetry
 import (
 	"context"
 	"fmt"
+
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/baggage"
@@ -58,6 +59,9 @@ type TracerOptions struct {
 
 	// DisableBaggage can be set to disable baggage propagation.
 	DisableBaggage bool
+
+	// DisableLogging can be set to disable logging of span and trace IDs.
+	DisableLogging bool
 
 	// AllowInvalidParentSpans will swallow errors interpreting parent
 	// spans from headers. Useful when migrating from one tracing library
@@ -229,6 +233,10 @@ func (t *tracer) StartSpan(opts *interceptor.TracerStartSpanOptions) (intercepto
 }
 
 func (t *tracer) GetLogger(logger log.Logger, ref interceptor.TracerSpanRef) log.Logger {
+	if t.options.DisableLogging {
+		return logger
+	}
+
 	span, ok := ref.(*tracerSpan)
 	if !ok {
 		return logger


### PR DESCRIPTION
The otel tracing interceptor currently adds a partial implementation of otel logging. This may be undesired as it pollutes the logs while not fully implementing otel logging.

## What was changed
Added a `DisableLogging` option to the OTel tracing interceptor.

## Why?
The current OTel tracing interceptor adds the `SpanID` and `TraceID` to the logs. For users who don't use OTel logging, this pollutes their logs without a way to disable it. For users who do use OTel logging, this is not enough as it doesn't fully conform to the OTel protocol. This option adds a way to disable it so it either doesn't add unneeded log attributes when you don't need it, and allows OTel users to implement their own logger without having side effects from this interceptor.
