### PR TITLE
Remove history truncation

### DIFF
--- a/internal/internal_task_handlers_test.go
+++ b/internal/internal_task_handlers_test.go
@@ -2725,7 +2725,6 @@ func TestHistoryIterator(t *testing.T) {
 				WorkflowId: "test-workflow-id",
 				RunId:      "test-run-id",
 			},
-			3,
 			metrics.NopHandler,
 			"test-task-queue",
 		),

--- a/internal/internal_task_handlers_test.go
+++ b/internal/internal_task_handlers_test.go
@@ -2688,3 +2688,52 @@ func TestResetIfDestroyedTaskPrep(t *testing.T) {
 		requireContainsMsgWithID(t, task.Messages, wftNewMsgID)
 	})
 }
+
+func TestHistoryIterator(t *testing.T) {
+	testEvents := []*historypb.HistoryEvent{
+		createTestEventWorkflowExecutionStarted(1, &historypb.WorkflowExecutionStartedEventAttributes{TaskQueue: &taskqueuepb.TaskQueue{Name: testWorkflowTaskTaskqueue}}),
+		createTestEventWorkflowTaskScheduled(2, &historypb.WorkflowTaskScheduledEventAttributes{}),
+		createTestEventWorkflowTaskStarted(3),
+	}
+
+	nextEvents := []*historypb.HistoryEvent{
+		createTestEventWorkflowTaskCompleted(4, &historypb.WorkflowTaskCompletedEventAttributes{}),
+	}
+
+	ctx := context.Background()
+	mockCtrl := gomock.NewController(t)
+	mockService := workflowservicemock.NewMockWorkflowServiceClient(mockCtrl)
+	mockService.EXPECT().GetWorkflowExecutionHistory(gomock.Any(), gomock.Any(), gomock.Any()).Return(&workflowservice.GetWorkflowExecutionHistoryResponse{
+		History: &historypb.History{
+			Events: testEvents,
+		},
+		NextPageToken: []byte("token"),
+	}, nil)
+
+	mockService.EXPECT().GetWorkflowExecutionHistory(gomock.Any(), gomock.Any(), gomock.Any()).Return(&workflowservice.GetWorkflowExecutionHistoryResponse{
+		History: &historypb.History{
+			Events: nextEvents,
+		},
+	}, nil)
+
+	historyIterator := &historyIteratorImpl{
+		iteratorFunc: newGetHistoryPageFunc(
+			ctx,
+			mockService,
+			"test-namespace",
+			&commonpb.WorkflowExecution{
+				WorkflowId: "test-workflow-id",
+				RunId:      "test-run-id",
+			},
+			3,
+			metrics.NopHandler,
+			"test-task-queue",
+		),
+	}
+
+	_, err := historyIterator.GetNextPage()
+	require.NoError(t, err)
+	_, err = historyIterator.GetNextPage()
+	require.NoError(t, err)
+
+}

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -138,16 +138,11 @@ type (
 	}
 
 	historyIteratorImpl struct {
-		iteratorFunc  func(nextPageToken []byte) (*historypb.History, []byte, error)
-		execution     *commonpb.WorkflowExecution
-		nextPageToken []byte
-		namespace     string
-		service       workflowservice.WorkflowServiceClient
-		// maxEventID is the maximum eventID that the iterator should return
-		// it is used to filter out events that are not needed
-		// for example, when polling for a workflow task, we only need events up to the startedEventID.
-		// If set to 0, it means return all events.
-		maxEventID     int64
+		iteratorFunc   func(nextPageToken []byte) (*historypb.History, []byte, error)
+		execution      *commonpb.WorkflowExecution
+		nextPageToken  []byte
+		namespace      string
+		service        workflowservice.WorkflowServiceClient
 		metricsHandler metrics.Handler
 		taskQueue      string
 	}
@@ -874,7 +869,6 @@ func (wtp *workflowTaskPoller) toWorkflowTask(response *workflowservice.PollWork
 		nextPageToken:  response.NextPageToken,
 		namespace:      wtp.namespace,
 		service:        wtp.service,
-		maxEventID:     response.GetStartedEventId(),
 		metricsHandler: wtp.metricsHandler,
 		taskQueue:      wtp.taskQueueName,
 	}
