### PR TITLE
Fix `WorkflowId` being wrongly capitalized on example comments

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1036,7 +1036,7 @@ type (
 		ListOpenWorkflow(ctx context.Context, request *workflowservice.ListOpenWorkflowExecutionsRequest) (*workflowservice.ListOpenWorkflowExecutionsResponse, error)
 
 		// ListWorkflow gets workflow executions based on query. The query is basically the SQL WHERE clause, examples:
-		//  - "(WorkflowID = 'wid1' or (WorkflowType = 'type2' and WorkflowID = 'wid2'))".
+		//  - "(WorkflowId = 'wid1' or (WorkflowType = 'type2' and WorkflowId = 'wid2'))".
 		//  - "CloseTime between '2019-08-27T15:04:05+00:00' and '2019-08-28T15:04:05+00:00'".
 		//  - to list only open workflow use "CloseTime is null"
 		// For supported operations on different server versions see https://docs.temporal.io/visibility.

--- a/internal/client.go
+++ b/internal/client.go
@@ -253,7 +253,7 @@ type (
 
 		// ListWorkflow gets workflow executions based on query.The query is basically the SQL WHERE clause,
 		// examples:
-		//  - "(WorkflowID = 'wid1' or (WorkflowType = 'type2' and WorkflowID = 'wid2'))".
+		//  - "(WorkflowId = 'wid1' or (WorkflowType = 'type2' and WorkflowId = 'wid2'))".
 		//  - "CloseTime between '2019-08-27T15:04:05+00:00' and '2019-08-28T15:04:05+00:00'".
 		//  - to list only open workflow use "CloseTime is null"
 		// Retrieved workflow executions are sorted by StartTime in descending order when list open workflow,


### PR DESCRIPTION
## What was changed

This PR changes the capitalization of `WorkflowID` to `WorkflowId` in the comments of the example code for `ListWorkflow`

## Why?

I copied the example code to use in a query like so:

```go
temporalClient.ListWorkflow(context.Background(), &workflowservice.ListWorkflowExecutionsRequest{
		Namespace: TemporalNamespace,
		Query:     fmt.Sprintf("(WorkflowID = '%s' or WorkflowID = '%s')", workflow1, workflow2),
	})
```

And was greeted with the following error:

`invalid query: invalid expression: column name 'WorkflowID' is not a valid search attribute`

Changing `WorkflowID` to `WorkflowId` fixed the issue, so I'm opening this PR so others after me don't fall into the same mistake.

## Checklist

1. How was this tested:
- Ran a `ListWorkflow` query with the updated example code.
1. Any docs updates needed?
I don't think so? At least I'm not sure if this example is in the docs.