### PR TITLE
Fix Nexus test env to respect ScheduleToCloseTimeout

### DIFF
--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -2351,7 +2351,11 @@ func (env *testWorkflowEnvironmentImpl) newTestNexusTaskHandler() *nexusTaskHand
 	)
 }
 
-func (env *testWorkflowEnvironmentImpl) ExecuteNexusOperation(params executeNexusOperationParams, callback func(*commonpb.Payload, error), startedHandler func(opID string, e error)) int64 {
+func (env *testWorkflowEnvironmentImpl) ExecuteNexusOperation(
+	params executeNexusOperationParams,
+	callback func(*commonpb.Payload, error),
+	startedHandler func(opID string, e error),
+) int64 {
 	seq := env.nextID()
 	taskHandler := env.newTestNexusTaskHandler()
 	handle := &testNexusOperationHandle{
@@ -2362,6 +2366,32 @@ func (env *testWorkflowEnvironmentImpl) ExecuteNexusOperation(params executeNexu
 		onStarted:   startedHandler,
 	}
 	env.runningNexusOperations[seq] = handle
+
+	var opID string
+	if params.options.ScheduleToCloseTimeout > 0 {
+		env.NewTimer(
+			params.options.ScheduleToCloseTimeout,
+			TimerOptions{},
+			func(result *commonpb.Payloads, err error) {
+				timeoutErr := env.failureConverter.FailureToError(nexusOperationFailure(
+					params,
+					opID,
+					&failurepb.Failure{
+						Message: "operation timed out",
+						FailureInfo: &failurepb.Failure_TimeoutFailureInfo{
+							TimeoutFailureInfo: &failurepb.TimeoutFailureInfo{
+								TimeoutType: enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE,
+							},
+						},
+					},
+				))
+				env.postCallback(func() {
+					handle.startedCallback(opID, timeoutErr)
+					handle.completedCallback(nil, timeoutErr)
+				}, true)
+			},
+		)
+	}
 
 	task := handle.newStartTask()
 	env.runningCount++
@@ -2385,31 +2415,32 @@ func (env *testWorkflowEnvironmentImpl) ExecuteNexusOperation(params executeNexu
 				handle.completedCallback(nil, err)
 			}, true)
 			return
-		} else {
-			switch v := response.GetResponse().GetStartOperation().GetVariant().(type) {
-			case *nexuspb.StartOperationResponse_SyncSuccess:
-				env.postCallback(func() {
-					handle.startedCallback("", nil)
-					handle.completedCallback(v.SyncSuccess.GetPayload(), nil)
-				}, true)
-			case *nexuspb.StartOperationResponse_AsyncSuccess:
-				env.postCallback(func() {
-					handle.startedCallback(v.AsyncSuccess.GetOperationId(), nil)
-					if handle.cancelRequested {
-						handle.cancel()
-					}
-				}, true)
-			case *nexuspb.StartOperationResponse_OperationError:
-				err := env.failureConverter.FailureToError(
-					nexusOperationFailure(params, "", unsuccessfulOperationErrorToTemporalFailure(v.OperationError)),
-				)
-				env.postCallback(func() {
-					handle.startedCallback("", err)
-					handle.completedCallback(nil, err)
-				}, true)
-			default:
-				panic(fmt.Errorf("unknown response variant: %v", v))
-			}
+		}
+
+		switch v := response.GetResponse().GetStartOperation().GetVariant().(type) {
+		case *nexuspb.StartOperationResponse_SyncSuccess:
+			env.postCallback(func() {
+				handle.startedCallback("", nil)
+				handle.completedCallback(v.SyncSuccess.GetPayload(), nil)
+			}, true)
+		case *nexuspb.StartOperationResponse_AsyncSuccess:
+			opID = v.AsyncSuccess.GetOperationId()
+			env.postCallback(func() {
+				handle.startedCallback(v.AsyncSuccess.GetOperationId(), nil)
+				if handle.cancelRequested {
+					handle.cancel()
+				}
+			}, true)
+		case *nexuspb.StartOperationResponse_OperationError:
+			err := env.failureConverter.FailureToError(
+				nexusOperationFailure(params, "", unsuccessfulOperationErrorToTemporalFailure(v.OperationError)),
+			)
+			env.postCallback(func() {
+				handle.startedCallback("", err)
+				handle.completedCallback(nil, err)
+			}, true)
+		default:
+			panic(fmt.Errorf("unknown response variant: %v", v))
 		}
 	}()
 	return seq
@@ -2887,6 +2918,10 @@ func (h *testNexusOperationHandle) completedCallback(result *commonpb.Payload, e
 // startedCallback is a callback registered to handle operation start.
 // Must be called in a postCallback block.
 func (h *testNexusOperationHandle) startedCallback(opID string, e error) {
+	if h.started {
+		// Ignore duplciate starts.
+		return
+	}
 	h.operationID = opID
 	h.started = true
 	h.onStarted(opID, e)


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Fix Nexus test env to respect `ScheduleToCloseTimeout` and return operation time out error.

## Why?
<!-- Tell your future self why have you made these changes -->
Users can test the `ScheduleToCloseTimeout` when writing their tests.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
