### PR TITLE
Expand arguments in UpdateWorkflow call when args equal one

### DIFF
--- a/internal/workflow_testsuite.go
+++ b/internal/workflow_testsuite.go
@@ -1133,7 +1133,12 @@ func (e *TestWorkflowEnvironment) UpdateWorkflowNoRejection(updateName string, u
 		OnAccept:   func() {},
 		OnComplete: func(interface{}, error) {},
 	}
-	e.UpdateWorkflow(updateName, updateID, uc, args)
+
+	if len(args) == 1 {
+		e.UpdateWorkflow(updateName, updateID, uc, args...)
+	} else {
+		e.UpdateWorkflow(updateName, updateID, uc, args)
+	}
 }
 
 // QueryWorkflowByID queries a child workflow by its ID and returns the result synchronously

--- a/internal/workflow_testsuite.go
+++ b/internal/workflow_testsuite.go
@@ -1134,11 +1134,7 @@ func (e *TestWorkflowEnvironment) UpdateWorkflowNoRejection(updateName string, u
 		OnComplete: func(interface{}, error) {},
 	}
 
-	if len(args) == 1 {
-		e.UpdateWorkflow(updateName, updateID, uc, args...)
-	} else {
-		e.UpdateWorkflow(updateName, updateID, uc, args)
-	}
+	e.UpdateWorkflow(updateName, updateID, uc, args...)
 }
 
 // QueryWorkflowByID queries a child workflow by its ID and returns the result synchronously

--- a/internal/workflow_testsuite_test.go
+++ b/internal/workflow_testsuite_test.go
@@ -441,14 +441,15 @@ func TestWorkflowUpdateOrderWithMultiArgs(t *testing.T) {
 	env.ExecuteWorkflow(func(ctx Context) (int, error) {
 		var inflightUpdates int
 		var ranUpdates int
-		err := SetUpdateHandler(ctx, "update", func(ctx Context, args []string) error {
+		err := SetUpdateHandler(ctx, "update", func(ctx Context, args1, args2 string) error {
 			inflightUpdates++
 			ranUpdates++
 			defer func() {
 				inflightUpdates--
 			}()
 
-			require.Equal(t, args, []string{"args1", "args2"})
+			require.Equal(t, args1, "args1")
+			require.Equal(t, args2, "args2")
 
 			return Sleep(ctx, time.Hour)
 		}, UpdateHandlerOptions{})

--- a/internal/workflow_testsuite_test.go
+++ b/internal/workflow_testsuite_test.go
@@ -401,7 +401,7 @@ func TestWorkflowUpdateOrderWithOneArg(t *testing.T) {
 	env := suite.NewTestWorkflowEnvironment()
 	env.RegisterDelayedCallback(func() {
 		env.UpdateWorkflowNoRejection("update", "id", t, "args")
-	}, 0*time.Second)
+	}, 0)
 
 	env.ExecuteWorkflow(func(ctx Context) (int, error) {
 		var inflightUpdates int


### PR DESCRIPTION
## What was changed
Ensure UpdateWorkflowNoRejection is correctly triggered with one or variadic arguments.

## Why?
It's a bug in unit test.

## Checklist
1. Closes
2. How was this tested
3. Any docs updates needed?
