### PR TITLE
added method to set workflowID when testing workflows

### DIFF
--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -491,6 +491,10 @@ func (env *testWorkflowEnvironmentImpl) setIdentity(identity string) {
 	env.identity = identity
 }
 
+func (env *testWorkflowEnvironmentImpl) setWorkflowID(workflowID string) {
+	env.workflowInfo.WorkflowExecution.ID = workflowID
+}
+
 func (env *testWorkflowEnvironmentImpl) setDataConverter(dataConverter converter.DataConverter) {
 	env.dataConverter = dataConverter
 }

--- a/internal/workflow_testsuite.go
+++ b/internal/workflow_testsuite.go
@@ -826,6 +826,12 @@ func (e *TestWorkflowEnvironment) SetIdentity(identity string) *TestWorkflowEnvi
 	return e
 }
 
+// SetWorkflowID sets the workflowID.
+func (e *TestWorkflowEnvironment) SetWorkflowID(workflowID string) *TestWorkflowEnvironment {
+	e.impl.setWorkflowID(workflowID)
+	return e
+}
+
 // SetDetachedChildWait, if true, will make ExecuteWorkflow wait on all child
 // workflows to complete even if their close policy is set to abandon or request
 // cancel, meaning they are "detached". If false, ExecuteWorkflow will block


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
- Added a method to be able to set the `workflowID` in the workflow test environment

## Why?
<!-- Tell your future self why have you made these changes -->
- This is a direct dependency for some of the work I have been doing with respect to `versioning-3`
- During unit testing, I will require the ability to alter workflowID's when starting `deployment` (versioning-3 concept) workflows and having this method in proves to be handy.

## Checklist
<!--- add/delete as needed --->
1. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
- Current unit tests. No new tests were added since this is a getter.
