### PR TITLE
Minor correction to TQ stats docs

### DIFF
--- a/internal/internal_versioning_client.go
+++ b/internal/internal_versioning_client.go
@@ -166,8 +166,7 @@ type (
 		// Special note for workflow task queue type: this metric does not count sticky queue tasks. Hence, the reported
 		// value may be significantly lower than the actual number of workflow tasks added. Note that typically, only
 		// the first workflow task of each workflow goes to a normal queue, and the rest workflow tasks go to the sticky
-		// queue associated with a specific worker instance. Activity tasks always go to normal queues so their reported
-		// rate is accurate.
+		// queue associated with a specific worker instance. Activity tasks always go to normal queues.
 		TasksAddRate float32
 		// Approximate tasks per second dispatched to workers, averaging the last 30 seconds. This includes both
 		// backlogged and sync-matched tasks, but excludes the Eagerly dispatched workflow and activity tasks (see
@@ -179,8 +178,7 @@ type (
 		// Special note for workflow task queue type: this metric does not count sticky queue tasks. Hence, the reported
 		// value may be significantly lower than the actual number of workflow tasks dispatched. Note that typically, only
 		// the first workflow task of each workflow goes to a normal queue, and the rest workflow tasks go to the sticky
-		// queue associated with a specific worker instance. Activity tasks always go to normal queues so their reported
-		// rate is accurate.
+		// queue associated with a specific worker instance. Activity tasks always go to normal queues.
 		TasksDispatchRate float32
 	}
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Remove a comment about task add and dispatch rate metrics that could mislead users.
```
"Activity tasks always go to normal queues ~so their reported rate is accurate.~"
```
## Why?
<!-- Tell your future self why have you made these changes -->
Activities do not go to sticky queues, but because they are dispatched eagerly by default the rates are still inaccurate.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
