### PR TITLE
Added SpanFromWorkflowContext function

### DIFF
--- a/contrib/datadog/tracing/interceptor.go
+++ b/contrib/datadog/tracing/interceptor.go
@@ -143,6 +143,20 @@ func (t *tracerImpl) ContextWithSpan(ctx context.Context, span interceptor.Trace
 	return tracer.ContextWithSpan(ctx, span.(*tracerSpan).Span)
 }
 
+// SpanFromWorkflowContext extracts the DataDog Span object from the workflow context.
+func SpanFromWorkflowContext(ctx workflow.Context) (ddtrace.Span, bool) {
+	val := ctx.Value(activeSpanContextKey)
+	if val == nil {
+		return tracer.SpanFromContext(nil)
+	}
+
+	if span, ok := val.(*tracerSpan); ok {
+		return span.Span, true
+	}
+
+	return tracer.SpanFromContext(nil)
+}
+
 func genSpanID(idempotencyKey string) uint64 {
 	h := fnv.New64()
 	// Write() always writes all bytes and never fails; the count and error result are for implementing io.Writer.


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Added a `SpanFromWorkflowContext` function to allow access to the DataDog span object from within a workflow.
<!-- Describe what has changed in this PR -->

## Why?
This allows users to access the Span from within a workflow to (for example) add custom tags on the span.
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes #1701 
2. How was this tested: New unit test added
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed? Would be nice, please let me know where I could add these if this is desired.
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
