### PR TITLE
Support New Versioning in WorkflowInfo.GetCurrentBuildID()

### DIFF
--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -500,6 +500,10 @@ OrderEvents:
 			if event.GetEventType() == enumspb.EVENT_TYPE_WORKFLOW_TASK_COMPLETED {
 				bidStr := event.GetWorkflowTaskCompletedEventAttributes().
 					GetWorkerVersion().GetBuildId()
+				version := event.GetWorkflowTaskCompletedEventAttributes().GetWorkerDeploymentVersion()
+				if splitVersion := strings.SplitN(version, ".", 2); len(splitVersion) == 2 {
+					bidStr = splitVersion[1]
+				}
 				taskEvents.buildID = &bidStr
 			} else if isPreloadMarkerEvent(event) {
 				taskEvents.markers = append(taskEvents.markers, event)


### PR DESCRIPTION

## What was changed
<!-- Describe what has changed in this PR -->
See #1471 
Note that the relevant info (version) to extract the BuildID is still in `EVENT_TYPE_WORKFLOW_TASK_COMPLETED`

## Why?
<!-- Tell your future self why have you made these changes -->

Previous method to extract BuildID used deprecated fields in versioning 3.1

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->
#1471 
2. How was this tested:
 System test added
<!--- Please describe how you tested your changes/how we can test them -->
