### PR TITLE
Error for unused Update operation

### DIFF
--- a/internal/client.go
+++ b/internal/client.go
@@ -1083,7 +1083,7 @@ func (op *UpdateWithStartWorkflowOperation) Get(ctx context.Context) (WorkflowUp
 		return op.handle, op.err
 	case <-ctx.Done():
 		if !op.executed.Load() {
-			return nil, fmt.Errorf("%v: %v", ctx.Err(), fmt.Errorf("operation was not executed"))
+			return nil, fmt.Errorf("%w: %w", ctx.Err(), fmt.Errorf("operation was not executed"))
 		}
 		return nil, ctx.Err()
 	}

--- a/internal/client.go
+++ b/internal/client.go
@@ -746,7 +746,7 @@ type (
 		// workflow completion callback. Only settable by the SDK - e.g. [temporalnexus.workflowRunOperation].
 		callbacks []*commonpb.Callback
 		// links. Only settable by the SDK - e.g. [temporalnexus.workflowRunOperation].
-		links     []*commonpb.Link
+		links []*commonpb.Link
 	}
 
 	// WithStartWorkflowOperation is a type of operation that can be executed as part of a workflow start.
@@ -1082,6 +1082,9 @@ func (op *UpdateWithStartWorkflowOperation) Get(ctx context.Context) (WorkflowUp
 	case <-op.doneCh:
 		return op.handle, op.err
 	case <-ctx.Done():
+		if !op.executed.Load() {
+			return nil, fmt.Errorf("%v: %v", ctx.Err(), fmt.Errorf("operation was not executed"))
+		}
 		return nil, ctx.Err()
 	}
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

When the request for the update operation's handle times out, it now returns a more specific error if the operation was never actually executed as part of a MultiOperation.

## Why?
<!-- Tell your future self why have you made these changes -->

It's easy to forget to specify `WithStartOperation` (happened to me when I worked on a Go sample). This signals more clearly to the user that they forgot to run it. However, IMO the error cannot be more specific than that, since there _could_ be other reasons why the operation was never executed.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
