### PR TITLE
Make a polling task timeout configurable

### DIFF
--- a/internal/internal_nexus_task_poller.go
+++ b/internal/internal_nexus_task_poller.go
@@ -63,6 +63,7 @@ func newNexusTaskPoller(
 			workerBuildID:        params.getBuildID(),
 			useBuildIDVersioning: params.UseBuildIDForVersioning,
 			capabilities:         params.capabilities,
+			pollTaskTimeout:      params.PollTaskTimeout,
 		},
 		taskHandler:     taskHandler,
 		service:         service,

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -215,6 +215,9 @@ type (
 
 		MaxHeartbeatThrottleInterval time.Duration
 
+		// The timeout for polling tasks
+		PollTaskTimeout time.Duration
+
 		// Pointer to the shared worker cache
 		cache *WorkerCache
 
@@ -266,6 +269,9 @@ func ensureRequiredParams(params *workerExecutionParameters) {
 				NumLocalActivitySlots: defaultMaxConcurrentLocalActivityExecutionSize,
 				NumNexusSlots:         defaultMaxConcurrentTaskExecutionSize,
 			})
+	}
+	if params.PollTaskTimeout.Seconds() == 0 {
+		params.PollTaskTimeout = defaultPollTaskTimeOutSeconds * time.Second
 	}
 }
 
@@ -1681,6 +1687,7 @@ func NewAggregatedWorker(client *WorkflowClient, taskQueue string, options Worke
 		DeadlockDetectionTimeout:              options.DeadlockDetectionTimeout,
 		DefaultHeartbeatThrottleInterval:      options.DefaultHeartbeatThrottleInterval,
 		MaxHeartbeatThrottleInterval:          options.MaxHeartbeatThrottleInterval,
+		PollTaskTimeout:                       options.PollTaskTimeout,
 		cache:                                 cache,
 		eagerActivityExecutor: newEagerActivityExecutor(eagerActivityExecutorOptions{
 			disabled:      options.DisableEagerActivities,
@@ -1922,6 +1929,9 @@ func setWorkerOptionsDefaults(options *WorkerOptions) {
 			NumLocalActivitySlots: maxConcurrentLA,
 			NumNexusSlots:         maxConcurrentNexus})
 
+	}
+	if options.PollTaskTimeout.Seconds() == 0 {
+		options.PollTaskTimeout = defaultPollTaskTimeOutSeconds * time.Second
 	}
 }
 

--- a/internal/worker.go
+++ b/internal/worker.go
@@ -256,6 +256,12 @@ type (
 		// MaxConcurrentActivityExecutionSize, and MaxConcurrentLocalActivityExecutionSize.
 		// NOTE: Experimental
 		Tuner WorkerTuner
+
+		// Optional: The timeout for polling tasks defaults to 70 seconds if not specified
+		// Server returns empty task after dynamicconfig.MatchingLongPollExpirationInterval (default is 60 seconds).
+		// PollTaskTimeout should be dynamicconfig.MatchingLongPollExpirationInterval + some delta for full round trip to matching
+		// because empty task should be returned before timeout is expired (expired timeout counts against SLO).
+		PollTaskTimeout time.Duration
 	}
 )
 


### PR DESCRIPTION
An internal task poller currently hardcodes the polling task timeout to 70 seconds. However, it should be set to dynamicconfig.MatchingLongPollExpirationInterval + some delta to account for the full round trip to matching.dynamicconfig.MatchingLongPollExpirationInterval (default is 60 seconds) is the maximum wait time for a new task, after which the server will return empty.

This change will make the polling task timeout configurable when the poller is created.

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
