### PR TITLE
Add accessors for ChildWorkflowExecutionError fields

### DIFF
--- a/internal/error.go
+++ b/internal/error.go
@@ -823,6 +823,41 @@ func (e *ChildWorkflowExecutionError) Unwrap() error {
 	return e.cause
 }
 
+// Namespace returns namespace of the child workflow.
+func (e *ChildWorkflowExecutionError) Namespace() string {
+	return e.namespace
+}
+
+// WorkflowId returns workflow ID of the child workflow.
+func (e *ChildWorkflowExecutionError) WorkflowID() string {
+	return e.workflowID
+}
+
+// RunID returns run ID of the child workflow.
+func (e *ChildWorkflowExecutionError) RunID() string {
+	return e.runID
+}
+
+// WorkflowType returns type of the child workflow.
+func (e *ChildWorkflowExecutionError) WorkflowType() string {
+	return e.workflowType
+}
+
+// InitiatedEventID returns event ID of the child workflow initiated event.
+func (e *ChildWorkflowExecutionError) InitiatedEventID() int64 {
+	return e.initiatedEventID
+}
+
+// StartedEventID returns event ID of the child workflow started event.
+func (e *ChildWorkflowExecutionError) StartedEventID() int64 {
+	return e.startedEventID
+}
+
+// RetryState returns details on why child workflow failed.
+func (e *ChildWorkflowExecutionError) RetryState() enumspb.RetryState {
+	return e.retryState
+}
+
 // Error implements the error interface.
 func (e *NexusOperationError) Error() string {
 	msg := fmt.Sprintf(


### PR DESCRIPTION


## What was changed
<!-- Describe what has changed in this PR -->
Added public accessors for `ChildWorkflowExecutionError`

## Why?
<!-- Tell your future self why have you made these changes -->
Someone would like to react to maximum attempts of child workflow https://community.temporal.io/t/reacting-to-maximum-attempts/15366

## Checklist
<!--- add/delete as needed --->

1. Closes #1725

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
