### PR TITLE
Add FIPs to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,7 @@ jobs:
     strategy:
       matrix:
         go-version: ["oldstable", "stable"]
+        fips: [true, false]
       # Try to avoid running tests in parallel to avoid workflow ID conflict
       max-parallel: 1
     # Only supported in non-fork runs, since secrets are not available in forks.
@@ -106,6 +107,8 @@ jobs:
       TEMPORAL_NAMESPACE: sdk-ci.a2dd6
       TEMPORAL_CLIENT_CERT: ${{ secrets.TEMPORAL_CLIENT_CERT }}
       TEMPORAL_CLIENT_KEY: ${{ secrets.TEMPORAL_CLIENT_KEY }}
+      GODEBUG: ${{ matrix.fips && 'fips140=only' || '' }}
+
     steps:
       - uses: actions/checkout@v4
         with:

--- a/internal/checksum.go
+++ b/internal/checksum.go
@@ -57,7 +57,7 @@ func initBinaryChecksumLocked() error {
 
 	var h hash.Hash
 	if fips140.Enabled() {
-		h := sha256.New()
+		h = sha256.New()
 		if _, err := io.Copy(h, f); err != nil {
 			return err
 		}

--- a/internal/checksum.go
+++ b/internal/checksum.go
@@ -1,0 +1,75 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+//go:build go1.24
+
+package internal
+
+import (
+	"crypto/fips140"
+	"crypto/md5"
+	"crypto/sha256"
+	"encoding/hex"
+	"hash"
+	"io"
+	"os"
+)
+
+// callers MUST hold binaryChecksumLock before calling
+func initBinaryChecksumLocked() error {
+	if len(binaryChecksum) > 0 {
+		return nil
+	}
+
+	exec, err := os.Executable()
+	if err != nil {
+		return err
+	}
+
+	f, err := os.Open(exec)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = f.Close() // error is unimportant as it is read-only
+	}()
+
+	var h hash.Hash
+	if fips140.Enabled() {
+		h := sha256.New()
+		if _, err := io.Copy(h, f); err != nil {
+			return err
+		}
+	} else {
+		h = md5.New()
+		if _, err := io.Copy(h, f); err != nil {
+			return err
+		}
+	}
+
+	checksum := h.Sum(nil)
+	binaryChecksum = hex.EncodeToString(checksum[:])
+
+	return nil
+}

--- a/internal/checksum_legacy.go
+++ b/internal/checksum_legacy.go
@@ -1,0 +1,64 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+//go:build !go1.24
+
+package internal
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"io"
+	"os"
+)
+
+// callers MUST hold binaryChecksumLock before calling
+func initBinaryChecksumLocked() error {
+	if len(binaryChecksum) > 0 {
+		return nil
+	}
+
+	exec, err := os.Executable()
+	if err != nil {
+		return err
+	}
+
+	f, err := os.Open(exec)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = f.Close() // error is unimportant as it is read-only
+	}()
+
+	h := md5.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return err
+	}
+
+	checksum := h.Sum(nil)
+	binaryChecksum = hex.EncodeToString(checksum[:])
+
+	return nil
+}

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -28,7 +28,7 @@ package internal
 
 import (
 	"context"
-	"crypto/md5"
+	"crypto/sha256"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -1235,7 +1235,7 @@ func initBinaryChecksumLocked() error {
 		_ = f.Close() // error is unimportant as it is read-only
 	}()
 
-	h := md5.New()
+	h := sha256.New()
 	if _, err := io.Copy(h, f); err != nil {
 		return err
 	}

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -28,8 +28,6 @@ package internal
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -1214,36 +1212,6 @@ func initBinaryChecksum() error {
 	defer binaryChecksumLock.Unlock()
 
 	return initBinaryChecksumLocked()
-}
-
-// callers MUST hold binaryChecksumLock before calling
-func initBinaryChecksumLocked() error {
-	if len(binaryChecksum) > 0 {
-		return nil
-	}
-
-	exec, err := os.Executable()
-	if err != nil {
-		return err
-	}
-
-	f, err := os.Open(exec)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		_ = f.Close() // error is unimportant as it is read-only
-	}()
-
-	h := sha256.New()
-	if _, err := io.Copy(h, f); err != nil {
-		return err
-	}
-
-	checksum := h.Sum(nil)
-	binaryChecksum = hex.EncodeToString(checksum[:])
-
-	return nil
 }
 
 func getBinaryChecksum() string {


### PR DESCRIPTION
Switch from using `md5` to `sha256` to in `initBinaryChecksumLocked` so the Go SDK will work with `fips140` mode. I also added this to our CI when we connect to Temporal cloud over TLS

see also https://go.dev/doc/security/fips140

closes https://github.com/temporalio/sdk-go/issues/1887
