### PR TITLE
Doc: Add blank lines before "Optional", "default", and "note" lines for clarity

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -83,17 +83,20 @@ const (
 // WorkerDeploymentVersionDrainageStatus specifies the drainage status for a Worker
 // Deployment Version enabling users to decide when they can safely decommission this
 // Version.
+//
 // NOTE: Experimental
 type WorkerDeploymentVersionDrainageStatus = internal.WorkerDeploymentVersionDrainageStatus
 
 const (
 	// WorkerDeploymentVersionDrainageStatusUnspecified - Drainage status not specified.
+	//
 	// NOTE: Experimental
 	WorkerDeploymentVersionDrainageStatusUnspecified = internal.WorkerDeploymentVersionDrainageStatusUnspecified
 
 	// WorkerDeploymentVersionDrainageStatusDraining - The Worker Deployment Version is not
 	// used by new workflows, but it is still used by open pinned workflows.
 	// This Version cannot be decommissioned safely.
+	//
 	// NOTE: Experimental
 	WorkerDeploymentVersionDrainageStatusDraining = internal.WorkerDeploymentVersionDrainageStatusDraining
 
@@ -102,6 +105,7 @@ const (
 	// Queries sent to closed workflows. This Version can be decommissioned safely if the user
 	// does not expect to query closed workflows. In some cases this requires waiting for some
 	// time after it is drained to guarantee no pending queries.
+	//
 	// NOTE: Experimental
 	WorkerDeploymentVersionDrainageStatusDrained = internal.WorkerDeploymentVersionDrainageStatusDrained
 )
@@ -109,17 +113,20 @@ const (
 // WorkerVersioningMode specifies whether the workflows processed by this
 // worker use the worker's Version. The Temporal Server will use this worker's
 // choice when dispatching tasks to it.
+//
 // NOTE: Experimental
 type WorkerVersioningMode = internal.WorkerVersioningMode
 
 const (
 	// WorkerVersioningModeUnspecified - Versioning mode not reported.
+	//
 	// NOTE: Experimental
 	WorkerVersioningModeUnspecified = internal.WorkerVersioningModeUnspecified
 
 	// WorkerVersioningModeUnversioned - Workers with this mode are not
 	// distinguished from each other for task routing, even if they
 	// have different versions.
+	//
 	// NOTE: Experimental
 	WorkerVersioningModeUnversioned = internal.WorkerVersioningModeUnversioned
 
@@ -129,6 +136,7 @@ const (
 	// Each Deployment Version is distinguished from other Versions for task
 	// routing, and users can configure the Temporal Server to send tasks to a
 	// particular Version.
+	//
 	// NOTE: Experimental
 	WorkerVersioningModeVersioned = internal.WorkerVersioningModeVersioned
 )
@@ -169,6 +177,7 @@ const (
 )
 
 // BuildIDTaskReachability specifies which category of tasks may reach a versioned worker of a certain Build ID.
+//
 // NOTE: future activities who inherit their workflow's Build ID but not its task queue will not be
 // accounted for reachability as server cannot know if they'll happen as they do not use
 // assignment rules of their task queue. Same goes for Child Workflows or Continue-As-New Workflows
@@ -241,6 +250,7 @@ type (
 
 	// WithStartWorkflowOperation defines how to start a workflow when using UpdateWithStartWorkflow.
 	// See [client.Client.NewWithStartWorkflowOperation] and [client.Client.UpdateWithStartWorkflow].
+	//
 	// NOTE: Experimental
 	WithStartWorkflowOperation = internal.WithStartWorkflowOperation
 
@@ -352,124 +362,151 @@ type (
 
 	// UpdateWithStartWorkflowOptions encapsulates the parameters used by UpdateWithStartWorkflow.
 	// See [client.Client.UpdateWithStartWorkflow] and [client.Client.NewWithStartWorkflowOperation].
+	//
 	// NOTE: Experimental
 	UpdateWithStartWorkflowOptions = internal.UpdateWithStartWorkflowOptions
 
 	// WorkerDeploymentDescribeOptions provides options for [WorkerDeploymentHandle.Describe].
+	//
 	// NOTE: Experimental
 	WorkerDeploymentDescribeOptions = internal.WorkerDeploymentDescribeOptions
 
 	// WorkerDeploymentVersionSummary provides a brief description of a Version.
+	//
 	// NOTE: Experimental
 	WorkerDeploymentVersionSummary = internal.WorkerDeploymentVersionSummary
 
 	// WorkerDeploymentInfo provides information about a Worker Deployment.
+	//
 	// NOTE: Experimental
 	WorkerDeploymentInfo = internal.WorkerDeploymentInfo
 
 	// WorkerDeploymentDescribeResponse is the response type for [WorkerDeploymentHandle.Describe].
+	//
 	// NOTE: Experimental
 	WorkerDeploymentDescribeResponse = internal.WorkerDeploymentDescribeResponse
 
 	// WorkerDeploymentSetCurrentVersionOptions provides options for
 	// [WorkerDeploymentHandle.SetCurrentVersion].
+	//
 	// NOTE: Experimental
 	WorkerDeploymentSetCurrentVersionOptions = internal.WorkerDeploymentSetCurrentVersionOptions
 
 	// WorkerDeploymentSetCurrentVersionResponse is the response for
 	// [WorkerDeploymentHandle.SetCurrentVersion].
+	//
 	// NOTE: Experimental
 	WorkerDeploymentSetCurrentVersionResponse = internal.WorkerDeploymentSetCurrentVersionResponse
 
 	// WorkerDeploymentSetRampingVersionOptions provides options for
 	// [WorkerDeploymentHandle.SetRampingVersion].
+	//
 	// NOTE: Experimental
 	WorkerDeploymentSetRampingVersionOptions = internal.WorkerDeploymentSetRampingVersionOptions
 
 	// WorkerDeploymentSetRampingVersionResponse is the response for
 	// [WorkerDeploymentHandle.SetRampingVersion].
+	//
 	// NOTE: Experimental
 	WorkerDeploymentSetRampingVersionResponse = internal.WorkerDeploymentSetRampingVersionResponse
 
 	// WorkerDeploymentDescribeVersionOptions provides options for
 	// [WorkerDeploymentHandle.DescribeVersion].
+	//
 	// NOTE: Experimental
 	WorkerDeploymentDescribeVersionOptions = internal.WorkerDeploymentDescribeVersionOptions
 
 	// WorkerDeploymentTaskQueueInfo describes properties of the Task Queues involved
 	// in a Deployment Version.
+	//
 	// NOTE: Experimental
 	WorkerDeploymentTaskQueueInfo = internal.WorkerDeploymentTaskQueueInfo
 
 	// WorkerDeploymentVersionDrainageInfo describes drainage properties of a Deployment Version.
 	// This enables users to safely decide when they can decommission a Version.
+	//
 	// NOTE: Experimental
 	WorkerDeploymentVersionDrainageInfo = internal.WorkerDeploymentVersionDrainageInfo
 
 	// WorkerDeploymentVersionInfo provides information about a Worker Deployment Version.
+	//
 	// NOTE: Experimental
 	WorkerDeploymentVersionInfo = internal.WorkerDeploymentVersionInfo
 
 	// WorkerDeploymentVersionDescription is the response for
 	// [WorkerDeploymentHandle.DescribeVersion].
+	//
 	// NOTE: Experimental
 	WorkerDeploymentVersionDescription = internal.WorkerDeploymentVersionDescription
 
 	// WorkerDeploymentDeleteVersionOptions provides options for
 	// [WorkerDeploymentHandle.DeleteVersion].
+	//
 	// NOTE: Experimental
 	WorkerDeploymentDeleteVersionOptions = internal.WorkerDeploymentDeleteVersionOptions
 
 	// WorkerDeploymentDeleteVersionResponse is the response for
 	// [WorkerDeploymentHandle.DeleteVersion].
+	//
 	// NOTE: Experimental
 	WorkerDeploymentDeleteVersionResponse = internal.WorkerDeploymentDeleteVersionResponse
 
 	// WorkerDeploymentMetadataUpdate modifies user-defined metadata entries that describe
 	// a Version.
+	//
 	// NOTE: Experimental
 	WorkerDeploymentMetadataUpdate = internal.WorkerDeploymentMetadataUpdate
 
 	// WorkerDeploymentUpdateVersionMetadataOptions provides options for
 	// [WorkerDeploymentHandle.UpdateVersionMetadata].
+	//
 	// NOTE: Experimental
 	WorkerDeploymentUpdateVersionMetadataOptions = internal.WorkerDeploymentUpdateVersionMetadataOptions
 
 	// WorkerDeploymentUpdateVersionMetadataResponse is the response for
 	// [WorkerDeploymentHandle.UpdateVersionMetadata].
+	//
 	// NOTE: Experimental
 	WorkerDeploymentUpdateVersionMetadataResponse = internal.WorkerDeploymentUpdateVersionMetadataResponse
 
 	// WorkerDeploymentHandle is a handle to a Worker Deployment.
+	//
 	// NOTE: Experimental
 	WorkerDeploymentHandle = internal.WorkerDeploymentHandle
 
 	// DeploymentListOptions are the parameters for configuring listing Worker Deployments.
+	//
 	// NOTE: Experimental
 	WorkerDeploymentListOptions = internal.WorkerDeploymentListOptions
 
 	// WorkerDeploymentRoutingConfig describes when new or existing Workflow Tasks are
 	// executed with this Worker Deployment.
+	//
 	// NOTE: Experimental
 	WorkerDeploymentRoutingConfig = internal.WorkerDeploymentRoutingConfig
 
 	// WorkerDeploymentListEntry is a subset of fields from [WorkerDeploymentInfo].
+	//
 	// NOTE: Experimental
 	WorkerDeploymentListEntry = internal.WorkerDeploymentListEntry
 
 	// WorkerDeploymentListIterator is an iterator for deployments.
+	//
 	// NOTE: Experimental
 	WorkerDeploymentListIterator = internal.WorkerDeploymentListIterator
 
 	// WorkerDeploymentDeleteOptions provides options for [WorkerDeploymentClient.Delete].
+	//
 	// NOTE: Experimental
 	WorkerDeploymentDeleteOptions = internal.WorkerDeploymentDeleteOptions
 
 	// WorkerDeploymentDeleteResponse is the response for [WorkerDeploymentClient.Delete].
+	//
 	// NOTE: Experimental
 	WorkerDeploymentDeleteResponse = internal.WorkerDeploymentDeleteResponse
 
 	// WorkerDeploymentClient is the client that manages Worker Deployments.
+	//
 	// NOTE: Experimental
 	WorkerDeploymentClient = internal.WorkerDeploymentClient
 
@@ -560,16 +597,19 @@ type (
 	DeploymentClient = internal.DeploymentClient
 
 	// UpdateWorkflowExecutionOptionsRequest is a request for [client.Client.UpdateWorkflowExecutionOptions].
+	//
 	// NOTE: Experimental
 	UpdateWorkflowExecutionOptionsRequest = internal.UpdateWorkflowExecutionOptionsRequest
 
 	// WorkflowExecutionOptions contains a set of properties of an existing workflow
 	// that can be overriden using [client.Client.UpdateWorkflowExecutionOptions].
+	//
 	// NOTE: Experimental
 	WorkflowExecutionOptions = internal.WorkflowExecutionOptions
 
 	// WorkflowExecutionOptionsChanges describes changes to [WorkflowExecutionOptions]
 	// in the [client.Client.UpdateWorkflowExecutionOptions] API.
+	//
 	// NOTE: Experimental
 	WorkflowExecutionOptionsChanges = internal.WorkflowExecutionOptionsChanges
 
@@ -577,6 +617,7 @@ type (
 	// configuration of a specific workflow execution.
 	// If set, it takes precedence over the Versioning Behavior provided with workflow type registration, or
 	// default worker options.
+	//
 	// NOTE: Experimental
 	VersioningOverride = internal.VersioningOverride
 
@@ -667,6 +708,7 @@ type (
 	// TaskQueueVersioningInfo provides worker deployment configuration for this
 	// task queue.
 	// It is part of [Client.TaskQueueDescription].
+	//
 	// NOTE: Experimental
 	TaskQueueVersioningInfo = internal.TaskQueueVersioningInfo
 
@@ -820,6 +862,7 @@ type (
 		//  - Get(ctx context.Context, valuePtr interface{}) error: which will fill the workflow
 		//    execution result to valuePtr, if workflow execution is a success, or return corresponding
 		//    error. This is a blocking API.
+		//
 		// NOTE: If the started workflow returns ContinueAsNewError during the workflow execution, the
 		// returned result of GetRunID() will be the started workflow run ID, not the new run ID caused by ContinueAsNewError.
 		// However, Get(ctx context.Context, valuePtr interface{}) will return result from the run which did not return ContinueAsNewError.
@@ -840,6 +883,7 @@ type (
 		//    execution result to valuePtr, if workflow execution is a success, or return corresponding
 		//    error. This is a blocking API.
 		// If workflow not found, the Get() will return serviceerror.NotFound.
+		//
 		// NOTE: if the started workflow return ContinueAsNewError during the workflow execution, the
 		// return result of GetRunID() will be the started workflow run ID, not the new run ID caused by ContinueAsNewError,
 		// however, Get(ctx context.Context, valuePtr interface{}) will return result from the run which did not return ContinueAsNewError.
@@ -863,6 +907,7 @@ type (
 		//  - workflowID, signalName, signalArg are same as SignalWorkflow's parameters
 		//  - options, workflow, workflowArgs are same as StartWorkflow's parameters
 		//  - the workflowID parameter is used instead of options.ID. If the latter is present, it must match the workflowID.
+		//
 		// NOTE: options.WorkflowIDReusePolicy is default to AllowDuplicate in this API.
 		// The errors it can return:
 		//  - serviceerror.NotFound
@@ -874,6 +919,7 @@ type (
 
 		// NewWithStartWorkflowOperation returns a WithStartWorkflowOperation for use with UpdateWithStartWorkflow.
 		// See [client.Client.UpdateWithStartWorkflow].
+		//
 		// NOTE: Experimental
 		NewWithStartWorkflowOperation(options StartWorkflowOptions, workflow interface{}, args ...interface{}) WithStartWorkflowOperation
 
@@ -969,6 +1015,7 @@ type (
 
 		// ListClosedWorkflow gets closed workflow executions based on request filters.
 		// Retrieved workflow executions are sorted by close time in descending order.
+		//
 		// NOTE: heavy usage of this API may cause huge persistence pressure.
 		// The errors it can return:
 		//  - serviceerror.InvalidArgument
@@ -979,6 +1026,7 @@ type (
 
 		// ListOpenWorkflow gets open workflow executions based on request filters.
 		// Retrieved workflow executions are sorted by start time in descending order.
+		//
 		// NOTE: heavy usage of this API may cause huge persistence pressure.
 		// The errors it can return:
 		//  - serviceerror.InvalidArgument
@@ -1036,6 +1084,7 @@ type (
 		// GetSearchAttributes returns valid search attributes keys and value types.
 		// The search attributes can be used in query of List/Scan/Count APIs. Adding new search attributes requires temporal server
 		// to update dynamic config ValidSearchAttributes.
+		//
 		// NOTE: This API is not supported on Temporal Cloud.
 		GetSearchAttributes(ctx context.Context) (*workflowservice.GetSearchAttributesResponse, error)
 
@@ -1160,6 +1209,7 @@ type (
 		// and returns the new [WorkflowExecutionOptions] after applying the changes.
 		// It is intended for building tools that can selectively apply ad-hoc workflow configuration changes.
 		// Use [DescribeWorkflowExecution] to get similar information without modifying options.
+		//
 		// NOTE: Experimental
 		UpdateWorkflowExecutionOptions(ctx context.Context, options UpdateWorkflowExecutionOptionsRequest) (WorkflowExecutionOptions, error)
 
@@ -1174,6 +1224,7 @@ type (
 		// has reached the WaitForStage in the options. Note that this means
 		// that the call will not return successfully until the update has been
 		// delivered to a worker.
+		//
 		// NOTE: Experimental
 		UpdateWithStartWorkflow(ctx context.Context, options UpdateWithStartWorkflowOptions) (WorkflowUpdateHandle, error)
 
@@ -1199,6 +1250,7 @@ type (
 		DeploymentClient() DeploymentClient
 
 		// WorkerDeploymentClient create a new worker deployment client with the same gRPC connections as this client.
+		//
 		// NOTE: Experimental
 		WorkerDeploymentClient() WorkerDeploymentClient
 

--- a/contrib/opentelemetry/handler.go
+++ b/contrib/opentelemetry/handler.go
@@ -49,9 +49,11 @@ type MetricsHandlerOptions struct {
 	// meter provider using the name "temporal-sdk-go".
 	Meter metric.Meter
 	// InitialAttributes to set on the handler
+	//
 	// Optional: Defaults to the empty set.
 	InitialAttributes attribute.Set
 	// OnError Callback to invoke if the provided meter returns an error.
+	//
 	// Optional: Defaults to panicking on any error.
 	OnError func(error)
 }

--- a/converter/grpc_interceptor.go
+++ b/converter/grpc_interceptor.go
@@ -42,6 +42,7 @@ type PayloadCodecGRPCClientInterceptorOptions struct {
 
 // NewPayloadCodecGRPCClientInterceptor returns a GRPC Client Interceptor that will mimic the encoding
 // that the SDK system would perform when configured with a matching EncodingDataConverter.
+//
 // Note: This approach does not support use cases that rely on the ContextAware DataConverter interface as
 // workflow context is not available at the GRPC level.
 func NewPayloadCodecGRPCClientInterceptor(options PayloadCodecGRPCClientInterceptorOptions) (grpc.UnaryClientInterceptor, error) {

--- a/internal/activity.go
+++ b/internal/activity.go
@@ -91,6 +91,7 @@ type (
 	// Exposed as: [go.temporal.io/sdk/workflow.ActivityOptions]
 	ActivityOptions struct {
 		// TaskQueue - Name of the task queue that the activity needs to be scheduled on.
+		//
 		// Optional: The default task queue with the same name as the workflow task queue.
 		TaskQueue string
 
@@ -107,6 +108,7 @@ type (
 		// better to rely on the default value.
 		// ScheduleToStartTimeout is always non-retryable. Retrying after this timeout doesn't make sense, as it would
 		// just put the Activity Task back into the same Task Queue.
+		//
 		// Optional: Defaults to unlimited.
 		ScheduleToStartTimeout time.Duration
 
@@ -124,11 +126,13 @@ type (
 
 		// WaitForCancellation - Whether to wait for canceled activity to be completed(
 		// activity can be failed, completed, cancel accepted)
+		//
 		// Optional: default false
 		WaitForCancellation bool
 
 		// ActivityID - Business level activity ID, this is not needed for most of the cases if you have
 		// to specify this then talk to the temporal team. This is something will be done in the future.
+		//
 		// Optional: default empty string
 		ActivityID string
 
@@ -182,6 +186,7 @@ type (
 		StartToCloseTimeout time.Duration
 
 		// RetryPolicy - Specify how to retry activity if error happens.
+		//
 		// Optional: default is to retry according to the default retry policy up to ScheduleToCloseTimeout
 		// with 1sec initial delay between retries and 2x backoff.
 		RetryPolicy *RetryPolicy

--- a/internal/client.go
+++ b/internal/client.go
@@ -662,7 +662,7 @@ type (
 		//
 		// NOTE: WorkflowExecutionErrorWhenAlreadyStarted will affect if Client.ExecuteWorkflow returns an error
 		// when a re-run would be disallowed. See its docstring for more information.
-    //
+		//
 		// Optional: defaulted to AllowDuplicate.
 		WorkflowIDReusePolicy enumspb.WorkflowIdReusePolicy
 
@@ -671,8 +671,8 @@ type (
 		//
 		// NOTE: WorkflowExecutionErrorWhenAlreadyStarted will affect if Client.ExecuteWorkflow returns an error
 		// when a re-run would be disallowed. See its docstring for more information.
-    //
- 		// Optional: defaulted to Fail - required when used in WithStartWorkflowOperation.
+		//
+		// Optional: defaulted to Fail - required when used in WithStartWorkflowOperation.
 		WorkflowIDConflictPolicy enumspb.WorkflowIdConflictPolicy
 
 		// When WorkflowExecutionErrorWhenAlreadyStarted is true, Client.ExecuteWorkflow will return an error if the

--- a/internal/client.go
+++ b/internal/client.go
@@ -92,6 +92,7 @@ type (
 		//  - Get(ctx context.Context, valuePtr interface{}) error: which will fill the workflow
 		//    execution result to valuePtr, if workflow execution is a success, or return corresponding
 		//    error. This is a blocking API.
+		//
 		// NOTE: If the started workflow returns ContinueAsNewError during the workflow execution, the
 		// returned result of GetRunID() will be the started workflow run ID, not the new run ID caused by ContinueAsNewError.
 		// However, Get(ctx context.Context, valuePtr interface{}) will return result from the run which did not return ContinueAsNewError.
@@ -112,6 +113,7 @@ type (
 		//  - Get(ctx context.Context, valuePtr interface{}) error: which will fill the workflow
 		//    execution result to valuePtr, if workflow execution is a success, or return corresponding
 		//    error. This is a blocking API.
+		//
 		// NOTE: if the retrieved workflow returned ContinueAsNewError during the workflow execution, the
 		// return result of GetRunID() will be the retrieved workflow run ID, not the new run ID caused by ContinueAsNewError,
 		// however, Get(ctx context.Context, valuePtr interface{}) will return result from the run which did not return ContinueAsNewError.
@@ -142,6 +144,7 @@ type (
 			options StartWorkflowOptions, workflow interface{}, workflowArgs ...interface{}) (WorkflowRun, error)
 
 		// NewWithStartWorkflowOperation returns a WithStartWorkflowOperation for use in UpdateWithStartWorkflow.
+		//
 		// NOTE: Experimental
 		NewWithStartWorkflowOperation(options StartWorkflowOptions, workflow interface{}, args ...interface{}) WithStartWorkflowOperation
 
@@ -347,6 +350,7 @@ type (
 		// UpdateWorkflowExecutionOptions partially overrides the [WorkflowExecutionOptions] of an existing workflow execution
 		// and returns the new [WorkflowExecutionOptions] after applying the changes.
 		// It is intended for building tools that can selectively apply ad-hoc workflow configuration changes.
+		//
 		// NOTE: Experimental
 		UpdateWorkflowExecutionOptions(ctx context.Context, options UpdateWorkflowExecutionOptionsRequest) (WorkflowExecutionOptions, error)
 
@@ -455,6 +459,7 @@ type (
 	// Exposed as: [go.temporal.io/sdk/client.Options]
 	ClientOptions struct {
 		// Optional: To set the host:port for this client to connect to.
+		//
 		// default: localhost:7233
 		//
 		// This is a gRPC address and therefore can also support a special-formatted address of "<resolver>:///<value>" that
@@ -474,6 +479,7 @@ type (
 		HostPort string
 
 		// Optional: To set the namespace name for this client to work with.
+		//
 		// default: default
 		Namespace string
 
@@ -481,31 +487,38 @@ type (
 		Credentials Credentials
 
 		// Optional: Logger framework can use to log.
+		//
 		// default: default logger provided.
 		Logger log.Logger
 
 		// Optional: Metrics handler for reporting metrics.
+		//
 		// default: no metrics.
 		MetricsHandler metrics.Handler
 
 		// Optional: Sets an identify that can be used to track this host for debugging.
+		//
 		// default: default identity that include hostname, groupName and process ID.
 		Identity string
 
 		// Optional: Sets DataConverter to customize serialization/deserialization of arguments in Temporal
+		//
 		// default: defaultDataConverter, an combination of google protobuf converter, gogo protobuf converter and json converter
 		DataConverter converter.DataConverter
 
 		// Optional: Sets FailureConverter to customize serialization/deserialization of errors.
+		//
 		// default: temporal.DefaultFailureConverter, does not encode any fields of the error. Use temporal.NewDefaultFailureConverter
 		// options to configure or create a custom converter.
 		FailureConverter converter.FailureConverter
 
 		// Optional: Sets ContextPropagators that allows users to control the context information passed through a workflow
+		//
 		// default: nil
 		ContextPropagators []ContextPropagator
 
 		// Optional: Sets options for server connection that allow users to control features of connections such as TLS settings.
+		//
 		// default: no extra options
 		ConnectionOptions ConnectionOptions
 
@@ -559,12 +572,14 @@ type (
 		// After a duration of this time if the client doesn't see any activity it
 		// pings the server to see if the transport is still alive.
 		// If set below 10s, a minimum value of 10s will be used instead.
+		//
 		// default: 30s
 		KeepAliveTime time.Duration
 
 		// After having pinged for keepalive check, the client waits for a duration
 		// of Timeout and if no activity is seen even after that the connection is
 		// closed.
+		//
 		// default: 15s
 		KeepAliveTimeout time.Duration
 
@@ -575,6 +590,7 @@ type (
 		// if true, when there are no active RPCs, Time and Timeout will be ignored and no
 		// keepalive pings will be sent.
 		// If false, client sends keepalive pings even with no active RPCs
+		//
 		// default: false
 		DisableKeepAlivePermitWithoutStream bool
 
@@ -609,12 +625,14 @@ type (
 	// Exposed as: [go.temporal.io/sdk/client.StartWorkflowOptions]
 	StartWorkflowOptions struct {
 		// ID - The business identifier of the workflow execution.
+		//
 		// Optional: defaulted to a uuid.
 		ID string
 
 		// TaskQueue - The workflow tasks of the workflow are scheduled on the queue with this name.
 		// This is also the name of the activity task queue on which activities are scheduled.
 		// The workflow author can choose to override this using activity options.
+		//
 		// Mandatory: No default.
 		TaskQueue string
 
@@ -622,27 +640,32 @@ type (
 		// It includes retries and continue as new. Use WorkflowRunTimeout to limit execution time
 		// of a single workflow run.
 		// The resolution is seconds.
+		//
 		// Optional: defaulted to unlimited.
 		WorkflowExecutionTimeout time.Duration
 
 		// WorkflowRunTimeout - The timeout for duration of a single workflow run.
 		// The resolution is seconds.
+		//
 		// Optional: defaulted to WorkflowExecutionTimeout.
 		WorkflowRunTimeout time.Duration
 
 		// WorkflowTaskTimeout - The timeout for processing workflow task from the time the worker
 		// pulled this task. If a workflow task is lost, it is retried after this timeout.
 		// The resolution is seconds.
+		//
 		// Optional: defaulted to 10 secs.
 		WorkflowTaskTimeout time.Duration
 
 		// WorkflowIDReusePolicy - Specifies server behavior if a *completed* workflow with the same id exists.
 		// This can be useful for dedupe logic if set to RejectDuplicate
+		//
 		// Optional: defaulted to AllowDuplicate.
 		WorkflowIDReusePolicy enumspb.WorkflowIdReusePolicy
 
 		// WorkflowIDConflictPolicy - Specifies server behavior if a *running* workflow with the same id exists.
 		// This cannot be set if WorkflowIDReusePolicy is set to TerminateIfRunning.
+		//
 		// Optional: defaulted to Fail - required when used in WithStartWorkflowOperation.
 		WorkflowIDConflictPolicy enumspb.WorkflowIdConflictPolicy
 
@@ -736,6 +759,7 @@ type (
 		// VersioningOverride - Sets the versioning configuration of a specific workflow execution, ignoring current
 		// server or worker default policies. This enables running canary tests without affecting existing workflows.
 		// To unset the override after the workflow is running, use [UpdateWorkflowExecutionOptions].
+		//
 		// Optional: defaults to no override.
 		//
 		// NOTE: Experimental
@@ -759,6 +783,7 @@ type (
 
 	// WithStartWorkflowOperation defines how to start a workflow when using UpdateWithStartWorkflow.
 	// See [NewWithStartWorkflowOperation] and [UpdateWithStartWorkflow].
+	//
 	// NOTE: Experimental
 	WithStartWorkflowOperation interface {
 		// Get returns the WorkflowRun that was targeted by the UpdateWithStartWorkflow call.
@@ -804,6 +829,7 @@ type (
 		MaximumAttempts int32
 
 		// Non-Retriable errors. This is optional. Temporal server will stop retry if error type matches this list.
+		//
 		// Note:
 		//  - cancellation is not a failure, so it won't be retried,
 		//  - only StartToClose or Heartbeat timeouts are retryable.

--- a/internal/deployment_client.go
+++ b/internal/deployment_client.go
@@ -31,6 +31,7 @@ import (
 
 // DeploymentReachability specifies which category of tasks may reach a worker
 // associated with a deployment, simplifying safe decommission.
+//
 // NOTE: Experimental
 //
 // Exposed as: [go.temporal.io/sdk/client.DeploymentReachability]
@@ -38,6 +39,7 @@ type DeploymentReachability int
 
 const (
 	// DeploymentReachabilityUnspecified - Reachability level not specified.
+	//
 	// NOTE: Experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.DeploymentReachabilityUnspecified]
@@ -45,6 +47,7 @@ const (
 
 	// DeploymentReachabilityReachable - The deployment is reachable by new
 	// and/or open workflows. The deployment cannot be decommissioned safely.
+	//
 	// NOTE: Experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.DeploymentReachabilityReachable]
@@ -54,6 +57,7 @@ const (
 	// by new or open workflows, but might be still needed by
 	// Queries sent to closed workflows. The deployment can be decommissioned
 	// safely if user does not query closed workflows.
+	//
 	// NOTE: Experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.DeploymentReachabilityClosedWorkflows]
@@ -63,6 +67,7 @@ const (
 	// any workflow because all the workflows who needed this
 	// deployment are out of the retention period. The deployment can be
 	// decommissioned safely.
+	//
 	// NOTE: Experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.DeploymentReachabilityUnreachable]
@@ -72,6 +77,7 @@ const (
 type (
 	// Deployment identifies a set of workers. This identifier combines
 	// the deployment series name with their Build ID.
+	//
 	// NOTE: Experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.Deployment]
@@ -86,6 +92,7 @@ type (
 
 	// DeploymentTaskQueueInfo describes properties of the Task Queues involved
 	// in a deployment.
+	//
 	// NOTE: Experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.DeploymentTaskQueueInfo]
@@ -105,6 +112,7 @@ type (
 	// workers in this deployment.
 	// Workers can poll multiple task queues in a single deployment,
 	// which are listed in this message.
+	//
 	// NOTE: Experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.DeploymentInfo]
@@ -126,6 +134,7 @@ type (
 	}
 
 	// DeploymentDescription is the response type for [DeploymentClient.Describe].
+	//
 	// NOTE: Experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.DeploymentDescription]
@@ -135,6 +144,7 @@ type (
 	}
 
 	// DeploymentListEntry is a subset of fields from DeploymentInfo
+	//
 	// NOTE: Experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.DeploymentListEntry]
@@ -150,6 +160,7 @@ type (
 	}
 
 	// DeploymentListIterator is an iterator for deployments.
+	//
 	// NOTE: Experimental
 	DeploymentListIterator interface {
 		// HasNext - Return whether this iterator has next value.
@@ -160,20 +171,24 @@ type (
 	}
 
 	// DeploymentListOptions are the parameters for configuring listing deployments.
+	//
 	// NOTE: Experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.DeploymentListOptions]
 	DeploymentListOptions struct {
 		// PageSize - How many results to fetch from the Server at a time.
+		//
 		// Optional: defaulted to 1000
 		PageSize int
 
 		// SeriesName - Filter with the name of the deployment series.
+		//
 		// Optional: If present, use an exact series name match.
 		SeriesName string
 	}
 
 	// DeploymentReachabilityInfo extends [DeploymentInfo] with reachability information.
+	//
 	// NOTE: Experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.DeploymentReachabilityInfo]
@@ -192,6 +207,7 @@ type (
 
 	// DeploymentMetadataUpdate modifies user-defined metadata entries that describe
 	// a deployment.
+	//
 	// NOTE: Experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.DeploymentMetadataUpdate]
@@ -206,6 +222,7 @@ type (
 	}
 
 	// DeploymentGetCurrentResponse is the response type for [DeploymentClient.GetCurrent]
+	//
 	// NOTE: Experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.DeploymentGetCurrentResponse]
@@ -215,6 +232,7 @@ type (
 	}
 
 	// DeploymentSetCurrentOptions provides options for [DeploymentClient.SetCurrent].
+	//
 	// NOTE: Experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.DeploymentSetCurrentOptions]
@@ -228,6 +246,7 @@ type (
 	}
 
 	// DeploymentSetCurrentResponse is the response type for [DeploymentClient.SetCurrent].
+	//
 	// NOTE: Experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.DeploymentSetCurrentResponse]
@@ -240,6 +259,7 @@ type (
 	}
 
 	// DeploymentDescribeOptions provides options for [DeploymentClient.Describe].
+	//
 	// NOTE: Experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.DeploymentDescribeOptions]
@@ -249,6 +269,7 @@ type (
 	}
 
 	// DeploymentGetReachabilityOptions provides options for [DeploymentClient.GetReachability].
+	//
 	// NOTE: Experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.DeploymentGetReachabilityOptions]
@@ -258,6 +279,7 @@ type (
 	}
 
 	// DeploymentGetCurrentOptions provides options for [DeploymentClient.GetCurrent].
+	//
 	// NOTE: Experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.DeploymentGetCurrentOptions]
@@ -267,14 +289,17 @@ type (
 	}
 
 	// DeploymentClient is the client that manages deployments.
+	//
 	// NOTE: Experimental
 	DeploymentClient interface {
 		// Describes an existing deployment.
+		//
 		// NOTE: Experimental
 		Describe(ctx context.Context, options DeploymentDescribeOptions) (DeploymentDescription, error)
 
 		// List returns an iterator to enumerate deployments in the client's namespace.
 		// It can also optionally filter deployments by series name.
+		//
 		// NOTE: Experimental
 		List(ctx context.Context, options DeploymentListOptions) (DeploymentListIterator, error)
 
@@ -283,15 +308,18 @@ type (
 		// to estimate cache staleness.
 		// When reachability is not required, always prefer [Describe] over [GetReachability]
 		// for the most up-to-date information.
+		//
 		// NOTE: Experimental
 		GetReachability(ctx context.Context, options DeploymentGetReachabilityOptions) (DeploymentReachabilityInfo, error)
 
 		// GetCurrent returns the current deployment for a given deployment series.
+		//
 		// NOTE: Experimental
 		GetCurrent(ctx context.Context, options DeploymentGetCurrentOptions) (DeploymentGetCurrentResponse, error)
 
 		// SetCurrent changes the current deployment for a given deployment series. It can also
 		// update metadata for this deployment.
+		//
 		// NOTE: Experimental
 		SetCurrent(ctx context.Context, options DeploymentSetCurrentOptions) (DeploymentSetCurrentResponse, error)
 	}

--- a/internal/error.go
+++ b/internal/error.go
@@ -134,6 +134,7 @@ type (
 		// server according to the RetryPolicy set by the Workflow.
 		// It is impossible to specify immediate retry as it is indistinguishable from the default value. As a
 		// workaround you could set NextRetryDelay to some small value.
+		//
 		// NOTE: This option is supported by Temporal Server >= v1.24.2 older version will ignore this value.
 		NextRetryDelay time.Duration
 	}

--- a/internal/failure_converter.go
+++ b/internal/failure_converter.go
@@ -51,10 +51,12 @@ func GetDefaultFailureConverter() converter.FailureConverter {
 // Exposed as: [go.temporal.io/sdk/temporal.DefaultFailureConverterOptions]
 type DefaultFailureConverterOptions struct {
 	// Optional: Sets DataConverter to customize serialization/deserialization of fields.
+	//
 	// default: Default data converter
 	DataConverter converter.DataConverter
 
 	// Optional: Whether to encode error messages and stack traces.
+	//
 	// default: false
 	EncodeCommonAttributes bool
 }

--- a/internal/internal_versioning_client.go
+++ b/internal/internal_versioning_client.go
@@ -75,6 +75,7 @@ const (
 // WorkerVersioningMode specifies whether the workflows processed by this
 // worker use the worker's Version. The Temporal Server will use this worker's
 // choice when dispatching tasks to it.
+//
 // NOTE: Experimental
 //
 // Exposed as: [go.temporal.io/sdk/client.WorkerVersioningMode]
@@ -82,6 +83,7 @@ type WorkerVersioningMode int
 
 const (
 	// WorkerVersioningModeUnspecified - Versioning mode not reported.
+	//
 	// NOTE: Experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.WorkerVersioningModeUnspecified]
@@ -90,6 +92,7 @@ const (
 	// WorkerVersioningModeUnversioned - Workers with this mode are not
 	// distinguished from each other for task routing, even if they
 	// have different versions.
+	//
 	// NOTE: Experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.WorkerVersioningModeUnversioned]
@@ -101,6 +104,7 @@ const (
 	// Each Deployment Version is distinguished from other Versions for task
 	// routing, and users can configure the Temporal Server to send tasks to a
 	// particular Version.
+	//
 	// NOTE: Experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.WorkerVersioningModeVersioned]
@@ -156,6 +160,7 @@ type (
 	// WorkerDeploymentPollerOptions are Worker initialization settings
 	// related to Worker Deployment Versioning, which are propagated to the
 	// Temporal Server during polling.
+	//
 	// NOTE: Experimental
 	WorkerDeploymentPollerOptions struct {
 		// DeploymentName - The name of the Worker Deployment.
@@ -258,6 +263,7 @@ type (
 	// TaskQueueVersioningInfo provides worker deployment configuration for this
 	// task queue.
 	// It is part of [TaskQueueDescription].
+	//
 	// NOTE: Experimental
 	TaskQueueVersioningInfo struct {
 		// CurrentVersion - Specifies which Deployment Version should receive new workflow
@@ -265,6 +271,7 @@ type (
 		// Can be one of the following:
 		// - A Deployment Version identifier in the form "<deployment_name>.<build_id>".
 		// - Or, the "__unversioned__" special value to represent all the unversioned workers
+		//
 		// NOTE: Experimental
 		CurrentVersion string
 
@@ -275,6 +282,7 @@ type (
 		// - Or, the "__unversioned__" special value, to represent all the unversioned workers
 		// Note that it is possible to ramp from one Version to another Version, or from unversioned
 		// workers to a particular Version, or from a particular Version to unversioned workers.
+		//
 		// NOTE: Experimental
 		RampingVersion string
 
@@ -282,10 +290,12 @@ type (
 		// of the Current Version.
 		// Valid range: [0, 100]. A 100% value means the Ramping Version is receiving full traffic but
 		// not yet "promoted" to be the Current Version, likely due to pending validations.
+		//
 		// NOTE: Experimental
 		RampingVersionPercentage float32
 
 		// UpdateTime - The last time versioning information of this Task Queue changed.
+		//
 		// NOTE: Experimental
 		UpdateTime time.Time
 	}

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -1320,6 +1320,7 @@ type WorkflowReplayerOptions struct {
 	FailureConverter converter.FailureConverter
 
 	// Optional: Sets ContextPropagators that allows users to control the context information passed through a workflow
+	//
 	// default: nil
 	ContextPropagators []ContextPropagator
 
@@ -1336,6 +1337,7 @@ type WorkflowReplayerOptions struct {
 	// In the workflow code you can use workflow.GetLogger(ctx) to write logs. By default, the logger will skip log
 	// entry during replay mode so you won't see duplicate logs. This option will enable the logging in replay mode.
 	// This is only useful for debugging purpose.
+	//
 	// default: false
 	EnableLoggingInReplay bool
 

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -223,6 +223,7 @@ type (
 //
 // The current timeout resolution implementation is in seconds and uses math.Ceil(d.Seconds()) as the duration. But is
 // subjected to change in the future.
+//
 // NOTE: the context.Context should have a fairly large timeout, since workflow execution may take a while to be finished
 func (wc *WorkflowClient) ExecuteWorkflow(ctx context.Context, options StartWorkflowOptions, workflow interface{}, args ...interface{}) (WorkflowRun, error) {
 	if err := wc.ensureInitialized(ctx); err != nil {
@@ -789,6 +790,7 @@ type UpdateWorkflowOptions struct {
 
 	// WaitForStage is a required field which specifies which stage to wait until returning.
 	// See https://docs.temporal.io/develop/go/message-passing#send-update-from-client for more details.
+	//
 	// NOTE: Specifying WorkflowUpdateStageAdmitted is not supported.
 	WaitForStage WorkflowUpdateStage
 
@@ -801,6 +803,7 @@ type UpdateWorkflowOptions struct {
 
 // UpdateWithStartWorkflowOptions encapsulates the parameters used by UpdateWithStartWorkflow.
 // See UpdateWithStartWorkflow and NewWithStartWorkflowOperation.
+//
 // NOTE: Experimental
 type UpdateWithStartWorkflowOptions struct {
 	StartWorkflowOperation WithStartWorkflowOperation
@@ -1061,6 +1064,7 @@ func (wc *WorkflowClient) GetWorkerTaskReachability(ctx context.Context, options
 // UpdateWorkflowExecutionOptions partially overrides the [WorkflowExecutionOptions] of an existing workflow execution,
 // and returns the new [WorkflowExecutionOptions] after applying the changes.
 // It is intended for building tools that can selectively apply ad-hoc workflow configuration changes.
+//
 // NOTE: Experimental
 func (wc *WorkflowClient) UpdateWorkflowExecutionOptions(ctx context.Context, request UpdateWorkflowExecutionOptionsRequest) (WorkflowExecutionOptions, error) {
 	if err := wc.ensureInitialized(ctx); err != nil {

--- a/internal/internal_workflow_execution_options.go
+++ b/internal/internal_workflow_execution_options.go
@@ -35,6 +35,7 @@ import (
 
 type (
 	// UpdateWorkflowExecutionOptionsRequest is a request for [Client.UpdateWorkflowExecutionOptions].
+	//
 	// NOTE: Experimental
 	UpdateWorkflowExecutionOptionsRequest struct {
 		// ID of the workflow.
@@ -46,6 +47,7 @@ type (
 	}
 
 	// WorkflowExecutionOptions describes options for a workflow execution.
+	//
 	// NOTE: Experimental
 	WorkflowExecutionOptions struct {
 		// If set, it takes precedence over the Versioning Behavior provided with code annotations.
@@ -56,6 +58,7 @@ type (
 	// An entry with a `nil` pointer means do not change.
 	// An entry with a pointer to an empty value means delete the entry, i.e., the empty value is a tombstone.
 	// An entry with a pointer to a non-empty value means replace the entry, i.e., there is no deep merging.
+	//
 	// NOTE: Experimental
 	WorkflowExecutionOptionsChanges struct {
 		VersioningOverride *VersioningOverride
@@ -67,6 +70,7 @@ type (
 	// To remove the override, the [UpdateWorkflowExecutionOptionsRequest] should include a pointer to
 	// an empty [VersioningOverride] value in [WorkflowExecutionOptionsChanges].
 	// See [WorkflowExecutionOptionsChanges] for details.
+	//
 	// NOTE: Experimental
 	VersioningOverride struct {
 		// Behavior - The new Versioning Behavior. This field is required.

--- a/internal/schedule_client.go
+++ b/internal/schedule_client.go
@@ -42,10 +42,12 @@ type (
 		Start int
 
 		// End of the range (inclusive)
+		//
 		// Optional: defaulted to Start
 		End int
 
 		// Step to be take between each value
+		//
 		// Optional: defaulted to 1
 		Step int
 	}
@@ -127,6 +129,7 @@ type (
 		Every time.Duration
 
 		// Offset - is a fixed offset added to the intervals period.
+		//
 		// Optional: Defaulted to 0
 		Offset time.Duration
 	}
@@ -208,15 +211,18 @@ type (
 		Skip []ScheduleCalendarSpec
 
 		// StartAt - Any times before `startAt` will be skipped. Together, `startAt` and `endAt` make an inclusive interval.
+		//
 		// Optional: Defaulted to the beginning of time
 		StartAt time.Time
 
 		// EndAt - Any times after `endAt` will be skipped.
+		//
 		// Optional: Defaulted to the end of time
 		EndAt time.Time
 
 		// Jitter - All times will be incremented by a random value from 0 to this amount of jitter, capped
 		// by the time until the next schedule.
+		//
 		// Optional: Defaulted to 0
 		Jitter time.Duration
 
@@ -231,6 +237,7 @@ type (
 		// fires at 1:30am will be triggered twice on the day that has two 1:30s.
 		//
 		// Note: No actions are taken on leap-seconds (e.g. 23:59:60 UTC).
+		//
 		// Optional: Defaulted to UTC
 		TimeZoneName string
 	}
@@ -247,6 +254,7 @@ type (
 		// ID - The business identifier of the workflow execution.
 		// The workflow ID of the started workflow may not match this exactly,
 		// it may have a timestamp appended for uniqueness.
+		//
 		// Optional: defaulted to a uuid.
 		ID string
 
@@ -297,6 +305,7 @@ type (
 		// VersioningOverride - Sets the versioning configuration of a specific workflow execution, ignoring current
 		// server or worker default policies. This enables running canary tests without affecting existing workflows.
 		// To unset the override after the workflow is running, use [Client.UpdateWorkflowExecutionOptions].
+		//
 		// Optional: defaults to no override.
 		//
 		// NOTE: Experimental
@@ -345,6 +354,7 @@ type (
 		// minute, which means that the Schedule attempts to take any Actions that wouldn't be more than one minute late. It
 		// takes those Actions according to the Overlap. An outage that lasts longer than the Catchup
 		// Window could lead to missed Actions.
+		//
 		// Optional: defaulted to 1 minute
 		CatchupWindow time.Duration
 
@@ -353,6 +363,7 @@ type (
 		// With SCHEDULE_OVERLAP_POLICY_ALLOW_ALL, this pause might not apply to the next Action, because the next Action
 		// might have already started previous to the failed one finishing. Pausing applies only to Actions that are scheduled
 		// to start after the failed one finishes.
+		//
 		// Optional: defaulted to false
 		PauseOnFailure bool
 
@@ -362,6 +373,7 @@ type (
 		Note string
 
 		// Paused - Start in paused state.
+		//
 		// Optional: defaulted to false
 		Paused bool
 
@@ -374,6 +386,7 @@ type (
 		RemainingActions int
 
 		// TriggerImmediately - Trigger one Action immediately on creating the schedule.
+		//
 		// Optional: defaulted to false
 		TriggerImmediately bool
 
@@ -578,6 +591,7 @@ type (
 	// Exposed as: [go.temporal.io/sdk/client.SchedulePauseOptions]
 	SchedulePauseOptions struct {
 		// Note - Informative human-readable message with contextual notes.
+		//
 		// Optional: defaulted to 'Paused via Go SDK'
 		Note string
 	}
@@ -587,6 +601,7 @@ type (
 	// Exposed as: [go.temporal.io/sdk/client.ScheduleUnpauseOptions]
 	ScheduleUnpauseOptions struct {
 		// Note - Informative human-readable message with contextual notes.
+		//
 		// Optional: defaulted to 'Unpaused via Go SDK'
 		Note string
 	}
@@ -692,6 +707,7 @@ type (
 	// Exposed as: [go.temporal.io/sdk/client.ScheduleListOptions]
 	ScheduleListOptions struct {
 		// PageSize - How many results to fetch from the Server at a time.
+		//
 		// Optional: defaulted to 1000
 		PageSize int
 

--- a/internal/worker.go
+++ b/internal/worker.go
@@ -35,8 +35,10 @@ import (
 
 type (
 	// WorkerDeploymentOptions provides configuration for Worker Deployment Versioning.
+	//
 	// NOTE: Both [WorkerDeploymentOptions.Version] and [WorkerDeploymentOptions.UseVersioning]
 	// need to be set for enabling Worker Deployment Versioning.
+	//
 	// NOTE: Experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/worker.DeploymentOptions]
@@ -44,13 +46,16 @@ type (
 		// If set, opts this worker into the Worker Deployment Versioning feature. It will only
 		// operate on workflows it claims to be compatible with. You must set [Version] if this flag
 		// is true.
+		//
 		// NOTE: Experimental
+		//
 		// NOTE: Cannot be enabled at the same time as [WorkerOptions.EnableSessionWorker]
 		UseVersioning bool
 
 		// Assign a Deployment Version identifier to this worker. The format of this identifier
 		// is "<deployment_name>.<build_id>". If [Version] is set both [WorkerOptions.BuildID] and
 		// [DeploymentSeriesName] will be ignored.
+		//
 		// NOTE: Experimental
 		Version string
 
@@ -62,9 +67,11 @@ type (
 
 		// Optional: Provides a default Versioning Behavior to workflows that do not set one with the
 		// registration option [RegisterWorkflowOptions.VersioningBehavior].
+		//
 		// NOTE: When the new Deployment-based Worker Versioning feature is on,
 		// and [DefaultVersioningBehavior] is unspecified,
 		// workflows that do not set the Versioning Behavior will fail at registration time.
+		//
 		// NOTE: Experimental
 		DefaultVersioningBehavior VersioningBehavior
 	}
@@ -77,6 +84,7 @@ type (
 	WorkerOptions struct {
 		// Optional: To set the maximum concurrent activity executions this worker can have.
 		// The zero value of this uses the default value.
+		//
 		// default: defaultMaxConcurrentActivityExecutionSize(1k)
 		MaxConcurrentActivityExecutionSize int
 
@@ -86,11 +94,13 @@ type (
 		// 1 if needed. For example, set the number to 0.1 means you want your activity to be executed
 		// once for every 10 seconds. This can be used to protect down stream services from flooding.
 		// The zero value of this uses the default value
+		//
 		// default: 100k
 		WorkerActivitiesPerSecond float64
 
 		// Optional: To set the maximum concurrent local activity executions this worker can have.
 		// The zero value of this uses the default value.
+		//
 		// default: 1k
 		MaxConcurrentLocalActivityExecutionSize int
 
@@ -100,6 +110,7 @@ type (
 		// 1 if needed. For example, set the number to 0.1 means you want your local activity to be executed
 		// once for every 10 seconds. This can be used to protect down stream services from flooding.
 		// The zero value of this uses the default value
+		//
 		// default: 100k
 		WorkerLocalActivitiesPerSecond float64
 
@@ -110,6 +121,7 @@ type (
 		// 1 if needed. For example, set the number to 0.1 means you want your activity to be executed
 		// once for every 10 seconds. This can be used to protect down stream services from flooding.
 		// The zero value of this uses the default value.
+		//
 		// default: 100k
 		//
 		// NOTE: Setting this to a non zero value will also disable eager activities.
@@ -118,6 +130,7 @@ type (
 		// Optional: Sets the maximum number of goroutines that will concurrently poll the
 		// temporal-server to retrieve activity tasks. Changing this value will affect the
 		// rate at which the worker is able to consume tasks from a task queue.
+		//
 		// default: 2
 		MaxConcurrentActivityTaskPollers int
 
@@ -125,6 +138,7 @@ type (
 		// The zero value of this uses the default value. Due to internal logic where pollers
 		// alternate between stick and non-sticky queues, this
 		// value cannot be 1 and will panic if set to that value.
+		//
 		// default: defaultMaxConcurrentTaskExecutionSize(1k)
 		MaxConcurrentWorkflowTaskExecutionSize int
 
@@ -133,17 +147,20 @@ type (
 		// rate at which the worker is able to consume tasks from a task queue. Due to
 		// internal logic where pollers alternate between stick and non-sticky queues, this
 		// value cannot be 1 and will panic if set to that value.
+		//
 		// default: 2
 		MaxConcurrentWorkflowTaskPollers int
 
 		// Optional: Sets the maximum concurrent nexus task executions this worker can have.
 		// The zero value of this uses the default value.
+		//
 		// default: defaultMaxConcurrentTaskExecutionSize(1k)
 		MaxConcurrentNexusTaskExecutionSize int
 
 		// Optional: Sets the maximum number of goroutines that will concurrently poll the
 		// temporal-server to retrieve nexus tasks. Changing this value will affect the
 		// rate at which the worker is able to consume tasks from a task queue.
+		//
 		// default: 2
 		MaxConcurrentNexusTaskPollers int
 
@@ -151,6 +168,7 @@ type (
 		// In the workflow code you can use workflow.GetLogger(ctx) to write logs. By default, the logger will skip log
 		// entry during replay mode so you won't see duplicate logs. This option will enable the logging in replay mode.
 		// This is only useful for debugging purpose.
+		//
 		// default: false
 		EnableLoggingInReplay bool
 
@@ -177,16 +195,19 @@ type (
 		// Optional: Sets how workflow worker deals with non-deterministic history events
 		// (presumably arising from non-deterministic workflow definitions or non-backward compatible workflow
 		// definition changes) and other panics raised from workflow code.
+		//
 		// default: BlockWorkflow, which just logs error but doesn't fail workflow.
 		WorkflowPanicPolicy WorkflowPanicPolicy
 
 		// Optional: worker graceful stop timeout
+		//
 		// default: 0s
 		WorkerStopTimeout time.Duration
 
 		// Optional: Enable running session workers.
 		// Session workers is for activities within a session.
 		// Enable this option to allow worker to process sessions.
+		//
 		// default: false
 		EnableSessionWorker bool
 
@@ -197,21 +218,25 @@ type (
 		// SessionResourceID string
 
 		// Optional: Sets the maximum number of concurrently running sessions the resource supports.
+		//
 		// default: 1000
 		MaxConcurrentSessionExecutionSize int
 
 		// Optional: If set to true, a workflow worker is not started for this
 		// worker and workflows cannot be registered with this worker. Use this if
 		// you only want your worker to execute activities.
+		//
 		// default: false
 		DisableWorkflowWorker bool
 
 		// Optional: If set to true worker will only handle workflow tasks and local activities.
 		// Non-local activities will not be executed by this worker.
+		//
 		// default: false
 		LocalActivityWorkerOnly bool
 
 		// Optional: If set overwrites the client level Identity value.
+		//
 		// default: client identity
 		Identity string
 
@@ -221,12 +246,14 @@ type (
 		// Optional: The maximum amount of time between sending each pending heartbeat to the server. Regardless of
 		// heartbeat timeout, no pending heartbeat will wait longer than this amount of time to send. To effectively disable
 		// heartbeat throttling, this can be set to something like 1 nanosecond, but it is not recommended.
+		//
 		// default: 60 seconds
 		MaxHeartbeatThrottleInterval time.Duration
 
 		// Optional: The default amount of time between sending each pending heartbeat to the server. This is used if the
 		// ActivityOptions do not provide a HeartbeatTimeout. Otherwise, the interval becomes a value a bit smaller than the
 		// given HeartbeatTimeout.
+		//
 		// default: 30 seconds
 		DefaultHeartbeatThrottleInterval time.Duration
 
@@ -291,17 +318,20 @@ type (
 		// is true.
 		//
 		// Deprecated: Use [WorkerDeploymentOptions.UseVersioning]
+		//
 		// NOTE: Cannot be enabled at the same time as [WorkerOptions.EnableSessionWorker]
 		UseBuildIDForVersioning bool
 
 		// Optional: If set it configures Worker Versioning for this worker. See [WorkerDeploymentOptions]
 		// for more.
+		//
 		// NOTE: Experimental
 		DeploymentOptions WorkerDeploymentOptions
 
 		// Optional: If set, use a custom tuner for this worker. See WorkerTuner for more.
 		// Mutually exclusive with MaxConcurrentWorkflowTaskExecutionSize,
 		// MaxConcurrentActivityExecutionSize, and MaxConcurrentLocalActivityExecutionSize.
+		//
 		// NOTE: Experimental
 		Tuner WorkerTuner
 	}

--- a/internal/worker_deployment_client.go
+++ b/internal/worker_deployment_client.go
@@ -32,6 +32,7 @@ import (
 // WorkerDeploymentVersionDrainageStatus specifies the drainage status for a Worker
 // Deployment Version enabling users to decide when they can safely decommission this
 // Version.
+//
 // NOTE: Experimental
 //
 // Exposed as: [go.temporal.io/sdk/client.WorkerDeploymentVersionDrainageStatus]
@@ -39,6 +40,7 @@ type WorkerDeploymentVersionDrainageStatus int
 
 const (
 	// WorkerDeploymentVersionDrainageStatusUnspecified - Drainage status not specified.
+	//
 	// NOTE: Experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.WorkerDeploymentVersionDrainageStatusUnspecified]
@@ -47,6 +49,7 @@ const (
 	// WorkerDeploymentVersionDrainageStatusDraining - The Worker Deployment Version is not
 	// used by new workflows, but it is still used by open pinned workflows.
 	// This Version cannot be decommissioned safely.
+	//
 	// NOTE: Experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.WorkerDeploymentVersionDrainageStatusDraining]
@@ -57,6 +60,7 @@ const (
 	// Queries sent to closed workflows. This Version can be decommissioned safely if the user
 	// does not expect to query closed workflows. In some cases this requires waiting for some
 	// time after it is drained to guarantee no pending queries.
+	//
 	// NOTE: Experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.WorkerDeploymentVersionDrainageStatusDrained]
@@ -66,6 +70,7 @@ const (
 type (
 
 	// WorkerDeploymentDescribeOptions provides options for [WorkerDeploymentHandle.Describe].
+	//
 	// NOTE: Experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.WorkerDeploymentDescribeOptions]
@@ -73,6 +78,7 @@ type (
 	}
 
 	// WorkerDeploymentVersionSummary provides a brief description of a Version.
+	//
 	// NOTE: Experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.WorkerDeploymentVersionSummary]
@@ -89,6 +95,7 @@ type (
 	}
 
 	// WorkerDeploymentInfo provides information about a Worker Deployment.
+	//
 	// NOTE: Experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.WorkerDeploymentInfo]
@@ -117,6 +124,7 @@ type (
 	}
 
 	// WorkerDeploymentDescribeResponse is the response type for [WorkerDeploymentHandle.Describe].
+	//
 	// NOTE: Experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.WorkerDeploymentDescribeResponse]
@@ -130,6 +138,7 @@ type (
 
 	// WorkerDeploymentSetCurrentVersionOptions provides options for
 	// [WorkerDeploymentHandle.SetCurrentVersion].
+	//
 	// NOTE: Experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.WorkerDeploymentSetCurrentVersionOptions]
@@ -145,10 +154,12 @@ type (
 		// generated the token and this one.
 		// The current token can be obtained with [WorkerDeploymentHandle.Describe],
 		// or returned by other successful Worker Deployment operations.
+		//
 		// Optional: defaulted to empty token, which bypasses conflict detection.
 		ConflictToken []byte
 
 		// Identity: The identity of the client who initiated this request.
+		//
 		// Optional: default to the identity of the underlying workflow client.
 		Identity string
 
@@ -161,12 +172,14 @@ type (
 		//   - Task Queues moved to another Worker Deployment, i.e., current in a different Deployment.
 		// WARNING: setting this flag could lead to missing Task Queues polled by late starting
 		// Workers.
+		//
 		// Optional: default to reject request when queues are missing.
 		IgnoreMissingTaskQueues bool
 	}
 
 	// WorkerDeploymentSetCurrentVersionResponse is the response for
 	// [WorkerDeploymentHandle.SetCurrentVersion].
+	//
 	// NOTE: Experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.WorkerDeploymentSetCurrentVersionResponse]
@@ -182,6 +195,7 @@ type (
 
 	// WorkerDeploymentSetRampingVersionOptions provides options for
 	// [WorkerDeploymentHandle.SetRampingVersion].
+	//
 	// NOTE: Experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.WorkerDeploymentSetRampingVersionOptions]
@@ -201,10 +215,12 @@ type (
 		// generated the token and this one.
 		// The current token can be obtained with [WorkerDeploymentHandle.Describe],
 		// or returned by other successful Worker Deployment operations.
+		//
 		// Optional: defaulted to empty token, which bypasses conflict detection.
 		ConflictToken []byte
 
 		// Identity: The identity of the client who initiated this request.
+		//
 		// Optional: default to the identity of the underlying workflow client.
 		Identity string
 
@@ -217,12 +233,14 @@ type (
 		//   - Task Queues moved to another Worker Deployment, i.e., current in a different Deployment.
 		// WARNING: setting this flag could lead to missing Task Queues polled by late starting
 		// Workers.
+		//
 		// Optional: default to reject request when queues are missing.
 		IgnoreMissingTaskQueues bool
 	}
 
 	// WorkerDeploymentSetRampingVersionResponse is the response for
 	// [WorkerDeploymentHandle.SetRampingVersion].
+	//
 	// NOTE: Experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.WorkerDeploymentSetRampingVersionResponse]
@@ -241,6 +259,7 @@ type (
 
 	// WorkerDeploymentDescribeVersionOptions provides options for
 	// [WorkerDeploymentHandle.DescribeVersion].
+	//
 	// NOTE: Experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.WorkerDeploymentDescribeVersionOptions]
@@ -251,6 +270,7 @@ type (
 
 	// WorkerDeploymentTaskQueueInfo describes properties of the Task Queues involved
 	// in a Deployment Version.
+	//
 	// NOTE: Experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.WorkerDeploymentTaskQueueInfo]
@@ -264,6 +284,7 @@ type (
 
 	// WorkerDeploymentVersionDrainageInfo describes drainage properties of a Deployment Version.
 	// This enables users to safely decide when they can decommission a Version.
+	//
 	// NOTE: Experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.WorkerDeploymentVersionDrainageInfo]
@@ -282,6 +303,7 @@ type (
 	}
 
 	// WorkerDeploymentVersionInfo provides information about a Worker Deployment Version.
+	//
 	// NOTE: Experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.WorkerDeploymentVersionInfo]
@@ -309,6 +331,7 @@ type (
 
 		// DrainageInfo - Drainage information for a Worker Deployment Version, enabling users to
 		// decide when they can safely decommission this Version.
+		//
 		// Optional: not present when the version is Current or Ramping.
 		DrainageInfo *WorkerDeploymentVersionDrainageInfo
 
@@ -318,6 +341,7 @@ type (
 
 	// WorkerDeploymentVersionDescription is the response for
 	// [WorkerDeploymentHandle.DescribeVersion].
+	//
 	// NOTE: Experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.WorkerDeploymentVersionDescription]
@@ -328,6 +352,7 @@ type (
 
 	// WorkerDeploymentDeleteVersionOptions provides options for
 	// [WorkerDeploymentHandle.DeleteVersion].
+	//
 	// NOTE: Experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.WorkerDeploymentDeleteVersionOptions]
@@ -337,16 +362,19 @@ type (
 		Version string
 
 		// SkipDrainage - Force deletion even if the Version is still draining.
+		//
 		// Optional: default to always drain before deletion
 		SkipDrainage bool
 
 		// Identity - The identity of the client who initiated this request.
+		//
 		// Optional: default to the identity of the underlying workflow client.
 		Identity string
 	}
 
 	// WorkerDeploymentDeleteVersionResponse is the response for
 	// [WorkerDeploymentHandle.DeleteVersion].
+	//
 	// NOTE: Experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.WorkerDeploymentDeleteVersionResponse]
@@ -355,6 +383,7 @@ type (
 
 	// WorkerDeploymentMetadataUpdate modifies user-defined metadata entries that describe
 	// a Version.
+	//
 	// NOTE: Experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.WorkerDeploymentMetadataUpdate]
@@ -370,6 +399,7 @@ type (
 
 	// WorkerDeploymentUpdateVersionMetadataOptions provides options for
 	// [WorkerDeploymentHandle.UpdateVersionMetadata].
+	//
 	// NOTE: Experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.WorkerDeploymentUpdateVersionMetadataOptions]
@@ -384,6 +414,7 @@ type (
 
 	// WorkerDeploymentUpdateVersionMetadataResponse is the response for
 	// [WorkerDeploymentHandle.UpdateVersionMetadata].
+	//
 	// NOTE: Experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.WorkerDeploymentUpdateVersionMetadataResponse]
@@ -393,26 +424,31 @@ type (
 	}
 
 	// WorkerDeploymentHandle is a handle to a Worker Deployment.
+	//
 	// NOTE: Experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.WorkerDeploymentHandle]
 	WorkerDeploymentHandle interface {
 		// Describe returns a description of this Worker Deployment.
+		//
 		// NOTE: Experimental
 		Describe(ctx context.Context, options WorkerDeploymentDescribeOptions) (WorkerDeploymentDescribeResponse, error)
 
 		// SetCurrentVersion changes the Current Version for this Worker Deployment.
 		//
 		// It also unsets the Ramping Version when it matches the Version being set as Current.
+		//
 		// NOTE: Experimental
 		SetCurrentVersion(ctx context.Context, options WorkerDeploymentSetCurrentVersionOptions) (WorkerDeploymentSetCurrentVersionResponse, error)
 
 		// SetRampingVersion changes the Ramping Version of this Worker Deployment and its ramp
 		// percentage.
+		//
 		// NOTE: Experimental
 		SetRampingVersion(ctx context.Context, options WorkerDeploymentSetRampingVersionOptions) (WorkerDeploymentSetRampingVersionResponse, error)
 
 		// DescribeVersion gives a description of one the Versions in this Worker Deployment.
+		//
 		// NOTE: Experimental
 		DescribeVersion(ctx context.Context, options WorkerDeploymentDescribeVersionOptions) (WorkerDeploymentVersionDescription, error)
 
@@ -422,29 +458,32 @@ type (
 		//  - It is not the Current or Ramping Version for this Deployment.
 		//  - It has no active pollers, i.e., none of the task queues in the Version have pollers.
 		//  - It is not draining. This requirement can be ignored with the option SkipDrainage.
+		//
 		// NOTE: Experimental
 		DeleteVersion(ctx context.Context, options WorkerDeploymentDeleteVersionOptions) (WorkerDeploymentDeleteVersionResponse, error)
 
 		// UpdateVersionMetadata changes the metadata associated with a Worker Version in this
 		// Deployment.
 		//
-		//
 		// NOTE: Experimental
 		UpdateVersionMetadata(ctx context.Context, options WorkerDeploymentUpdateVersionMetadataOptions) (WorkerDeploymentUpdateVersionMetadataResponse, error)
 	}
 
 	// DeploymentListOptions are the parameters for configuring listing Worker Deployments.
+	//
 	// NOTE: Experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.WorkerDeploymentListOptions]
 	WorkerDeploymentListOptions struct {
 		// PageSize - How many results to fetch from the Server at a time.
+		//
 		// Optional: defaulted to 1000
 		PageSize int
 	}
 
 	// WorkerDeploymentRoutingConfig describes when new or existing Workflow Tasks are
 	// executed with this Worker Deployment.
+	//
 	// NOTE: Experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.WorkerDeploymentRoutingConfig]
@@ -487,6 +526,7 @@ type (
 	}
 
 	// WorkerDeploymentListEntry is a subset of fields from [WorkerDeploymentInfo].
+	//
 	// NOTE: Experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.WorkerDeploymentListEntry]
@@ -502,6 +542,7 @@ type (
 	}
 
 	// WorkerDeploymentListIterator is an iterator for deployments.
+	//
 	// NOTE: Experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.WorkerDeploymentListIterator]
@@ -514,6 +555,7 @@ type (
 	}
 
 	// WorkerDeploymentDeleteOptions provides options for [WorkerDeploymentClient.Delete].
+	//
 	// NOTE: Experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.WorkerDeploymentDeleteOptions]
@@ -522,11 +564,13 @@ type (
 		Name string
 
 		// Identity - The identity of the client who initiated this request.
+		//
 		// Optional: default to the identity of the underlying workflow client.
 		Identity string
 	}
 
 	// WorkerDeploymentDeleteResponse is the response for [WorkerDeploymentClient.Delete].
+	//
 	// NOTE: Experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.WorkerDeploymentDeleteResponse]
@@ -534,11 +578,13 @@ type (
 	}
 
 	// WorkerDeploymentClient is the client that manages Worker Deployments.
+	//
 	// NOTE: Experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.WorkerDeploymentClient]
 	WorkerDeploymentClient interface {
 		// List returns an iterator to enumerate Worker Deployments in the client's namespace.
+		//
 		// NOTE: Experimental
 		List(ctx context.Context, options WorkerDeploymentListOptions) (WorkerDeploymentListIterator, error)
 
@@ -547,6 +593,7 @@ type (
 		// This method does not validate the Worker Deployment Name. If there is no deployment
 		// with that name in this namespace, methods like WorkerDeploymentHandle.Describe()
 		// will return an error.
+		//
 		// NOTE: Experimental
 		//
 		// TODO(antlai-temporal): The following annotation is wrong but I cannot pass `check`
@@ -558,6 +605,7 @@ type (
 
 		// Delete removes the records of a Worker Deployment. A Deployment can only be
 		// deleted if it has no Version in it.
+		//
 		// NOTE: Experimental
 		Delete(ctx context.Context, options WorkerDeploymentDeleteOptions) (WorkerDeploymentDeleteResponse, error)
 	}

--- a/internal/worker_version_sets.go
+++ b/internal/worker_version_sets.go
@@ -207,9 +207,11 @@ type GetWorkerTaskReachabilityOptions struct {
 	BuildIDs []string
 	// TaskQueues - The task queues with Build IDs defined on them that the request is
 	// concerned with.
+	//
 	// Optional: defaults to all task queues
 	TaskQueues []string
 	// Reachability - The reachability this request is concerned with.
+	//
 	// Optional: defaults to all types of reachability
 	Reachability TaskReachability
 }

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -67,6 +67,7 @@ const (
 )
 
 // VersioningBehavior specifies when existing workflows could change their Build ID.
+//
 // NOTE: Experimental
 //
 // Exposed as: [go.temporal.io/sdk/workflow.VersioningBehavior]
@@ -330,25 +331,30 @@ type (
 	// Exposed as: [go.temporal.io/sdk/workflow.ChildWorkflowOptions]
 	ChildWorkflowOptions struct {
 		// Namespace of the child workflow.
+		//
 		// Optional: the current workflow (parent)'s namespace will be used if this is not provided.
 		Namespace string
 
 		// WorkflowID of the child workflow to be scheduled.
+		//
 		// Optional: an auto generated workflowID will be used if this is not provided.
 		WorkflowID string
 
 		// TaskQueue that the child workflow needs to be scheduled on.
+		//
 		// Optional: the parent workflow task queue will be used if this is not provided.
 		TaskQueue string
 
 		// WorkflowExecutionTimeout - The end to end timeout for the child workflow execution including retries
 		// and continue as new.
+		//
 		// Optional: defaults to unlimited.
 		WorkflowExecutionTimeout time.Duration
 
 		// WorkflowRunTimeout - The timeout for a single run of the child workflow execution. Each retry or
 		// continue as new should obey this timeout. Use WorkflowExecutionTimeout to specify how long the parent
 		// is willing to wait for the child completion.
+		//
 		// Optional: defaults to WorkflowExecutionTimeout
 		WorkflowRunTimeout time.Duration
 
@@ -360,6 +366,7 @@ type (
 
 		// WaitForCancellation - Whether to wait for canceled child workflow to be ended (child workflow can be ended
 		// as: completed/failed/timedout/terminated/canceled)
+		//
 		// Optional: default false
 		WaitForCancellation bool
 
@@ -368,6 +375,7 @@ type (
 		WorkflowIDReusePolicy enumspb.WorkflowIdReusePolicy
 
 		// RetryPolicy specify how to retry child workflow if error happens.
+		//
 		// Optional: default is no retry
 		RetryPolicy *RetryPolicy
 
@@ -453,6 +461,7 @@ type (
 		// Optional: Provides a Versioning Behavior to workflows of this type. It is required
 		// when WorkerOptions does not specify [DeploymentOptions.DefaultVersioningBehavior],
 		// [DeploymentOptions.DeploymentSeriesName] is set, and [UseBuildIDForVersioning] is true.
+		//
 		// NOTE: Experimental
 		VersioningBehavior VersioningBehavior
 	}

--- a/internal/workflow_testsuite.go
+++ b/internal/workflow_testsuite.go
@@ -224,6 +224,7 @@ func (t *TestActivityEnvironment) ExecuteLocalActivity(activityFn interface{}, a
 // SetWorkerOptions sets the WorkerOptions that will be use by TestActivityEnvironment. TestActivityEnvironment will
 // use options of BackgroundActivityContext, MaxConcurrentSessionExecutionSize, and WorkflowInterceptorChainFactories on the WorkerOptions.
 // Other options are ignored.
+//
 // Note: WorkerOptions is defined in internal package, use public type worker.Options instead.
 func (t *TestActivityEnvironment) SetWorkerOptions(options WorkerOptions) *TestActivityEnvironment {
 	t.impl.setWorkerOptions(options)
@@ -281,6 +282,7 @@ func (t *TestActivityEnvironment) SetWorkerStopChannel(c chan struct{}) {
 // SetOnActivityHeartbeatListener sets a listener that will be called when
 // activity heartbeat is called. ActivityInfo is defined in internal package,
 // use public type activity.Info instead.
+//
 // Note: The provided listener may be called concurrently.
 //
 // Note: Due to internal caching by the activity system, this may not get called
@@ -563,6 +565,7 @@ func (e *TestWorkflowEnvironment) OnUpsertSearchAttributes(attributes interface{
 // OnUpsertTypedSearchAttributes setup a mock for workflow.UpsertTypedSearchAttributes call.
 // If mock is not setup, the UpsertTypedSearchAttributes call will only validate input attributes.
 // If mock is setup, all UpsertTypedSearchAttributes calls in workflow have to be mocked.
+//
 // Note: The mock is called with a temporal.SearchAttributes constructed from the inputs to workflow.UpsertTypedSearchAttributes.
 func (e *TestWorkflowEnvironment) OnUpsertTypedSearchAttributes(attributes interface{}) *MockCallWrapper {
 	call := e.workflowMock.On(mockMethodForUpsertTypedSearchAttributes, attributes)
@@ -829,6 +832,7 @@ func (e *TestWorkflowEnvironment) Now() time.Time {
 // SetWorkerOptions sets the WorkerOptions that will be use by TestActivityEnvironment. TestActivityEnvironment will
 // use options of BackgroundActivityContext, MaxConcurrentSessionExecutionSize, and WorkflowInterceptorChainFactories on the WorkerOptions.
 // Other options are ignored.
+//
 // Note: WorkerOptions is defined in internal package, use public type worker.Options instead.
 func (e *TestWorkflowEnvironment) SetWorkerOptions(options WorkerOptions) *TestWorkflowEnvironment {
 	e.impl.setWorkerOptions(options)
@@ -910,6 +914,7 @@ func (e *TestWorkflowEnvironment) SetWorkflowRunTimeout(runTimeout time.Duration
 }
 
 // SetOnActivityStartedListener sets a listener that will be called before activity starts execution.
+//
 // Note: ActivityInfo is defined in internal package, use public type activity.Info instead.
 func (e *TestWorkflowEnvironment) SetOnActivityStartedListener(
 	listener func(activityInfo *ActivityInfo, ctx context.Context, args converter.EncodedValues)) *TestWorkflowEnvironment {
@@ -918,6 +923,7 @@ func (e *TestWorkflowEnvironment) SetOnActivityStartedListener(
 }
 
 // SetOnActivityCompletedListener sets a listener that will be called after an activity is completed.
+//
 // Note: ActivityInfo is defined in internal package, use public type activity.Info instead.
 func (e *TestWorkflowEnvironment) SetOnActivityCompletedListener(
 	listener func(activityInfo *ActivityInfo, result converter.EncodedValue, err error)) *TestWorkflowEnvironment {
@@ -926,6 +932,7 @@ func (e *TestWorkflowEnvironment) SetOnActivityCompletedListener(
 }
 
 // SetOnActivityCanceledListener sets a listener that will be called after an activity is canceled.
+//
 // Note: ActivityInfo is defined in internal package, use public type activity.Info instead.
 func (e *TestWorkflowEnvironment) SetOnActivityCanceledListener(
 	listener func(activityInfo *ActivityInfo)) *TestWorkflowEnvironment {
@@ -934,7 +941,9 @@ func (e *TestWorkflowEnvironment) SetOnActivityCanceledListener(
 }
 
 // SetOnActivityHeartbeatListener sets a listener that will be called when activity heartbeat.
+//
 // Note: ActivityInfo is defined in internal package, use public type activity.Info instead.
+//
 // Note: The provided listener may be called concurrently.
 //
 // Note: Due to internal caching by the activity system, this may not get called
@@ -948,6 +957,7 @@ func (e *TestWorkflowEnvironment) SetOnActivityHeartbeatListener(
 }
 
 // SetOnChildWorkflowStartedListener sets a listener that will be called before a child workflow starts execution.
+//
 // Note: WorkflowInfo is defined in internal package, use public type workflow.Info instead.
 func (e *TestWorkflowEnvironment) SetOnChildWorkflowStartedListener(
 	listener func(workflowInfo *WorkflowInfo, ctx Context, args converter.EncodedValues)) *TestWorkflowEnvironment {
@@ -956,6 +966,7 @@ func (e *TestWorkflowEnvironment) SetOnChildWorkflowStartedListener(
 }
 
 // SetOnChildWorkflowCompletedListener sets a listener that will be called after a child workflow is completed.
+//
 // Note: WorkflowInfo is defined in internal package, use public type workflow.Info instead.
 func (e *TestWorkflowEnvironment) SetOnChildWorkflowCompletedListener(
 	listener func(workflowInfo *WorkflowInfo, result converter.EncodedValue, err error)) *TestWorkflowEnvironment {
@@ -964,6 +975,7 @@ func (e *TestWorkflowEnvironment) SetOnChildWorkflowCompletedListener(
 }
 
 // SetOnChildWorkflowCanceledListener sets a listener that will be called when a child workflow is canceled.
+//
 // Note: WorkflowInfo is defined in internal package, use public type workflow.Info instead.
 func (e *TestWorkflowEnvironment) SetOnChildWorkflowCanceledListener(
 	listener func(workflowInfo *WorkflowInfo)) *TestWorkflowEnvironment {
@@ -991,6 +1003,7 @@ func (e *TestWorkflowEnvironment) SetOnTimerCanceledListener(listener func(timer
 }
 
 // SetOnLocalActivityStartedListener sets a listener that will be called before local activity starts execution.
+//
 // Note: ActivityInfo is defined in internal package, use public type activity.Info instead.
 func (e *TestWorkflowEnvironment) SetOnLocalActivityStartedListener(
 	listener func(activityInfo *ActivityInfo, ctx context.Context, args []interface{})) *TestWorkflowEnvironment {
@@ -999,6 +1012,7 @@ func (e *TestWorkflowEnvironment) SetOnLocalActivityStartedListener(
 }
 
 // SetOnLocalActivityCompletedListener sets a listener that will be called after local activity is completed.
+//
 // Note: ActivityInfo is defined in internal package, use public type activity.Info instead.
 func (e *TestWorkflowEnvironment) SetOnLocalActivityCompletedListener(
 	listener func(activityInfo *ActivityInfo, result converter.EncodedValue, err error)) *TestWorkflowEnvironment {
@@ -1007,6 +1021,7 @@ func (e *TestWorkflowEnvironment) SetOnLocalActivityCompletedListener(
 }
 
 // SetOnLocalActivityCanceledListener sets a listener that will be called after local activity is canceled.
+//
 // Note: ActivityInfo is defined in internal package, use public type activity.Info instead.
 func (e *TestWorkflowEnvironment) SetOnLocalActivityCanceledListener(
 	listener func(activityInfo *ActivityInfo)) *TestWorkflowEnvironment {

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -212,6 +212,7 @@ type (
 	}
 
 	// DeploymentOptions provides configuration to enable Worker Versioning.
+	//
 	// NOTE: Experimental
 	DeploymentOptions = internal.WorkerDeploymentOptions
 

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -36,6 +36,7 @@ import (
 )
 
 // VersioningBehavior specifies when existing workflows could change their Build ID.
+//
 // NOTE: Experimental
 type VersioningBehavior = internal.VersioningBehavior
 


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->
Added blank lines before "Optional", "default", and "note" lines for clarity.

This was already happening in some place and not others, so also just converging on consistency.

## Why?
<!-- Tell your future self why have you made these changes -->
for clarity when rendered in IDE

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
