### PR TITLE
Add RawValue support

### DIFF
--- a/converter/codec.go
+++ b/converter/codec.go
@@ -133,6 +133,9 @@ func (*zlibCodec) Decode(payloads []*commonpb.Payload) ([]*commonpb.Payload, err
 // CodecDataConverter is a DataConverter that wraps an underlying data
 // converter and supports chained encoding of just the payload without regard
 // for serialization to/from actual types.
+//
+// CodecDataConverter provides support for RawValue handling, where it skips the
+// parent data converter and directly encodes/decodes the RawValue payload.
 type CodecDataConverter struct {
 	parent DataConverter
 	codecs []PayloadCodec
@@ -200,7 +203,6 @@ func (e *CodecDataConverter) ToPayload(value interface{}) (*commonpb.Payload, er
 func (e *CodecDataConverter) ToPayloads(value ...interface{}) (*commonpb.Payloads, error) {
 	var payloads *commonpb.Payloads
 	var rawValuePayloads []*commonpb.Payload
-	fmt.Println("len(value)", value)
 	for _, v := range value {
 		rawValue, ok := v.(RawValue)
 		if ok {

--- a/converter/codec.go
+++ b/converter/codec.go
@@ -176,7 +176,7 @@ func (e *CodecDataConverter) ToPayload(value interface{}) (*commonpb.Payload, er
 
 	var payload *commonpb.Payload
 	if ok {
-		payload = rawValue.Payload
+		payload = rawValue.Payload()
 	} else {
 		var err error
 		payload, err = e.parent.ToPayload(value)
@@ -204,7 +204,7 @@ func (e *CodecDataConverter) ToPayloads(value ...interface{}) (*commonpb.Payload
 	for _, v := range value {
 		rawValue, ok := v.(RawValue)
 		if ok {
-			rawValuePayloads = append(rawValuePayloads, rawValue.Payload)
+			rawValuePayloads = append(rawValuePayloads, rawValue.Payload())
 		}
 	}
 

--- a/converter/codec.go
+++ b/converter/codec.go
@@ -172,9 +172,17 @@ func (e *CodecDataConverter) decode(payloads []*commonpb.Payload) ([]*commonpb.P
 // ToPayload implements DataConverter.ToPayload performing encoding on the
 // result of the parent's ToPayload call.
 func (e *CodecDataConverter) ToPayload(value interface{}) (*commonpb.Payload, error) {
-	payload, err := e.parent.ToPayload(value)
-	if payload == nil || err != nil {
-		return payload, err
+	rawValue, ok := value.(RawValue)
+
+	var payload *commonpb.Payload
+	if ok {
+		payload = rawValue.Payload
+	} else {
+		var err error
+		payload, err = e.parent.ToPayload(value)
+		if payload == nil || err != nil {
+			return payload, err
+		}
 	}
 
 	encodedPayloads, err := e.encode([]*commonpb.Payload{payload})
@@ -190,10 +198,26 @@ func (e *CodecDataConverter) ToPayload(value interface{}) (*commonpb.Payload, er
 // ToPayloads implements DataConverter.ToPayloads performing encoding on the
 // result of the parent's ToPayloads call.
 func (e *CodecDataConverter) ToPayloads(value ...interface{}) (*commonpb.Payloads, error) {
-	payloads, err := e.parent.ToPayloads(value...)
-	if payloads == nil || err != nil {
-		return payloads, err
+	var payloads *commonpb.Payloads
+	var rawValuePayloads []*commonpb.Payload
+	fmt.Println("len(value)", value)
+	for _, v := range value {
+		rawValue, ok := v.(RawValue)
+		if ok {
+			rawValuePayloads = append(rawValuePayloads, rawValue.Payload)
+		}
 	}
+
+	if len(rawValuePayloads) > 0 {
+		payloads = &commonpb.Payloads{Payloads: rawValuePayloads}
+	} else {
+		var err error
+		payloads, err = e.parent.ToPayloads(value...)
+		if payloads == nil || err != nil {
+			return payloads, err
+		}
+	}
+
 	encodedPayloads, err := e.encode(payloads.Payloads)
 	return &commonpb.Payloads{Payloads: encodedPayloads}, err
 }
@@ -212,6 +236,12 @@ func (e *CodecDataConverter) FromPayload(payload *commonpb.Payload, valuePtr int
 		return fmt.Errorf("received %d payloads from codec, expected 1", len(decodedPayloads))
 	}
 
+	rawValue, ok := valuePtr.(*RawValue)
+	if ok {
+		*rawValue = RawValue{Payload: decodedPayloads[0]}
+		return nil
+	}
+
 	return e.parent.FromPayload(decodedPayloads[0], valuePtr)
 }
 
@@ -225,6 +255,22 @@ func (e *CodecDataConverter) FromPayloads(payloads *commonpb.Payloads, valuePtrs
 	if err != nil {
 		return err
 	}
+
+	var isRawValue bool
+	for i, payload := range decodedPayloads {
+		if i >= len(valuePtrs) {
+			break
+		}
+		rawValue, ok := valuePtrs[i].(*RawValue)
+		if ok {
+			isRawValue = true
+			*rawValue = RawValue{Payload: payload}
+		}
+	}
+	if isRawValue {
+		return nil
+	}
+
 	return e.parent.FromPayloads(&commonpb.Payloads{Payloads: decodedPayloads}, valuePtrs...)
 }
 

--- a/converter/codec.go
+++ b/converter/codec.go
@@ -238,7 +238,7 @@ func (e *CodecDataConverter) FromPayload(payload *commonpb.Payload, valuePtr int
 
 	rawValue, ok := valuePtr.(*RawValue)
 	if ok {
-		*rawValue = RawValue{Payload: decodedPayloads[0]}
+		*rawValue = NewRawValue(decodedPayloads[0])
 		return nil
 	}
 
@@ -264,7 +264,7 @@ func (e *CodecDataConverter) FromPayloads(payloads *commonpb.Payloads, valuePtrs
 		rawValue, ok := valuePtrs[i].(*RawValue)
 		if ok {
 			isRawValue = true
-			*rawValue = RawValue{Payload: payload}
+			*rawValue = NewRawValue(payload)
 		}
 	}
 	if isRawValue {

--- a/converter/codec_test.go
+++ b/converter/codec_test.go
@@ -299,7 +299,7 @@ func TestRawValueCompositeDataConverter(t *testing.T) {
 	origPayload, err := defaultConv.ToPayload("test raw value")
 	require.NoError(err)
 
-	rv := converter.RawValue{Payload: origPayload}
+	rv := converter.NewRawValue(origPayload)
 	// To/FromPayload
 	payload, err := defaultConv.ToPayload(rv)
 	require.NoError(err)
@@ -336,7 +336,7 @@ func TestRawValueCodec(t *testing.T) {
 	// To/FromPayload
 	data := "test raw value"
 	dataPayload, err := defaultConv.ToPayload(data)
-	rawValue := converter.RawValue{Payload: dataPayload}
+	rawValue := converter.NewRawValue(dataPayload)
 	require.NoError(err)
 
 	compPayload, err := zlibConv.ToPayload(rawValue)

--- a/converter/composite_data_converter.go
+++ b/converter/composite_data_converter.go
@@ -97,7 +97,7 @@ func (dc *CompositeDataConverter) FromPayloads(payloads *commonpb.Payloads, valu
 		}
 		rawValue, ok := valuePtrs[i].(*RawValue)
 		if ok {
-			*rawValue = RawValue{Payload: payload}
+			*rawValue = NewRawValue(payload)
 		} else {
 			err := dc.FromPayload(payload, valuePtrs[i])
 			if err != nil {
@@ -138,7 +138,7 @@ func (dc *CompositeDataConverter) FromPayload(payload *commonpb.Payload, valuePt
 
 	rawValue, ok := valuePtr.(*RawValue)
 	if ok {
-		*rawValue = RawValue{Payload: payload}
+		*rawValue = NewRawValue(payload)
 		return nil
 	}
 

--- a/converter/composite_data_converter.go
+++ b/converter/composite_data_converter.go
@@ -65,7 +65,7 @@ func (dc *CompositeDataConverter) ToPayloads(values ...interface{}) (*commonpb.P
 	for _, v := range values {
 		rawValue, ok := v.(RawValue)
 		if ok {
-			rawValuePayloads = append(rawValuePayloads, rawValue.Payload)
+			rawValuePayloads = append(rawValuePayloads, rawValue.Payload())
 		}
 	}
 	if len(rawValuePayloads) > 0 {
@@ -113,7 +113,7 @@ func (dc *CompositeDataConverter) FromPayloads(payloads *commonpb.Payloads, valu
 func (dc *CompositeDataConverter) ToPayload(value interface{}) (*commonpb.Payload, error) {
 	rawValue, ok := value.(RawValue)
 	if ok {
-		return rawValue.Payload, nil
+		return rawValue.Payload(), nil
 	}
 
 	for _, enc := range dc.orderedEncodings {

--- a/converter/composite_data_converter.go
+++ b/converter/composite_data_converter.go
@@ -61,6 +61,16 @@ func (dc *CompositeDataConverter) ToPayloads(values ...interface{}) (*commonpb.P
 	if len(values) == 0 {
 		return nil, nil
 	}
+	var rawValuePayloads []*commonpb.Payload
+	for _, v := range values {
+		rawValue, ok := v.(RawValue)
+		if ok {
+			rawValuePayloads = append(rawValuePayloads, rawValue.Payload)
+		}
+	}
+	if len(rawValuePayloads) > 0 {
+		return &commonpb.Payloads{Payloads: rawValuePayloads}, nil
+	}
 
 	result := &commonpb.Payloads{}
 	for i, value := range values {
@@ -85,10 +95,14 @@ func (dc *CompositeDataConverter) FromPayloads(payloads *commonpb.Payloads, valu
 		if i >= len(valuePtrs) {
 			break
 		}
-
-		err := dc.FromPayload(payload, valuePtrs[i])
-		if err != nil {
-			return fmt.Errorf("payload item %d: %w", i, err)
+		rawValue, ok := valuePtrs[i].(*RawValue)
+		if ok {
+			*rawValue = RawValue{Payload: payload}
+		} else {
+			err := dc.FromPayload(payload, valuePtrs[i])
+			if err != nil {
+				return fmt.Errorf("payload item %d: %w", i, err)
+			}
 		}
 	}
 
@@ -97,6 +111,11 @@ func (dc *CompositeDataConverter) FromPayloads(payloads *commonpb.Payloads, valu
 
 // ToPayload converts single value to payload.
 func (dc *CompositeDataConverter) ToPayload(value interface{}) (*commonpb.Payload, error) {
+	rawValue, ok := value.(RawValue)
+	if ok {
+		return rawValue.Payload, nil
+	}
+
 	for _, enc := range dc.orderedEncodings {
 		payloadConverter := dc.payloadConverters[enc]
 		payload, err := payloadConverter.ToPayload(value)
@@ -114,6 +133,12 @@ func (dc *CompositeDataConverter) ToPayload(value interface{}) (*commonpb.Payloa
 // FromPayload converts single value from payload.
 func (dc *CompositeDataConverter) FromPayload(payload *commonpb.Payload, valuePtr interface{}) error {
 	if payload == nil {
+		return nil
+	}
+
+	rawValue, ok := valuePtr.(*RawValue)
+	if ok {
+		*rawValue = RawValue{Payload: payload}
 		return nil
 	}
 

--- a/converter/data_converter.go
+++ b/converter/data_converter.go
@@ -40,12 +40,16 @@ type (
 	// workflow.DataConverterWithoutDeadlockDetection.
 	DataConverter interface {
 		// ToPayload converts single value to payload.
+		//
+		// Note: When value is of RawValue type, encoding should occur, but data conversion must be skipped.
 		ToPayload(value interface{}) (*commonpb.Payload, error)
 		// FromPayload converts single value from payload.
 		//
 		// Note, values should not be reused for extraction here because merging on
 		// top of existing values may result in unexpected behavior similar to
 		// json.Unmarshal.
+		//
+		// Note: When valuePtr is of RawValue type, decryption should occur but data conversion must be skipped.
 		FromPayload(payload *commonpb.Payload, valuePtr interface{}) error
 
 		// ToPayloads converts a list of values.

--- a/converter/value.go
+++ b/converter/value.go
@@ -24,6 +24,8 @@
 
 package converter
 
+import commonpb "go.temporal.io/api/common/v1"
+
 type (
 	// EncodedValue is used to encapsulate/extract encoded value from workflow/activity.
 	EncodedValue interface {
@@ -47,5 +49,13 @@ type (
 		// top of existing values may result in unexpected behavior similar to
 		// json.Unmarshal.
 		Get(valuePtr ...interface{}) error
+	}
+
+	// RawValue is a representation of an unconverted, raw payload.
+	//
+	// This type can be used as a paramter or return type in workflows and activities to pass through
+	// a raw payload. Encoding/decoding of the payload is still done by the system.
+	RawValue struct {
+		Payload *commonpb.Payload
 	}
 )

--- a/converter/value.go
+++ b/converter/value.go
@@ -24,7 +24,10 @@
 
 package converter
 
-import commonpb "go.temporal.io/api/common/v1"
+import (
+	"fmt"
+	commonpb "go.temporal.io/api/common/v1"
+)
 
 type (
 	// EncodedValue is used to encapsulate/extract encoded value from workflow/activity.
@@ -56,11 +59,23 @@ type (
 	// This type can be used as a paramter or return type in workflows and activities to pass through
 	// a raw payload. Encoding/decoding of the payload is still done by the system.
 	RawValue struct {
-		Payload *commonpb.Payload
+		payload *commonpb.Payload
 	}
 )
 
 // NewRawValue creates a new RawValue instance.
 func NewRawValue(payload *commonpb.Payload) RawValue {
-	return RawValue{Payload: payload}
+	return RawValue{payload: payload}
+}
+
+func (v RawValue) Payload() *commonpb.Payload {
+	return v.payload
+}
+
+func (v RawValue) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("RawValue is not JSON serializable")
+}
+
+func (v *RawValue) UnmarshalJSON(b []byte) error {
+	return fmt.Errorf("RawValue is not JSON serializable")
 }

--- a/converter/value.go
+++ b/converter/value.go
@@ -59,3 +59,8 @@ type (
 		Payload *commonpb.Payload
 	}
 )
+
+// NewRawValue creates a new RawValue instance.
+func NewRawValue(payload *commonpb.Payload) RawValue {
+	return RawValue{Payload: payload}
+}

--- a/test/activity_test.go
+++ b/test/activity_test.go
@@ -29,6 +29,7 @@ import (
 	"errors"
 	"fmt"
 	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/sdk/converter"
 	"strconv"
 	"strings"
 	"sync"
@@ -450,4 +451,9 @@ func (a *Activities) ClientFromActivity(ctx context.Context) error {
 		return fmt.Errorf("expected non-empty list of executions")
 	}
 	return nil
+}
+
+func (a *Activities) RawValueActivity(ctx context.Context, value converter.RawValue) (converter.RawValue, error) {
+	activity.GetLogger(ctx).Info("RawValue value", value.Payload())
+	return value, nil
 }

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -7252,3 +7252,25 @@ func (ts *IntegrationTestSuite) TestPartialHistoryReplayFuzzer() {
 		ts.NoError(replayer.ReplayWorkflowHistory(nil, &history))
 	}
 }
+
+func (ts *IntegrationTestSuite) TestRawValue() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	value := "new_value_1"
+	payload, _ := converter.GetDefaultDataConverter().ToPayload(value)
+
+	val := converter.NewRawValue(payload)
+	run, err := ts.client.ExecuteWorkflow(ctx, ts.startWorkflowOptions("test-raw-value"), ts.workflows.WorkflowRawValue, val)
+	ts.NotNil(run)
+	ts.NoError(err)
+	var returnValue converter.RawValue
+	ts.NoError(run.Get(ctx, &returnValue))
+
+	ts.Equal(payload.Data, returnValue.Payload().Data)
+
+	var newValue string
+	err = converter.GetDefaultDataConverter().FromPayload(returnValue.Payload(), &newValue)
+	ts.NoError(err)
+	ts.Equal(newValue, value)
+}

--- a/test/workflow_test.go
+++ b/test/workflow_test.go
@@ -3412,6 +3412,15 @@ func (w *Workflows) WorkflowWithChildren(ctx workflow.Context) (string, error) {
 	return "Parent Workflow Complete", nil
 }
 
+func (w *Workflows) WorkflowRawValue(ctx workflow.Context, value converter.RawValue) (converter.RawValue, error) {
+	ctx = workflow.WithActivityOptions(ctx, w.defaultActivityOptions())
+	var returnVal converter.RawValue
+	var activities *Activities
+	err := workflow.ExecuteActivity(ctx, activities.RawValueActivity, value).Get(ctx, &returnVal)
+	fmt.Println("err", err)
+	return returnVal, err
+}
+
 func (w *Workflows) register(worker worker.Worker) {
 	worker.RegisterWorkflow(w.ActivityCancelRepro)
 	worker.RegisterWorkflow(w.ActivityCompletionUsingID)
@@ -3555,6 +3564,7 @@ func (w *Workflows) register(worker worker.Worker) {
 	worker.RegisterWorkflow(w.CommandsFuzz)
 	worker.RegisterWorkflow(w.WorkflowClientFromActivity)
 	worker.RegisterWorkflow(w.WorkflowTemporalPrefixSignal)
+	worker.RegisterWorkflow(w.WorkflowRawValue)
 }
 
 func (w *Workflows) defaultActivityOptions() workflow.ActivityOptions {


### PR DESCRIPTION
## What was changed
Added new RawValue type and add support in codec and composite data converter.

## Why?
SDKs need to support a payload wrapper called "raw value" that is just a payload but is passed through the conversion stage (but still applies to codec).

## Checklist
<!--- add/delete as needed --->

1. Closes #1231 

2. How was this tested:
Added unit tests for both codec and composite data converter, and an integration test that pass a payload to and from a workflow and activity

3. Any docs updates needed?
No
