### PR TITLE
Fix TestNonDeterminismFailureCauseReplay integration test

### DIFF
--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -4502,7 +4502,6 @@ func (ts *IntegrationTestSuite) TestNonDeterminismFailureCauseReplay() {
 	fmt.Println("Querying workflow")
 	_, err = ts.client.QueryWorkflow(ctx, run.GetID(), run.GetRunID(), client.QueryTypeStackTrace, nil)
 	ts.Error(err)
-	ts.Equal("context deadline exceeded", err.Error())
 
 	taskFailedMetric = fetchMetrics()
 	ts.True(taskFailedMetric >= 1)


### PR DESCRIPTION
## What was changed
Stop checking for specific error for QueryWorkflow that we expect to fail.

## Why?
Sometimes we hit `Context deadline exceeded`, and sometimes we hit `query timed out before a worker could process it`, which is the server hitting `context deadline exceeded`.

## Checklist
<!--- add/delete as needed --->

1. Closes #1441 

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
