### PR TITLE
Ensure WorkflowTaskExecutionFailureCounter is called with a tag

### DIFF
--- a/internal/internal_event_handlers.go
+++ b/internal/internal_event_handlers.go
@@ -1170,7 +1170,7 @@ func (weh *workflowExecutionEventHandlerImpl) ProcessEvent(
 	}
 	defer func() {
 		if p := recover(); p != nil {
-			weh.metricsHandler.Counter(metrics.WorkflowTaskExecutionFailureCounter).Inc(1)
+			incrementWorkflowTaskFailureCounter(weh.metricsHandler, "NonDeterminismError")
 			topLine := fmt.Sprintf("process event for %s [panic]:", weh.workflowInfo.TaskQueueName)
 			st := getStackTraceRaw(topLine, 7, 0)
 			weh.Complete(nil, newWorkflowPanicError(p, st))
@@ -1373,7 +1373,7 @@ func (weh *workflowExecutionEventHandlerImpl) ProcessMessage(
 ) error {
 	defer func() {
 		if p := recover(); p != nil {
-			weh.metricsHandler.Counter(metrics.WorkflowTaskExecutionFailureCounter).Inc(1)
+			incrementWorkflowTaskFailureCounter(weh.metricsHandler, "NonDeterminismError")
 			topLine := fmt.Sprintf("process message for %s [panic]:", weh.workflowInfo.TaskQueueName)
 			st := getStackTraceRaw(topLine, 7, 0)
 			weh.Complete(nil, newWorkflowPanicError(p, st))

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -471,7 +471,7 @@ func (wtp *workflowTaskPoller) RespondTaskCompletedWithMetrics(
 		if failWorkflowTask.Cause == enumspb.WORKFLOW_TASK_FAILED_CAUSE_NON_DETERMINISTIC_ERROR {
 			failureReason = "NonDeterminismError"
 		}
-		metricsHandler.WithTags(metrics.WorkflowTaskFailedTags(failureReason)).Counter(metrics.WorkflowTaskExecutionFailureCounter).Inc(1)
+		incrementWorkflowTaskFailureCounter(metricsHandler, failureReason)
 		completedRequest = failWorkflowTask
 	}
 

--- a/internal/internal_workflow.go
+++ b/internal/internal_workflow.go
@@ -1960,3 +1960,7 @@ func (s *semaphoreImpl) Release(n int64) {
 		panic("Semaphore.Release() released more than held")
 	}
 }
+
+func incrementWorkflowTaskFailureCounter(metricsHandler metrics.Handler, failureReason string) {
+	metricsHandler.WithTags(metrics.WorkflowTaskFailedTags(failureReason)).Counter(metrics.WorkflowTaskExecutionFailureCounter).Inc(1)
+}


### PR DESCRIPTION
## What was changed
Ensure the WorkflowTaskExecutionFailureCounter metric always has a tag set included.

## Why?
<!-- Tell your future self why have you made these changes -->
Prometheus returns an error when you try incrementing the same counter if one instance has a tag set and the other didn't.

I validated that Prometheus is okay with different tag sets (in this case if we happen to call one instance with `WorkflowError` and the other with `NonDeterminismError` tag sets). I'm not sure there's a scenario where we increment this counter from different sources, but if there is, this shouldn't be an issue with Prometheus.

## Checklist
<!--- add/delete as needed --->

1. Closes #1450 