### PR TITLE
Disable TestPinnedBehaviorThreeWorkers() test

### DIFF
--- a/test/deployment_test.go
+++ b/test/deployment_test.go
@@ -99,6 +99,7 @@ func (ts *DeploymentTestSuite) waitForReachability(ctx context.Context, deployme
 }
 
 func (ts *DeploymentTestSuite) TestPinnedBehaviorThreeWorkers() {
+	ts.T().Skip("temporal server 1.26.2 has a setCurrent bug, see https://github.com/temporalio/temporal/pull/6978")
 	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
 	defer cancel()
 


### PR DESCRIPTION

## What was changed
<!-- Describe what has changed in this PR -->
Server 1.26.2 creates a test flake because the SetCurrent API is eventually consistent.

This was fixed in https://github.com/temporalio/temporal/pull/6978 but unfortunately it is not available
in any OSS release just yet.

Disabling the test TestPinnedBehaviorThreeWorkers()  for now
