### PR TITLE
Support mocking Nexus operation with operation reference

### DIFF
--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -768,6 +768,22 @@ func (r *registry) getWorkflowDefinition(wt WorkflowType) (WorkflowDefinition, e
 	return newSyncWorkflowDefinition(executor), nil
 }
 
+func (r *registry) getNexusService(service string) *nexus.Service {
+	r.Lock()
+	defer r.Unlock()
+	return r.nexusServices[service]
+}
+
+func (r *registry) getRegisteredNexusServices() []*nexus.Service {
+	r.Lock()
+	defer r.Unlock()
+	result := make([]*nexus.Service, 0, len(r.nexusServices))
+	for _, s := range r.nexusServices {
+		result = append(result, s)
+	}
+	return result
+}
+
 // Validate function parameters.
 func validateFnFormat(fnType reflect.Type, isWorkflow bool) error {
 	if fnType.Kind() != reflect.Func {
@@ -1058,7 +1074,7 @@ func (aw *AggregatedWorker) start() error {
 			return err
 		}
 	}
-	nexusServices := aw.registry.nexusServices
+	nexusServices := aw.registry.getRegisteredNexusServices()
 	if len(nexusServices) > 0 {
 		reg := nexus.NewServiceRegistry()
 		for _, service := range nexusServices {

--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -121,6 +121,13 @@ type (
 		delay  time.Duration
 	}
 
+	// Interface for nexus.OperationReference without the types as generics.
+	testNexusOperationReference interface {
+		Name() string
+		InputType() reflect.Type
+		OutputType() reflect.Type
+	}
+
 	testCallbackHandle struct {
 		callback          func()
 		startWorkflowTask bool // start a new workflow task after callback() is handled.
@@ -181,6 +188,7 @@ type (
 		runningWorkflows       map[string]*testWorkflowHandle
 		runningNexusOperations map[int64]*testNexusOperationHandle
 		nexusAsyncOpHandle     map[string]*testNexusAsyncOperationHandle
+		nexusOperationRefs     map[string]map[string]testNexusOperationReference
 
 		runningCount int
 
@@ -273,6 +281,7 @@ func newTestWorkflowEnvironmentImpl(s *WorkflowTestSuite, parentRegistry *regist
 			runningWorkflows:          make(map[string]*testWorkflowHandle),
 			runningNexusOperations:    make(map[int64]*testNexusOperationHandle),
 			nexusAsyncOpHandle:        make(map[string]*testNexusAsyncOperationHandle),
+			nexusOperationRefs:        make(map[string]map[string]testNexusOperationReference),
 			callbackChannel:           make(chan testCallbackHandle, 1000),
 			testTimeout:               3 * time.Second,
 			expectedWorkflowMockCalls: make(map[string]struct{}),
@@ -2541,6 +2550,24 @@ func (env *testWorkflowEnvironmentImpl) RegisterNexusAsyncOperationCompletion(
 	err error,
 	delay time.Duration,
 ) error {
+	opRef := env.nexusOperationRefs[service][operation]
+	if opRef == nil {
+		panic(fmt.Sprintf(
+			"nexus service %q operation %q not mocked",
+			service,
+			operation,
+		))
+	}
+	if reflect.TypeOf(result) != opRef.OutputType() {
+		panic(fmt.Sprintf(
+			"nexus service %q operation %q expected result type %s, got %T",
+			service,
+			operation,
+			opRef.OutputType(),
+			result,
+		))
+	}
+
 	var data *commonpb.Payload
 	if result != nil {
 		var encodeErr error
@@ -3149,6 +3176,13 @@ func newTestNexusHandler(
 ) (nexus.Handler, error) {
 	reg := nexus.NewServiceRegistry()
 	for _, service := range env.registry.nexusServices {
+		// register a dummy operation to make sure the service has at least 1 operation
+		_ = service.Register(nexus.NewSyncOperation(
+			"__internal__dummy",
+			func(_ context.Context, _ nexus.NoValue, _ nexus.StartOperationOptions) (nexus.NoValue, error) {
+				return nil, nil
+			},
+		))
 		if err := reg.Register(service); err != nil {
 			return nil, fmt.Errorf("failed to register nexus service '%v': %w", service, err)
 		}
@@ -3178,23 +3212,28 @@ func (r *testNexusHandler) StartOperation(
 			service,
 		))
 	}
+
+	opRef := r.env.nexusOperationRefs[service][operation]
 	op := s.Operation(operation)
-	if op == nil {
-		panic(fmt.Sprintf(
-			"nexus operation %q is not registered in service %q with the TestWorkflowEnvironment",
-			operation,
-			service,
-		))
+	if opRef == nil {
+		if op == nil {
+			panic(fmt.Sprintf(
+				"nexus service %q operation %q not registered and not mocked",
+				service,
+				operation,
+			))
+		}
+		opRef = op.(testNexusOperationReference)
 	}
-	fn, _ := reflect.TypeOf(op).MethodByName("Start")
-	inputType := fn.Type.In(2)
-	ptr := reflect.New(inputType)
-	if err := input.Consume(ptr.Interface()); err != nil {
+
+	inputPtr := reflect.New(opRef.InputType())
+	err := input.Consume(inputPtr.Interface())
+	if err != nil {
 		panic("mock of ExecuteNexusOperation failed to deserialize input")
 	}
 
 	// rebuild the input as *nexus.LazyValue
-	payload, err := r.env.dataConverter.ToPayload(ptr.Elem().Interface())
+	payload, err := r.env.dataConverter.ToPayload(inputPtr.Elem().Interface())
 	if err != nil {
 		// this should not be possible
 		panic("mock of ExecuteNexusOperation failed to convert input to payload")
@@ -3229,47 +3268,61 @@ func (r *testNexusHandler) StartOperation(
 	m := &mockWrapper{
 		env:           r.env,
 		name:          service,
-		fn:            fn.Func.Interface(),
+		fn:            nil,
 		isWorkflow:    false,
 		dataConverter: r.env.dataConverter,
 	}
-	mockRet := m.getNexusMockReturn(ctx, operation, ptr.Elem().Interface(), r.opHandle.params.options)
+	mockRet := m.getNexusMockReturn(
+		ctx,
+		operation,
+		inputPtr.Elem().Interface(),
+		r.opHandle.params.options,
+	)
 	if mockRet != nil {
 		mockRetLen := len(mockRet)
 		if mockRetLen != 2 {
 			panic(fmt.Sprintf(
-				"mock of ExecuteNexusOperation has incorrect number of returns, expected 2, but actual is %d",
+				"mock of ExecuteNexusOperation has incorrect number of returns, expected 2, got %d",
 				mockRetLen,
 			))
 		}
 
-		// we already verified function either has 1 return value (error) or 2 return values (result, error)
-		var retErr error
-		mockErr := mockRet[mockRetLen-1] // last mock return must be error
-		if mockErr == nil {
-			retErr = nil
-		} else if err, ok := mockErr.(error); ok {
-			retErr = err
-		} else {
+		// we already verified function has 2 return values (result, error)
+		mockErr := mockRet[1] // last mock return must be error
+		if mockErr != nil {
+			if err, ok := mockErr.(error); ok {
+				return nil, err
+			}
 			panic(fmt.Sprintf(
-				"mock of ExecuteNexusOperation has incorrect return type, expected error, but actual is %T (%v)",
-				mockErr,
+				"mock of ExecuteNexusOperation has incorrect return type, expected error, got %T",
 				mockErr,
 			))
 		}
 
 		mockResult := mockRet[0]
-		ret, ok := mockResult.(nexus.HandlerStartOperationResult[any])
+		result, ok := mockResult.(nexus.HandlerStartOperationResult[any])
 		if mockResult != nil && !ok {
 			panic(fmt.Sprintf(
-				"mock of ExecuteNexusOperation has incorrect return type, expected nexus.HandlerStartOperationResult[T], but actual is %T (%v)",
-				mockResult,
+				"mock of ExecuteNexusOperation has incorrect return type, expected nexus.HandlerStartOperationResult[T], but actual is %T",
 				mockResult,
 			))
 		}
 
+		// If the result is nexus.HandlerStartOperationResultSync, check the result value type
+		// matches the operation return type.
+		value := reflect.ValueOf(result).Elem().FieldByName("Value")
+		if (value != reflect.Value{}) {
+			if value.Type() != opRef.OutputType() {
+				panic(fmt.Sprintf(
+					"mock of ExecuteNexusOperation has incorrect return type, operation expects to return %s, got %s",
+					opRef.OutputType(),
+					value.Type(),
+				))
+			}
+		}
+
 		r.opHandle.isMocked = true
-		return ret, retErr
+		return result, nil
 	}
 
 	return r.handler.StartOperation(ctx, service, operation, input, options)
@@ -3307,4 +3360,19 @@ func (r *testNexusHandler) GetOperationResult(
 	options nexus.GetOperationResultOptions,
 ) (any, error) {
 	return r.handler.GetOperationResult(ctx, service, operation, operationID, options)
+}
+
+func (env *testWorkflowEnvironmentImpl) registerNexusOperationReference(
+	service string,
+	opRef testNexusOperationReference,
+) {
+	m := env.nexusOperationRefs[service]
+	if m == nil {
+		m = make(map[string]testNexusOperationReference)
+		env.nexusOperationRefs[service] = m
+	}
+	if opRef.Name() == "" {
+		panic("tried to register an operation with no name")
+	}
+	m[opRef.Name()] = opRef
 }

--- a/internal/workflow_testsuite.go
+++ b/internal/workflow_testsuite.go
@@ -546,12 +546,15 @@ func (e *TestWorkflowEnvironment) OnUpsertMemo(attributes interface{}) *MockCall
 
 // OnNexusOperation setup a mock call for Nexus operation.
 // Parameter service must be Nexus service (*nexus.Service) or service name (string).
-// Parameter operation must be Nexus operation (nexus.RegisterableOperation) or operation name (string).
-// You must call Return() with appropriate parameters on the returned *MockCallWrapper instance. The
-// supplied parameters to Return() call must be an instance of nexus.HandlerStartOperationResult[T]
-// and an error. If your mock returns nexus.HandlerStartOperationResultAsync, you need to register the
+// Parameter operation must be Nexus operation (nexus.RegisterableOperation), Nexus operation
+// reference (nexus.OperationReference), or operation name (string).
+// You must call Return() with appropriate parameters on the returned *MockCallWrapper instance.
+// The first parameter of Return() is the result of type nexus.HandlerStartOperationResult[T], ie.,
+// it must be *nexus.HandlerStartOperationResultSync[T] or *nexus.HandlerStartOperationResultAsync.
+// The second parameter of Return() is an error.
+// If your mock returns *nexus.HandlerStartOperationResultAsync, then you need to register the
 // completion of the async operation by calling RegisterNexusAsyncOperationCompletion.
-// Example: assume the Nexus operation you want to mock is as follows:
+// Example: assume the Nexus operation input/output types are as follows:
 //
 //	type (
 //		HelloInput struct {
@@ -562,35 +565,22 @@ func (e *TestWorkflowEnvironment) OnUpsertMemo(attributes interface{}) *MockCall
 //		}
 //	)
 //
-//	var HelloOperation = temporalnexus.NewWorkflowRunOperation(
-//		"hello-operation",
-//		HelloHandlerWorkflow,
-//		func(ctx context.Context, input HelloInput, options nexus.StartOperationOptions) (client.StartWorkflowOptions, error) {
-//			return client.StartWorkflowOptions{}, nil
-//		},
-//	)
-//
-//	func HelloHandlerWorkflow(_ workflow.Context, input HelloInput) (HelloOutput, error) {
-//		return HelloOutput{Message: "Hello " + input.Message}, nil
-//	}
-//
 // Then, you can mock workflow.NexusClient.ExecuteOperation as follows:
 //
 //	t.OnNexusOperation(
-//		service,
-//		HelloOperation,
+//		"my-service",
+//		nexus.NewOperationReference[HelloInput, HelloOutput]("hello-operation"),
 //		HelloInput{Message: "Temporal"},
-//		mock.Anything,
+//		mock.Anything, // NexusOperationOptions
 //	).Return(
 //		&nexus.HandlerStartOperationResultAsync{
 //			OperationID: "hello-operation-id",
 //		},
 //		nil,
 //	)
-//
 //	t.RegisterNexusAsyncOperationCompletion(
-//		service,
-//		HelloOperation.Name(),
+//		"service-name",
+//		"hello-operation",
 //		"hello-operation-id",
 //		HelloOutput{Message: "Hello Temporal"},
 //		nil,
@@ -612,38 +602,53 @@ func (e *TestWorkflowEnvironment) OnNexusOperation(
 	case string:
 		s = e.impl.registry.nexusServices[stp]
 		if s == nil {
-			panic(fmt.Sprintf(
-				"nexus service %q is not registered with the TestWorkflowEnvironment",
-				service,
-			))
+			s = nexus.NewService(stp)
+			e.RegisterNexusService(s)
 		}
 	default:
 		panic("service must be *nexus.Service or string")
 	}
 
-	var op nexus.RegisterableOperation
+	var opRef testNexusOperationReference
 	switch otp := operation.(type) {
-	case nexus.RegisterableOperation:
-		op = otp
-		if s.Operation(op.Name()) == nil {
-			if err := s.Register(op); err != nil {
-				panic(fmt.Sprintf("failed to register operation %q: %v", op.Name(), err))
-			}
-		}
+	case testNexusOperationReference:
+		// This case covers both nexus.RegisterableOperation and nexus.OperationReference.
+		// All nexus.RegisterableOperation embeds nexus.UnimplementedOperation which
+		// implements nexus.OperationReference.
+		opRef = otp
+		e.impl.registerNexusOperationReference(s.Name, opRef)
 	case string:
-		op = s.Operation(otp)
-		if op == nil {
-			panic(fmt.Sprintf(
-				"nexus operation %q is not registered in service %q with the TestWorkflowEnvironment",
-				operation,
-				service,
-			))
+		if op := s.Operation(otp); op != nil {
+			opRef = op.(testNexusOperationReference)
+			e.impl.registerNexusOperationReference(s.Name, opRef)
+		} else {
+			panic(fmt.Sprintf("operation %q not registered in service %q", otp, s.Name))
 		}
 	default:
-		panic("operation must be nexus.RegisterableOperation or string")
+		panic("operation must be nexus.RegisterableOperation, nexus.OperationReference, or string")
 	}
 
-	call := e.nexusMock.On(s.Name, op.Name(), input, options)
+	if input != mock.Anything {
+		if opRef.InputType() != reflect.TypeOf(input) {
+			panic(fmt.Sprintf(
+				"operation %q expects input type %s, got %T",
+				opRef.Name(),
+				opRef.InputType(),
+				input,
+			))
+		}
+	}
+
+	if options != mock.Anything {
+		if _, ok := options.(NexusOperationOptions); !ok {
+			panic(fmt.Sprintf(
+				"options must be an instance of NexusOperationOptions or mock.Anything, got %T",
+				options,
+			))
+		}
+	}
+
+	call := e.nexusMock.On(s.Name, opRef.Name(), input, options)
 	return e.wrapNexusOperationCall(call)
 }
 
@@ -658,18 +663,17 @@ func (e *TestWorkflowEnvironment) RegisterNexusAsyncOperationCompletion(
 	err error,
 	delay time.Duration,
 ) error {
-	s, ok := e.impl.registry.nexusServices[service]
-	if !ok {
+	if _, ok := e.impl.registry.nexusServices[service]; !ok {
 		panic(fmt.Sprintf(
 			"nexus service %q is not registered with the TestWorkflowEnvironment",
 			service,
 		))
 	}
-	if s.Operation(operation) == nil {
+	if _, ok := e.impl.nexusOperationRefs[service][operation]; !ok {
 		panic(fmt.Sprintf(
-			"nexus operation %q is not registered in service %q with the TestWorkflowEnvironment",
-			operation,
+			"nexus service %q operation %q has not been mocked with the TestWorkflowEnvironment",
 			service,
+			operation,
 		))
 	}
 	return e.impl.RegisterNexusAsyncOperationCompletion(

--- a/test/nexus_test.go
+++ b/test/nexus_test.go
@@ -1323,6 +1323,29 @@ func TestWorkflowTestSuite_MockNexusOperation(t *testing.T) {
 		require.Equal(t, "fake result", res)
 	})
 
+	t.Run("mock operation reference existing service", func(t *testing.T) {
+		suite := testsuite.WorkflowTestSuite{}
+		env := suite.NewTestWorkflowEnvironment()
+		env.RegisterNexusService(service)
+		env.OnNexusOperation(
+			serviceName,
+			nexus.NewOperationReference[string, string](dummyOpName),
+			"Temporal",
+			mock.Anything,
+		).Return(
+			&nexus.HandlerStartOperationResultSync[string]{
+				Value: "fake result",
+			},
+			nil,
+		)
+		env.ExecuteWorkflow(wf, "Temporal")
+		require.True(t, env.IsWorkflowCompleted())
+		require.NoError(t, env.GetWorkflowError())
+		var res string
+		require.NoError(t, env.GetWorkflowResult(&res))
+		require.Equal(t, "fake result", res)
+	})
+
 	t.Run("mock error operation", func(t *testing.T) {
 		suite := testsuite.WorkflowTestSuite{}
 		env := suite.NewTestWorkflowEnvironment()


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Support mocking Nexus operation using `nexus.OperationReference`.

## Why?
<!-- Tell your future self why have you made these changes -->
The user won't need to create a dummy implementation of Nexus operation to mock it.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
