### PR TITLE
Fix issue #1703

### DIFF
--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -1412,6 +1412,8 @@ func (env *testWorkflowEnvironmentImpl) getActivityHandle(activityID, runID stri
 }
 
 func (env *testWorkflowEnvironmentImpl) setActivityHandle(activityID, runID string, handle *testActivityHandle) {
+	env.locker.Lock()
+	defer env.locker.Unlock()
 	env.activities[env.makeUniqueActivityID(activityID, runID)] = handle
 }
 


### PR DESCRIPTION
protect the write to the map env.activities with env.locker

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
protect the write to the map env.activities with env.locker

## Why?
Fix crash as described I issue # 1703

## Checklist
<!--- add/delete as needed --->

1. Closes #1703 

