### PR TITLE
Fix Version test failure due to 1.25.0 server release

### DIFF
--- a/test/worker_versioning_test.go
+++ b/test/worker_versioning_test.go
@@ -334,7 +334,7 @@ func (ts *WorkerVersioningTestSuite) TestCommitRules() {
 	ts.Equal(1, len(res.AssignmentRules))
 	ts.Equal("2.0", res.AssignmentRules[0].Rule.TargetBuildID)
 	_, ok := res.AssignmentRules[0].Rule.Ramp.(*client.VersioningRampByPercentage)
-	ts.Falsef(ok, "Still has a percentage ramp")
+	ts.Truef(ok, "Ramp at 100 but type isn't updated")
 }
 
 func (ts *WorkerVersioningTestSuite) TestConflictTokens() {

--- a/test/worker_versioning_test.go
+++ b/test/worker_versioning_test.go
@@ -333,8 +333,8 @@ func (ts *WorkerVersioningTestSuite) TestCommitRules() {
 	// replace all rules by unconditional "2.0"
 	ts.Equal(1, len(res.AssignmentRules))
 	ts.Equal("2.0", res.AssignmentRules[0].Rule.TargetBuildID)
-	_, ok := res.AssignmentRules[0].Rule.Ramp.(*client.VersioningRampByPercentage)
-	ts.Truef(ok, "Ramp at 100 but type isn't updated")
+	ramp, ok := res.AssignmentRules[0].Rule.Ramp.(*client.VersioningRampByPercentage)
+	ts.Truef(!ok || ramp.Percentage == 100, "There should either be no ramp or ramp should be 100%")
 }
 
 func (ts *WorkerVersioningTestSuite) TestConflictTokens() {


### PR DESCRIPTION
## What was changed
Changing a test assert based off of changed behavior from 1.25.0 server release. Test now checks for either no ramp or percentage is 100%

## Why?
1.25.0 server release caused this test to start failing. Server was changed so we can specify a 100% ramp as equivalent to no ramp.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Test passes locally

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
