### PR TITLE
Support annotations for versioning behavior

### DIFF
--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -1918,9 +1918,9 @@ func (wth *workflowTaskHandlerImpl) completeWorkflow(
 	}
 	if wth.useBuildIDForVersioning && wth.deploymentName != "" {
 		if workflowContext.workflowInfo.currentVersioningBehavior != VersioningBehaviorUnspecified {
-			builtRequest.VersioningBehavior = VersioningBehaviorToProto(workflowContext.workflowInfo.currentVersioningBehavior)
+			builtRequest.VersioningBehavior = versioningBehaviorToProto(workflowContext.workflowInfo.currentVersioningBehavior)
 		} else {
-			builtRequest.VersioningBehavior = VersioningBehaviorToProto(wth.defaultVersioningBehavior)
+			builtRequest.VersioningBehavior = versioningBehaviorToProto(wth.defaultVersioningBehavior)
 		}
 	}
 	return builtRequest

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -170,6 +170,9 @@ type (
 		// The worker's deployment name, an identifier in versioning-3 to group Task Queues for a given build ID.
 		DeploymentName string
 
+		// The Versioning Behavior for workflows that do not set one in their first task.
+		DefaultVersioningBehavior VersioningBehavior
+
 		MetricsHandler metrics.Handler
 
 		Logger log.Logger
@@ -1668,6 +1671,7 @@ func NewAggregatedWorker(client *WorkflowClient, taskQueue string, options Worke
 		WorkerBuildID:                         options.BuildID,
 		UseBuildIDForVersioning:               options.UseBuildIDForVersioning,
 		DeploymentName:                        options.DeploymentName,
+		DefaultVersioningBehavior:             options.DefaultVersioningBehavior,
 		MetricsHandler:                        client.metricsHandler.WithTags(metrics.TaskQueueTags(taskQueue)),
 		Logger:                                client.logger,
 		EnableLoggingInReplay:                 options.EnableLoggingInReplay,

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -1624,7 +1624,7 @@ func NewAggregatedWorker(client *WorkflowClient, taskQueue string, options Worke
 
 	// Sessions are not currently compatible with worker versioning
 	// See: https://github.com/temporalio/sdk-go/issues/1227
-	if options.EnableSessionWorker && options.UseBuildIDForVersioning {
+	if options.EnableSessionWorker && options.DeploymentOptions.UseBuildIDForVersioning {
 		panic("cannot set both EnableSessionWorker and UseBuildIDForVersioning")
 	}
 
@@ -1668,10 +1668,10 @@ func NewAggregatedWorker(client *WorkflowClient, taskQueue string, options Worke
 		MaxConcurrentWorkflowTaskQueuePollers: options.MaxConcurrentWorkflowTaskPollers,
 		MaxConcurrentNexusTaskQueuePollers:    options.MaxConcurrentNexusTaskPollers,
 		Identity:                              client.identity,
-		WorkerBuildID:                         options.BuildID,
-		UseBuildIDForVersioning:               options.UseBuildIDForVersioning,
-		DeploymentName:                        options.DeploymentName,
-		DefaultVersioningBehavior:             options.DefaultVersioningBehavior,
+		WorkerBuildID:                         options.DeploymentOptions.BuildID,
+		UseBuildIDForVersioning:               options.DeploymentOptions.UseBuildIDForVersioning,
+		DeploymentName:                        options.DeploymentOptions.DeploymentName,
+		DefaultVersioningBehavior:             options.DeploymentOptions.DefaultVersioningBehavior,
 		MetricsHandler:                        client.metricsHandler.WithTags(metrics.TaskQueueTags(taskQueue)),
 		Logger:                                client.logger,
 		EnableLoggingInReplay:                 options.EnableLoggingInReplay,

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -2865,7 +2865,8 @@ func TestWorkerBuildIDAndSessionPanic(t *testing.T) {
 	var recovered interface{}
 	func() {
 		defer func() { recovered = recover() }()
-		worker := NewAggregatedWorker(&WorkflowClient{}, "some-task-queue", WorkerOptions{EnableSessionWorker: true, UseBuildIDForVersioning: true})
+		worker := NewAggregatedWorker(&WorkflowClient{}, "some-task-queue", WorkerOptions{EnableSessionWorker: true,
+			DeploymentOptions: WorkerDeploymentOptions{UseBuildIDForVersioning: true}})
 		worker.RegisterWorkflow(testReplayWorkflow)
 	}()
 	require.Equal(t, "cannot set both EnableSessionWorker and UseBuildIDForVersioning", recovered)

--- a/internal/internal_workflow.go
+++ b/internal/internal_workflow.go
@@ -1620,6 +1620,14 @@ func SetVersioningBehavior(ctx Context, behavior VersioningBehavior) {
 	env.WorkflowInfo().currentVersioningBehavior = behavior
 }
 
+// GetVersioningBehavior returns the last versioning behavior set with SetVersioningBehavior.
+//
+// NOTE: Experimental
+func GetVersioningBehavior(ctx Context) VersioningBehavior {
+	env := getWorkflowEnvironment(ctx)
+	return env.WorkflowInfo().currentVersioningBehavior
+}
+
 func getWorkflowMetadata(ctx Context) (*sdk.WorkflowMetadata, error) {
 	info := GetWorkflowInfo(ctx)
 	eo := getWorkflowEnvOptions(ctx)

--- a/internal/internal_workflow.go
+++ b/internal/internal_workflow.go
@@ -1611,6 +1611,15 @@ func SetCurrentDetails(ctx Context, details string) {
 	getWorkflowEnvOptions(ctx).currentDetails = details
 }
 
+// SetVersioningBehavior sets the strategy to upgrade this workflow when the default Build ID
+// has changed, and Worker Versioning-3 has been enabled.
+//
+// NOTE: Experimental
+func SetVersioningBehavior(ctx Context, behavior VersioningBehavior) {
+	env := getWorkflowEnvironment(ctx)
+	env.WorkflowInfo().currentVersioningBehavior = behavior
+}
+
 func getWorkflowMetadata(ctx Context) (*sdk.WorkflowMetadata, error) {
 	info := GetWorkflowInfo(ctx)
 	eo := getWorkflowEnvOptions(ctx)

--- a/internal/worker.go
+++ b/internal/worker.go
@@ -30,6 +30,36 @@ import (
 )
 
 type (
+	// WorkerDeploymentOptions provides configuration to enable Worker Versioning.
+	// NOTE: Experimental
+	WorkerDeploymentOptions struct {
+		// Assign a BuildID to this worker. This replaces the deprecated binary checksum concept,
+		// and is used to provide a unique identifier for a set of worker code, and is necessary
+		// to opt in to the Worker Versioning feature. See UseBuildIDForVersioning.
+		// NOTE: Experimental
+		BuildID string
+
+		// If set, opts this worker into the Worker Versioning feature. It will only
+		// operate on workflows it claims to be compatible with. You must set BuildID if this flag
+		// is true.
+		// NOTE: Experimental
+		// Note: Cannot be enabled at the same time as WorkerOptions.EnableSessionWorker
+		UseBuildIDForVersioning bool
+
+		// Assign a Deployment Name to this worker, an identifier for Worker Versioning that
+		// groups task queues for the given BuildID.
+		// NOTE: Experimental
+		// NOTE: Both BuildID and UseBuildIDForVersioning need to also be set to enable the new Worker Versioning-3 feature.
+		DeploymentName string
+
+		// Optional: Provides a default Versioning Behavior to workflows that do not set one in their first task
+		// (see workflow.SetVersioningBehavior).
+		// NOTE: Experimental
+		// NOTE: If the Worker Versioning-3 feature is on, and DefaultVersioningBehavior is unspecified,
+		// workflows that do not set the Versioning Behavior will fail in their first task.
+		DefaultVersioningBehavior VersioningBehavior
+	}
+
 	// WorkerOptions is used to configure a worker instance.
 	// The current timeout resolution implementation is in seconds and uses math.Ceil(d.Seconds()) as the duration. But is
 	// subjected to change in the future.
@@ -238,31 +268,10 @@ type (
 		// workflow or activities.
 		DisableRegistrationAliasing bool
 
-		// Assign a BuildID to this worker. This replaces the deprecated binary checksum concept,
-		// and is used to provide a unique identifier for a set of worker code, and is necessary
-		// to opt in to the Worker Versioning feature. See UseBuildIDForVersioning.
+		// Optional: If set, configure Worker Versioning for this worker. See WorkerDeploymentOptions
+		// for more. This is incompatible with setting EnableSessionWorker.
 		// NOTE: Experimental
-		BuildID string
-
-		// Optional: If set, opts this worker into the Worker Versioning feature. It will only
-		// operate on workflows it claims to be compatible with. You must set BuildID if this flag
-		// is true.
-		// NOTE: Experimental
-		// Note: Cannot be enabled at the same time as EnableSessionWorker
-		UseBuildIDForVersioning bool
-
-		// Optional: Assign a Deployment Name to this worker, an identifier for Worker Versioning that
-		// groups task queues for the given BuildID.
-		// NOTE: Experimental
-		// NOTE: Both BuildID and UseBuildIDForVersioning need to also be set to enable the new Worker Versioning-3 feature.
-		DeploymentName string
-
-		// Optional: Provides a default Versioning Behavior to workflows that do not set one in their first task
-		// (see workflow.SetVersioningBehavior).
-		// NOTE: Experimental
-		// NOTE: If the Worker Versioning-3 feature is on, and DefaultVersioningBehavior is unspecified,
-		// workflows that do not set the Versioning Behavior will fail in their first task.
-		DefaultVersioningBehavior VersioningBehavior
+		DeploymentOptions WorkerDeploymentOptions
 
 		// Optional: If set, use a custom tuner for this worker. See WorkerTuner for more.
 		// Mutually exclusive with MaxConcurrentWorkflowTaskExecutionSize,

--- a/internal/worker.go
+++ b/internal/worker.go
@@ -257,6 +257,13 @@ type (
 		// NOTE: Both BuildID and UseBuildIDForVersioning need to also be set to enable the new Worker Versioning-3 feature.
 		DeploymentName string
 
+		// Optional: Provides a default Versioning Behavior to workflows that do not set one in their first task
+		// (see workflow.SetVersioningBehavior).
+		// NOTE: Experimental
+		// NOTE: If the Worker Versioning-3 feature is on, and DefaultVersioningBehavior is unspecified,
+		// workflows that do not set the Versioning Behavior will fail in their first task.
+		DefaultVersioningBehavior VersioningBehavior
+
 		// Optional: If set, use a custom tuner for this worker. See WorkerTuner for more.
 		// Mutually exclusive with MaxConcurrentWorkflowTaskExecutionSize,
 		// MaxConcurrentActivityExecutionSize, and MaxConcurrentLocalActivityExecutionSize.

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -2555,7 +2555,7 @@ func (wc *workflowEnvironmentInterceptor) RequestCancelNexusOperation(ctx Contex
 	wc.env.RequestCancelNexusOperation(input.seq)
 }
 
-func VersioningBehaviorToProto(t VersioningBehavior) enumspb.VersioningBehavior {
+func versioningBehaviorToProto(t VersioningBehavior) enumspb.VersioningBehavior {
 	switch t {
 	case VersioningBehaviorUnspecified:
 		return enumspb.VERSIONING_BEHAVIOR_UNSPECIFIED
@@ -2565,18 +2565,5 @@ func VersioningBehaviorToProto(t VersioningBehavior) enumspb.VersioningBehavior 
 		return enumspb.VERSIONING_BEHAVIOR_AUTO_UPGRADE
 	default:
 		panic("unknown versioning behavior type")
-	}
-}
-
-func VersioningBehaviorFromProto(t enumspb.VersioningBehavior) VersioningBehavior {
-	switch t {
-	case enumspb.VERSIONING_BEHAVIOR_UNSPECIFIED:
-		return VersioningBehaviorUnspecified
-	case enumspb.VERSIONING_BEHAVIOR_PINNED:
-		return VersioningBehaviorPinned
-	case enumspb.VERSIONING_BEHAVIOR_AUTO_UPGRADE:
-		return VersioningBehaviorAutoUpgrade
-	default:
-		panic("unknown versioning behavior type from proto")
 	}
 }

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -59,6 +59,23 @@ const (
 	HandlerUnfinishedPolicyAbandon
 )
 
+// VersioningBehavior specifies when existing workflows could change their Build ID.
+// NOTE: Experimental
+type VersioningBehavior int
+
+const (
+	// Workflow versioning policy unknown. A default VersioningBehaviorUnspecified policy forces
+	// every workflow to explicitly set a VersioningBehavior different from VersioningBehaviorUnspecified.
+	VersioningBehaviorUnspecified VersioningBehavior = iota
+
+	// Workflow should be pinned to the current Build ID until manually moved.
+	VersioningBehaviorPinned
+
+	// Workflow automatically moves to the latest version (default Build ID of the task queue)
+	// when the next task is dispatched.
+	VersioningBehaviorAutoUpgrade
+)
+
 var (
 	errWorkflowIDNotSet              = errors.New("workflowId is not set")
 	errLocalActivityParamsBadRequest = errors.New("missing local activity parameters through context, check LocalActivityOptions")
@@ -1171,6 +1188,12 @@ type WorkflowInfo struct {
 	// which is currently or about to be executing. If no longer replaying will be set to the ID of
 	// this worker
 	currentTaskBuildID string
+	// currentVersioningBehavior, if not unspecified,  sets the strategy to upgrade
+	// this workflow when the default Build ID
+	// has changed, and Worker Versioning-3 has been enabled. Otherwise, the current Worker
+	// option DefaultVersioningBehavior will be used instead.
+	// NOTE: Experimental
+	currentVersioningBehavior VersioningBehavior
 
 	continueAsNewSuggested bool
 	currentHistorySize     int
@@ -2530,4 +2553,30 @@ func (wc *workflowEnvironmentInterceptor) ExecuteNexusOperation(ctx Context, inp
 
 func (wc *workflowEnvironmentInterceptor) RequestCancelNexusOperation(ctx Context, input RequestCancelNexusOperationInput) {
 	wc.env.RequestCancelNexusOperation(input.seq)
+}
+
+func VersioningBehaviorToProto(t VersioningBehavior) enumspb.VersioningBehavior {
+	switch t {
+	case VersioningBehaviorUnspecified:
+		return enumspb.VERSIONING_BEHAVIOR_UNSPECIFIED
+	case VersioningBehaviorPinned:
+		return enumspb.VERSIONING_BEHAVIOR_PINNED
+	case VersioningBehaviorAutoUpgrade:
+		return enumspb.VERSIONING_BEHAVIOR_AUTO_UPGRADE
+	default:
+		panic("unknown versioning behavior type")
+	}
+}
+
+func VersioningBehaviorFromProto(t enumspb.VersioningBehavior) VersioningBehavior {
+	switch t {
+	case enumspb.VERSIONING_BEHAVIOR_UNSPECIFIED:
+		return VersioningBehaviorUnspecified
+	case enumspb.VERSIONING_BEHAVIOR_PINNED:
+		return VersioningBehaviorPinned
+	case enumspb.VERSIONING_BEHAVIOR_AUTO_UPGRADE:
+		return VersioningBehaviorAutoUpgrade
+	default:
+		panic("unknown versioning behavior type from proto")
+	}
 }

--- a/test/worker_versioning_test.go
+++ b/test/worker_versioning_test.go
@@ -400,7 +400,12 @@ func (ts *WorkerVersioningTestSuite) TestTwoWorkersGetDifferentTasks() {
 	})
 	ts.NoError(err)
 
-	worker1 := worker.New(ts.client, ts.taskQueueName, worker.Options{BuildID: "1.0", UseBuildIDForVersioning: true})
+	worker1 := worker.New(ts.client, ts.taskQueueName, worker.Options{
+		DeploymentOptions: worker.DeploymentOptions{
+			BuildID:                 "1.0",
+			UseBuildIDForVersioning: true,
+		},
+	})
 	ts.workflows.register(worker1)
 	ts.NoError(worker1.Start())
 	defer worker1.Stop()
@@ -419,14 +424,24 @@ func (ts *WorkerVersioningTestSuite) TestTwoWorkersGetDifferentTasks() {
 		},
 	})
 	ts.NoError(err)
-	worker2 := worker.New(ts.client, ts.taskQueueName, worker.Options{BuildID: "2.0", UseBuildIDForVersioning: true})
+	worker2 := worker.New(ts.client, ts.taskQueueName, worker.Options{
+		DeploymentOptions: worker.DeploymentOptions{
+			BuildID:                 "2.0",
+			UseBuildIDForVersioning: true,
+		},
+	})
 	ts.workflows.register(worker2)
 	ts.NoError(worker2.Start())
 	defer worker2.Stop()
 
 	// If we add the worker before the BuildID "2.0" has been registered, the worker poller ends up
 	// in the new versioning queue, and it only recovers after 1m timeout.
-	worker3 := worker.New(ts.client, ts.taskQueueName, worker.Options{BuildID: "2.0", UseBuildIDForVersioning: true})
+	worker3 := worker.New(ts.client, ts.taskQueueName, worker.Options{
+		DeploymentOptions: worker.DeploymentOptions{
+			BuildID:                 "2.0",
+			UseBuildIDForVersioning: true,
+		},
+	})
 	ts.workflows.register(worker3)
 	ts.NoError(worker3.Start())
 	defer worker3.Stop()
@@ -471,11 +486,21 @@ func (ts *WorkerVersioningTestSuite) TestTwoWorkersGetDifferentTasksWithRules() 
 	})
 	ts.NoError(err)
 
-	worker1 := worker.New(ts.client, ts.taskQueueName, worker.Options{BuildID: "1.0", UseBuildIDForVersioning: true})
+	worker1 := worker.New(ts.client, ts.taskQueueName, worker.Options{
+		DeploymentOptions: worker.DeploymentOptions{
+			BuildID:                 "1.0",
+			UseBuildIDForVersioning: true,
+		},
+	})
 	ts.workflows.register(worker1)
 	ts.NoError(worker1.Start())
 	defer worker1.Stop()
-	worker2 := worker.New(ts.client, ts.taskQueueName, worker.Options{BuildID: "2.0", UseBuildIDForVersioning: true})
+	worker2 := worker.New(ts.client, ts.taskQueueName, worker.Options{
+		DeploymentOptions: worker.DeploymentOptions{
+			BuildID:                 "2.0",
+			UseBuildIDForVersioning: true,
+		},
+	})
 	ts.workflows.register(worker2)
 	ts.NoError(worker2.Start())
 	defer worker2.Stop()
@@ -643,10 +668,12 @@ func (ts *WorkerVersioningTestSuite) TestDeploymentNameWorker() {
 	defer cancel()
 
 	worker1 := worker.New(ts.client, ts.taskQueueName, worker.Options{
-		Identity:                "worker1",
-		BuildID:                 "b1",
-		UseBuildIDForVersioning: false,
-		DeploymentName:          "deploy1",
+		Identity: "worker1",
+		DeploymentOptions: worker.DeploymentOptions{
+			BuildID:                 "b1",
+			UseBuildIDForVersioning: false,
+			DeploymentName:          "deploy1",
+		},
 	})
 	ts.workflows.register(worker1)
 	ts.NoError(worker1.Start())
@@ -700,7 +727,12 @@ func (ts *WorkerVersioningTestSuite) TestReachabilityVersions() {
 	})
 	ts.NoError(err)
 
-	worker1 := worker.New(ts.client, ts.taskQueueName, worker.Options{BuildID: buildID1, UseBuildIDForVersioning: true})
+	worker1 := worker.New(ts.client, ts.taskQueueName, worker.Options{
+		DeploymentOptions: worker.DeploymentOptions{
+			BuildID:                 buildID1,
+			UseBuildIDForVersioning: true,
+		},
+	})
 	ts.workflows.register(worker1)
 	ts.NoError(worker1.Start())
 	defer worker1.Stop()
@@ -719,7 +751,12 @@ func (ts *WorkerVersioningTestSuite) TestReachabilityVersions() {
 	ts.NoError(handle12.Get(ctx, nil))
 
 	// Start the second worker
-	worker2 := worker.New(ts.client, ts.taskQueueName, worker.Options{BuildID: buildID2, UseBuildIDForVersioning: true})
+	worker2 := worker.New(ts.client, ts.taskQueueName, worker.Options{
+		DeploymentOptions: worker.DeploymentOptions{
+			BuildID:                 buildID2,
+			UseBuildIDForVersioning: true,
+		},
+	})
 	ts.workflows.register(worker2)
 	ts.NoError(worker2.Start())
 	defer worker2.Stop()
@@ -789,7 +826,12 @@ func (ts *WorkerVersioningTestSuite) TestReachabilityVersionsWithRules() {
 	})
 	ts.NoError(err)
 
-	worker1 := worker.New(ts.client, ts.taskQueueName, worker.Options{BuildID: buildID1, UseBuildIDForVersioning: true})
+	worker1 := worker.New(ts.client, ts.taskQueueName, worker.Options{
+		DeploymentOptions: worker.DeploymentOptions{
+			BuildID:                 buildID1,
+			UseBuildIDForVersioning: true,
+		},
+	})
 	ts.workflows.register(worker1)
 	ts.NoError(worker1.Start())
 	defer worker1.Stop()
@@ -808,7 +850,12 @@ func (ts *WorkerVersioningTestSuite) TestReachabilityVersionsWithRules() {
 	ts.NoError(handle12.Get(ctx, nil))
 
 	// Start the second worker
-	worker2 := worker.New(ts.client, ts.taskQueueName, worker.Options{BuildID: buildID2, UseBuildIDForVersioning: true})
+	worker2 := worker.New(ts.client, ts.taskQueueName, worker.Options{
+		DeploymentOptions: worker.DeploymentOptions{
+			BuildID:                 buildID2,
+			UseBuildIDForVersioning: true,
+		},
+	})
 	ts.workflows.register(worker2)
 	ts.NoError(worker2.Start())
 	defer worker2.Stop()
@@ -962,7 +1009,12 @@ func (ts *WorkerVersioningTestSuite) TestBuildIDChangesOverWorkflowLifetime() {
 	})
 	ts.NoError(err)
 
-	worker1 := worker.New(ts.client, ts.taskQueueName, worker.Options{BuildID: "1.0", UseBuildIDForVersioning: true})
+	worker1 := worker.New(ts.client, ts.taskQueueName, worker.Options{
+		DeploymentOptions: worker.DeploymentOptions{
+			BuildID:                 "1.0",
+			UseBuildIDForVersioning: true,
+		},
+	})
 	ts.workflows.register(worker1)
 	ts.activities.register(worker1)
 	ts.NoError(worker1.Start())
@@ -996,7 +1048,12 @@ func (ts *WorkerVersioningTestSuite) TestBuildIDChangesOverWorkflowLifetime() {
 	})
 	ts.NoError(err)
 
-	worker11 := worker.New(ts.client, ts.taskQueueName, worker.Options{BuildID: "1.1", UseBuildIDForVersioning: true})
+	worker11 := worker.New(ts.client, ts.taskQueueName, worker.Options{
+		DeploymentOptions: worker.DeploymentOptions{
+			BuildID:                 "1.1",
+			UseBuildIDForVersioning: true,
+		},
+	})
 	ts.workflows.register(worker11)
 	ts.activities.register(worker11)
 	ts.NoError(worker11.Start())
@@ -1052,7 +1109,12 @@ func (ts *WorkerVersioningTestSuite) TestBuildIDChangesOverWorkflowLifetimeWithR
 	})
 	ts.NoError(err)
 
-	worker1 := worker.New(ts.client, ts.taskQueueName, worker.Options{BuildID: "1.0", UseBuildIDForVersioning: true})
+	worker1 := worker.New(ts.client, ts.taskQueueName, worker.Options{
+		DeploymentOptions: worker.DeploymentOptions{
+			BuildID:                 "1.0",
+			UseBuildIDForVersioning: true,
+		},
+	})
 	ts.workflows.register(worker1)
 	ts.activities.register(worker1)
 	ts.NoError(worker1.Start())
@@ -1100,7 +1162,12 @@ func (ts *WorkerVersioningTestSuite) TestBuildIDChangesOverWorkflowLifetimeWithR
 	})
 	ts.NoError(err)
 
-	worker11 := worker.New(ts.client, ts.taskQueueName, worker.Options{BuildID: "1.1", UseBuildIDForVersioning: true})
+	worker11 := worker.New(ts.client, ts.taskQueueName, worker.Options{
+		DeploymentOptions: worker.DeploymentOptions{
+			BuildID:                 "1.1",
+			UseBuildIDForVersioning: true,
+		},
+	})
 	ts.workflows.register(worker11)
 	ts.activities.register(worker11)
 	ts.NoError(worker11.Start())

--- a/test/workflow_test.go
+++ b/test/workflow_test.go
@@ -74,10 +74,17 @@ func (w *Workflows) Basic(ctx workflow.Context) ([]string, error) {
 func (w *Workflows) SetPinnedVersioningBehavior(ctx workflow.Context) ([]string, error) {
 	workflow.SetVersioningBehavior(ctx, workflow.VersioningBehaviorPinned)
 
+	err := workflow.SetQueryHandler(ctx, "get-versioning-behavior", func(input []byte) (workflow.VersioningBehavior, error) {
+		return workflow.GetVersioningBehavior(ctx), nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
 	ctx = workflow.WithActivityOptions(ctx, w.defaultActivityOptions())
 	var ans1 string
 	workflow.GetLogger(ctx).Info("calling ExecuteActivity")
-	err := workflow.ExecuteActivity(ctx, "Prefix_ToUpperWithDelay", "hello", time.Second).Get(ctx, &ans1)
+	err = workflow.ExecuteActivity(ctx, "Prefix_ToUpperWithDelay", "hello", time.Second).Get(ctx, &ans1)
 	if err != nil {
 		return nil, err
 	}

--- a/test/workflow_test.go
+++ b/test/workflow_test.go
@@ -70,6 +70,27 @@ func (w *Workflows) Basic(ctx workflow.Context) ([]string, error) {
 	return []string{"toUpperWithDelay", "toUpper"}, nil
 }
 
+// Similar to Basic, but setting the versioning behavior to pinned.
+func (w *Workflows) SetPinnedVersioningBehavior(ctx workflow.Context) ([]string, error) {
+	workflow.SetVersioningBehavior(ctx, workflow.VersioningBehaviorPinned)
+
+	ctx = workflow.WithActivityOptions(ctx, w.defaultActivityOptions())
+	var ans1 string
+	workflow.GetLogger(ctx).Info("calling ExecuteActivity")
+	err := workflow.ExecuteActivity(ctx, "Prefix_ToUpperWithDelay", "hello", time.Second).Get(ctx, &ans1)
+	if err != nil {
+		return nil, err
+	}
+	var ans2 string
+	if err := workflow.ExecuteActivity(ctx, "Prefix_ToUpper", ans1).Get(ctx, &ans2); err != nil {
+		return nil, err
+	}
+	if ans2 != "HELLO" {
+		return nil, fmt.Errorf("incorrect return value from activity: expected=%v,got=%v", "HELLO", ans2)
+	}
+	return []string{"toUpperWithDelay", "toUpper"}, nil
+}
+
 func (w *Workflows) Echo(ctx workflow.Context, message string) (string, error) {
 	ctx = workflow.WithActivityOptions(ctx, w.defaultActivityOptions())
 	var ans1 string
@@ -3186,6 +3207,7 @@ func (w *Workflows) register(worker worker.Worker) {
 	worker.RegisterWorkflow(w.ActivityWaitForWorkerStop)
 	worker.RegisterWorkflow(w.ActivityHeartbeatUntilSignal)
 	worker.RegisterWorkflow(w.Basic)
+	worker.RegisterWorkflow(w.SetPinnedVersioningBehavior)
 	worker.RegisterWorkflow(w.Deadlocked)
 	worker.RegisterWorkflow(w.DeadlockedWithLocalActivity)
 	worker.RegisterWorkflow(w.Panicked)

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -211,6 +211,10 @@ type (
 		ReplayWorkflowExecution(ctx context.Context, service workflowservice.WorkflowServiceClient, logger log.Logger, namespace string, execution workflow.Execution) error
 	}
 
+	// DeploymentOptions provides configuration to enable Worker Versioning.
+	// NOTE: Experimental
+	DeploymentOptions = internal.WorkerDeploymentOptions
+
 	// Options is used to configure a worker instance.
 	Options = internal.WorkerOptions
 

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -35,6 +35,22 @@ import (
 	"golang.org/x/exp/constraints"
 )
 
+// VersioningBehavior specifies when existing workflows could change their Build ID.
+// NOTE: Experimental
+type VersioningBehavior = internal.VersioningBehavior
+
+const (
+	// Workflow versioning policy unknown.
+	VersioningBehaviorUnspecified = internal.VersioningBehaviorUnspecified
+
+	// Workflow should be pinned to the current Build ID until manually moved.
+	VersioningBehaviorPinned = internal.VersioningBehaviorPinned
+
+	// Workflow automatically moves to the latest version (default Build ID of the task queue)
+	// when the next task is dispatched.
+	VersioningBehaviorAutoUpgrade = internal.VersioningBehaviorAutoUpgrade
+)
+
 // HandlerUnfinishedPolicy defines the actions taken when a workflow exits while update handlers are
 // running. The workflow exit may be due to successful return, failure, cancellation, or
 // continue-as-new.
@@ -281,7 +297,7 @@ func GetCurrentUpdateInfo(ctx Context) *UpdateInfo {
 // GetLogger returns a logger to be used in workflow's context.
 // This logger does not record logs during replay.
 //
-// The logger may also extract additional fields from the context, such as update info 
+// The logger may also extract additional fields from the context, such as update info
 // if used in an update handler.
 func GetLogger(ctx Context) log.Logger {
 	return internal.GetLogger(ctx)
@@ -605,6 +621,22 @@ func GetCurrentDetails(ctx Context) string {
 // NOTE: Experimental
 func SetCurrentDetails(ctx Context, details string) {
 	internal.SetCurrentDetails(ctx, details)
+}
+
+// SetVersioningBehavior sets the strategy to upgrade this workflow when the default Build ID
+// has changed, and Worker Versioning-3 has been enabled.
+//
+// SetVersioningBehavior should be called during the first workflow task, and the context `ctx` should
+// be the original context workflow argument, or derived from this context.
+//
+// If not set, a default behavior provided in worker.Options.DefaultVersioningBehavior will be used.
+//
+// If not set, and the default behavior is also unspecified in the Worker, the first task of this workflow
+// will fail when Worker Versioning-3 has been enabled.
+//
+// NOTE: Experimental
+func SetVersioningBehavior(ctx Context, behavior VersioningBehavior) {
+	internal.SetVersioningBehavior(ctx, behavior)
 }
 
 // IsReplaying returns whether the current workflow code is replaying.

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -639,6 +639,18 @@ func SetVersioningBehavior(ctx Context, behavior VersioningBehavior) {
 	internal.SetVersioningBehavior(ctx, behavior)
 }
 
+// GetVersioningBehavior returns the last versioning behavior set with
+// the SetVersioningBehavior method.
+//
+// When SetVersioningBehavior has not been called, it always returns
+// VersioningBehaviorUnspecified, ignoring any Worker
+// defaults to avoid non-deterministic errors.
+//
+// NOTE: Experimental
+func GetVersioningBehavior(ctx Context) VersioningBehavior {
+	return internal.GetVersioningBehavior(ctx)
+}
+
 // IsReplaying returns whether the current workflow code is replaying.
 //
 // Warning! Never make commands, like schedule activity/childWorkflow/timer or send/wait on future/channel, based on


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->
This PR supports providing a default versioning behavior in Worker Options, and a programmatic API to override these defaults:

For example:
``` go
	workflow.SetVersioningBehavior(ctx, workflow.VersioningBehaviorPinned)
```
called  during the first workflow task sets the versioning mode for that workflow to `Pinned`, eliminating the need of patching.

And 
```go
	w := worker.New(c, ts.taskQueueName, worker.Options{
		DeploymentOptions: worker.DeploymentOptions{
                            BuildID:                   "1.0",
		            UseBuildIDForVersioning:   true,
		            DeploymentName:            "deploy-test1",
		            DefaultVersioningBehavior: workflow.VersioningBehaviorAutoUpgrade,
              }
	})
```
sets the default versioning behavior to `AutoUpgrade`. Note that `DeploymentName`, `UseBuildIDForVersioning` and `BuildID` need to be set to enable versioning-3.
If versioning-3 is on, but no default or programmatic versioning behavior has been set for a workflow, the server will fail its first workflow task. 

## Why?
<!-- Tell your future self why have you made these changes -->
A hint that a workflow is short-running, and therefore, does not need to be moved to the new Build ID on the next task, eliminates the need of patching for many workflow types. 


## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->
#1663 
2. How was this tested:
Integration test that uses versioning-2 and a grpc interceptor to show that versioning behaviors are propagated with responses.
The dependency on versioning-2 is just to set a default Build ID.
