### PR TITLE
Fix doclink tool's duplicate docstring generation issue

### DIFF
--- a/internal/cmd/tools/doclink/doclink.go
+++ b/internal/cmd/tools/doclink/doclink.go
@@ -373,7 +373,7 @@ func processInternal(cfg config, file *os.File, pairs map[string]map[string]stri
 		} else {
 			commentBlock = ""
 		}
-		
+
 		// Check for old docs links to remove
 		if strings.Contains(trimmedNextLine, exposedAs) {
 			links := strings.Split(strings.TrimPrefix(trimmedNextLine, exposedAs), ", ")
@@ -381,7 +381,7 @@ func processInternal(cfg config, file *os.File, pairs map[string]map[string]stri
 			for _, link := range links {
 				staleLink := true
 				for packageName, pair := range pairs {
-					for public, _ := range pair {
+					for public := range pair {
 						docLink := fmt.Sprintf("[go.temporal.io/sdk/%s.%s]", packageName, public)
 						if link == docLink {
 							staleLink = false

--- a/internal/error.go
+++ b/internal/error.go
@@ -386,7 +386,7 @@ func NewApplicationError(msg string, errType string, nonRetryable bool, cause er
 	)
 }
 
-// Exposed as: [go.temporal.io/sdk/temporal.NewApplicationErrorWithOptions], [go.temporal.io/sdk/temporal.NewApplicationErrorWithCause], [go.temporal.io/sdk/temporal.NewApplicationError], [go.temporal.io/sdk/temporal.NewNonRetryableApplicationError]
+// Exposed as: [go.temporal.io/sdk/temporal.NewApplicationError], [go.temporal.io/sdk/temporal.NewApplicationErrorWithOptions], [go.temporal.io/sdk/temporal.NewApplicationErrorWithCause], [go.temporal.io/sdk/temporal.NewNonRetryableApplicationError]
 func NewApplicationErrorWithOptions(msg string, errType string, options ApplicationErrorOptions) error {
 	applicationErr := &ApplicationError{
 		msg:            msg,

--- a/internal/interceptor.go
+++ b/internal/interceptor.go
@@ -39,8 +39,6 @@ import (
 // the interceptor package for more details.
 //
 // Exposed as: [go.temporal.io/sdk/interceptor.Interceptor]
-//
-// Exposed as: [go.temporal.io/sdk/interceptor.Interceptor]
 type Interceptor interface {
 	ClientInterceptor
 	WorkerInterceptor
@@ -48,8 +46,6 @@ type Interceptor interface {
 
 // WorkerInterceptor is a common interface for all interceptors. See
 // documentation in the interceptor package for more details.
-//
-// Exposed as: [go.temporal.io/sdk/interceptor.WorkerInterceptor]
 //
 // Exposed as: [go.temporal.io/sdk/interceptor.WorkerInterceptor]
 type WorkerInterceptor interface {
@@ -69,8 +65,6 @@ type WorkerInterceptor interface {
 // details.
 //
 // Exposed as: [go.temporal.io/sdk/interceptor.ActivityInboundInterceptor]
-//
-// Exposed as: [go.temporal.io/sdk/interceptor.ActivityInboundInterceptor]
 type ActivityInboundInterceptor interface {
 	// Init is the first call of this interceptor. Implementations can change/wrap
 	// the outbound interceptor before calling Init on the next interceptor.
@@ -86,8 +80,6 @@ type ActivityInboundInterceptor interface {
 // ExecuteActivityInput is the input to ActivityInboundInterceptor.ExecuteActivity.
 //
 // Exposed as: [go.temporal.io/sdk/interceptor.ExecuteActivityInput]
-//
-// Exposed as: [go.temporal.io/sdk/interceptor.ExecuteActivityInput]
 type ExecuteActivityInput struct {
 	Args []interface{}
 }
@@ -95,8 +87,6 @@ type ExecuteActivityInput struct {
 // ActivityOutboundInterceptor is an interface for all activity calls
 // originating from the SDK. See documentation in the interceptor package for
 // more details.
-//
-// Exposed as: [go.temporal.io/sdk/interceptor.ActivityOutboundInterceptor]
 //
 // Exposed as: [go.temporal.io/sdk/interceptor.ActivityOutboundInterceptor]
 type ActivityOutboundInterceptor interface {
@@ -127,8 +117,6 @@ type ActivityOutboundInterceptor interface {
 // WorkflowInboundInterceptor is an interface for all workflow calls originating
 // from the server. See documentation in the interceptor package for more
 // details.
-//
-// Exposed as: [go.temporal.io/sdk/interceptor.WorkflowInboundInterceptor]
 //
 // Exposed as: [go.temporal.io/sdk/interceptor.WorkflowInboundInterceptor]
 type WorkflowInboundInterceptor interface {
@@ -168,15 +156,11 @@ type WorkflowInboundInterceptor interface {
 // WorkflowInboundInterceptor.ExecuteWorkflow.
 //
 // Exposed as: [go.temporal.io/sdk/interceptor.ExecuteWorkflowInput]
-//
-// Exposed as: [go.temporal.io/sdk/interceptor.ExecuteWorkflowInput]
 type ExecuteWorkflowInput struct {
 	Args []interface{}
 }
 
 // HandleSignalInput is the input to WorkflowInboundInterceptor.HandleSignal.
-//
-// Exposed as: [go.temporal.io/sdk/interceptor.HandleSignalInput]
 //
 // Exposed as: [go.temporal.io/sdk/interceptor.HandleSignalInput]
 type HandleSignalInput struct {
@@ -189,16 +173,12 @@ type HandleSignalInput struct {
 // UpdateInput carries the name and arguments of a workflow update invocation.
 //
 // Exposed as: [go.temporal.io/sdk/interceptor.UpdateInput]
-//
-// Exposed as: [go.temporal.io/sdk/interceptor.UpdateInput]
 type UpdateInput struct {
 	Name string
 	Args []interface{}
 }
 
 // HandleQueryInput is the input to WorkflowInboundInterceptor.HandleQuery.
-//
-// Exposed as: [go.temporal.io/sdk/interceptor.HandleQueryInput]
 //
 // Exposed as: [go.temporal.io/sdk/interceptor.HandleQueryInput]
 type HandleQueryInput struct {
@@ -209,8 +189,6 @@ type HandleQueryInput struct {
 // ExecuteNexusOperationInput is the input to WorkflowOutboundInterceptor.ExecuteNexusOperation.
 //
 // NOTE: Experimental
-//
-// Exposed as: [go.temporal.io/sdk/interceptor.ExecuteNexusOperationInput]
 //
 // Exposed as: [go.temporal.io/sdk/interceptor.ExecuteNexusOperationInput]
 type ExecuteNexusOperationInput struct {
@@ -231,8 +209,6 @@ type ExecuteNexusOperationInput struct {
 // NOTE: Experimental
 //
 // Exposed as: [go.temporal.io/sdk/interceptor.RequestCancelNexusOperationInput]
-//
-// Exposed as: [go.temporal.io/sdk/interceptor.RequestCancelNexusOperationInput]
 type RequestCancelNexusOperationInput struct {
 	// Client that was used to start the operation.
 	Client NexusClient
@@ -247,8 +223,6 @@ type RequestCancelNexusOperationInput struct {
 // WorkflowOutboundInterceptor is an interface for all workflow calls
 // originating from the SDK. See documentation in the interceptor package for
 // more details.
-//
-// Exposed as: [go.temporal.io/sdk/interceptor.WorkflowOutboundInterceptor]
 //
 // Exposed as: [go.temporal.io/sdk/interceptor.WorkflowOutboundInterceptor]
 type WorkflowOutboundInterceptor interface {
@@ -396,8 +370,6 @@ type WorkflowOutboundInterceptor interface {
 // interceptor package for more details.
 //
 // Exposed as: [go.temporal.io/sdk/interceptor.ClientInterceptor]
-//
-// Exposed as: [go.temporal.io/sdk/interceptor.ClientInterceptor]
 type ClientInterceptor interface {
 	// This is called on client creation if set via client options
 	InterceptClient(next ClientOutboundInterceptor) ClientOutboundInterceptor
@@ -408,8 +380,6 @@ type ClientInterceptor interface {
 // ClientOutboundInterceptor is an interface for certain workflow-specific calls
 // originating from the SDK. See documentation in the interceptor package for
 // more details.
-//
-// Exposed as: [go.temporal.io/sdk/interceptor.ClientOutboundInterceptor]
 //
 // Exposed as: [go.temporal.io/sdk/interceptor.ClientOutboundInterceptor]
 type ClientOutboundInterceptor interface {
@@ -494,16 +464,12 @@ type ClientPollWorkflowUpdateOutput struct {
 // ClientOutboundInterceptor.CreateSchedule.
 //
 // Exposed as: [go.temporal.io/sdk/interceptor.ScheduleClientCreateInput]
-//
-// Exposed as: [go.temporal.io/sdk/interceptor.ScheduleClientCreateInput]
 type ScheduleClientCreateInput struct {
 	Options *ScheduleOptions
 }
 
 // ClientExecuteWorkflowInput is the input to
 // ClientOutboundInterceptor.ExecuteWorkflow.
-//
-// Exposed as: [go.temporal.io/sdk/interceptor.ClientExecuteWorkflowInput]
 //
 // Exposed as: [go.temporal.io/sdk/interceptor.ClientExecuteWorkflowInput]
 type ClientExecuteWorkflowInput struct {
@@ -516,8 +482,6 @@ type ClientExecuteWorkflowInput struct {
 // ClientOutboundInterceptor.SignalWorkflow.
 //
 // Exposed as: [go.temporal.io/sdk/interceptor.ClientSignalWorkflowInput]
-//
-// Exposed as: [go.temporal.io/sdk/interceptor.ClientSignalWorkflowInput]
 type ClientSignalWorkflowInput struct {
 	WorkflowID string
 	RunID      string
@@ -527,8 +491,6 @@ type ClientSignalWorkflowInput struct {
 
 // ClientSignalWithStartWorkflowInput is the input to
 // ClientOutboundInterceptor.SignalWithStartWorkflow.
-//
-// Exposed as: [go.temporal.io/sdk/interceptor.ClientSignalWithStartWorkflowInput]
 //
 // Exposed as: [go.temporal.io/sdk/interceptor.ClientSignalWithStartWorkflowInput]
 type ClientSignalWithStartWorkflowInput struct {
@@ -543,8 +505,6 @@ type ClientSignalWithStartWorkflowInput struct {
 // ClientOutboundInterceptor.CancelWorkflow.
 //
 // Exposed as: [go.temporal.io/sdk/interceptor.ClientCancelWorkflowInput]
-//
-// Exposed as: [go.temporal.io/sdk/interceptor.ClientCancelWorkflowInput]
 type ClientCancelWorkflowInput struct {
 	WorkflowID string
 	RunID      string
@@ -552,8 +512,6 @@ type ClientCancelWorkflowInput struct {
 
 // ClientTerminateWorkflowInput is the input to
 // ClientOutboundInterceptor.TerminateWorkflow.
-//
-// Exposed as: [go.temporal.io/sdk/interceptor.ClientTerminateWorkflowInput]
 //
 // Exposed as: [go.temporal.io/sdk/interceptor.ClientTerminateWorkflowInput]
 type ClientTerminateWorkflowInput struct {
@@ -565,8 +523,6 @@ type ClientTerminateWorkflowInput struct {
 
 // ClientQueryWorkflowInput is the input to
 // ClientOutboundInterceptor.QueryWorkflow.
-//
-// Exposed as: [go.temporal.io/sdk/interceptor.ClientQueryWorkflowInput]
 //
 // Exposed as: [go.temporal.io/sdk/interceptor.ClientQueryWorkflowInput]
 type ClientQueryWorkflowInput struct {

--- a/internal/nexus_operations.go
+++ b/internal/nexus_operations.go
@@ -42,12 +42,12 @@ import (
 
 // NexusOperationContext is an internal only struct that holds fields used by the temporalnexus functions.
 type NexusOperationContext struct {
-	Client              Client
-	Namespace           string
-	TaskQueue           string
-	MetricsHandler      metrics.Handler
-	Log                 log.Logger
-	registry *registry
+	Client         Client
+	Namespace      string
+	TaskQueue      string
+	MetricsHandler metrics.Handler
+	Log            log.Logger
+	registry       *registry
 }
 
 func (nc *NexusOperationContext) ResolveWorkflowName(wf any) (string, error) {


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->
- Removed duplicate "Exposed as" comments
- added ability to detect/delete stale aliases
- handle edge case where gofmt reorders the doc comment (i.e. `UpsertSearchAttributes` from workflow.go)

## Why?
<!-- Tell your future self why have you made these changes -->
Unintended behavior

## Checklist
<!--- add/delete as needed --->

1. Closes #1774

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Manually added and removed aliases

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
