### PR TITLE
Fix withLogger caller skip overcount

### DIFF
--- a/log/with_logger.go
+++ b/log/with_logger.go
@@ -81,7 +81,7 @@ func (l *withLogger) Error(msg string, keyvals ...interface{}) {
 
 func (l *withLogger) WithCallerSkip(depth int) Logger {
 	if sl, ok := l.logger.(WithSkipCallers); ok {
-		return newWithLogger(sl.WithCallerSkip(depth), l.keyvals...)
+		return newWithLogger(sl.WithCallerSkip(depth-1), l.keyvals...)
 	}
 	return l
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Decrementing caller skip depth by 1 to offset the increment by 1 in `newWithLogger`.

## Why?
- The `withLogger` logger, whose `WithCallerSkip()` function is called, is replaced by a new `withLogger` using the same underlying logger `l.logger`. 
- Each new `withLogger` adds 1 skip in `newWithLogger`.
- When a `withLogger` is removed, its added skip should be decremented as well to fix the overcounting issue.

## Checklist

1. Closes https://github.com/temporalio/sdk-go/issues/1882

2. How was this tested:
Ran the same code as in the issue and got the expected behavior:
```
--- skip: 0
--- skip: 1
--- skip: -1
--- skip: 1
--- skip: 0
--- skip: 1
{"level":"error","ts":1742900242.772918,"caller":"play/business.go:11","msg":"HelloWorld: this is an error inside the workflow","Namespace":"default","TaskQueue":"main_queue","WorkerID":"60774@KCJ74K6WJ2@","WorkflowType":"HelloWorld","WorkflowID":"3827b52a-a075-4f93-887d-9347c7b933d5","RunID":"210f13ef-f403-454d-9da9-d3161a5ec078","Attempt":1,"stacktrace":"main.HelloWorld\n\t/payrails/sdk-go/play/business.go:11\nreflect.Value.call\n\t/usr/local/go/src/reflect/value.go:581\nreflect.Value.Call\n\t/usr/local/go/src/reflect/value.go:365\ngo.temporal.io/sdk/internal.executeFunction\n\t/payrails/sdk-go/internal/internal_worker.go:2087\ngo.temporal.io/sdk/internal.(*workflowEnvironmentInterceptor).ExecuteWorkflow\n\t/payrails/sdk-go/internal/workflow.go:797\ngo.temporal.io/sdk/internal.(*workflowExecutor).Execute\n\t/payrails/sdk-go/internal/internal_worker.go:922\ngo.temporal.io/sdk/internal.(*syncWorkflowDefinition).Execute.func1\n\t/payrails/sdk-go/internal/internal_workflow.go:574\ngo.temporal.io/sdk/internal.(*coroutineState).run\n\t/payrails/sdk-go/internal/internal_workflow.go:1217"}
```

3. Any docs updates needed?
No
