### PR TITLE
Fix doc links on pkg.go.dev/

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ If you're unsure then you should specify it anyways as there's no harm in doing 
 ### Incompatible proto/json encoding
 
 Proto enums will, when formatted to JSON, now be in SCREAMING_SNAKE_CASE rather than PascalCase.
-    * If trying to deserialize old JSON with PascalCase to proto use [go.temporal.io/api/temporalproto]
+    * If trying to deserialize old JSON with PascalCase to proto use [go.temporal.io/api/temporalproto](https://pkg.go.dev/go.temporal.io/api/temporalproto).
 
 If users used Temporal proto types in their Workflows, such as for activity output, users may need to modify the default data converter to handle these payloads.
 ``` go

--- a/activity/activity.go
+++ b/activity/activity.go
@@ -73,7 +73,7 @@ func GetMetricsHandler(ctx context.Context) metrics.Handler {
 // can check error with TimeoutType()/Details().
 //
 // Note: If using asynchronous activity completion,
-// after returning [ErrResultPending] users should heartbeat with [client.Client.RecordActivityHeartbeat]
+// after returning [ErrResultPending] users should heartbeat with [github.com/temporalio/sdk-go/client.Client.RecordActivityHeartbeat]
 func RecordHeartbeat(ctx context.Context, details ...interface{}) {
 	internal.RecordActivityHeartbeat(ctx, details...)
 }

--- a/activity/doc.go
+++ b/activity/doc.go
@@ -102,7 +102,7 @@ the Temporal managed service.
 	}
 
 When the Activity times out due to a missed heartbeat, the last value of the details (progress in the above sample) is
-returned from the [workflow.ExecuteActivity] function as the details field of [temporal.TimeoutError] with TimeoutType_HEARTBEAT.
+returned from the [github.com/temporalio/sdk-go/workflow.ExecuteActivity] function as the details field of [github.com/temporalio/sdk-go/temporal.TimeoutError] with TimeoutType_HEARTBEAT.
 
 It is also possible to heartbeat an Activity from an external source:
 

--- a/client/client.go
+++ b/client/client.go
@@ -188,7 +188,7 @@ type (
 	StartWorkflowOptions = internal.StartWorkflowOptions
 
 	// WithStartWorkflowOperation defines how to start a workflow when using UpdateWithStartWorkflow.
-	// See [Client.NewWithStartWorkflowOperation] and [Client.UpdateWithStartWorkflow].
+	// See [client.Client.NewWithStartWorkflowOperation] and [client.Client.UpdateWithStartWorkflow].
 	// NOTE: Experimental
 	WithStartWorkflowOperation = internal.WithStartWorkflowOperation
 
@@ -299,7 +299,7 @@ type (
 	UpdateWorkflowOptions = internal.UpdateWorkflowOptions
 
 	// UpdateWithStartWorkflowOptions encapsulates the parameters used by UpdateWithStartWorkflow.
-	// See [Client.UpdateWithStartWorkflow] and [Client.NewWithStartWorkflowOperation].
+	// See [client.Client.UpdateWithStartWorkflow] and [client.Client.NewWithStartWorkflowOperation].
 	// NOTE: Experimental
 	UpdateWithStartWorkflowOptions = internal.UpdateWithStartWorkflowOptions
 
@@ -341,31 +341,31 @@ type (
 	// NOTE: Experimental
 	DeploymentMetadataUpdate = internal.DeploymentMetadataUpdate
 
-	// DeploymentDescribeOptions provides options for [DeploymentClient.Describe].
+	// DeploymentDescribeOptions provides options for [internal.DeploymentClient.Describe].
 	// NOTE: Experimental
 	DeploymentDescribeOptions = internal.DeploymentDescribeOptions
 
-	// DeploymentDescription is the response type for [DeploymentClient.Describe].
+	// DeploymentDescription is the response type for [internal.DeploymentClient.Describe].
 	// NOTE: Experimental
 	DeploymentDescription = internal.DeploymentDescription
 
-	// DeploymentGetReachabilityOptions provides options for [DeploymentClient.GetReachability].
+	// DeploymentGetReachabilityOptions provides options for [internal.DeploymentClient.GetReachability].
 	// NOTE: Experimental
 	DeploymentGetReachabilityOptions = internal.DeploymentGetReachabilityOptions
 
-	// DeploymentGetCurrentOptions provides options for [DeploymentClient.GetCurrent].
+	// DeploymentGetCurrentOptions provides options for [internal.DeploymentClient.GetCurrent].
 	// NOTE: Experimental
 	DeploymentGetCurrentOptions = internal.DeploymentGetCurrentOptions
 
-	// DeploymentGetCurrentResponse is the response type for [DeploymentClient.GetCurrent].
+	// DeploymentGetCurrentResponse is the response type for [internal.DeploymentClient.GetCurrent].
 	// NOTE: Experimental
 	DeploymentGetCurrentResponse = internal.DeploymentGetCurrentResponse
 
-	// DeploymentSetCurrentOptions provides options for [DeploymentClient.SetCurrent].
+	// DeploymentSetCurrentOptions provides options for [internal.DeploymentClient.SetCurrent].
 	// NOTE: Experimental
 	DeploymentSetCurrentOptions = internal.DeploymentSetCurrentOptions
 
-	// DeploymentSetCurrentResponse is the response type for [DeploymentClient.SetCurrent].
+	// DeploymentSetCurrentResponse is the response type for [internal.DeploymentClient.SetCurrent].
 	// NOTE: Experimental
 	DeploymentSetCurrentResponse = internal.DeploymentSetCurrentResponse
 
@@ -373,17 +373,17 @@ type (
 	// NOTE: Experimental
 	DeploymentClient = internal.DeploymentClient
 
-	// UpdateWorkflowExecutionOptionsRequest is a request for [Client.UpdateWorkflowExecutionOptions].
+	// UpdateWorkflowExecutionOptionsRequest is a request for [client.Client.UpdateWorkflowExecutionOptions].
 	// NOTE: Experimental
 	UpdateWorkflowExecutionOptionsRequest = internal.UpdateWorkflowExecutionOptionsRequest
 
 	// WorkflowExecutionOptions contains a set of properties of an existing workflow
-	// that can be overriden using [UpdateWorkflowExecutionOptions].
+	// that can be overriden using [client.Client.UpdateWorkflowExecutionOptions].
 	// NOTE: Experimental
 	WorkflowExecutionOptions = internal.WorkflowExecutionOptions
 
 	// WorkflowExecutionOptionsChanges describes changes to [WorkflowExecutionOptions]
-	// in the [UpdateWorkflowExecutionOptions] API.
+	// in the [client.Client.UpdateWorkflowExecutionOptions] API.
 	// NOTE: Experimental
 	WorkflowExecutionOptionsChanges = internal.WorkflowExecutionOptionsChanges
 
@@ -461,27 +461,27 @@ type (
 	// Deprecated: Replaced by the new worker versioning api.
 	TaskQueueReachability = internal.TaskQueueReachability
 
-	// DescribeTaskQueueEnhancedOptions is the input to [Client.DescribeTaskQueueEnhanced].
+	// DescribeTaskQueueEnhancedOptions is the input to [client.Client.DescribeTaskQueueEnhanced].
 	DescribeTaskQueueEnhancedOptions = internal.DescribeTaskQueueEnhancedOptions
 
 	// TaskQueueVersionSelection is a task queue filter based on versioning.
-	// It is an optional component of [Client.DescribeTaskQueueEnhancedOptions].
+	// It is an optional component of [DescribeTaskQueueEnhancedOptions].
 	// WARNING: Worker versioning is currently experimental.
 	TaskQueueVersionSelection = internal.TaskQueueVersionSelection
 
-	// TaskQueueDescription is the response to [Client.DescribeTaskQueueEnhanced].
+	// TaskQueueDescription is the response to [client.Client.DescribeTaskQueueEnhanced].
 	TaskQueueDescription = internal.TaskQueueDescription
 
 	// TaskQueueVersionInfo includes task queue information per Build ID.
-	// It is part of [Client.TaskQueueDescription].
+	// It is part of [TaskQueueDescription].
 	TaskQueueVersionInfo = internal.TaskQueueVersionInfo
 
 	// TaskQueueTypeInfo specifies task queue information per task type and Build ID.
-	// It is included in [Client.TaskQueueVersionInfo].
+	// It is included in [TaskQueueVersionInfo].
 	TaskQueueTypeInfo = internal.TaskQueueTypeInfo
 
 	// TaskQueuePollerInfo provides information about a worker/client polling a task queue.
-	// It is used by [Client.TaskQueueTypeInfo].
+	// It is used by [TaskQueueTypeInfo].
 	TaskQueuePollerInfo = internal.TaskQueuePollerInfo
 
 	// TaskQueueStats contains statistics about task queue backlog and activity.
@@ -492,18 +492,18 @@ type (
 
 	// WorkerVersionCapabilities includes a worker's build identifier
 	// and whether it is choosing to use the versioning feature.
-	// It is an optional component of [Client.TaskQueuePollerInfo].
+	// It is an optional component of [TaskQueuePollerInfo].
 	// WARNING: Worker versioning is currently experimental.
 	WorkerVersionCapabilities = internal.WorkerVersionCapabilities
 
-	// UpdateWorkerVersioningRulesOptions is the input to [Client.UpdateWorkerVersioningRules].
+	// UpdateWorkerVersioningRulesOptions is the input to [client.Client.UpdateWorkerVersioningRules].
 	// WARNING: Worker versioning is currently experimental.
 	UpdateWorkerVersioningRulesOptions = internal.UpdateWorkerVersioningRulesOptions
 
-	// VersioningConflictToken is a conflict token to serialize calls to Client.UpdateWorkerVersioningRules.
+	// VersioningConflictToken is a conflict token to serialize calls to [client.Client.UpdateWorkerVersioningRules].
 	// An update with an old token fails with `serviceerror.FailedPrecondition`.
-	// The current token can be obtained with [GetWorkerVersioningRules],
-	// or returned by a successful [UpdateWorkerVersioningRules].
+	// The current token can be obtained with [client.Client.GetWorkerVersioningRules],
+	// or returned by a successful [client.Client.UpdateWorkerVersioningRules].
 	// WARNING: Worker versioning is currently experimental.
 	VersioningConflictToken = internal.VersioningConflictToken
 
@@ -590,11 +590,11 @@ type (
 	// WARNING: Worker versioning is currently experimental.
 	VersioningOperationCommitBuildID = internal.VersioningOperationCommitBuildID
 
-	// GetWorkerVersioningOptions is the input to [Client.GetWorkerVersioningRules].
+	// GetWorkerVersioningOptions is the input to [client.Client.GetWorkerVersioningRules].
 	// WARNING: Worker versioning is currently experimental.
 	GetWorkerVersioningOptions = internal.GetWorkerVersioningOptions
 
-	// WorkerVersioningRules is the response for [Client.GetWorkerVersioningRules].
+	// WorkerVersioningRules is the response for [client.Client.GetWorkerVersioningRules].
 	// WARNING: Worker versioning is currently experimental.
 	WorkerVersioningRules = internal.WorkerVersioningRules
 
@@ -677,7 +677,7 @@ type (
 			options StartWorkflowOptions, workflow interface{}, workflowArgs ...interface{}) (WorkflowRun, error)
 
 		// NewWithStartWorkflowOperation returns a WithStartWorkflowOperation for use with UpdateWithStartWorkflow.
-		// See [Client.UpdateWithStartWorkflow].
+		// See [client.Client.UpdateWithStartWorkflow].
 		// NOTE: Experimental
 		NewWithStartWorkflowOperation(options StartWorkflowOptions, workflow interface{}, args ...interface{}) WithStartWorkflowOperation
 
@@ -911,13 +911,13 @@ type (
 		// Allows you to update the worker-build-id based version sets for a particular task queue. This is used in
 		// conjunction with workers who specify their build id and thus opt into the feature.
 		//
-		// Deprecated: Use [UpdateWorkerVersioningRules] with the versioning api.
+		// Deprecated: Use [client.Client.UpdateWorkerVersioningRules] with the versioning api.
 		UpdateWorkerBuildIdCompatibility(ctx context.Context, options *UpdateWorkerBuildIdCompatibilityOptions) error
 
 		// GetWorkerBuildIdCompatibility
 		// Returns the worker-build-id based version sets for a particular task queue.
 		//
-		// Deprecated: Use [GetWorkerVersioningRules] with the versioning api.
+		// Deprecated: Use [client.Client.GetWorkerVersioningRules] with the versioning api.
 		GetWorkerBuildIdCompatibility(ctx context.Context, options *GetWorkerBuildIdCompatibilityOptions) (*WorkerBuildIDVersionSets, error)
 
 		// GetWorkerTaskReachability
@@ -1162,7 +1162,7 @@ var (
 )
 
 // NewValue creates a new [converter.EncodedValue] which can be used to decode binary data returned by Temporal.  For example:
-// User had Activity.RecordHeartbeat(ctx, "my-heartbeat") and then got response from calling Client.DescribeWorkflowExecution.
+// User had Activity.RecordHeartbeat(ctx, "my-heartbeat") and then got response from calling [client.Client.DescribeWorkflowExecution].
 // The response contains binary field PendingActivityInfo.HeartbeatDetails,
 // which can be decoded by using:
 //
@@ -1173,7 +1173,7 @@ func NewValue(data *commonpb.Payloads) converter.EncodedValue {
 }
 
 // NewValues creates a new [converter.EncodedValues] which can be used to decode binary data returned by Temporal. For example:
-// User had Activity.RecordHeartbeat(ctx, "my-heartbeat", 123) and then got response from calling Client.DescribeWorkflowExecution.
+// User had Activity.RecordHeartbeat(ctx, "my-heartbeat", 123) and then got response from calling [client.Client.DescribeWorkflowExecution].
 // The response contains binary field PendingActivityInfo.HeartbeatDetails,
 // which can be decoded by using:
 //

--- a/contrib/tally/handler.go
+++ b/contrib/tally/handler.go
@@ -48,7 +48,7 @@ func NewMetricsHandler(scope tally.Scope) client.MetricsHandler {
 }
 
 // ScopeFromHandler returns the underlying scope of the handler. Callers may
-// need to check [workflow.IsReplaying] to avoid recording metrics during
+// need to check [github.com/temporalio/sdk-go/workflow.IsReplaying] to avoid recording metrics during
 // replay. If this handler was not created via this package, [github.com/uber-go/tally.NoopScope] is
 // returned.
 //

--- a/workflow/doc.go
+++ b/workflow/doc.go
@@ -381,7 +381,7 @@ Workflows that need to rerun periodically could naively be implemented as a big 
 logic of the workflow is inside the body of the for loop. The problem with this approach is that the history for that
 workflow will keep growing to a point where it reaches the maximum size enforced by the service.
 
-[ContinueAsNew] is the low level construct that enables implementing such workflows without the risk of failures down the
+ContinueAsNew is the low level construct that enables implementing such workflows without the risk of failures down the
 road. The operation atomically completes the current execution and starts a new execution of the workflow with the same
 workflow ID. The new execution will not carry over any history from the old execution. To trigger this behavior, the
 workflow function should terminate by returning the special ContinueAsNewError error:
@@ -552,9 +552,9 @@ The code below implements the unit tests for the SimpleWorkflow sample.
 
 First, we define a "test suite" struct that absorbs both the basic suite functionality from [testify]
 via suite.Suite and the suite functionality from the Temporal test
-framework via [testsuite.WorkflowTestSuite]. Since every test in this suite will test our workflow we add a property to
+framework via [github.com/temporalio/sdk-go/testsuite.WorkflowTestSuite]. Since every test in this suite will test our workflow we add a property to
 our struct to hold an instance of the test environment. This will allow us to initialize the test environment in a
-setup method. For testing workflows we use a [testsuite.TestWorkflowEnvironment].
+setup method. For testing workflows we use a [github.com/temporalio/sdk-go/testsuite.TestWorkflowEnvironment].
 
 We then implement a SetupTest method to setup a new test environment before each test. Doing so ensure that each test
 runs in it's own isolated sandbox. We also implement an AfterTest function where we assert that all mocks we setup were

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -144,7 +144,7 @@ type (
 	// NOTE: Experimental
 	NexusOperationFuture = internal.NexusOperationFuture
 
-	// NexusOperationExecution is the result of [NexusOperationFuture.GetNexusOperationExecution].
+	// NexusOperationExecution is the result of [internal.NexusOperationFuture.GetNexusOperationExecution].
 	//
 	// NOTE: Experimental
 	NexusOperationExecution = internal.NexusOperationExecution


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->
Fixed all of the broken links that wouldn't generate on https://pkg.go.dev/go.temporal.io/sdk

## Why?
<!-- Tell your future self why have you made these changes -->
Most of the links I changed are actually correct, there is a bug that's been around for over 2 years in go/doc https://github.com/golang/go/issues/54033. Current workaround solution is quite verbose, but i think it's better to have proper links. We can easily revert back when this issue is fixed. (There were a few incorrect links I fixed)

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here --> #1756 

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Built docs locally with `pkgsite -http=:6060` and verified broken links are fixed.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
