### PR TITLE
Block using conflict policy UseExisting for Nexus WorkflowRunOperation

### DIFF
--- a/temporalnexus/operation.go
+++ b/temporalnexus/operation.go
@@ -53,8 +53,6 @@ import (
 	"go.temporal.io/sdk/workflow"
 )
 
-var errConflictPolicyUseExistingNotSupported = errors.New("workflow ID conflict policy UseExisting is not supported for Nexus WorkflowRunOperation")
-
 // GetMetricsHandler returns a metrics handler to be used in a Nexus operation's context.
 func GetMetricsHandler(ctx context.Context) metrics.Handler {
 	return internal.GetNexusOperationMetricsHandler(ctx)
@@ -396,7 +394,7 @@ func ExecuteUntypedWorkflow[R any](
 		return nil, &nexus.HandlerError{
 			Type:          nexus.HandlerErrorTypeInternal,
 			RetryBehavior: nexus.HandlerErrorRetryBehaviorNonRetryable,
-			Cause:         errConflictPolicyUseExistingNotSupported,
+			Cause:         errors.New("workflow ID conflict policy UseExisting is not supported for Nexus WorkflowRunOperation"),
 		}
 	}
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Block using conflict policy `UseExisting` for Nexus `WorkflowRunOperation`.
Returning a non-retryable internal error at this moment.

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
