### PR TITLE
Update documentation for `Next` history iterator

### DIFF
--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -1454,7 +1454,7 @@ func (iter *historyEventIteratorImpl) HasNext() bool {
 func (iter *historyEventIteratorImpl) Next() (*historypb.HistoryEvent, error) {
 	// if caller call the Next() when iteration is over, just return nil, nil
 	if !iter.HasNext() {
-		panic("HistoryEventIterator Next() called without checking HasNext()")
+		return nil, nil
 	}
 
 	// we have cached events

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -1451,10 +1451,12 @@ func (iter *historyEventIteratorImpl) HasNext() bool {
 	return false
 }
 
+// Next returns the next history event.
+// If next is called with not more events, it will panic.
+// Call [historyEventIteratorImpl.HasNext] to check if there are more events.
 func (iter *historyEventIteratorImpl) Next() (*historypb.HistoryEvent, error) {
-	// if caller call the Next() when iteration is over, just return nil, nil
 	if !iter.HasNext() {
-		return nil, nil
+		panic("HistoryEventIterator Next() called without checking HasNext()")
 	}
 
 	// we have cached events

--- a/internal/internal_workflow_client_test.go
+++ b/internal/internal_workflow_client_test.go
@@ -286,6 +286,27 @@ func (s *historyEventIteratorSuite) TestIterator_NoError_EmptyPage() {
 	s.Equal(2, len(events))
 }
 
+func (s *historyEventIteratorSuite) TestIterator_NoError_EmptyPageNoHasHasNext() {
+	filterType := enumspb.HISTORY_EVENT_FILTER_TYPE_ALL_EVENT
+	request := getGetWorkflowExecutionHistoryRequest(filterType)
+	response := &workflowservice.GetWorkflowExecutionHistoryResponse{
+		History: &historypb.History{
+			Events: []*historypb.HistoryEvent{},
+		},
+		NextPageToken: nil,
+	}
+
+	s.workflowServiceClient.EXPECT().GetWorkflowExecutionHistory(gomock.Any(), request, gomock.Any()).Return(response, nil).Times(1)
+
+	times := 0
+	iter := s.wfClient.GetWorkflowHistory(context.Background(), workflowID, runID, true, enumspb.HISTORY_EVENT_FILTER_TYPE_ALL_EVENT)
+	for event, err := iter.Next(); event != nil; event, err = iter.Next() {
+		s.Nil(err)
+		s.Nil(event)
+	}
+	s.Equal(times, 0)
+}
+
 func (s *historyEventIteratorSuite) TestIteratorError() {
 	filterType := enumspb.HISTORY_EVENT_FILTER_TYPE_ALL_EVENT
 	request1 := getGetWorkflowExecutionHistoryRequest(filterType)

--- a/internal/internal_workflow_client_test.go
+++ b/internal/internal_workflow_client_test.go
@@ -295,16 +295,19 @@ func (s *historyEventIteratorSuite) TestIterator_NoError_EmptyPageNoHasHasNext()
 		},
 		NextPageToken: nil,
 	}
+	defer func() {
+		if r := recover(); r == nil {
+			s.Fail("expected panic")
+		} else {
+			s.Equal("HistoryEventIterator Next() called without checking HasNext()", r)
+		}
+	}()
 
 	s.workflowServiceClient.EXPECT().GetWorkflowExecutionHistory(gomock.Any(), request, gomock.Any()).Return(response, nil).Times(1)
 
-	times := 0
-	iter := s.wfClient.GetWorkflowHistory(context.Background(), workflowID, runID, true, enumspb.HISTORY_EVENT_FILTER_TYPE_ALL_EVENT)
-	for event, err := iter.Next(); event != nil; event, err = iter.Next() {
-		s.Nil(err)
-		s.Nil(event)
-	}
-	s.Equal(times, 0)
+	iter := s.wfClient.GetWorkflowHistory(context.Background(), workflowID, runID, true, filterType)
+	s.False(iter.HasNext())
+	_, _ = iter.Next()
 }
 
 func (s *historyEventIteratorSuite) TestIteratorError() {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
This change:
- Removes comment that contradicts behavior
- Add documentation comment to make the functions behavior and dependency to `HasNext` clear.
- Adds test to ensure that and breaking changes to this behavior is caught

## Why?
<!-- Tell your future self why have you made these changes -->
While I was exploring the documentation for the get history calls at work, I was trying to figure out what happens with the iterator if `HasNext()` is false but the `Next()` function was called, and I noticed that there was this line where the comment contradicted it.

## Checklist
<!--- add/delete as needed --->

1. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Added unit test.

2. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
I don't think so