@@ -892,7 +886,6 @@ func (h *historyIteratorImpl) GetNextPage() (*historypb.History, error) {
 			h.service,
 			h.namespace,
 			h.execution,
-			h.maxEventID,
 			h.metricsHandler,
 			h.taskQueue,
 		)
@@ -919,7 +912,6 @@ func newGetHistoryPageFunc(
 	service workflowservice.WorkflowServiceClient,
 	namespace string,
 	execution *commonpb.WorkflowExecution,
-	atWorkflowTaskCompletedEventID int64,
 	metricsHandler metrics.Handler,
 	taskQueue string,
 ) func(nextPageToken []byte) (*historypb.History, []byte, error) {
@@ -948,18 +940,6 @@ func newGetHistoryPageFunc(
 			}
 		} else {
 			h = resp.History
-		}
-
-		size := len(h.Events)
-		if size > 0 && atWorkflowTaskCompletedEventID > 0 &&
-			h.Events[size-1].GetEventId() > atWorkflowTaskCompletedEventID {
-			first := h.Events[0].GetEventId() // eventIds start from 1
-			h.Events = h.Events[:atWorkflowTaskCompletedEventID-first+1]
-			if h.Events[len(h.Events)-1].GetEventType() != enumspb.EVENT_TYPE_WORKFLOW_TASK_COMPLETED {
-				return nil, nil, fmt.Errorf("newGetHistoryPageFunc: atWorkflowTaskCompletedEventID(%v) "+
-					"points to event that is not WorkflowTaskCompleted", atWorkflowTaskCompletedEventID)
-			}
-			return h, nil, nil
 		}
 		return h, resp.NextPageToken, nil
 	}

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -138,11 +138,15 @@ type (
 	}
 
 	historyIteratorImpl struct {
-		iteratorFunc   func(nextPageToken []byte) (*historypb.History, []byte, error)
-		execution      *commonpb.WorkflowExecution
-		nextPageToken  []byte
-		namespace      string
-		service        workflowservice.WorkflowServiceClient
+		iteratorFunc  func(nextPageToken []byte) (*historypb.History, []byte, error)
+		execution     *commonpb.WorkflowExecution
+		nextPageToken []byte
+		namespace     string
+		service       workflowservice.WorkflowServiceClient
+		// maxEventID is the maximum eventID that the iterator should return
+		// it is used to filter out events that are not needed
+		// for example, when polling for a workflow task, we only need events up to the startedEventID.
+		// If set to 0, it means return all events.
 		maxEventID     int64
 		metricsHandler metrics.Handler
 		taskQueue      string

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -1447,7 +1447,6 @@ func (aw *WorkflowReplayer) replayWorkflowHistory(logger log.Logger, service wor
 		execution:     task.WorkflowExecution,
 		namespace:     ReplayNamespace,
 		service:       service,
-		maxEventID:    task.GetStartedEventId(),
 		taskQueue:     taskQueue,
 	}
 	cache := NewWorkerCache()


### PR DESCRIPTION
Remove history truncation. As far back in the Go SDK as I can find we have this code to try to truncate any events past `atWorkflowTaskCompletedEventID`. It is not clear what the point of this code is and it has a number of bugs. Some of the issues are:
* It can panic if `h.Events[0].GetEventId() > atWorkflowTaskCompletedEventID`
* It is trying to check if the last event in history after truncation is a `EVENT_TYPE_WORKFLOW_TASK_COMPLETED`, but `atWorkflowTaskCompletedEventID` is from the workflow tasks `GetStartedEventId` so it should be a `EVENT_TYPE_WORKFLOW_TASK_STARTED`.
* If history does go beyond `GetStartedEventId` then that indicated this workflow task is stale and will be rejected by the server anyway

Note: The cadence team also pointed out the strangeness of this code https://github.com/uber-go/cadence-client/blob/4d4c09f5053b53caea43100e170c327058731f5c/internal/internal_task_pollers.go#L961