### PR TITLE
Fail registration without versioning behavior

### DIFF
--- a/internal/deployment_client.go
+++ b/internal/deployment_client.go
@@ -99,8 +99,8 @@ type (
 		// CreateTime - When this deployment was created.
 		CreateTime time.Time
 
-		// Current - Whether this deployment is the current one for its deployment series.
-		Current bool
+		// IsCurrent - Whether this deployment is the current one for its deployment series.
+		IsCurrent bool
 
 		// TaskQueuesInfo - List of task queues polled by workers in this deployment.
 		TaskQueuesInfo []DeploymentTaskQueueInfo
@@ -119,7 +119,7 @@ type (
 		CreateTime time.Time
 
 		// Whether this deployment is the current one for its deployment series.
-		Current bool
+		IsCurrent bool
 	}
 
 	// DeploymentListIterator is an iterator for deployments.
@@ -147,7 +147,7 @@ type (
 	// DeploymentReachabilityInfo extends DeploymentInfo with reachability information.
 	// NOTE: Experimental
 	DeploymentReachabilityInfo struct {
-		DeploymentInfo
+		DeploymentInfo DeploymentInfo
 
 		// Reachability - Kind of tasks that may reach a worker
 		// associated with a deployment.

--- a/internal/internal_deployment_client.go
+++ b/internal/internal_deployment_client.go
@@ -95,7 +95,7 @@ func deploymentListEntryFromProto(deployment *deployment.DeploymentListInfo) *De
 	return &DeploymentListEntry{
 		Deployment: deploymentFromProto(deployment.GetDeployment()),
 		CreateTime: deployment.GetCreateTime().AsTime(),
-		Current:    deployment.GetIsCurrent(),
+		IsCurrent:  deployment.GetIsCurrent(),
 	}
 }
 
@@ -115,7 +115,7 @@ func deploymentInfoFromProto(deploymentInfo *deployment.DeploymentInfo) Deployme
 	return DeploymentInfo{
 		Deployment:     deploymentFromProto(deploymentInfo.GetDeployment()),
 		CreateTime:     deploymentInfo.GetCreateTime().AsTime(),
-		Current:        deploymentInfo.GetIsCurrent(),
+		IsCurrent:      deploymentInfo.GetIsCurrent(),
 		TaskQueuesInfo: deploymentTaskQueuesInfoFromProto(deploymentInfo.GetTaskQueueInfos()),
 		Metadata:       deploymentInfo.GetMetadata(),
 	}

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -1922,15 +1922,11 @@ func (wth *workflowTaskHandlerImpl) completeWorkflow(
 		builtRequest.BinaryChecksum = ""
 	}
 	if wth.useBuildIDForVersioning && wth.deploymentSeriesName != "" {
-		if workflowContext.workflowInfo.currentVersioningBehavior != VersioningBehaviorUnspecified {
-			builtRequest.VersioningBehavior = versioningBehaviorToProto(workflowContext.workflowInfo.currentVersioningBehavior)
+		workflowType := workflowContext.workflowInfo.WorkflowType
+		if behavior, ok := wth.registry.getWorkflowVersioningBehavior(workflowType); ok {
+			builtRequest.VersioningBehavior = versioningBehaviorToProto(behavior)
 		} else {
-			workflowType := workflowContext.workflowInfo.WorkflowType
-			if behavior, ok := wth.registry.getWorkflowVersioningBehavior(workflowType); ok {
-				builtRequest.VersioningBehavior = versioningBehaviorToProto(behavior)
-			} else {
-				builtRequest.VersioningBehavior = versioningBehaviorToProto(wth.defaultVersioningBehavior)
-			}
+			builtRequest.VersioningBehavior = versioningBehaviorToProto(wth.defaultVersioningBehavior)
 		}
 	}
 	return builtRequest

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -994,6 +994,10 @@ func (aw *AggregatedWorker) RegisterWorkflow(w interface{}) {
 	if aw.workflowWorker == nil {
 		panic("workflow worker disabled, cannot register workflow")
 	}
+	if aw.executionParams.UseBuildIDForVersioning &&
+		aw.executionParams.DefaultVersioningBehavior == VersioningBehaviorUnspecified {
+		panic("workflow type does not have a versioning behavior")
+	}
 	aw.registry.RegisterWorkflow(w)
 }
 
@@ -1001,6 +1005,11 @@ func (aw *AggregatedWorker) RegisterWorkflow(w interface{}) {
 func (aw *AggregatedWorker) RegisterWorkflowWithOptions(w interface{}, options RegisterWorkflowOptions) {
 	if aw.workflowWorker == nil {
 		panic("workflow worker disabled, cannot register workflow")
+	}
+	if options.VersioningBehavior == VersioningBehaviorUnspecified &&
+		aw.executionParams.UseBuildIDForVersioning &&
+		aw.executionParams.DefaultVersioningBehavior == VersioningBehaviorUnspecified {
+		panic("workflow type does not have a versioning behavior")
 	}
 	aw.registry.RegisterWorkflowWithOptions(w, options)
 }

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -995,6 +995,7 @@ func (aw *AggregatedWorker) RegisterWorkflow(w interface{}) {
 		panic("workflow worker disabled, cannot register workflow")
 	}
 	if aw.executionParams.UseBuildIDForVersioning &&
+		aw.executionParams.DeploymentSeriesName != "" &&
 		aw.executionParams.DefaultVersioningBehavior == VersioningBehaviorUnspecified {
 		panic("workflow type does not have a versioning behavior")
 	}
@@ -1007,6 +1008,7 @@ func (aw *AggregatedWorker) RegisterWorkflowWithOptions(w interface{}, options R
 		panic("workflow worker disabled, cannot register workflow")
 	}
 	if options.VersioningBehavior == VersioningBehaviorUnspecified &&
+		aw.executionParams.DeploymentSeriesName != "" &&
 		aw.executionParams.UseBuildIDForVersioning &&
 		aw.executionParams.DefaultVersioningBehavior == VersioningBehaviorUnspecified {
 		panic("workflow type does not have a versioning behavior")

--- a/internal/internal_workflow.go
+++ b/internal/internal_workflow.go
@@ -1611,23 +1611,6 @@ func SetCurrentDetails(ctx Context, details string) {
 	getWorkflowEnvOptions(ctx).currentDetails = details
 }
 
-// SetVersioningBehavior sets the strategy to upgrade this workflow when the default Build ID
-// has changed, and Worker Versioning-3 has been enabled.
-//
-// NOTE: Experimental
-func SetVersioningBehavior(ctx Context, behavior VersioningBehavior) {
-	env := getWorkflowEnvironment(ctx)
-	env.WorkflowInfo().currentVersioningBehavior = behavior
-}
-
-// GetVersioningBehavior returns the last versioning behavior set with SetVersioningBehavior.
-//
-// NOTE: Experimental
-func GetVersioningBehavior(ctx Context) VersioningBehavior {
-	env := getWorkflowEnvironment(ctx)
-	return env.WorkflowInfo().currentVersioningBehavior
-}
-
 func getWorkflowMetadata(ctx Context) (*sdk.WorkflowMetadata, error) {
 	info := GetWorkflowInfo(ctx)
 	eo := getWorkflowEnvOptions(ctx)

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -413,7 +413,9 @@ type (
 		// inside a workflow as a child workflow.
 		Name                          string
 		DisableAlreadyRegisteredCheck bool
-		// Optional: Provides a Versioning Behavior to workflows of this type.
+		// Optional: Provides a Versioning Behavior to workflows of this type. It is required
+		// when WorkerOptions does not specify DeploymentOptions.DefaultVersioningBehavior,
+		// DeploymentOptions.DeploymentSeriesName is set, and UseBuildIDForVersioning is true.
 		// NOTE: Experimental
 		VersioningBehavior VersioningBehavior
 	}

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -413,8 +413,7 @@ type (
 		// inside a workflow as a child workflow.
 		Name                          string
 		DisableAlreadyRegisteredCheck bool
-		// Optional: Provides a default Versioning Behavior to workflows of this type.
-		// See workflow.SetVersioningBehavior to override this default.
+		// Optional: Provides a Versioning Behavior to workflows of this type.
 		// NOTE: Experimental
 		VersioningBehavior VersioningBehavior
 	}
@@ -1192,12 +1191,6 @@ type WorkflowInfo struct {
 	// which is currently or about to be executing. If no longer replaying will be set to the ID of
 	// this worker
 	currentTaskBuildID string
-	// currentVersioningBehavior, if not unspecified,  sets the strategy to upgrade
-	// this workflow when the default Build ID
-	// has changed, and Worker Versioning-3 has been enabled. Otherwise, the current Worker
-	// option DefaultVersioningBehavior will be used instead.
-	// NOTE: Experimental
-	currentVersioningBehavior VersioningBehavior
 
 	continueAsNewSuggested bool
 	currentHistorySize     int

--- a/test/workflow_test.go
+++ b/test/workflow_test.go
@@ -70,34 +70,6 @@ func (w *Workflows) Basic(ctx workflow.Context) ([]string, error) {
 	return []string{"toUpperWithDelay", "toUpper"}, nil
 }
 
-// Similar to Basic, but setting the versioning behavior to pinned.
-func (w *Workflows) SetPinnedVersioningBehavior(ctx workflow.Context) ([]string, error) {
-	workflow.SetVersioningBehavior(ctx, workflow.VersioningBehaviorPinned)
-
-	err := workflow.SetQueryHandler(ctx, "get-versioning-behavior", func(input []byte) (workflow.VersioningBehavior, error) {
-		return workflow.GetVersioningBehavior(ctx), nil
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	ctx = workflow.WithActivityOptions(ctx, w.defaultActivityOptions())
-	var ans1 string
-	workflow.GetLogger(ctx).Info("calling ExecuteActivity")
-	err = workflow.ExecuteActivity(ctx, "Prefix_ToUpperWithDelay", "hello", time.Second).Get(ctx, &ans1)
-	if err != nil {
-		return nil, err
-	}
-	var ans2 string
-	if err := workflow.ExecuteActivity(ctx, "Prefix_ToUpper", ans1).Get(ctx, &ans2); err != nil {
-		return nil, err
-	}
-	if ans2 != "HELLO" {
-		return nil, fmt.Errorf("incorrect return value from activity: expected=%v,got=%v", "HELLO", ans2)
-	}
-	return []string{"toUpperWithDelay", "toUpper"}, nil
-}
-
 func (w *Workflows) Echo(ctx workflow.Context, message string) (string, error) {
 	ctx = workflow.WithActivityOptions(ctx, w.defaultActivityOptions())
 	var ans1 string
@@ -3214,7 +3186,6 @@ func (w *Workflows) register(worker worker.Worker) {
 	worker.RegisterWorkflow(w.ActivityWaitForWorkerStop)
 	worker.RegisterWorkflow(w.ActivityHeartbeatUntilSignal)
 	worker.RegisterWorkflow(w.Basic)
-	worker.RegisterWorkflow(w.SetPinnedVersioningBehavior)
 	worker.RegisterWorkflow(w.Deadlocked)
 	worker.RegisterWorkflow(w.DeadlockedWithLocalActivity)
 	worker.RegisterWorkflow(w.Panicked)

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -623,34 +623,6 @@ func SetCurrentDetails(ctx Context, details string) {
 	internal.SetCurrentDetails(ctx, details)
 }
 
-// SetVersioningBehavior sets the strategy to upgrade this workflow when the default Build ID
-// has changed, and Worker Versioning-3 has been enabled.
-//
-// SetVersioningBehavior should be called during the first workflow task, and the context `ctx` should
-// be the original context workflow argument, or derived from this context.
-//
-// If not set, a default behavior provided in worker.Options.DefaultVersioningBehavior will be used.
-//
-// If not set, and the default behavior is also unspecified in the Worker, the first task of this workflow
-// will fail when Worker Versioning-3 has been enabled.
-//
-// NOTE: Experimental
-func SetVersioningBehavior(ctx Context, behavior VersioningBehavior) {
-	internal.SetVersioningBehavior(ctx, behavior)
-}
-
-// GetVersioningBehavior returns the last versioning behavior set with
-// the SetVersioningBehavior method.
-//
-// When SetVersioningBehavior has not been called, it always returns
-// VersioningBehaviorUnspecified, ignoring any Worker
-// defaults to avoid non-deterministic errors.
-//
-// NOTE: Experimental
-func GetVersioningBehavior(ctx Context) VersioningBehavior {
-	return internal.GetVersioningBehavior(ctx)
-}
-
 // IsReplaying returns whether the current workflow code is replaying.
 //
 // Warning! Never make commands, like schedule activity/childWorkflow/timer or send/wait on future/channel, based on


### PR DESCRIPTION

## What was changed

Remove programmatic SetVersioningBehavior API, and fail workflow registration when behavior missing.See #1739 for details.


1. Closes <!-- add issue number here -->
#1739 
2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
One system test
