### PR TITLE
Doc: Add note about NewFailureGRPCClientInterceptor before NewPayloadCodecGRPCClientInterceptor

### DIFF
--- a/converter/grpc_interceptor.go
+++ b/converter/grpc_interceptor.go
@@ -42,6 +42,9 @@ type PayloadCodecGRPCClientInterceptorOptions struct {
 
 // NewPayloadCodecGRPCClientInterceptor returns a GRPC Client Interceptor that will mimic the encoding
 // that the SDK system would perform when configured with a matching EncodingDataConverter.
+// When combining this with NewFailureGRPCClientInterceptor you should ensure that NewFailureGRPCClientInterceptor is
+// before NewPayloadCodecGRPCClientInterceptor in the chain.
+//
 // Note: This approach does not support use cases that rely on the ContextAware DataConverter interface as
 // workflow context is not available at the GRPC level.
 func NewPayloadCodecGRPCClientInterceptor(options PayloadCodecGRPCClientInterceptorOptions) (grpc.UnaryClientInterceptor, error) {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
NewFailureGRPCClientInterceptor already has this note, adding the same note to NewPayloadCodecGRPCClientInterceptor.

## Why?
<!-- Tell your future self why have you made these changes -->
Clarity

## Checklist
<!--- add/delete as needed --->

1. Closes #1886

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
doc only change

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
