### PR TITLE
mock: in order mock calls

### DIFF
--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -385,6 +385,12 @@ func (env *testWorkflowEnvironmentImpl) setContinuedExecutionRunID(rid string) {
 	env.workflowInfo.ContinuedExecutionRunID = rid
 }
 
+func (env *testWorkflowEnvironmentImpl) inOrderMockCalls(calls ...*MockCallWrapper) {
+	for i := 1; i < len(calls); i++ {
+		calls[i].NotBefore(calls[i-1])
+	}
+}
+
 func (env *testWorkflowEnvironmentImpl) newTestWorkflowEnvironmentForChild(params *ExecuteWorkflowParams, callback ResultHandler, startedHandler func(r WorkflowExecution, e error)) (*testWorkflowEnvironmentImpl, error) {
 	// create a new test env
 	childEnv := newTestWorkflowEnvironmentImpl(env.testSuite, env.registry)

--- a/internal/workflow_testsuite.go
+++ b/internal/workflow_testsuite.go
@@ -338,6 +338,11 @@ func (e *TestWorkflowEnvironment) SetContinuedExecutionRunID(rid string) {
 	e.impl.setContinuedExecutionRunID(rid)
 }
 
+// InOrderMockCalls declares that the given calls should occur in order.
+func (e *TestWorkflowEnvironment) InOrderMockCalls(calls ...*MockCallWrapper) {
+	e.impl.inOrderMockCalls(calls...)
+}
+
 // OnActivity setup a mock call for activity. Parameter activity must be activity function (func) or activity name (string).
 // You must call Return() with appropriate parameters on the returned *MockCallWrapper instance. The supplied parameters to
 // the Return() call should either be a function that has exact same signature as the mocked activity, or it should be


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Adding an `InOrderMockCalls(calls ...*MockCallWrapper)` helper method to setup mock calls in order. It just loops through the `calls` and sets the order by calling `.NotBefore()`

## Why?
<!-- Tell your future self why have you made these changes -->

A more intuitive and cleaner way to define mock calls in order. For example:

```
env.InOrderMockCalls(
	env.OnActivity(namedActivity, mock.Anything, "call1").Return("result1", nil),
	env.OnActivity(namedActivity, mock.Anything, "call2").Return("result2", nil),
	env.OnActivity(namedActivity, mock.Anything, "call3").Return("result3", nil),
)

```

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
