### PR TITLE
Fix versioning override with AutoUpgrade behavior

### DIFF
--- a/contrib/tools/workflowcheck/determinism/testdata/src/a/ignore.go
+++ b/contrib/tools/workflowcheck/determinism/testdata/src/a/ignore.go
@@ -15,8 +15,9 @@ func IgnoreAboveLine() { // want IgnoreAboveLine:"calls non-deterministic functi
 	fmt.Println("Do not ignore this")
 }
 
-//workflowcheck:ignore
 // IgnoreEntireFunction can have a Godoc comment too
+//
+//workflowcheck:ignore
 func IgnoreEntireFunction() {
 	fmt.Print("Do not ignore this")
 	fmt.Printf("Ignore this")

--- a/internal/internal_workflow_execution_options.go
+++ b/internal/internal_workflow_execution_options.go
@@ -105,6 +105,12 @@ func workflowExecutionOptionsMaskToProto(mask []string) *fieldmaskpb.FieldMask {
 }
 
 func workerDeploymentToProto(d Deployment) *deploymentpb.Deployment {
+	// Server 1.26.2 requires a nil Deployment pointer, and not just a pointer to an empty Deployment,
+	// to indicate that there is no Deployment.
+	// It is a server error to override versioning behavior to AutoUpgrade while providing a Deployment,
+	// and we need to replace it by nil. See https://github.com/temporalio/sdk-go/issues/1764.
+	//
+	// Future server versions may relax this requirement.
 	if (Deployment{}) == d {
 		return nil
 	}

--- a/internal/internal_workflow_execution_options.go
+++ b/internal/internal_workflow_execution_options.go
@@ -105,6 +105,9 @@ func workflowExecutionOptionsMaskToProto(mask []string) *fieldmaskpb.FieldMask {
 }
 
 func workerDeploymentToProto(d Deployment) *deploymentpb.Deployment {
+	if (Deployment{}) == d {
+		return nil
+	}
 	return &deploymentpb.Deployment{
 		SeriesName: d.SeriesName,
 		BuildId:    d.BuildID,

--- a/internal/workflow_test.go
+++ b/internal/workflow_test.go
@@ -61,8 +61,8 @@ func TestGetChildWorkflowOptions(t *testing.T) {
 		},
 		ParentClosePolicy: enums.PARENT_CLOSE_POLICY_REQUEST_CANCEL,
 		VersioningIntent:  VersioningIntentDefault,
-		StaticSummary: "child workflow summary",
-		StaticDetails: "child workflow details",
+		StaticSummary:     "child workflow summary",
+		StaticDetails:     "child workflow details",
 	}
 
 	// Require test options to have non-zero value for each field. This ensures that we update tests (and the
@@ -84,7 +84,7 @@ func TestGetActivityOptions(t *testing.T) {
 		RetryPolicy:            newTestRetryPolicy(),
 		DisableEagerExecution:  true,
 		VersioningIntent:       VersioningIntentDefault,
-		Summary: 			  "activity summary",
+		Summary:                "activity summary",
 	}
 
 	assertNonZero(t, opts)

--- a/mocks/Client.go
+++ b/mocks/Client.go
@@ -950,6 +950,7 @@ func (_m *Client) UpdateWithStartWorkflow(ctx context.Context, options client.Up
 
 	return r0, r1
 }
+
 // UpdateWorkerBuildIdCompatibility provides a mock function with given fields: ctx, options
 //
 //lint:ignore SA1019 ignore for SDK mocks

--- a/test/deployment_test.go
+++ b/test/deployment_test.go
@@ -492,7 +492,7 @@ func (ts *DeploymentTestSuite) TestUpdateWorkflowExecutionOptions() {
 	ts.True(IsVersionOne(result))
 
 	ts.NoError(handle4.Get(ctx, &result))
-	// no override
+	// override + autoUpgrade
 	ts.True(IsVersionTwo(result))
 
 }


### PR DESCRIPTION

## What was changed
<!-- Describe what has changed in this PR -->

The current implementation for versioning override fails for AutoUpgrade
because it uses an empty Deployment struct instead of a nil pointer.

See #1764 for details.

Also missing `gofmt` of some unrelated files corrected.

## Why?
<!-- Tell your future self why have you made these changes -->
This is a blocker for the new versioning-3 implementation.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->
#1764 
2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Integration test

