### PR TITLE
Improve/Fix WaitForStage documentation link

### DIFF
--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -794,7 +794,7 @@ type UpdateWorkflowOptions struct {
 	Args []interface{}
 
 	// WaitForStage is a required field which specifies which stage to wait until returning.
-	// See https://docs.temporal.io/workflows#update for more details.
+	// See https://docs.temporal.io/develop/go/message-passing#send-update-from-client for more details.
 	// NOTE: Specifying WorkflowUpdateStageAdmitted is not supported.
 	WaitForStage WorkflowUpdateStage
 


### PR DESCRIPTION
Previous link points to generic workflows page that doesn't have any information on WaitForStage, pointing to the appropriate link https://docs.temporal.io/develop/go/message-passing#send-update-from-client