### PR TITLE
Add option to override UI port

### DIFF
--- a/testsuite/devserver.go
+++ b/testsuite/devserver.go
@@ -71,6 +71,9 @@ type DevServerOptions struct {
 	DBFilename string
 	// Whether to enable the UI.
 	EnableUI bool
+	// Override UI port if EnableUI is true.
+	// If not provided, a free port will be used.
+	UIPort string
 	// Log format - defaults to "pretty".
 	LogFormat string
 	// Log level - defaults to "warn".
@@ -157,6 +160,9 @@ func prepareCommand(options *DevServerOptions, host, port, namespace string) []s
 	}
 	if options.DBFilename != "" {
 		args = append(args, "--db-filename", options.DBFilename)
+	}
+	if options.UIPort != "" {
+		args = append(args, "--ui-port", options.UIPort)
 	}
 	return append(args, options.ExtraArgs...)
 }


### PR DESCRIPTION
Add option to override UI port


closes: https://github.com/temporalio/sdk-go/issues/1788