### PR TITLE
Fix typo in doc.go

### DIFF
--- a/workflow/doc.go
+++ b/workflow/doc.go
@@ -60,7 +60,7 @@ the sole parameter it receives as part of its initialization as a parameter to t
 		}
 		ctx = workflow.WithActivityOptions(ctx, ao)
 
-		future := [workflow.ExecuteActivity](ctx, SimpleActivity, value)
+		future := workflow.ExecuteActivity(ctx, SimpleActivity, value)
 		var result string
 		if err := future.Get(ctx, &result); err != nil {
 			return err


### PR DESCRIPTION
The use of square brackets around the `workflow.ExecuteActivity` invocation in the first example caused confusion for less experienced readers.

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Removed square brackets in the example used in doc.go

## Why?
It's confusing for less experience readers.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
