### PR TITLE
Improve active build ID definition

### DIFF
--- a/internal/internal_versioning_client.go
+++ b/internal/internal_versioning_client.go
@@ -79,8 +79,8 @@ type (
 		BuildIDs []string
 		// Include the unversioned queue.
 		Unversioned bool
-		// Include all active versions. A version is active if it has had new
-		// tasks or polls recently.
+		// Include all active versions. A version is considered active if, in the last few minutes,
+		// it has had new tasks or polls, or it has been the subject of certain task queue API calls.
 		AllActive bool
 	}
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->
Counterpart to this API PR: https://github.com/temporalio/api/pull/452

## What was changed
Refining the definition of AllActive flag to align it to what server actually returns.

## Why?
The AllActive options essentially returns all build IDs that are loaded in the server. Besides receiving recent tasks and polls, a build ID would be loaded/active if it was the subject of server APIs such as DescribeTaskQueue.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
