### PR TITLE
Allow workflow interceptors to add nexus headers

### DIFF
--- a/interceptor/interceptor.go
+++ b/interceptor/interceptor.go
@@ -131,6 +131,11 @@ type HandleQueryInput = internal.HandleQueryInput
 // NOTE: Experimental
 type UpdateInput = internal.UpdateInput
 
+// ExecuteNexusOperationInput is the input to WorkflowOutboundInterceptor.ExecuteNexusOperation.
+//
+// NOTE: Experimental
+type ExecuteNexusOperationInput = internal.ExecuteNexusOperationInput
+
 // RequestCancelNexusOperationInput is the input to WorkflowOutboundInterceptor.RequestCancelNexusOperation.
 //
 // NOTE: Experimental

--- a/internal/interceptor.go
+++ b/internal/interceptor.go
@@ -26,6 +26,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/nexus-rpc/sdk-go/nexus"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	updatepb "go.temporal.io/api/update/v1"
@@ -169,13 +170,29 @@ type HandleQueryInput struct {
 	Args      []interface{}
 }
 
+// ExecuteNexusOperationInput is the input to WorkflowOutboundInterceptor.ExecuteNexusOperation.
+//
+// NOTE: Experimental
+type ExecuteNexusOperationInput struct {
+	// Client to start the operation with.
+	Client NexusClient
+	// Operation name or OperationReference from the Nexus SDK.
+	Operation any
+	// Operation input.
+	Input any
+	// Options for starting the operation.
+	Options NexusOperationOptions
+	// Header to attach to the request.
+	NexusHeader nexus.Header
+}
+
 // RequestCancelNexusOperationInput is the input to WorkflowOutboundInterceptor.RequestCancelNexusOperation.
 //
 // NOTE: Experimental
 type RequestCancelNexusOperationInput struct {
 	// Client that was used to start the operation.
 	Client NexusClient
-	// Operation name.
+	// Operation name or OperationReference from the Nexus SDK.
 	Operation any
 	// Operation ID. May be empty if the operation is synchronous or has not started yet.
 	ID string
@@ -300,7 +317,7 @@ type WorkflowOutboundInterceptor interface {
 	// ExecuteNexusOperation intercepts NexusClient.ExecuteOperation.
 	//
 	// NOTE: Experimental
-	ExecuteNexusOperation(ctx Context, client NexusClient, operation any, input any, options NexusOperationOptions) NexusOperationFuture
+	ExecuteNexusOperation(ctx Context, input ExecuteNexusOperationInput) NexusOperationFuture
 	// RequestCancelNexusOperation intercepts Nexus Operation cancelation via context.
 	//
 	// NOTE: Experimental

--- a/internal/interceptor_base.go
+++ b/internal/interceptor_base.go
@@ -393,12 +393,9 @@ func (w *WorkflowOutboundInterceptorBase) NewContinueAsNewError(
 // WorkflowOutboundInterceptor.ExecuteNexusOperation.
 func (w *WorkflowOutboundInterceptorBase) ExecuteNexusOperation(
 	ctx Context,
-	client NexusClient,
-	operation any,
-	input any,
-	options NexusOperationOptions,
+	input ExecuteNexusOperationInput,
 ) NexusOperationFuture {
-	return w.Next.ExecuteNexusOperation(ctx, client, operation, input, options)
+	return w.Next.ExecuteNexusOperation(ctx, input)
 }
 
 // RequestCancelNexusOperation implements


### PR DESCRIPTION
I missed this when doing the initial implementation.

Note that for cancelation requests we do not yet support attaching headers, it's not available on the command / event and may be added if there's demand for it.