### PR TITLE
Add Deployment Names to Worker options 

### DIFF
--- a/internal/internal_nexus_task_poller.go
+++ b/internal/internal_nexus_task_poller.go
@@ -62,6 +62,7 @@ func newNexusTaskPoller(
 			stopC:                params.WorkerStopChannel,
 			workerBuildID:        params.getBuildID(),
 			useBuildIDVersioning: params.UseBuildIDForVersioning,
+			deploymentName:       params.DeploymentName,
 			capabilities:         params.capabilities,
 		},
 		taskHandler:     taskHandler,
@@ -91,8 +92,9 @@ func (ntp *nexusTaskPoller) poll(ctx context.Context) (taskForWorker, error) {
 		TaskQueue: &taskqueuepb.TaskQueue{Name: ntp.taskQueueName, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		Identity:  ntp.identity,
 		WorkerVersionCapabilities: &commonpb.WorkerVersionCapabilities{
-			BuildId:       ntp.workerBuildID,
-			UseVersioning: ntp.useBuildIDVersioning,
+			BuildId:        ntp.workerBuildID,
+			UseVersioning:  ntp.useBuildIDVersioning,
+			DeploymentName: ntp.deploymentName,
 		},
 	}
 

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -137,6 +137,7 @@ type (
 		identity                 string
 		workerBuildID            string
 		useBuildIDForVersioning  bool
+		deploymentName           string
 		enableLoggingInReplay    bool
 		registry                 *registry
 		laTunnel                 *localActivityTunnel
@@ -556,6 +557,7 @@ func newWorkflowTaskHandler(params workerExecutionParameters, ppMgr pressurePoin
 		identity:                 params.Identity,
 		workerBuildID:            params.getBuildID(),
 		useBuildIDForVersioning:  params.UseBuildIDForVersioning,
+		deploymentName:           params.DeploymentName,
 		enableLoggingInReplay:    params.EnableLoggingInReplay,
 		registry:                 registry,
 		workflowPanicPolicy:      params.WorkflowPanicPolicy,
@@ -1904,8 +1906,9 @@ func (wth *workflowTaskHandlerImpl) completeWorkflow(
 			SdkVersion:    eventHandler.getNewSdkVersionAndReset(),
 		},
 		WorkerVersionStamp: &commonpb.WorkerVersionStamp{
-			BuildId:       wth.workerBuildID,
-			UseVersioning: wth.useBuildIDForVersioning,
+			BuildId:        wth.workerBuildID,
+			UseVersioning:  wth.useBuildIDForVersioning,
+			DeploymentName: wth.deploymentName,
 		},
 	}
 	if wth.capabilities != nil && wth.capabilities.BuildIdBasedVersioning {
@@ -1961,8 +1964,9 @@ func newActivityTaskHandlerWithCustomProvider(
 		defaultHeartbeatThrottleInterval: params.DefaultHeartbeatThrottleInterval,
 		maxHeartbeatThrottleInterval:     params.MaxHeartbeatThrottleInterval,
 		versionStamp: &commonpb.WorkerVersionStamp{
-			BuildId:       params.getBuildID(),
-			UseVersioning: params.UseBuildIDForVersioning,
+			BuildId:        params.getBuildID(),
+			UseVersioning:  params.UseBuildIDForVersioning,
+			DeploymentName: params.DeploymentName,
 		},
 	}
 }

--- a/internal/internal_versioning_client.go
+++ b/internal/internal_versioning_client.go
@@ -113,6 +113,8 @@ type (
 		BuildID string
 		// Whether the worker is using the versioning feature.
 		UseVersioning bool
+		// An identifier to group task queues based on Build ID.
+		DeploymentName string
 	}
 
 	// TaskQueuePollerInfo provides information about a worker/client polling a task queue.
@@ -243,8 +245,9 @@ func workerVersionCapabilitiesFromResponse(response *common.WorkerVersionCapabil
 	}
 
 	return &WorkerVersionCapabilities{
-		BuildID:       response.GetBuildId(),
-		UseVersioning: response.GetUseVersioning(),
+		BuildID:        response.GetBuildId(),
+		UseVersioning:  response.GetUseVersioning(),
+		DeploymentName: response.GetDeploymentName(),
 	}
 }
 

--- a/internal/internal_versioning_client_test.go
+++ b/internal/internal_versioning_client_test.go
@@ -94,7 +94,7 @@ func Test_TaskQueueDescription_fromProtoResponse(t *testing.T) {
 						TypesInfo: map[int32]*taskqueuepb.TaskQueueTypeInfo{
 							int32(enumspb.TASK_QUEUE_TYPE_WORKFLOW): {
 								Pollers: []*taskqueuepb.PollerInfo{
-									{LastAccessTime: nowProto, Identity: "me", RatePerSecond: 3.0, WorkerVersionCapabilities: &common.WorkerVersionCapabilities{BuildId: "1.0", UseVersioning: true}},
+									{LastAccessTime: nowProto, Identity: "me", RatePerSecond: 3.0, WorkerVersionCapabilities: &common.WorkerVersionCapabilities{BuildId: "1.0", UseVersioning: true, DeploymentName: "prod1"}},
 								},
 							},
 						},
@@ -108,7 +108,7 @@ func Test_TaskQueueDescription_fromProtoResponse(t *testing.T) {
 						TypesInfo: map[TaskQueueType]TaskQueueTypeInfo{
 							TaskQueueTypeWorkflow: {
 								Pollers: []TaskQueuePollerInfo{
-									{LastAccessTime: now, Identity: "me", RatePerSecond: 3.0, WorkerVersionCapabilities: &WorkerVersionCapabilities{BuildID: "1.0", UseVersioning: true}},
+									{LastAccessTime: now, Identity: "me", RatePerSecond: 3.0, WorkerVersionCapabilities: &WorkerVersionCapabilities{BuildID: "1.0", UseVersioning: true, DeploymentName: "prod1"}},
 								},
 							},
 						},

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -167,6 +167,8 @@ type (
 		WorkerBuildID string
 		// If true the worker is opting in to build ID based versioning.
 		UseBuildIDForVersioning bool
+		// The worker's deployment name, an identifier in versioning-3 to group Task Queues for a given build ID.
+		DeploymentName string
 
 		MetricsHandler metrics.Handler
 
@@ -1665,6 +1667,7 @@ func NewAggregatedWorker(client *WorkflowClient, taskQueue string, options Worke
 		Identity:                              client.identity,
 		WorkerBuildID:                         options.BuildID,
 		UseBuildIDForVersioning:               options.UseBuildIDForVersioning,
+		DeploymentName:                        options.DeploymentName,
 		MetricsHandler:                        client.metricsHandler.WithTags(metrics.TaskQueueTags(taskQueue)),
 		Logger:                                client.logger,
 		EnableLoggingInReplay:                 options.EnableLoggingInReplay,

--- a/internal/worker.go
+++ b/internal/worker.go
@@ -251,6 +251,12 @@ type (
 		// Note: Cannot be enabled at the same time as EnableSessionWorker
 		UseBuildIDForVersioning bool
 
+		// Optional: Assign a Deployment Name to this worker, an identifier for Worker Versioning that
+		// groups task queues for the given BuildID.
+		// NOTE: Experimental
+		// Note: Both BuildID and UseBuildIDForVersioning need to also be set to enable the new Worker Versioning-3 feature.
+		DeploymentName string
+
 		// Optional: If set, use a custom tuner for this worker. See WorkerTuner for more.
 		// Mutually exclusive with MaxConcurrentWorkflowTaskExecutionSize,
 		// MaxConcurrentActivityExecutionSize, and MaxConcurrentLocalActivityExecutionSize.

--- a/internal/worker.go
+++ b/internal/worker.go
@@ -254,7 +254,7 @@ type (
 		// Optional: Assign a Deployment Name to this worker, an identifier for Worker Versioning that
 		// groups task queues for the given BuildID.
 		// NOTE: Experimental
-		// Note: Both BuildID and UseBuildIDForVersioning need to also be set to enable the new Worker Versioning-3 feature.
+		// NOTE: Both BuildID and UseBuildIDForVersioning need to also be set to enable the new Worker Versioning-3 feature.
 		DeploymentName string
 
 		// Optional: If set, use a custom tuner for this worker. See WorkerTuner for more.


### PR DESCRIPTION

## What was changed
<!-- Describe what has changed in this PR -->
Deployment Names are a new way to group task queues, based on Build IDs, to simplify rollouts in versioning-3.

In this PR we just add a new Worker Option for it, propagate  it during polling, and include it with task completion responses.
