### PR TITLE
SetStickyWorkflowCacheSize for all testsuites

### DIFF
--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -225,8 +225,6 @@ func (ts *IntegrationTestSuite) SetupTest() {
 		WorkflowPanicPolicy: panicPolicy,
 	}
 
-	worker.SetStickyWorkflowCacheSize(ts.config.maxWorkflowCacheSize)
-
 	if strings.Contains(ts.T().Name(), "Session") {
 		options.EnableSessionWorker = true
 		// Limit the session execution size
@@ -2896,35 +2894,26 @@ func (ts *IntegrationTestSuite) waitForQueryTrue(run client.WorkflowRun, query s
 	ts.True(result, "query didn't return true in reasonable amount of time")
 }
 
-//func (ts *IntegrationTestSuite) TestNumPollersCounter() {
-//	_, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-//	defer cancel()
-//	assertNumPollersEventually := func(expected float64, pollerType string, tags ...string) {
-//		// Try for two seconds
-//		var lastCount float64
-//		for start := time.Now(); time.Since(start) <= 10*time.Second; {
-//			lastCount = ts.metricGauge(
-//				metrics.NumPoller,
-//				"poller_type", pollerType,
-//				"task_queue", ts.taskQueueName,
-//			)
-//			if lastCount == expected {
-//				return
-//			}
-//			time.Sleep(50 * time.Millisecond)
-//		}
-//		// Will fail
-//		ts.Equal(expected, lastCount)
-//	}
-//	if ts.config.maxWorkflowCacheSize == 0 {
-//		assertNumPollersEventually(2, "workflow_task")
-//		assertNumPollersEventually(0, "workflow_sticky_task")
-//	} else {
-//		assertNumPollersEventually(1, "workflow_task")
-//		assertNumPollersEventually(1, "workflow_sticky_task")
-//	}
-//	assertNumPollersEventually(2, "activity_task")
-//}
+func (ts *IntegrationTestSuite) TestNumPollersCounter() {
+	assertNumPollersEventually := func(expected float64, pollerType string) {
+		ts.Require().EventuallyWithT(func(t *assert.CollectT) {
+			lastCount := ts.metricGauge(
+				metrics.NumPoller,
+				"poller_type", pollerType,
+				"task_queue", ts.taskQueueName,
+			)
+			assert.Equal(t, expected, lastCount)
+		}, 10*time.Second, 50*time.Millisecond)
+	}
+	if ts.config.maxWorkflowCacheSize == 0 {
+		assertNumPollersEventually(2, "workflow_task")
+		assertNumPollersEventually(0, "workflow_sticky_task")
+	} else {
+		assertNumPollersEventually(1, "workflow_task")
+		assertNumPollersEventually(1, "workflow_sticky_task")
+	}
+	assertNumPollersEventually(2, "activity_task")
+}
 
 func (ts *IntegrationTestSuite) TestSlotsAvailableCounter() {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/test/test_utils_test.go
+++ b/test/test_utils_test.go
@@ -28,6 +28,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"go.temporal.io/sdk/worker"
 	"log"
 	"net"
 	"os"
@@ -92,6 +93,7 @@ func NewConfig() Config {
 		}
 		cfg.maxWorkflowCacheSize = asInt
 	}
+	worker.SetStickyWorkflowCacheSize(cfg.maxWorkflowCacheSize)
 	if debug := getDebug(); debug != "" {
 		cfg.Debug = debug == "true"
 	}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Moved `SetStickyWorkflowCacheSize` from `IntegrationTestSuite` to a more global spot, so all test suites set this config. 

## Why?
<!-- Tell your future self why have you made these changes -->
test suites in the same package are run in the same process, so a test suite that wasn't setting this cache size was causing the cache size in `IntegrationTestSuite` to be incorrect.

Still not exactly sure why this was suddenly hit with 1.24, maybe optimizations highlighted existing race condition between cleanup of one testsuite and the starting of the next testsuite.

## Checklist
<!--- add/delete as needed --->

1. Closes #1827

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
