### PR TITLE
make pause and resume deadlock detector functions public

### DIFF
--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -769,6 +769,16 @@ func IsContinueAsNewError(err error) bool {
 	return errors.As(err, &continueAsNewErr)
 }
 
+// PauseDeadlockDetector pauses the deadlock detector for all coroutines.
+func PauseDeadlockDetector(ctx Context) {
+	internal.PauseDeadlockDetector(ctx)
+}
+
+// ResumeDeadlockDetector resumes the deadlock detector for all coroutines.
+func ResumeDeadlockDetector(ctx Context) {
+	internal.ResumeDeadlockDetector(ctx)
+}
+
 // DataConverterWithoutDeadlockDetection returns a data converter that disables
 // workflow deadlock detection for each call on the data converter. This should
 // be used for advanced data converters that may perform remote calls or


### PR DESCRIPTION
## What was changed
Expose `PauseDeadlockDetector` and `ResumeDeadlockDetector` publicly.

## Why?
See https://github.com/temporalio/temporal/issues/6546:

We need to run some function that might block for a while (up to 10s, usually) during a Temporal workflow. That function cannot receive a Temporal workflow context. It also has to run every time the workflow runs, including replays. Further operations during this workflow rely on this function being run first.

Currently when we do this, the deadlock detection mechanism panics.


## Checklist
1. Closes #6546.
