### PR TITLE
Reserve "__temporal_" prefix 

### DIFF
--- a/internal/internal_utils.go
+++ b/internal/internal_utils.go
@@ -52,6 +52,9 @@ const (
 	minRPCTimeout = 1 * time.Second
 	// maxRPCTimeout is maximum gRPC call timeout allowed (should not be less than defaultRPCTimeout).
 	maxRPCTimeout = 10 * time.Second
+
+	temporalPrefix      = "__temporal_"
+	temporalPrefixError = "__temporal_ is a reserved prefix"
 )
 
 // grpcContextBuilder stores all gRPC-specific parameters that will

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -567,6 +567,9 @@ func (r *registry) RegisterWorkflowWithOptions(
 		if len(options.Name) == 0 {
 			panic("WorkflowDefinitionFactory must be registered with a name")
 		}
+		if strings.HasPrefix(options.Name, temporalPrefix) {
+			panic(temporalPrefixError)
+		}
 		r.workflowFuncMap[options.Name] = factory
 		r.workflowVersioningBehaviorMap[options.Name] = options.VersioningBehavior
 		return
@@ -581,6 +584,10 @@ func (r *registry) RegisterWorkflowWithOptions(
 	registerName := fnName
 	if len(alias) > 0 {
 		registerName = alias
+	}
+
+	if strings.HasPrefix(alias, temporalPrefix) || strings.HasPrefix(registerName, temporalPrefix) {
+		panic(temporalPrefixError)
 	}
 
 	r.Lock()
@@ -613,6 +620,9 @@ func (r *registry) RegisterActivityWithOptions(
 		if options.Name == "" {
 			panic("registration of activity interface requires name")
 		}
+		if strings.HasPrefix(options.Name, temporalPrefix) {
+			panic(temporalPrefixError)
+		}
 		r.addActivityWithLock(options.Name, a)
 		return
 	}
@@ -633,6 +643,10 @@ func (r *registry) RegisterActivityWithOptions(
 	registerName := fnName
 	if len(alias) > 0 {
 		registerName = alias
+	}
+
+	if strings.HasPrefix(alias, temporalPrefix) || strings.HasPrefix(registerName, temporalPrefix) {
+		panic(temporalPrefixError)
 	}
 
 	r.Lock()
@@ -1659,6 +1673,9 @@ func extractHistoryFromFile(jsonfileName string, lastEventID int64) (hist *histo
 
 // NewAggregatedWorker returns an instance to manage both activity and workflow workers
 func NewAggregatedWorker(client *WorkflowClient, taskQueue string, options WorkerOptions) *AggregatedWorker {
+	if strings.HasPrefix(taskQueue, temporalPrefix) {
+		panic(temporalPrefixError)
+	}
 	setClientDefaults(client)
 	setWorkerOptionsDefaults(&options)
 	ctx := options.BackgroundActivityContext

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -1897,6 +1897,9 @@ func (wc *workflowEnvironmentInterceptor) GetSignalChannelWithOptions(
 	signalName string,
 	options SignalChannelOptions,
 ) ReceiveChannel {
+	if strings.HasPrefix(signalName, temporalPrefix) {
+		panic(temporalPrefixError)
+	}
 	eo := getWorkflowEnvOptions(ctx)
 	ch := eo.getSignalChannel(ctx, signalName)
 	// Add as a requested channel if not already done
@@ -2619,6 +2622,12 @@ func NewNexusClient(endpoint, service string) NexusClient {
 	}
 	if service == "" {
 		panic("service must not be empty")
+	}
+	if strings.HasPrefix(endpoint, temporalPrefix) {
+		panic("endpoint cannot use reserved __temporal_ prefix")
+	}
+	if strings.HasPrefix(service, temporalPrefix) {
+		panic("service cannot use reserved __temporal_ prefix")
 	}
 	return nexusClient{endpoint, service}
 }

--- a/temporalnexus/operation.go
+++ b/temporalnexus/operation.go
@@ -41,6 +41,7 @@ package temporalnexus
 import (
 	"context"
 	"errors"
+	"strings"
 
 	"github.com/nexus-rpc/sdk-go/nexus"
 	"go.temporal.io/api/common/v1"
@@ -87,6 +88,9 @@ func NewSyncOperation[I any, O any](
 	name string,
 	handler func(context.Context, client.Client, I, nexus.StartOperationOptions) (O, error),
 ) nexus.Operation[I, O] {
+	if strings.HasPrefix(name, "__temporal_") {
+		panic(errors.New("temporalnexus NewSyncOperation __temporal_ is an reserved prefix"))
+	}
 	return &syncOperation[I, O]{
 		name:    name,
 		handler: handler,
@@ -184,6 +188,9 @@ func NewWorkflowRunOperation[I, O any](
 	workflow func(workflow.Context, I) (O, error),
 	getOptions func(context.Context, I, nexus.StartOperationOptions) (client.StartWorkflowOptions, error),
 ) nexus.Operation[I, O] {
+	if strings.HasPrefix(name, "__temporal_") {
+		panic(errors.New("temporalnexus NewWorkflowRunOperation __temporal_ is an invalid name"))
+	}
 	return &workflowRunOperation[I, O]{
 		options: WorkflowRunOperationOptions[I, O]{
 			Name:       name,
@@ -200,6 +207,9 @@ func NewWorkflowRunOperation[I, O any](
 func NewWorkflowRunOperationWithOptions[I, O any](options WorkflowRunOperationOptions[I, O]) (nexus.Operation[I, O], error) {
 	if options.Name == "" {
 		return nil, errors.New("invalid options: Name is required")
+	}
+	if strings.HasPrefix(options.Name, "__temporal_") {
+		return nil, errors.New("invalid options: __temporal_ is a reserved prefix")
 	}
 	if options.Workflow == nil && options.GetOptions == nil && options.Handler == nil {
 		return nil, errors.New("invalid options: either GetOptions and Workflow, or Handler are required")

--- a/temporalnexus/operation_test.go
+++ b/temporalnexus/operation_test.go
@@ -43,6 +43,11 @@ func TestNewWorkflowRunOperationWithOptions(t *testing.T) {
 	require.ErrorContains(t, err, "either GetOptions and Workflow, or Handler are required")
 
 	_, err = temporalnexus.NewWorkflowRunOperationWithOptions(temporalnexus.WorkflowRunOperationOptions[string, string]{
+		Name: "__temporal_test",
+	})
+	require.ErrorContains(t, err, "__temporal_ is a reserved prefix")
+
+	_, err = temporalnexus.NewWorkflowRunOperationWithOptions(temporalnexus.WorkflowRunOperationOptions[string, string]{
 		Name: "test",
 		Workflow: func(workflow.Context, string) (string, error) {
 			return "", nil

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -7024,3 +7024,17 @@ func (c *coroutineCountingWorkflowOutboundInterceptor) Go(
 		f(ctx)
 	})
 }
+
+func (ts *IntegrationTestSuite) TestTemporalPrefixSignal() {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	options := ts.startWorkflowOptions("test-temporal-prefix")
+	run, err := ts.client.ExecuteWorkflow(ctx, options, ts.workflows.WorkflowTemporalPrefixSignal)
+	ts.NoError(err)
+
+	err = ts.client.SignalWorkflow(ctx, run.GetID(), "", "__temporal_signal", nil)
+	ts.NoError(err)
+
+	err = run.Get(ctx, nil)
+	ts.Error(err)
+}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -7032,9 +7032,7 @@ func (ts *IntegrationTestSuite) TestTemporalPrefixSignal() {
 	run, err := ts.client.ExecuteWorkflow(ctx, options, ts.workflows.WorkflowTemporalPrefixSignal)
 	ts.NoError(err)
 
-	err = ts.client.SignalWorkflow(ctx, run.GetID(), "", "__temporal_signal", nil)
-	ts.NoError(err)
-
+	// Trying to GetSignalChannel with a __temporal_ prefixed name should return an error
 	err = run.Get(ctx, nil)
 	ts.Error(err)
 }

--- a/test/workflow_test.go
+++ b/test/workflow_test.go
@@ -3296,6 +3296,11 @@ func (w *Workflows) WorkflowClientFromActivity(ctx workflow.Context) error {
 	return workflow.ExecuteLocalActivity(ctx, activities.ClientFromActivity).Get(ctx, nil)
 }
 
+func (w *Workflows) WorkflowTemporalPrefixSignal(ctx workflow.Context) error {
+	_ = workflow.GetSignalChannel(ctx, "__temporal_signal").Receive(ctx, nil)
+	return nil
+}
+
 func (w *Workflows) register(worker worker.Worker) {
 	worker.RegisterWorkflow(w.ActivityCancelRepro)
 	worker.RegisterWorkflow(w.ActivityCompletionUsingID)
@@ -3435,6 +3440,7 @@ func (w *Workflows) register(worker worker.Worker) {
 	worker.RegisterWorkflow(w.RunsLocalAndNonlocalActsWithRetries)
 	worker.RegisterWorkflow(w.SelectorBlockSignal)
 	worker.RegisterWorkflow(w.WorkflowClientFromActivity)
+	worker.RegisterWorkflow(w.WorkflowTemporalPrefixSignal)
 }
 
 func (w *Workflows) defaultActivityOptions() workflow.ActivityOptions {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Prevent users from using `__temporal_` across workflows, activities, nexus operations/services, and signals.

Queries and updates already reserve the `__` prefix 

## Why?
<!-- Tell your future self why have you made these changes -->
We want to reserve a prefix to throw any special behavior under.

## Checklist
<!--- add/delete as needed ---> 

1. Closes <!-- add issue number here --> #1779 

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Added tests

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
