### PR TITLE
Doc: Add clarity to WorkflowIDReuse/ConflictPolicy's dependence on WorkflowExecutionErrorWhenAlreadyStarted

### DIFF
--- a/internal/client.go
+++ b/internal/client.go
@@ -638,11 +638,15 @@ type (
 
 		// WorkflowIDReusePolicy - Specifies server behavior if a *completed* workflow with the same id exists.
 		// This can be useful for dedupe logic if set to RejectDuplicate
+		// NOTE: WorkflowExecutionErrorWhenAlreadyStarted will affect if Client.ExecuteWorkflow returns an error
+		// when a re-run would be disallowed. See its docstring for more information.
 		// Optional: defaulted to AllowDuplicate.
 		WorkflowIDReusePolicy enumspb.WorkflowIdReusePolicy
 
 		// WorkflowIDConflictPolicy - Specifies server behavior if a *running* workflow with the same id exists.
 		// This cannot be set if WorkflowIDReusePolicy is set to TerminateIfRunning.
+		// NOTE: WorkflowExecutionErrorWhenAlreadyStarted will affect if Client.ExecuteWorkflow returns an error
+		// when a re-run would be disallowed. See its docstring for more information.
 		// Optional: defaulted to Fail - required when used in WithStartWorkflowOperation.
 		WorkflowIDConflictPolicy enumspb.WorkflowIdConflictPolicy
 


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->
Make it more clear that WorkflowIDReuse/ConflictPolicy relies on WorkflowExecutionErrorWhenAlreadyStarted

## Why?
<!-- Tell your future self why have you made these changes -->
Clarity

## Checklist
<!--- add/delete as needed --->

1. Closes #1857

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
comment only change

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
