### PR TITLE
Use stable CLI for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,13 +88,6 @@ jobs:
       - name: Docker compose - integration tests
         if: ${{ matrix.testDockerCompose }}
         run: go run . integration-test
-        env:
-          # TODO(bergundy): Remove this flag once server 1.25.0 is out.
-          DISABLE_NEXUS_TESTS: "1"
-          # TODO(bergundy): Remove this flag too once server 1.25.0 is out. Thanks Roey! :)
-          DISABLE_BACKLOG_STATS_TESTS: "1"
-          # TODO(cretz): Remove this flag once server 1.25.0 is out.
-          DISABLE_USER_METADATA_TESTS: "1"
         working-directory: ./internal/cmd/build
 
   cloud-test:

--- a/.github/workflows/docker/docker-compose.override.yaml
+++ b/.github/workflows/docker/docker-compose.override.yaml
@@ -2,3 +2,7 @@ services:
   temporal:
     environment:
       - DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/dynamic-config-custom.yaml
+      - FRONTEND_HTTP_PORT=7243
+    ports:
+      - 7233:7233
+      - 7243:7243

--- a/.github/workflows/docker/dynamic-config-custom.yaml
+++ b/.github/workflows/docker/dynamic-config-custom.yaml
@@ -21,3 +21,12 @@ worker.buildIdScavengerEnabled:
   - value: true
 worker.removableBuildIdDurationSinceDefault:
   - value: 1
+system.enableNexus:
+  - value: true
+component.nexusoperations.callback.endpoint.template:
+  - value: http://localhost:7243/namespaces/{{.NamespaceName}}/nexus/callback
+# SDK tests use arbitrary callback URLs, permit that on the server.
+component.callbacks.allowedAddresses:
+  - value:
+    - Pattern: "*"
+      AllowInsecure: true

--- a/internal/cmd/build/main.go
+++ b/internal/cmd/build/main.go
@@ -140,9 +140,8 @@ func (b *builder) integrationTest() error {
 				HostPort:  "127.0.0.1:7233",
 				Namespace: "integration-test-namespace",
 			},
-			// TODO(bergundy): Remove this override after server 1.25.0 is released.
 			CachedDownload: testsuite.CachedDownload{
-				Version: "v0.14.0-nexus.0",
+				Version: "v1.1.0",
 			},
 			LogLevel: "warn",
 			ExtraArgs: []string{

--- a/test/nexus_test.go
+++ b/test/nexus_test.go
@@ -29,7 +29,6 @@ import (
 	"net/http"
 	"os"
 	"slices"
-	"strings"
 	"testing"
 	"time"
 
@@ -77,7 +76,7 @@ func newTestContext(t *testing.T, ctx context.Context) *testContext {
 	require.NoError(t, err)
 
 	taskQueue := "sdk-go-nexus-test-tq-" + uuid.NewString()
-	endpoint := strings.ReplaceAll("sdk-go-nexus-test-ep-"+uuid.NewString(), "-", "_")
+	endpoint := "sdk-go-nexus-test-ep-" + uuid.NewString()
 	res, err := c.OperatorService().CreateNexusEndpoint(ctx, &operatorservice.CreateNexusEndpointRequest{
 		Spec: &nexuspb.EndpointSpec{
 			Name: endpoint,


### PR DESCRIPTION
Addressing a TODO I put in the code when working on Nexus while it wasn't available in a stable server / CLI release.

Also:
- Use dashes instead of underscores in the test endpoint names since that logic changed since the server RC was cut.
- [Enable 1.25.0 tests with docker-compose](https://github.com/temporalio/sdk-go/pull/1637/commits/719c86a665adcee0f7cb3f1acae74b2c4bcd4453)