### PR TITLE
Annotate versioning behavior per Workflow type

### DIFF
--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -1920,7 +1920,12 @@ func (wth *workflowTaskHandlerImpl) completeWorkflow(
 		if workflowContext.workflowInfo.currentVersioningBehavior != VersioningBehaviorUnspecified {
 			builtRequest.VersioningBehavior = versioningBehaviorToProto(workflowContext.workflowInfo.currentVersioningBehavior)
 		} else {
-			builtRequest.VersioningBehavior = versioningBehaviorToProto(wth.defaultVersioningBehavior)
+			workflowType := workflowContext.workflowInfo.WorkflowType
+			if behavior, ok := wth.registry.getWorkflowVersioningBehavior(workflowType); ok {
+				builtRequest.VersioningBehavior = versioningBehaviorToProto(behavior)
+			} else {
+				builtRequest.VersioningBehavior = versioningBehaviorToProto(wth.defaultVersioningBehavior)
+			}
 		}
 	}
 	return builtRequest

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -558,9 +558,7 @@ func (r *registry) RegisterWorkflowWithOptions(
 			panic("WorkflowDefinitionFactory must be registered with a name")
 		}
 		r.workflowFuncMap[options.Name] = factory
-		if options.VersioningBehavior != VersioningBehaviorUnspecified {
-			r.workflowVersioningBehaviorMap[options.Name] = options.VersioningBehavior
-		}
+		r.workflowVersioningBehaviorMap[options.Name] = options.VersioningBehavior
 		return
 	}
 	// Validate that it is a function
@@ -584,9 +582,8 @@ func (r *registry) RegisterWorkflowWithOptions(
 		}
 	}
 	r.workflowFuncMap[registerName] = wf
-	if options.VersioningBehavior != VersioningBehaviorUnspecified {
-		r.workflowVersioningBehaviorMap[registerName] = options.VersioningBehavior
-	}
+	r.workflowVersioningBehaviorMap[registerName] = options.VersioningBehavior
+
 	if len(alias) > 0 && r.workflowAliasMap != nil {
 		r.workflowAliasMap[fnName] = alias
 	}
@@ -787,8 +784,8 @@ func (r *registry) getWorkflowVersioningBehavior(wt WorkflowType) (VersioningBeh
 	}
 	r.Lock()
 	defer r.Unlock()
-	behavior, ok := r.workflowVersioningBehaviorMap[lookup]
-	return behavior, ok
+	behavior := r.workflowVersioningBehaviorMap[lookup]
+	return behavior, behavior != VersioningBehaviorUnspecified
 }
 
 // Validate function parameters.

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -413,6 +413,10 @@ type (
 		// inside a workflow as a child workflow.
 		Name                          string
 		DisableAlreadyRegisteredCheck bool
+		// Optional: Provides a default Versioning Behavior to workflows of this type.
+		// See workflow.SetVersioningBehavior to override this default.
+		// NOTE: Experimental
+		VersioningBehavior VersioningBehavior
 	}
 
 	localActivityContext struct {


### PR DESCRIPTION

## What was changed
<!-- Describe what has changed in this PR -->

Provides an alternative mechanism to provide a default versioning behavior per workflow type using workflow registration options.
```go
	w.RegisterWorkflowWithOptions(ts.workflows.Basic, workflow.RegisterOptions{
		VersioningBehavior: workflow.VersioningBehaviorPinned,
	})
```

## Why?
<!-- Tell your future self why have you made these changes -->
The programmatic  API to set Versioning Behavior is brittle because it needs to be called during the first workflow task.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->
#1698 
2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
An integration test using gRPC interceptors
