### PR TITLE
Don't heartbeat if poller is stopped

### DIFF
--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -415,6 +415,9 @@ func (wtp *workflowTaskPoller) processWorkflowTask(task *workflowTask) (retErr e
 			wfctx,
 			func(response interface{}, startTime time.Time) (*workflowTask, error) {
 				wtp.logger.Debug("Force RespondWorkflowTaskCompleted.", "TaskStartedEventID", task.task.GetStartedEventId())
+				if wtp.stopping() {
+					return nil, errStop
+				}
 				heartbeatResponse, err := wtp.RespondTaskCompletedWithMetrics(response, nil, task.task, startTime)
 				if err != nil {
 					return nil, err


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
`ProcessWorkflowTask` will now stop sending heartbeats if the worker is stopped.

## Why?
<!-- Tell your future self why have you made these changes -->
Without this change, workflows with local activities could hang indefinitely, waiting for a local activity to execute even when the local activity worker has already stopped.

## Checklist
<!--- add/delete as needed --->

1. Closes #1706

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
New unit test

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
No
