### PR TITLE
Remove docker flag that disables versioning tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,6 @@ jobs:
             runsOn: macos-13
           - os: macos-arm
             runsOn: macos-14
-
     runs-on: ${{ matrix.runsOn || matrix.os }}
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
             runsOn: macos-13
           - os: macos-arm
             runsOn: macos-14
-            
+
     runs-on: ${{ matrix.runsOn || matrix.os }}
     steps:
       - name: Checkout repository
@@ -88,9 +88,6 @@ jobs:
       - name: Docker compose - integration tests
         if: ${{ matrix.testDockerCompose }}
         run: go run . integration-test
-        env:
-          # TODO(antlai-temporal): Remove this flag once server 1.26.2 released.
-          DISABLE_DEPLOYMENT_TESTS: "1"
         working-directory: ./internal/cmd/build
 
   cloud-test:

--- a/.github/workflows/docker/dynamic-config-custom.yaml
+++ b/.github/workflows/docker/dynamic-config-custom.yaml
@@ -17,6 +17,8 @@ frontend.workerVersioningDataAPIs:
   - value: true
 frontend.workerVersioningWorkflowAPIs:
   - value: true
+system.enableDeployments:
+  - value: true
 worker.buildIdScavengerEnabled:
   - value: true
 worker.removableBuildIdDurationSinceDefault:

--- a/test/deployment_test.go
+++ b/test/deployment_test.go
@@ -24,7 +24,6 @@ package test_test
 
 import (
 	"context"
-	"os"
 	"reflect"
 	"sort"
 	"strings"
@@ -100,9 +99,6 @@ func (ts *DeploymentTestSuite) waitForReachability(ctx context.Context, deployme
 }
 
 func (ts *DeploymentTestSuite) TestPinnedBehaviorThreeWorkers() {
-	if os.Getenv("DISABLE_DEPLOYMENT_TESTS") != "" {
-		ts.T().Skip("temporal server 1.26.2+ required")
-	}
 	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
 	defer cancel()
 
@@ -250,9 +246,6 @@ func (ts *DeploymentTestSuite) TestPinnedBehaviorThreeWorkers() {
 }
 
 func (ts *DeploymentTestSuite) TestPinnedOverrideInWorkflowOptions() {
-	if os.Getenv("DISABLE_DEPLOYMENT_TESTS") != "" {
-		ts.T().Skip("temporal server 1.26.2+ required")
-	}
 	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
 	defer cancel()
 
@@ -333,9 +326,6 @@ func (ts *DeploymentTestSuite) TestPinnedOverrideInWorkflowOptions() {
 }
 
 func (ts *DeploymentTestSuite) TestUpdateWorkflowExecutionOptions() {
-	if os.Getenv("DISABLE_DEPLOYMENT_TESTS") != "" {
-		ts.T().Skip("temporal server 1.26.2+ required")
-	}
 	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
 	defer cancel()
 
@@ -498,9 +488,6 @@ func (ts *DeploymentTestSuite) TestUpdateWorkflowExecutionOptions() {
 }
 
 func (ts *DeploymentTestSuite) TestListDeployments() {
-	if os.Getenv("DISABLE_DEPLOYMENT_TESTS") != "" {
-		ts.T().Skip("temporal server 1.26.2+ required")
-	}
 	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
 	defer cancel()
 
@@ -567,9 +554,6 @@ func (ts *DeploymentTestSuite) TestListDeployments() {
 }
 
 func (ts *DeploymentTestSuite) TestDeploymentReachability() {
-	if os.Getenv("DISABLE_DEPLOYMENT_TESTS") != "" {
-		ts.T().Skip("temporal server 1.26.2+ required")
-	}
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Second)
 	defer cancel()
 

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -6262,9 +6262,6 @@ func (ts *IntegrationTestSuite) TestScheduleUpdateWorkflowActionMemo() {
 }
 
 func (ts *IntegrationTestSuite) TestVersioningBehaviorInRespondWorkflowTaskCompletedRequest() {
-	if os.Getenv("DISABLE_DEPLOYMENT_TESTS") != "" {
-		ts.T().Skip("temporal server 1.26.2+ required")
-	}
 	versioningBehaviorAll := make([]enumspb.VersioningBehavior, 0)
 	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
 	defer cancel()
@@ -6333,9 +6330,6 @@ func (ts *IntegrationTestSuite) TestVersioningBehaviorInRespondWorkflowTaskCompl
 }
 
 func (ts *IntegrationTestSuite) TestVersioningBehaviorPerWorkflowType() {
-	if os.Getenv("DISABLE_DEPLOYMENT_TESTS") != "" {
-		ts.T().Skip("temporal server 1.26.2+ required")
-	}
 	versioningBehaviorAll := make([]enumspb.VersioningBehavior, 0)
 	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
 	defer cancel()
@@ -6409,9 +6403,6 @@ func (ts *IntegrationTestSuite) TestVersioningBehaviorPerWorkflowType() {
 }
 
 func (ts *IntegrationTestSuite) TestNoVersioningBehaviorPanics() {
-	if os.Getenv("DISABLE_DEPLOYMENT_TESTS") != "" {
-		ts.T().Skip("temporal server 1.26.2+ required")
-	}
 	seriesName := "deploy-test-" + uuid.New()
 
 	c, err := client.Dial(client.Options{


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->

Server 1.26.2 is already enabled in `docker-compose` and we no longer need to disable
new versioning tests for docker container test.
