### PR TITLE
Add assertions for labels on Nexus metrics and logs

### DIFF
--- a/internal/log/memory_logger.go
+++ b/internal/log/memory_logger.go
@@ -82,7 +82,9 @@ func (l *MemoryLoggerWithoutWith) Error(msg string, keyvals ...interface{}) {
 func (l *MemoryLoggerWithoutWith) Lines() []string {
 	l.lock.RLock()
 	defer l.lock.RUnlock()
-	return *l.lines
+	ret := make([]string, len(*l.lines))
+	copy(ret, *l.lines)
+	return ret
 }
 
 type MemoryLogger struct {

--- a/internal/log/memory_logger.go
+++ b/internal/log/memory_logger.go
@@ -27,12 +27,14 @@ package log
 import (
 	"fmt"
 	"strings"
+	"sync"
 
 	"go.temporal.io/sdk/log"
 )
 
 // MemoryLoggerWithoutWith is a Logger implementation that stores logs in memory (useful for testing). Use Lines() to get log lines.
 type MemoryLoggerWithoutWith struct {
+	lock          sync.RWMutex
 	lines         *[]string
 	globalKeyvals string
 }
@@ -46,6 +48,8 @@ func NewMemoryLoggerWithoutWith() *MemoryLoggerWithoutWith {
 }
 
 func (l *MemoryLoggerWithoutWith) println(level, msg string, keyvals []interface{}) {
+	l.lock.Lock()
+	defer l.lock.Unlock()
 	// To avoid extra space when globalKeyvals is not specified.
 	if l.globalKeyvals == "" {
 		*l.lines = append(*l.lines, fmt.Sprintln(append([]interface{}{level, msg}, keyvals...)...))
@@ -76,6 +80,8 @@ func (l *MemoryLoggerWithoutWith) Error(msg string, keyvals ...interface{}) {
 
 // Lines returns written log lines.
 func (l *MemoryLoggerWithoutWith) Lines() []string {
+	l.lock.RLock()
+	defer l.lock.RUnlock()
 	return *l.lines
 }
 
@@ -92,6 +98,9 @@ func NewMemoryLogger() *MemoryLogger {
 
 // With returns new logger that prepend every log entry with keyvals.
 func (l *MemoryLogger) With(keyvals ...interface{}) log.Logger {
+	l.lock.RLock()
+	defer l.lock.RUnlock()
+
 	logger := &MemoryLoggerWithoutWith{
 		lines: l.lines,
 	}


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->
Added additional test assertions for labels on metrics and logs when using `temporalnexus.GetMetricsHandler` or `temporalnexus.GetLogger`

Closes https://github.com/temporalio/sdk-go/issues/1545
