### PR TITLE
[Nexus] Set OnConflictOptions for WorkflowRunOperation

### DIFF
--- a/internal/client.go
+++ b/internal/client.go
@@ -1208,9 +1208,6 @@ func SetLinksOnStartWorkflowOptions(opts *StartWorkflowOptions, links []*commonp
 // options on StartWorkflowOptions.
 // OnConflictOptions are purposefully not exposed to users for the time being.
 func SetOnConflictOptionsOnStartWorkflowOptions(opts *StartWorkflowOptions) {
-	if opts.WorkflowIDConflictPolicy == enumspb.WORKFLOW_ID_CONFLICT_POLICY_UNSPECIFIED {
-		opts.WorkflowIDConflictPolicy = enumspb.WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING
-	}
 	opts.onConflictOptions = &OnConflictOptions{
 		AttachRequestID:           true,
 		AttachCompletionCallbacks: true,

--- a/internal/client.go
+++ b/internal/client.go
@@ -647,8 +647,11 @@ type (
 		// When WorkflowExecutionErrorWhenAlreadyStarted is true, Client.ExecuteWorkflow will return an error if the
 		// workflow id has already been used and WorkflowIDReusePolicy or WorkflowIDConflictPolicy would
 		// disallow a re-run. If it is set to false, rather than erroring a WorkflowRun instance representing
-		// the current or last run will be returned. However, when WithStartOperation is set, this field is ignored and
-		// the WorkflowIDConflictPolicy UseExisting must be used instead to prevent erroring.
+		// the current or last run will be returned. However, this field is ignored in the following cases:
+		// - when WithStartOperation is set;
+		// - in the Nexus WorkflowRunOperation.
+		// When this field is ignored, you must set WorkflowIDConflictPolicy to UseExisting to prevent
+		// erroring.
 		//
 		// Optional: defaults to false
 		WorkflowExecutionErrorWhenAlreadyStarted bool

--- a/internal/client.go
+++ b/internal/client.go
@@ -742,6 +742,14 @@ type (
 		callbacks []*commonpb.Callback
 		// links. Only settable by the SDK - e.g. [temporalnexus.workflowRunOperation].
 		links []*commonpb.Link
+
+		// OnConflictOptions - Optional workflow ID conflict options used in conjunction with conflict policy
+		// WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING. If onConflictOptions is set and a workflow is already
+		// running, the options specifies the actions to be taken on the running workflow. If not set or use
+		// together with any other WorkflowIDConflictPolicy, this parameter is ignored.
+		//
+		// NOTE: Only settable by the SDK -- e.g. [temporalnexus.workflowRunOperation].
+		onConflictOptions *OnConflictOptions
 	}
 
 	// WithStartWorkflowOperation defines how to start a workflow when using UpdateWithStartWorkflow.
@@ -1194,4 +1202,18 @@ func SetCallbacksOnStartWorkflowOptions(opts *StartWorkflowOptions, callbacks []
 // Links are purposefully not exposed to users for the time being.
 func SetLinksOnStartWorkflowOptions(opts *StartWorkflowOptions, links []*commonpb.Link) {
 	opts.links = links
+}
+
+// SetOnConflictOptionsOnStartWorkflowOptions is an internal only method for setting conflict
+// options on StartWorkflowOptions.
+// OnConflictOptions are purposefully not exposed to users for the time being.
+func SetOnConflictOptionsOnStartWorkflowOptions(opts *StartWorkflowOptions) {
+	if opts.WorkflowIDConflictPolicy == enumspb.WORKFLOW_ID_CONFLICT_POLICY_UNSPECIFIED {
+		opts.WorkflowIDConflictPolicy = enumspb.WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING
+	}
+	opts.onConflictOptions = &OnConflictOptions{
+		AttachRequestID:           true,
+		AttachCompletionCallbacks: true,
+		AttachLinks:               true,
+	}
 }

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -1678,6 +1678,7 @@ func (w *workflowClientInterceptor) createStartWorkflowRequest(
 		CompletionCallbacks:      in.Options.callbacks,
 		Links:                    in.Options.links,
 		VersioningOverride:       versioningOverrideToProto(in.Options.VersioningOverride),
+		OnConflictOptions:        onConflictOptionsToProto(in.Options.onConflictOptions),
 	}
 
 	startRequest.UserMetadata, err = buildUserMetadata(in.Options.StaticSummary, in.Options.StaticDetails, dataConverter)

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -1678,7 +1678,7 @@ func (w *workflowClientInterceptor) createStartWorkflowRequest(
 		CompletionCallbacks:      in.Options.callbacks,
 		Links:                    in.Options.links,
 		VersioningOverride:       versioningOverrideToProto(in.Options.VersioningOverride),
-		OnConflictOptions:        onConflictOptionsToProto(in.Options.onConflictOptions),
+		OnConflictOptions:        in.Options.onConflictOptions.ToProto(),
 	}
 
 	startRequest.UserMetadata, err = buildUserMetadata(in.Options.StaticSummary, in.Options.StaticDetails, dataConverter)

--- a/internal/internal_workflow_execution_options.go
+++ b/internal/internal_workflow_execution_options.go
@@ -164,17 +164,6 @@ func versioningOverrideFromProto(versioningOverride *workflowpb.VersioningOverri
 	}
 }
 
-func onConflictOptionsToProto(onConflictOptions *OnConflictOptions) *workflowpb.OnConflictOptions {
-	if onConflictOptions == nil {
-		return nil
-	}
-	return &workflowpb.OnConflictOptions{
-		AttachRequestId:           onConflictOptions.AttachRequestID,
-		AttachCompletionCallbacks: onConflictOptions.AttachCompletionCallbacks,
-		AttachLinks:               onConflictOptions.AttachLinks,
-	}
-}
-
 func workflowExecutionOptionsToProto(options WorkflowExecutionOptions) *workflowpb.WorkflowExecutionOptions {
 	return &workflowpb.WorkflowExecutionOptions{
 		VersioningOverride: versioningOverrideToProto(options.VersioningOverride),
@@ -229,4 +218,15 @@ func (r *UpdateWorkflowExecutionOptionsRequest) validateAndConvertToProto(namesp
 	}
 
 	return requestMsg, nil
+}
+
+func (o *OnConflictOptions) ToProto() *workflowpb.OnConflictOptions {
+	if o == nil {
+		return nil
+	}
+	return &workflowpb.OnConflictOptions{
+		AttachRequestId:           o.AttachRequestID,
+		AttachCompletionCallbacks: o.AttachCompletionCallbacks,
+		AttachLinks:               o.AttachLinks,
+	}
 }

--- a/internal/internal_workflow_execution_options.go
+++ b/internal/internal_workflow_execution_options.go
@@ -81,6 +81,16 @@ type (
 		// Required if behavior is [VersioningBehaviorPinned]. Must be absent if behavior is not [VersioningBehaviorPinned].
 		PinnedVersion string
 	}
+
+	// OnConflictOptions specifies the actions to be taken when using the workflow ID conflict policy
+	// USE_EXISTING.
+	//
+	// NOTE: Experimental
+	OnConflictOptions struct {
+		AttachRequestID           bool
+		AttachCompletionCallbacks bool
+		AttachLinks               bool
+	}
 )
 
 // Mapping WorkflowExecutionOptions field names to proto ones.
@@ -151,6 +161,17 @@ func versioningOverrideFromProto(versioningOverride *workflowpb.VersioningOverri
 			BuildID: versioningOverride.GetDeployment().GetBuildId(),
 		},
 		PinnedVersion: versioningOverride.GetPinnedVersion(),
+	}
+}
+
+func onConflictOptionsToProto(onConflictOptions *OnConflictOptions) *workflowpb.OnConflictOptions {
+	if onConflictOptions == nil {
+		return nil
+	}
+	return &workflowpb.OnConflictOptions{
+		AttachRequestId:           onConflictOptions.AttachRequestID,
+		AttachCompletionCallbacks: onConflictOptions.AttachCompletionCallbacks,
+		AttachLinks:               onConflictOptions.AttachLinks,
 	}
 }
 

--- a/temporalnexus/operation.go
+++ b/temporalnexus/operation.go
@@ -382,6 +382,7 @@ func ExecuteUntypedWorkflow[R any](
 		}
 	}
 	internal.SetLinksOnStartWorkflowOptions(&startWorkflowOptions, links)
+	internal.SetOnConflictOptionsOnStartWorkflowOptions(&startWorkflowOptions)
 
 	run, err := GetClient(ctx).ExecuteWorkflow(ctx, startWorkflowOptions, workflowType, args...)
 	if err != nil {

--- a/temporalnexus/operation.go
+++ b/temporalnexus/operation.go
@@ -119,6 +119,11 @@ type WorkflowRunOperationOptions[I, O any] struct {
 	// The options returned must include a workflow ID that is deterministically generated from the input in order
 	// for the operation to be idempotent as the request to start the operation may be retried.
 	// TaskQueue is optional and defaults to the current worker's task queue.
+	// WorkflowExecutionErrorWhenAlreadyStarted is ignored and always set to true.
+	// WorkflowIDConflictPolicy is by default set to fail if a workflow is already running. That is,
+	// if a caller executes another operation that starts the same workflow, it will fail. You can set
+	// it to WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING to attach the caller's callback to the existing
+	// running workflow. This way, all attached callers will be notified when the workflow completes.
 	GetOptions func(context.Context, I, nexus.StartOperationOptions) (client.StartWorkflowOptions, error)
 	// Handler for starting a workflow with a different input than the operation. Mutually exclusive with Workflow
 	// and GetOptions.
@@ -383,6 +388,12 @@ func ExecuteUntypedWorkflow[R any](
 	}
 	internal.SetLinksOnStartWorkflowOptions(&startWorkflowOptions, links)
 	internal.SetOnConflictOptionsOnStartWorkflowOptions(&startWorkflowOptions)
+
+	// This makes sure that ExecuteWorkflow will respect the WorkflowIDConflictPolicy, ie., if the
+	// conflict policy is to fail (default value), then ExecuteWorkflow will return an error if the
+	// workflow already running. For Nexus, this ensures that operation has only started successfully
+	// when the callback has been attached to the workflow (new or existing running workflow).
+	startWorkflowOptions.WorkflowExecutionErrorWhenAlreadyStarted = true
 
 	run, err := GetClient(ctx).ExecuteWorkflow(ctx, startWorkflowOptions, workflowType, args...)
 	if err != nil {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Add `OnConflictOptions` to `StartWorkflowOptions`, and set it for Nexus `WorkflowRunOperation`.

Tests are done in https://github.com/temporalio/sdk-go/pull/1828

## Why?
<!-- Tell your future self why have you made these changes -->
Enabling attaching callbacks to running Nexus workflows.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
