### PR TITLE
Update bug issue template to use `bug` label

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Report a bug or unexpected behavior with the Temporal Go SDK
 title: ''
-labels: potential-bug
+labels: bug
 assignees: ''
 
 ---


### PR DESCRIPTION
We're trying to standardize on the same set of labels across SDK repos. Other repos use `bug` for newly-filed bugs and don't have the `potential-bug` distinction. Do the same for Go SDK.