### PR TITLE
Introduce separate slot supplier for session activities

### DIFF
--- a/contrib/resourcetuner/resourcetuner.go
+++ b/contrib/resourcetuner/resourcetuner.go
@@ -77,11 +77,14 @@ func NewResourceBasedTuner(opts ResourceBasedTunerOptions) (worker.WorkerTuner, 
 	}
 	nexusSS := &ResourceBasedSlotSupplier{controller: controller,
 		options: defaultWorkflowResourceBasedSlotSupplierOptions()}
+	sessSS := &ResourceBasedSlotSupplier{controller: controller,
+		options: defaultActivityResourceBasedSlotSupplierOptions()}
 	compositeTuner, err := worker.NewCompositeTuner(worker.CompositeTunerOptions{
-		WorkflowSlotSupplier:      wfSS,
-		ActivitySlotSupplier:      actSS,
-		LocalActivitySlotSupplier: laSS,
-		NexusSlotSupplier:         nexusSS,
+		WorkflowSlotSupplier:        wfSS,
+		ActivitySlotSupplier:        actSS,
+		LocalActivitySlotSupplier:   laSS,
+		NexusSlotSupplier:           nexusSS,
+		SessionActivitySlotSupplier: sessSS,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -399,7 +399,7 @@ func (ww *workflowWorker) Stop() {
 	ww.worker.Stop()
 }
 
-func newSessionWorker(service workflowservice.WorkflowServiceClient, params workerExecutionParameters, overrides *workerOverrides, env *registry, maxConcurrentSessionExecutionSize int) *sessionWorker {
+func newSessionWorker(service workflowservice.WorkflowServiceClient, params workerExecutionParameters, env *registry, maxConcurrentSessionExecutionSize int) *sessionWorker {
 	if params.Identity == "" {
 		params.Identity = getWorkerIdentity(params.TaskQueue)
 	}
@@ -412,15 +412,14 @@ func newSessionWorker(service workflowservice.WorkflowServiceClient, params work
 	creationTaskqueue := getCreationTaskqueue(params.TaskQueue)
 	params.UserContext = context.WithValue(params.UserContext, sessionEnvironmentContextKey, sessionEnvironment)
 	params.TaskQueue = sessionEnvironment.GetResourceSpecificTaskqueue()
-	activityWorker := newActivityWorker(service, params, overrides, env, nil)
+	activityWorker := newActivityWorker(service, params,
+		&workerOverrides{slotSupplier: params.Tuner.GetSessionActivitySlotSupplier()}, env, nil)
 
 	params.MaxConcurrentActivityTaskQueuePollers = 1
 	params.TaskQueue = creationTaskqueue
-	if overrides == nil {
-		overrides = &workerOverrides{}
-	}
 	// Although we have session token bucket to limit session size across creation
 	// and recreation, we also limit it here for creation only
+	overrides := &workerOverrides{}
 	overrides.slotSupplier, _ = NewFixedSizeSlotSupplier(maxConcurrentSessionExecutionSize)
 	creationWorker := newActivityWorker(service, params, overrides, env, sessionEnvironment.GetTokenBucket())
 
@@ -1758,7 +1757,7 @@ func NewAggregatedWorker(client *WorkflowClient, taskQueue string, options Worke
 
 	var sessionWorker *sessionWorker
 	if options.EnableSessionWorker && !options.LocalActivityWorkerOnly {
-		sessionWorker = newSessionWorker(client.workflowService, workerParams, nil, registry, options.MaxConcurrentSessionExecutionSize)
+		sessionWorker = newSessionWorker(client.workflowService, workerParams, registry, options.MaxConcurrentSessionExecutionSize)
 		registry.RegisterActivityWithOptions(sessionCreationActivity, RegisterActivityOptions{
 			Name: sessionCreationActivityName,
 		})

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -275,9 +275,7 @@ func (ts *IntegrationTestSuite) SetupTest() {
 		options.Tuner = tuner
 	}
 	if strings.Contains(ts.T().Name(), "SlotSuppliersWithSession") {
-		// TODO: Always works w/ max 3, but 2 only works with max pollers 1 (usually)
 		options.MaxConcurrentActivityExecutionSize = 1
-		options.MaxConcurrentActivityTaskPollers = 1
 		// Apparently this is on by default in these tests anyway, but to be explicit
 		options.EnableSessionWorker = true
 	}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -274,6 +274,13 @@ func (ts *IntegrationTestSuite) SetupTest() {
 		ts.NoError(err)
 		options.Tuner = tuner
 	}
+	if strings.Contains(ts.T().Name(), "SlotSuppliersWithSession") {
+		// TODO: Always works w/ max 3, but 2 only works with max pollers 1 (usually)
+		options.MaxConcurrentActivityExecutionSize = 1
+		options.MaxConcurrentActivityTaskPollers = 1
+		// Apparently this is on by default in these tests anyway, but to be explicit
+		options.EnableSessionWorker = true
+	}
 
 	ts.worker = worker.New(ts.client, ts.taskQueueName, options)
 	ts.workerStopped = false
@@ -3267,6 +3274,27 @@ func (ts *IntegrationTestSuite) TestResourceBasedSlotSupplierManyActs() {
 	ts.assertMetricGaugeEventually(metrics.WorkerTaskSlotsUsed, actWorkertags, 0)
 	ts.assertMetricGaugeEventually(metrics.WorkerTaskSlotsUsed, laWorkertags, 0)
 	ts.assertMetricGaugeEventually(metrics.WorkerTaskSlotsUsed, wfWorkertags, 0)
+}
+
+func (ts *IntegrationTestSuite) TestSlotSuppliersWithSessionAndOneConcurrentMax() {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	defer cancel()
+
+	// Activities time out without the fix, since obtaining a slot takes too long
+	wfRuns := make([]client.WorkflowRun, 0)
+	for i := 0; i < 3; i++ {
+		opts := ts.startWorkflowOptions("slot-suppliers-with-session" + strconv.Itoa(i))
+		opts.WorkflowExecutionTimeout = 1 * time.Minute
+		run, err := ts.client.ExecuteWorkflow(ctx, opts, ts.workflows.Echo, "hi")
+		ts.NoError(err)
+		ts.NotNil(run)
+		ts.NoError(err)
+		wfRuns = append(wfRuns, run)
+	}
+
+	for _, run := range wfRuns {
+		ts.NoError(run.Get(ctx, nil))
+	}
 }
 
 func (ts *IntegrationTestSuite) TestTooFewParams() {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
There's now a separate slot supplier for session activities. Turns out this was also broken before in a different way, since previous to the slot suppliers change, session activity workers would have their own independent max concurrent, equal to the normal activity setting. Hence users using sessions could easily exceed the max number they thought they set.

## Why?
Without it, pollers for the session TQ can starve the normal activity TQ of slots

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-go/issues/1732
2. How was this tested:
Added integ test

3. Any docs updates needed?
Need to add some Go specific changes to docs on slot suppliers
