### PR TITLE
Use omes branch pending UwS release

### DIFF
--- a/.github/workflows/omes.yml
+++ b/.github/workflows/omes.yml
@@ -11,7 +11,7 @@ jobs:
     with:
       lang: go
       sdk-repo-url: ${{ github.event.pull_request.head.repo.full_name || 'temporalio/sdk-go' }}
-      sdk-repo-ref: ${{ github.event.pull_request.head.ref || github.ref }}
+      sdk-repo-ref: new-uws-api
       # TODO: Remove once we have a good way of cleaning up sha-based pushed images
       docker-tag-ext: ci-latest
       do-push: true


### PR DESCRIPTION
Fix CI by using omes branch from https://github.com/temporalio/omes/pull/123 until new update-with-start API introduced in https://github.com/temporalio/sdk-go/pull/1731 is released.