### PR TITLE
Update workflow execution options (versioning)

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -283,10 +283,6 @@ type (
 	// NOTE: Experimental
 	UpdateWorkflowExecutionOptionsRequest = internal.UpdateWorkflowExecutionOptionsRequest
 
-	// GetWorkflowExecutionOptionsRequest is a request for Client.GetWorkflowExecutionOptions.
-	// NOTE: Experimental
-	GetWorkflowExecutionOptionsRequest = internal.GetWorkflowExecutionOptionsRequest
-
 	// WorkflowExecutionOptions contains a set of properties of an existing workflow
 	// that can be overriden using UpdateWorkflowExecutionOptions.
 	// NOTE: Experimental
@@ -863,12 +859,9 @@ type (
 		// UpdateWorkflowExecutionOptions partially overrides the WorkflowExecutionOptions of an existing workflow execution
 		// and returns the new WorkflowExecutionOptions after applying the changes.
 		// It is intended for building tools that can selectively apply ad-hoc workflow configuration changes.
+		// Use DescribeWorkflowExecution to get the current WorkflowExecutionOptions without modifying them.
 		// NOTE: Experimental
 		UpdateWorkflowExecutionOptions(ctx context.Context, options UpdateWorkflowExecutionOptionsRequest) (WorkflowExecutionOptions, error)
-
-		// GetWorkflowExecutionOptions returns the current WorkflowExecutionOptions of an existing workflow execution.
-		// NOTE: Experimental
-		GetWorkflowExecutionOptions(ctx context.Context, options GetWorkflowExecutionOptionsRequest) (WorkflowExecutionOptions, error)
 
 		// GetWorkflowUpdateHandle creates a handle to the referenced update
 		// which can be polled for an outcome. Note that runID is optional and

--- a/client/client.go
+++ b/client/client.go
@@ -279,6 +279,19 @@ type (
 	// NOTE: Experimental
 	UpdateWorkflowOptions = internal.UpdateWorkflowOptions
 
+	// UpdateWorkflowExecutionOptionsRequest is a request for Client.UpdateWorkflowExecutionOptions.
+	// NOTE: Experimental
+	UpdateWorkflowExecutionOptionsRequest = internal.UpdateWorkflowExecutionOptionsRequest
+
+	// GetWorkflowExecutionOptionsRequest is a request for Client.GetWorkflowExecutionOptions.
+	// NOTE: Experimental
+	GetWorkflowExecutionOptionsRequest = internal.GetWorkflowExecutionOptionsRequest
+
+	// WorkflowExecutionOptions contains a set of properties of a running workflow
+	// that can be overriden using UpdateWorkflowExecutionOptions.
+	// NOTE: Experimental
+	WorkflowExecutionOptions = internal.WorkflowExecutionOptions
+
 	// WorkflowUpdateHandle represents a running or completed workflow
 	// execution update and gives the holder access to the outcome of the same.
 	// NOTE: Experimental
@@ -839,6 +852,16 @@ type (
 		//  - WorkflowUpdateServiceTimeoutOrCanceledError
 		// NOTE: Experimental
 		UpdateWorkflow(ctx context.Context, options UpdateWorkflowOptions) (WorkflowUpdateHandle, error)
+
+		// UpdateWorkflowExecutionOptions partially overrides the WorkflowExecutionOptions of an existing workflow execution
+		// and returns the new WorkflowExecutionOptions after applying the changes.
+		// It is intended for building tools that can selectively apply ad-hoc workflow configuration changes.
+		// NOTE: Experimental
+		UpdateWorkflowExecutionOptions(ctx context.Context, options UpdateWorkflowExecutionOptionsRequest) (WorkflowExecutionOptions, error)
+
+		// GetWorkflowExecutionOptions returns the current WorkflowExecutionOptions of an existing workflow execution.
+		// NOTE: Experimental
+		GetWorkflowExecutionOptions(ctx context.Context, options GetWorkflowExecutionOptionsRequest) (WorkflowExecutionOptions, error)
 
 		// GetWorkflowUpdateHandle creates a handle to the referenced update
 		// which can be polled for an outcome. Note that runID is optional and

--- a/client/client.go
+++ b/client/client.go
@@ -287,10 +287,17 @@ type (
 	// NOTE: Experimental
 	GetWorkflowExecutionOptionsRequest = internal.GetWorkflowExecutionOptionsRequest
 
-	// WorkflowExecutionOptions contains a set of properties of a running workflow
+	// WorkflowExecutionOptions contains a set of properties of an existing workflow
 	// that can be overriden using UpdateWorkflowExecutionOptions.
 	// NOTE: Experimental
 	WorkflowExecutionOptions = internal.WorkflowExecutionOptions
+
+	// VersioningOverride is a property in WorkflowExecutionOptions that changes the versioning
+	// configuration of a specific workflow execution.
+	// If set, it takes precedence over the Versioning Behavior provided with workflow type registration, or
+	// default worker options.
+	// NOTE: Experimental
+	VersioningOverride = internal.VersioningOverride
 
 	// WorkflowUpdateHandle represents a running or completed workflow
 	// execution update and gives the holder access to the outcome of the same.

--- a/internal/client.go
+++ b/internal/client.go
@@ -332,6 +332,16 @@ type (
 		//  - serviceerror.NotFound
 		DescribeWorkflowExecution(ctx context.Context, workflowID, runID string) (*workflowservice.DescribeWorkflowExecutionResponse, error)
 
+		// UpdateWorkflowExecutionOptions partially overrides the WorkflowExecutionOptions of an existing workflow execution
+		// and returns the new WorkflowExecutionOptions after applying the changes.
+		// It is intended for building tools that can selectively apply ad-hoc workflow configuration changes.
+		// NOTE: Experimental
+		UpdateWorkflowExecutionOptions(ctx context.Context, options UpdateWorkflowExecutionOptionsRequest) (WorkflowExecutionOptions, error)
+
+		// GetWorkflowExecutionOptions returns the current WorkflowExecutionOptions for an existing workflow.
+		// NOTE: Experimental
+		GetWorkflowExecutionOptions(ctx context.Context, request GetWorkflowExecutionOptionsRequest) (WorkflowExecutionOptions, error)
+
 		// DescribeTaskQueue returns information about the target taskqueue, right now this API returns the
 		// pollers which polled this taskqueue in last few minutes.
 		// The errors it can return:

--- a/internal/client.go
+++ b/internal/client.go
@@ -338,7 +338,7 @@ type (
 		// NOTE: Experimental
 		UpdateWorkflowExecutionOptions(ctx context.Context, options UpdateWorkflowExecutionOptionsRequest) (WorkflowExecutionOptions, error)
 
-		// GetWorkflowExecutionOptions returns the current WorkflowExecutionOptions for an existing workflow.
+		// GetWorkflowExecutionOptions returns the current WorkflowExecutionOptions of an existing workflow.
 		// NOTE: Experimental
 		GetWorkflowExecutionOptions(ctx context.Context, request GetWorkflowExecutionOptionsRequest) (WorkflowExecutionOptions, error)
 

--- a/internal/client.go
+++ b/internal/client.go
@@ -338,10 +338,6 @@ type (
 		// NOTE: Experimental
 		UpdateWorkflowExecutionOptions(ctx context.Context, options UpdateWorkflowExecutionOptionsRequest) (WorkflowExecutionOptions, error)
 
-		// GetWorkflowExecutionOptions returns the current WorkflowExecutionOptions of an existing workflow.
-		// NOTE: Experimental
-		GetWorkflowExecutionOptions(ctx context.Context, request GetWorkflowExecutionOptionsRequest) (WorkflowExecutionOptions, error)
-
 		// DescribeTaskQueue returns information about the target taskqueue, right now this API returns the
 		// pollers which polled this taskqueue in last few minutes.
 		// The errors it can return:

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -87,7 +87,8 @@ type (
 		workerBuildID string
 		// Whether the worker has opted in to the build-id based versioning feature
 		useBuildIDVersioning bool
-		// The worker's deployment name, an identifier in versioning-3 to group Task Queues for a given build ID
+		// The worker's deployment series name, an identifier in Worker Versioning to link
+		// versions of the same worker service/application.
 		deploymentSeriesName string
 		// Server's capabilities
 		capabilities *workflowservice.GetSystemInfoResponse_Capabilities

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -165,9 +165,12 @@ type (
 
 		// The worker's build ID used for versioning, if one was set.
 		WorkerBuildID string
+
 		// If true the worker is opting in to build ID based versioning.
 		UseBuildIDForVersioning bool
-		// The worker's deployment name, an identifier in versioning-3 to group Task Queues for a given build ID.
+
+		// The worker's deployment series name, an identifier in versioning-3 to link versions of the same worker
+		// service/application.
 		DeploymentSeriesName string
 
 		// The Versioning Behavior for workflows that do not set one in their first task.
@@ -1640,7 +1643,7 @@ func NewAggregatedWorker(client *WorkflowClient, taskQueue string, options Worke
 
 	// Sessions are not currently compatible with worker versioning
 	// See: https://github.com/temporalio/sdk-go/issues/1227
-	if options.EnableSessionWorker && options.DeploymentOptions.UseBuildIDForVersioning {
+	if options.EnableSessionWorker && options.UseBuildIDForVersioning {
 		panic("cannot set both EnableSessionWorker and UseBuildIDForVersioning")
 	}
 
@@ -1684,8 +1687,8 @@ func NewAggregatedWorker(client *WorkflowClient, taskQueue string, options Worke
 		MaxConcurrentWorkflowTaskQueuePollers: options.MaxConcurrentWorkflowTaskPollers,
 		MaxConcurrentNexusTaskQueuePollers:    options.MaxConcurrentNexusTaskPollers,
 		Identity:                              client.identity,
-		WorkerBuildID:                         options.DeploymentOptions.BuildID,
-		UseBuildIDForVersioning:               options.DeploymentOptions.UseBuildIDForVersioning,
+		WorkerBuildID:                         options.BuildID,
+		UseBuildIDForVersioning:               options.UseBuildIDForVersioning,
 		DeploymentSeriesName:                  options.DeploymentOptions.DeploymentSeriesName,
 		DefaultVersioningBehavior:             options.DeploymentOptions.DefaultVersioningBehavior,
 		MetricsHandler:                        client.metricsHandler.WithTags(metrics.TaskQueueTags(taskQueue)),

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -2865,8 +2865,10 @@ func TestWorkerBuildIDAndSessionPanic(t *testing.T) {
 	var recovered interface{}
 	func() {
 		defer func() { recovered = recover() }()
-		worker := NewAggregatedWorker(&WorkflowClient{}, "some-task-queue", WorkerOptions{EnableSessionWorker: true,
-			DeploymentOptions: WorkerDeploymentOptions{UseBuildIDForVersioning: true}})
+		worker := NewAggregatedWorker(&WorkflowClient{}, "some-task-queue", WorkerOptions{
+			EnableSessionWorker:     true,
+			UseBuildIDForVersioning: true,
+		})
 		worker.RegisterWorkflow(testReplayWorkflow)
 	}()
 	require.Equal(t, "cannot set both EnableSessionWorker and UseBuildIDForVersioning", recovered)

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -1057,18 +1057,6 @@ func (wc *WorkflowClient) GetWorkerTaskReachability(ctx context.Context, options
 	return converted, nil
 }
 
-// GetWorkflowExecutionOptions returns the current WorkflowExecutionOptions of an existing workflow.
-// NOTE: Experimental
-func (wc *WorkflowClient) GetWorkflowExecutionOptions(ctx context.Context, request GetWorkflowExecutionOptionsRequest) (WorkflowExecutionOptions, error) {
-	// no side-effects, i.e., GET, when UpdateMask is empty and WorkflowExecutionOptions is not nil
-	return wc.UpdateWorkflowExecutionOptions(ctx, UpdateWorkflowExecutionOptionsRequest{
-		WorkflowId:               request.WorkflowId,
-		RunId:                    request.RunId,
-		WorkflowExecutionOptions: WorkflowExecutionOptions{},
-		UpdatedFields:            []string{},
-	})
-}
-
 // UpdateWorkflowExecutionOptions partially overrides the WorkflowExecutionOptions of an existing workflow execution,
 // and returns the new WorkflowExecutionOptions after applying the changes.
 // It is intended for building tools that can selectively apply ad-hoc workflow configuration changes.

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -1057,14 +1057,13 @@ func (wc *WorkflowClient) GetWorkerTaskReachability(ctx context.Context, options
 	return converted, nil
 }
 
-// GetWorkflowExecutionOptions returns the current WorkflowExecutionOptions for an existing workflow.
+// GetWorkflowExecutionOptions returns the current WorkflowExecutionOptions of an existing workflow.
 // NOTE: Experimental
 func (wc *WorkflowClient) GetWorkflowExecutionOptions(ctx context.Context, request GetWorkflowExecutionOptionsRequest) (WorkflowExecutionOptions, error) {
 	// no side-effects, i.e., GET, when UpdateMask is empty and WorkflowExecutionOptions is not nil
 	return wc.UpdateWorkflowExecutionOptions(ctx, UpdateWorkflowExecutionOptionsRequest{
 		WorkflowId:               request.WorkflowId,
 		RunId:                    request.RunId,
-		RequestId:                uuid.New(),
 		WorkflowExecutionOptions: WorkflowExecutionOptions{},
 		UpdatedFields:            []string{},
 	})
@@ -1082,17 +1081,12 @@ func (wc *WorkflowClient) UpdateWorkflowExecutionOptions(ctx context.Context, re
 	grpcCtx, cancel := newGRPCContext(ctx, defaultGrpcRetryParameters(ctx))
 	defer cancel()
 
-	if request.RequestId == "" {
-		request.RequestId = uuid.New()
-	}
-
 	requestMsg := &workflowservice.UpdateWorkflowExecutionOptionsRequest{
 		Namespace: wc.namespace,
 		WorkflowExecution: &commonpb.WorkflowExecution{
 			WorkflowId: request.WorkflowId,
 			RunId:      request.RunId,
 		},
-		RequestId:                request.RequestId,
 		WorkflowExecutionOptions: workflowExecutionOptionsToProto(request.WorkflowExecutionOptions),
 		UpdateMask:               workflowExecutionOptionsMaskToProto(request.UpdatedFields),
 	}

--- a/internal/internal_workflow_execution_options.go
+++ b/internal/internal_workflow_execution_options.go
@@ -50,15 +50,6 @@ type (
 		UpdatedFields []string
 	}
 
-	// GetWorkflowExecutionOptionsRequest is a request for Client.GetWorkflowExecutionOptions.
-	// NOTE: Experimental
-	GetWorkflowExecutionOptionsRequest struct {
-		// ID of the workflow.
-		WorkflowId string
-		// Running execution for a workflow ID. If empty string then it will pick the last running execution.
-		RunId string
-	}
-
 	// WorkflowExecutionOptions describes options for a workflow execution.
 	// NOTE: Experimental
 	WorkflowExecutionOptions struct {

--- a/internal/internal_workflow_execution_options.go
+++ b/internal/internal_workflow_execution_options.go
@@ -1,0 +1,153 @@
+// The MIT License
+//
+// Copyright (c) 2024 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package internal
+
+import (
+	"fmt"
+
+	commonpb "go.temporal.io/api/common/v1"
+	workflowpb "go.temporal.io/api/workflow/v1"
+	"go.temporal.io/api/workflowservice/v1"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+)
+
+type (
+	// UpdateWorkflowExecutionOptionsRequest is a request for Client.UpdateWorkflowExecutionOptions.
+	// NOTE: Experimental
+	UpdateWorkflowExecutionOptionsRequest struct {
+		// ID of the workflow.
+		WorkflowId string
+		// Running execution for a workflow ID. If empty string then it will pick the last running execution.
+		RunId string
+		// RequestId is an optional identifier to deduplicate requests.
+		RequestId string
+		// WorkflowExecutionOptions specifies options for a target workflow execution. Fields not in
+		// UpdatedFields are ignored.
+		WorkflowExecutionOptions WorkflowExecutionOptions
+		// Field names in WorkflowExecutionOptions that will be updated.
+		// When it includes a field name, but the corresponding WorkflowExecutionOptions field has not been set,
+		// it will remove previous overrides for that field.
+		// It panics when it includes a field name not in WorkflowExecutionOptions.
+		// An empty UpdatedFields never modifies WorkflowExecutionOptions.
+		UpdatedFields []string
+	}
+
+	// GetWorkflowExecutionOptionsRequest is a request for Client.GetWorkflowExecutionOptions.
+	// NOTE: Experimental
+	GetWorkflowExecutionOptionsRequest struct {
+		// ID of the workflow.
+		WorkflowId string
+		// Running execution for a workflow ID. If empty string then it will pick the last running execution.
+		RunId string
+	}
+
+	// WorkflowExecutionOptions describes options for a workflow execution.
+	// NOTE: Experimental
+	WorkflowExecutionOptions struct {
+		// If set, it takes precedence over the Versioning Behavior provided with code annotations.
+		VersioningOverride VersioningOverride
+	}
+
+	// VersioningOverride changes the Versioning Behavior of of a specific workflow execution. If set, it takes precedence
+	// over the Versioning Behavior provided with code annotations.
+	// To remove the override, the UpdateWorkflowExecutionOptionsRequest should include a default VersioningOverride value
+	// in WorkflowExecutionOptions, and a FieldMask that contains the string "VersioningOverride".
+	// NOTE: Experimental
+	VersioningOverride struct {
+		// The new Versioning Behavior. This field is required.
+		Behavior VersioningBehavior
+		// Identifies the Build ID and Deployment Name to pin the workflow to. Ignored when Behavior is not VersioningBehaviorPinned.
+		WorkerDeployment WorkerDeployment
+	}
+
+	// WorkerDeployment provides a Build ID and Deployment Name for the workflow.
+	// NOTE: Experimental
+	WorkerDeployment struct {
+		// Name of the deployment.
+		DeploymentName string
+		// Target Build ID for the deployment.
+		BuildId string
+	}
+)
+
+// Mapping WorkflowExecutionOptions field names to proto ones.
+var workflowExecutionOptionsMap map[string]string = map[string]string{
+	// TODO: change to "versioning_override" with API upgrade
+	"VersioningOverride": "versioning_behavior_override",
+}
+
+func generateWorkflowExecutionOptionsPaths(mask []string) []string {
+	var result []string
+	for _, field := range mask {
+		val, ok := workflowExecutionOptionsMap[field]
+		if !ok {
+			panic(fmt.Sprintf("invalid UpdatedFields entry %s not a field in WorkflowExecutionOptions", field))
+		}
+		result = append(result, val)
+	}
+	return result
+}
+
+func workflowExecutionOptionsMaskToProto(mask []string) *fieldmaskpb.FieldMask {
+	paths := generateWorkflowExecutionOptionsPaths(mask)
+	var workflowExecutionOptions *workflowpb.WorkflowExecutionOptions
+	protoMask, err := fieldmaskpb.New(workflowExecutionOptions, paths...)
+	if err != nil {
+		panic("invalid field mask for WorkflowExecutionOptions")
+	}
+	return protoMask
+}
+
+func workerDeploymentToProto(d WorkerDeployment) *commonpb.WorkerDeployment {
+	return &commonpb.WorkerDeployment{
+		DeploymentName: d.DeploymentName,
+		BuildId:        d.BuildId,
+	}
+}
+
+func workflowExecutionOptionsToProto(options WorkflowExecutionOptions) *workflowpb.WorkflowExecutionOptions {
+	return &workflowpb.WorkflowExecutionOptions{
+		VersioningBehaviorOverride: &commonpb.VersioningBehaviorOverride{
+			Behavior:         versioningBehaviorToProto(options.VersioningOverride.Behavior),
+			WorkerDeployment: workerDeploymentToProto(options.VersioningOverride.WorkerDeployment),
+		},
+	}
+}
+
+func workflowExecutionOptionsFromProtoUpdateResponse(response *workflowservice.UpdateWorkflowExecutionOptionsResponse) WorkflowExecutionOptions {
+	if response == nil {
+		return WorkflowExecutionOptions{}
+	}
+
+	behaviorOverride := response.GetWorkflowExecutionOptions().GetVersioningBehaviorOverride()
+
+	return WorkflowExecutionOptions{
+		VersioningOverride: VersioningOverride{
+			Behavior: VersioningBehavior(behaviorOverride.GetBehavior()),
+			WorkerDeployment: WorkerDeployment{
+				DeploymentName: behaviorOverride.GetWorkerDeployment().GetDeploymentName(),
+				BuildId:        behaviorOverride.GetWorkerDeployment().GetBuildId(),
+			},
+		},
+	}
+}

--- a/internal/internal_workflow_execution_options_test.go
+++ b/internal/internal_workflow_execution_options_test.go
@@ -1,0 +1,76 @@
+// The MIT License
+//
+// Copyright (c) 2024 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package internal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	deploymentpb "go.temporal.io/api/deployment/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	workflowpb "go.temporal.io/api/workflow/v1"
+	"go.temporal.io/api/workflowservice/v1"
+)
+
+func Test_WorkflowExecutionOptions_fromProtoResponse(t *testing.T) {
+	tests := []struct {
+		name     string
+		response *workflowservice.UpdateWorkflowExecutionOptionsResponse
+		want     WorkflowExecutionOptions
+	}{
+		{
+			name:     "nil response",
+			response: nil,
+			want:     WorkflowExecutionOptions{},
+		},
+		{
+			name: "normal workflow execution options",
+			response: &workflowservice.UpdateWorkflowExecutionOptionsResponse{
+				WorkflowExecutionOptions: &workflowpb.WorkflowExecutionOptions{
+					VersioningOverride: &workflowpb.VersioningOverride{
+						Behavior: enumspb.VersioningBehavior(VersioningBehaviorPinned),
+						Deployment: &deploymentpb.Deployment{
+							SeriesName: "my series",
+							BuildId:    "v1",
+						},
+					},
+				},
+			},
+			want: WorkflowExecutionOptions{
+				VersioningOverride: VersioningOverride{
+					Behavior: VersioningBehaviorPinned,
+					Deployment: Deployment{
+						SeriesName: "my series",
+						BuildId:    "v1",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, workflowExecutionOptionsFromProtoUpdateResponse(tt.response), "workflowExecutionOptions(%v)", tt.response)
+		})
+	}
+}

--- a/internal/nexus_operations.go
+++ b/internal/nexus_operations.go
@@ -399,11 +399,6 @@ func (t *testSuiteClientForNexusOperations) UpdateWorkflowExecutionOptions(ctx c
 	panic("not implemented in the test environment")
 }
 
-// GetWorkflowExecutionOptions implements Client.
-func (t *testSuiteClientForNexusOperations) GetWorkflowExecutionOptions(ctx context.Context, options GetWorkflowExecutionOptionsRequest) (WorkflowExecutionOptions, error) {
-	panic("not implemented in the test environment")
-}
-
 var _ Client = &testSuiteClientForNexusOperations{}
 
 // testEnvWorkflowRunForNexusOperations is a partial [WorkflowRun] implementation for the test workflow environment used

--- a/internal/nexus_operations.go
+++ b/internal/nexus_operations.go
@@ -394,6 +394,16 @@ func (t *testSuiteClientForNexusOperations) WorkflowService() workflowservice.Wo
 	panic("not implemented in the test environment")
 }
 
+// UpdateWorkflowExecutionOptions implements Client.
+func (t *testSuiteClientForNexusOperations) UpdateWorkflowExecutionOptions(ctx context.Context, options UpdateWorkflowExecutionOptionsRequest) (WorkflowExecutionOptions, error) {
+	panic("not implemented in the test environment")
+}
+
+// GetWorkflowExecutionOptions implements Client.
+func (t *testSuiteClientForNexusOperations) GetWorkflowExecutionOptions(ctx context.Context, options GetWorkflowExecutionOptionsRequest) (WorkflowExecutionOptions, error) {
+	panic("not implemented in the test environment")
+}
+
 var _ Client = &testSuiteClientForNexusOperations{}
 
 // testEnvWorkflowRunForNexusOperations is a partial [WorkflowRun] implementation for the test workflow environment used

--- a/internal/worker.go
+++ b/internal/worker.go
@@ -30,33 +30,21 @@ import (
 )
 
 type (
-	// WorkerDeploymentOptions provides configuration to enable Worker Versioning.
+	// WorkerDeploymentOptions provides configuration for Worker Versioning.
+	// NOTE: Both WorkerOptions.BuildID and WorkerOptions.UseBuildIDForVersioning need to be set for enabling
+	//  Worker Versioning.
 	// NOTE: Experimental
 	WorkerDeploymentOptions struct {
-		// Assign a BuildID to this worker. This replaces the deprecated binary checksum concept,
-		// and is used to provide a unique identifier for a set of worker code, and is necessary
-		// to opt in to the Worker Versioning feature. See UseBuildIDForVersioning.
+		// Assign a deployment series name to this worker. Different versions of the same worker
+		// service/application are linked together by sharing a series name.
 		// NOTE: Experimental
-		BuildID string
-
-		// If set, opts this worker into the Worker Versioning feature. It will only
-		// operate on workflows it claims to be compatible with. You must set BuildID if this flag
-		// is true.
-		// NOTE: Experimental
-		// Note: Cannot be enabled at the same time as WorkerOptions.EnableSessionWorker
-		UseBuildIDForVersioning bool
-
-		// Assign a Deployment Name to this worker, an identifier for Worker Versioning that
-		// groups task queues for the given BuildID.
-		// NOTE: Experimental
-		// NOTE: Both BuildID and UseBuildIDForVersioning need to also be set to enable the new Worker Versioning-3 feature.
 		DeploymentSeriesName string
 
-		// Optional: Provides a default Versioning Behavior to workflows that do not set one in their first task
-		// (see workflow.SetVersioningBehavior).
+		// Optional: Provides a default Versioning Behavior to workflows that do not set one with the
+		// registration option workflow.RegisterOptions.VersioningBehavior.
+		// NOTE: When the Worker Versioning-3 feature is on, and DefaultVersioningBehavior is unspecified,
+		// workflows that do not set the Versioning Behavior will fail at registration time.
 		// NOTE: Experimental
-		// NOTE: If the Worker Versioning-3 feature is on, and DefaultVersioningBehavior is unspecified,
-		// workflows that do not set the Versioning Behavior will fail in their first task.
 		DefaultVersioningBehavior VersioningBehavior
 	}
 
@@ -268,8 +256,21 @@ type (
 		// workflow or activities.
 		DisableRegistrationAliasing bool
 
-		// Optional: If set, configure Worker Versioning for this worker. See WorkerDeploymentOptions
-		// for more. This is incompatible with setting EnableSessionWorker.
+		// Assign a BuildID to this worker. This replaces the deprecated binary checksum concept,
+		// and is used to provide a unique identifier for a set of worker code, and is necessary
+		// to opt in to the Worker Versioning feature. See UseBuildIDForVersioning.
+		// NOTE: Experimental
+		BuildID string
+
+		// If set, opts this worker into the Worker Versioning feature. It will only
+		// operate on workflows it claims to be compatible with. You must set BuildID if this flag
+		// is true.
+		// NOTE: Experimental
+		// Note: Cannot be enabled at the same time as WorkerOptions.EnableSessionWorker
+		UseBuildIDForVersioning bool
+
+		// Optional: If set it configures Worker Versioning for this worker. See WorkerDeploymentOptions
+		// for more. Both BuildID and UseBuildIDForVersioning need to be set to enable Worker Versioning.
 		// NOTE: Experimental
 		DeploymentOptions WorkerDeploymentOptions
 

--- a/mocks/Client.go
+++ b/mocks/Client.go
@@ -441,34 +441,6 @@ func (_m *Client) GetWorkflow(ctx context.Context, workflowID string, runID stri
 	return r0
 }
 
-// GetWorkflowExecutionOptions provides a mock function with given fields: ctx, options
-func (_m *Client) GetWorkflowExecutionOptions(ctx context.Context, options client.GetWorkflowExecutionOptionsRequest) (client.WorkflowExecutionOptions, error) {
-	ret := _m.Called(ctx, options)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetWorkflowExecutionOptions")
-	}
-
-	var r0 client.WorkflowExecutionOptions
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, client.GetWorkflowExecutionOptionsRequest) (client.WorkflowExecutionOptions, error)); ok {
-		return rf(ctx, options)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, client.GetWorkflowExecutionOptionsRequest) client.WorkflowExecutionOptions); ok {
-		r0 = rf(ctx, options)
-	} else {
-		r0 = ret.Get(0).(client.WorkflowExecutionOptions)
-	}
-
-	if rf, ok := ret.Get(1).(func(context.Context, client.GetWorkflowExecutionOptionsRequest) error); ok {
-		r1 = rf(ctx, options)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
 // GetWorkflowHistory provides a mock function with given fields: ctx, workflowID, runID, isLongPoll, filterType
 func (_m *Client) GetWorkflowHistory(ctx context.Context, workflowID string, runID string, isLongPoll bool, filterType enums.HistoryEventFilterType) client.HistoryEventIterator {
 	ret := _m.Called(ctx, workflowID, runID, isLongPoll, filterType)

--- a/mocks/Client.go
+++ b/mocks/Client.go
@@ -441,6 +441,34 @@ func (_m *Client) GetWorkflow(ctx context.Context, workflowID string, runID stri
 	return r0
 }
 
+// GetWorkflowExecutionOptions provides a mock function with given fields: ctx, options
+func (_m *Client) GetWorkflowExecutionOptions(ctx context.Context, options client.GetWorkflowExecutionOptionsRequest) (client.WorkflowExecutionOptions, error) {
+	ret := _m.Called(ctx, options)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetWorkflowExecutionOptions")
+	}
+
+	var r0 client.WorkflowExecutionOptions
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, client.GetWorkflowExecutionOptionsRequest) (client.WorkflowExecutionOptions, error)); ok {
+		return rf(ctx, options)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, client.GetWorkflowExecutionOptionsRequest) client.WorkflowExecutionOptions); ok {
+		r0 = rf(ctx, options)
+	} else {
+		r0 = ret.Get(0).(client.WorkflowExecutionOptions)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, client.GetWorkflowExecutionOptionsRequest) error); ok {
+		r1 = rf(ctx, options)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetWorkflowHistory provides a mock function with given fields: ctx, workflowID, runID, isLongPoll, filterType
 func (_m *Client) GetWorkflowHistory(ctx context.Context, workflowID string, runID string, isLongPoll bool, filterType enums.HistoryEventFilterType) client.HistoryEventIterator {
 	ret := _m.Called(ctx, workflowID, runID, isLongPoll, filterType)
@@ -951,6 +979,34 @@ func (_m *Client) UpdateWorkflow(ctx context.Context, options client.UpdateWorkf
 	}
 
 	if rf, ok := ret.Get(1).(func(context.Context, client.UpdateWorkflowOptions) error); ok {
+		r1 = rf(ctx, options)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// UpdateWorkflowExecutionOptions provides a mock function with given fields: ctx, options
+func (_m *Client) UpdateWorkflowExecutionOptions(ctx context.Context, options client.UpdateWorkflowExecutionOptionsRequest) (client.WorkflowExecutionOptions, error) {
+	ret := _m.Called(ctx, options)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateWorkflowExecutionOptions")
+	}
+
+	var r0 client.WorkflowExecutionOptions
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, client.UpdateWorkflowExecutionOptionsRequest) (client.WorkflowExecutionOptions, error)); ok {
+		return rf(ctx, options)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, client.UpdateWorkflowExecutionOptionsRequest) client.WorkflowExecutionOptions); ok {
+		r0 = rf(ctx, options)
+	} else {
+		r0 = ret.Get(0).(client.WorkflowExecutionOptions)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, client.UpdateWorkflowExecutionOptionsRequest) error); ok {
 		r1 = rf(ctx, options)
 	} else {
 		r1 = ret.Error(1)

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -6229,9 +6229,9 @@ func (ts *IntegrationTestSuite) TestVersioningBehaviorInRespondWorkflowTaskCompl
 	ts.worker.Stop()
 	ts.workerStopped = true
 	w := worker.New(c, ts.taskQueueName, worker.Options{
+		BuildID:                 "1.0",
+		UseBuildIDForVersioning: true,
 		DeploymentOptions: worker.DeploymentOptions{
-			BuildID:                   "1.0",
-			UseBuildIDForVersioning:   true,
 			DeploymentSeriesName:      "deploy-test1",
 			DefaultVersioningBehavior: workflow.VersioningBehaviorAutoUpgrade,
 		},
@@ -6326,9 +6326,9 @@ func (ts *IntegrationTestSuite) TestVersioningBehaviorPerWorkflowType() {
 	ts.worker.Stop()
 	ts.workerStopped = true
 	w := worker.New(c, ts.taskQueueName, worker.Options{
+		BuildID:                 "1.0",
+		UseBuildIDForVersioning: true,
 		DeploymentOptions: worker.DeploymentOptions{
-			BuildID:                   "1.0",
-			UseBuildIDForVersioning:   true,
 			DeploymentSeriesName:      "deploy-test2",
 			DefaultVersioningBehavior: workflow.VersioningBehaviorAutoUpgrade,
 		},
@@ -6392,9 +6392,9 @@ func (ts *IntegrationTestSuite) TestGetVersioningBehavior() {
 	ts.worker.Stop()
 	ts.workerStopped = true
 	w := worker.New(ts.client, ts.taskQueueName, worker.Options{
+		BuildID:                 "1.0",
+		UseBuildIDForVersioning: true,
 		DeploymentOptions: worker.DeploymentOptions{
-			BuildID:                   "1.0",
-			UseBuildIDForVersioning:   true,
 			DeploymentSeriesName:      "deploy-test1",
 			DefaultVersioningBehavior: workflow.VersioningBehaviorAutoUpgrade,
 		},

--- a/test/worker_versioning_test.go
+++ b/test/worker_versioning_test.go
@@ -401,10 +401,8 @@ func (ts *WorkerVersioningTestSuite) TestTwoWorkersGetDifferentTasks() {
 	ts.NoError(err)
 
 	worker1 := worker.New(ts.client, ts.taskQueueName, worker.Options{
-		DeploymentOptions: worker.DeploymentOptions{
-			BuildID:                 "1.0",
-			UseBuildIDForVersioning: true,
-		},
+		BuildID:                 "1.0",
+		UseBuildIDForVersioning: true,
 	})
 	ts.workflows.register(worker1)
 	ts.NoError(worker1.Start())
@@ -425,10 +423,8 @@ func (ts *WorkerVersioningTestSuite) TestTwoWorkersGetDifferentTasks() {
 	})
 	ts.NoError(err)
 	worker2 := worker.New(ts.client, ts.taskQueueName, worker.Options{
-		DeploymentOptions: worker.DeploymentOptions{
-			BuildID:                 "2.0",
-			UseBuildIDForVersioning: true,
-		},
+		BuildID:                 "2.0",
+		UseBuildIDForVersioning: true,
 	})
 	ts.workflows.register(worker2)
 	ts.NoError(worker2.Start())
@@ -437,10 +433,8 @@ func (ts *WorkerVersioningTestSuite) TestTwoWorkersGetDifferentTasks() {
 	// If we add the worker before the BuildID "2.0" has been registered, the worker poller ends up
 	// in the new versioning queue, and it only recovers after 1m timeout.
 	worker3 := worker.New(ts.client, ts.taskQueueName, worker.Options{
-		DeploymentOptions: worker.DeploymentOptions{
-			BuildID:                 "2.0",
-			UseBuildIDForVersioning: true,
-		},
+		BuildID:                 "2.0",
+		UseBuildIDForVersioning: true,
 	})
 	ts.workflows.register(worker3)
 	ts.NoError(worker3.Start())
@@ -487,19 +481,15 @@ func (ts *WorkerVersioningTestSuite) TestTwoWorkersGetDifferentTasksWithRules() 
 	ts.NoError(err)
 
 	worker1 := worker.New(ts.client, ts.taskQueueName, worker.Options{
-		DeploymentOptions: worker.DeploymentOptions{
-			BuildID:                 "1.0",
-			UseBuildIDForVersioning: true,
-		},
+		BuildID:                 "1.0",
+		UseBuildIDForVersioning: true,
 	})
 	ts.workflows.register(worker1)
 	ts.NoError(worker1.Start())
 	defer worker1.Stop()
 	worker2 := worker.New(ts.client, ts.taskQueueName, worker.Options{
-		DeploymentOptions: worker.DeploymentOptions{
-			BuildID:                 "2.0",
-			UseBuildIDForVersioning: true,
-		},
+		BuildID:                 "2.0",
+		UseBuildIDForVersioning: true,
 	})
 	ts.workflows.register(worker2)
 	ts.NoError(worker2.Start())
@@ -668,11 +658,11 @@ func (ts *WorkerVersioningTestSuite) TestDeploymentSeriesNameWorker() {
 	defer cancel()
 
 	worker1 := worker.New(ts.client, ts.taskQueueName, worker.Options{
-		Identity: "worker1",
+		Identity:                "worker1",
+		BuildID:                 "b1",
+		UseBuildIDForVersioning: false,
 		DeploymentOptions: worker.DeploymentOptions{
-			BuildID:                 "b1",
-			UseBuildIDForVersioning: false,
-			DeploymentSeriesName:    "deploy1",
+			DeploymentSeriesName: "deploy1",
 		},
 	})
 	ts.workflows.register(worker1)
@@ -728,10 +718,8 @@ func (ts *WorkerVersioningTestSuite) TestReachabilityVersions() {
 	ts.NoError(err)
 
 	worker1 := worker.New(ts.client, ts.taskQueueName, worker.Options{
-		DeploymentOptions: worker.DeploymentOptions{
-			BuildID:                 buildID1,
-			UseBuildIDForVersioning: true,
-		},
+		BuildID:                 buildID1,
+		UseBuildIDForVersioning: true,
 	})
 	ts.workflows.register(worker1)
 	ts.NoError(worker1.Start())
@@ -752,10 +740,8 @@ func (ts *WorkerVersioningTestSuite) TestReachabilityVersions() {
 
 	// Start the second worker
 	worker2 := worker.New(ts.client, ts.taskQueueName, worker.Options{
-		DeploymentOptions: worker.DeploymentOptions{
-			BuildID:                 buildID2,
-			UseBuildIDForVersioning: true,
-		},
+		BuildID:                 buildID2,
+		UseBuildIDForVersioning: true,
 	})
 	ts.workflows.register(worker2)
 	ts.NoError(worker2.Start())
@@ -827,10 +813,8 @@ func (ts *WorkerVersioningTestSuite) TestReachabilityVersionsWithRules() {
 	ts.NoError(err)
 
 	worker1 := worker.New(ts.client, ts.taskQueueName, worker.Options{
-		DeploymentOptions: worker.DeploymentOptions{
-			BuildID:                 buildID1,
-			UseBuildIDForVersioning: true,
-		},
+		BuildID:                 buildID1,
+		UseBuildIDForVersioning: true,
 	})
 	ts.workflows.register(worker1)
 	ts.NoError(worker1.Start())
@@ -851,10 +835,8 @@ func (ts *WorkerVersioningTestSuite) TestReachabilityVersionsWithRules() {
 
 	// Start the second worker
 	worker2 := worker.New(ts.client, ts.taskQueueName, worker.Options{
-		DeploymentOptions: worker.DeploymentOptions{
-			BuildID:                 buildID2,
-			UseBuildIDForVersioning: true,
-		},
+		BuildID:                 buildID2,
+		UseBuildIDForVersioning: true,
 	})
 	ts.workflows.register(worker2)
 	ts.NoError(worker2.Start())
@@ -1010,10 +992,8 @@ func (ts *WorkerVersioningTestSuite) TestBuildIDChangesOverWorkflowLifetime() {
 	ts.NoError(err)
 
 	worker1 := worker.New(ts.client, ts.taskQueueName, worker.Options{
-		DeploymentOptions: worker.DeploymentOptions{
-			BuildID:                 "1.0",
-			UseBuildIDForVersioning: true,
-		},
+		BuildID:                 "1.0",
+		UseBuildIDForVersioning: true,
 	})
 	ts.workflows.register(worker1)
 	ts.activities.register(worker1)
@@ -1049,10 +1029,8 @@ func (ts *WorkerVersioningTestSuite) TestBuildIDChangesOverWorkflowLifetime() {
 	ts.NoError(err)
 
 	worker11 := worker.New(ts.client, ts.taskQueueName, worker.Options{
-		DeploymentOptions: worker.DeploymentOptions{
-			BuildID:                 "1.1",
-			UseBuildIDForVersioning: true,
-		},
+		BuildID:                 "1.1",
+		UseBuildIDForVersioning: true,
 	})
 	ts.workflows.register(worker11)
 	ts.activities.register(worker11)
@@ -1110,10 +1088,8 @@ func (ts *WorkerVersioningTestSuite) TestBuildIDChangesOverWorkflowLifetimeWithR
 	ts.NoError(err)
 
 	worker1 := worker.New(ts.client, ts.taskQueueName, worker.Options{
-		DeploymentOptions: worker.DeploymentOptions{
-			BuildID:                 "1.0",
-			UseBuildIDForVersioning: true,
-		},
+		BuildID:                 "1.0",
+		UseBuildIDForVersioning: true,
 	})
 	ts.workflows.register(worker1)
 	ts.activities.register(worker1)
@@ -1163,10 +1139,8 @@ func (ts *WorkerVersioningTestSuite) TestBuildIDChangesOverWorkflowLifetimeWithR
 	ts.NoError(err)
 
 	worker11 := worker.New(ts.client, ts.taskQueueName, worker.Options{
-		DeploymentOptions: worker.DeploymentOptions{
-			BuildID:                 "1.1",
-			UseBuildIDForVersioning: true,
-		},
+		BuildID:                 "1.1",
+		UseBuildIDForVersioning: true,
 	})
 	ts.workflows.register(worker11)
 	ts.activities.register(worker11)

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -215,6 +215,11 @@ type (
 	// NOTE: Experimental
 	DeploymentOptions = internal.WorkerDeploymentOptions
 
+	// Deployment identifies a set of workers. This identifier combines the deployment series
+	// name with their Build ID.
+	// NOTE: Experimental
+	Deployment = internal.Deployment
+
 	// Options is used to configure a worker instance.
 	Options = internal.WorkerOptions
 


### PR DESCRIPTION
## What was changed

The new versioning-3 introduces a config override API that enables external tools to change versioning behavior of
specific existing workflows. See #1712 for details. 

This PR exposes that API with a new client method:
```go
	UpdateWorkflowExecutionOptions(ctx context.Context, options UpdateWorkflowExecutionOptionsRequest) (WorkflowExecutionOptions, error)
```
and relies on 
```go
	DescribeWorkflowExecution(ctx context.Context, workflowID, runID string (*workflowservice.DescribeWorkflowExecutionResponse, error)
```
as getter.
## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->
#1712 
2. How was this tested:
There is currently no server implementation that supports this API. Integration tests will be added later, before merge into main. Only a basic protobuf unit test is included. 
