### PR TITLE
Disable some know flaky tests

### DIFF
--- a/internal/cmd/build/main.go
+++ b/internal/cmd/build/main.go
@@ -192,8 +192,7 @@ func (b *builder) integrationTest() error {
 	// Must run in test dir
 	cmd := b.cmdFromRoot(args...)
 	cmd.Dir = filepath.Join(cmd.Dir, "test")
-	cmd.Env = append(os.Environ(), "TEMPORAL_NAMESPACE=integration-test-namespace")
-	cmd.Env = append(os.Environ(), "DISABLE_SERVER_1_25_TESTS=1")
+	cmd.Env = append(os.Environ(), "DISABLE_SERVER_1_25_TESTS=1", "TEMPORAL_NAMESPACE=integration-test-namespace")
 	if err := b.runCmd(cmd); err != nil {
 		return fmt.Errorf("integration test failed: %w", err)
 	}

--- a/internal/cmd/build/main.go
+++ b/internal/cmd/build/main.go
@@ -144,8 +144,11 @@ func (b *builder) integrationTest() error {
 				HostPort:  "127.0.0.1:7233",
 				Namespace: "integration-test-namespace",
 			},
-			LogLevel: "warn",
+			DBFilename: "temporal.sqlite",
+			LogLevel:   "warn",
 			ExtraArgs: []string{
+				"--sqlite-pragma", "journal_mode=WAL",
+				"--sqlite-pragma", "synchronous=OFF",
 				"--dynamic-config-value", "frontend.enableExecuteMultiOperation=true",
 				"--dynamic-config-value", "frontend.enableUpdateWorkflowExecution=true",
 				"--dynamic-config-value", "frontend.enableUpdateWorkflowExecutionAsyncAccepted=true",

--- a/internal/cmd/build/main.go
+++ b/internal/cmd/build/main.go
@@ -149,6 +149,8 @@ func (b *builder) integrationTest() error {
 			ExtraArgs: []string{
 				"--sqlite-pragma", "journal_mode=WAL",
 				"--sqlite-pragma", "synchronous=OFF",
+				"--search-attribute", "CustomKeywordField=Keyword",
+				"--search-attribute", "CustomStringField=Text",
 				"--dynamic-config-value", "frontend.enableExecuteMultiOperation=true",
 				"--dynamic-config-value", "frontend.enableUpdateWorkflowExecution=true",
 				"--dynamic-config-value", "frontend.enableUpdateWorkflowExecutionAsyncAccepted=true",
@@ -190,6 +192,7 @@ func (b *builder) integrationTest() error {
 	// Must run in test dir
 	cmd := b.cmdFromRoot(args...)
 	cmd.Dir = filepath.Join(cmd.Dir, "test")
+	cmd.Env = append(os.Environ(), "TEMPORAL_NAMESPACE=integration-test-namespace")
 	cmd.Env = append(os.Environ(), "DISABLE_SERVER_1_25_TESTS=1")
 	if err := b.runCmd(cmd); err != nil {
 		return fmt.Errorf("integration test failed: %w", err)

--- a/internal/cmd/build/main.go
+++ b/internal/cmd/build/main.go
@@ -179,6 +179,7 @@ func (b *builder) integrationTest() error {
 
 	// Run integration test
 	args := []string{"go", "test", "-count", "1", "-race", "-v", "-timeout", "15m"}
+	env := append(os.Environ(), "DISABLE_SERVER_1_25_TESTS=1")
 	if *runFlag != "" {
 		args = append(args, "-run", *runFlag)
 	}
@@ -187,12 +188,13 @@ func (b *builder) integrationTest() error {
 	}
 	if *devServerFlag {
 		args = append(args, "-using-cli-dev-server")
+		env = append(env, "TEMPORAL_NAMESPACE=integration-test-namespace")
 	}
 	args = append(args, "./...")
 	// Must run in test dir
 	cmd := b.cmdFromRoot(args...)
 	cmd.Dir = filepath.Join(cmd.Dir, "test")
-	cmd.Env = append(os.Environ(), "DISABLE_SERVER_1_25_TESTS=1", "TEMPORAL_NAMESPACE=integration-test-namespace")
+	cmd.Env = env
 	if err := b.runCmd(cmd); err != nil {
 		return fmt.Errorf("integration test failed: %w", err)
 	}

--- a/internal/internal_task_handlers_test.go
+++ b/internal/internal_task_handlers_test.go
@@ -985,10 +985,12 @@ func (t *TaskHandlersTestSuite) TestWithTruncatedHistory() {
 }
 
 func (t *TaskHandlersTestSuite) TestSideEffectDefer() {
+	t.T().Skip("issue-1650: SideEffectDefer test is flaky")
 	t.testSideEffectDeferHelper(1)
 }
 
 func (t *TaskHandlersTestSuite) TestSideEffectDefer_NoCache() {
+	t.T().Skip("issue-1650: SideEffectDefer test is flaky")
 	t.testSideEffectDeferHelper(0)
 }
 

--- a/internal/internal_task_handlers_test.go
+++ b/internal/internal_task_handlers_test.go
@@ -1963,6 +1963,7 @@ func (t *TaskHandlersTestSuite) TestLocalActivityRetry_WorkflowTaskHeartbeatFail
 }
 
 func (t *TaskHandlersTestSuite) TestHeartBeat_NoError() {
+	t.T().Skip("issue-1650: TestHeartBeat_NoError is flaky")
 	mockCtrl := gomock.NewController(t.T())
 	mockService := workflowservicemock.NewMockWorkflowServiceClient(mockCtrl)
 	invocationChannel := make(chan int, 2)

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -87,7 +87,7 @@ func init() {
 }
 
 const (
-	ctxTimeout                    = 15 * time.Second
+	ctxTimeout                    = 30 * time.Second
 	namespaceCacheRefreshInterval = 20 * time.Second
 	testContextKey1               = "test-context-key1"
 	testContextKey2               = "test-context-key2"

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -2806,14 +2806,17 @@ func (ts *IntegrationTestSuite) TestInterceptorStartWithSignal() {
 }
 
 func (ts *IntegrationTestSuite) TestOpenTelemetryTracing() {
+	ts.T().Skip("issue-1650: Otel Tracing intergation tests are flaky")
 	ts.testOpenTelemetryTracing(true, false)
 }
 
 func (ts *IntegrationTestSuite) TestOpenTelemetryTracingWithUpdateWithStart() {
+	ts.T().Skip("issue-1650: Otel Tracing intergation tests are flaky")
 	ts.testOpenTelemetryTracing(true, true)
 }
 
 func (ts *IntegrationTestSuite) TestOpenTelemetryTracingWithoutMessages() {
+	ts.T().Skip("issue-1650: Otel Tracing intergation tests are flaky")
 	ts.testOpenTelemetryTracing(false, false)
 }
 

--- a/test/test_utils_test.go
+++ b/test/test_utils_test.go
@@ -236,9 +236,9 @@ func (ts *ConfigAndClientSuiteBase) InitConfigAndNamespace() error {
 	}
 	if ts.config.ShouldRegisterNamespace {
 		if err = ts.registerNamespace(); err != nil {
-			return err
+			return fmt.Errorf("unable to register namespace: %w", err)
 		} else if err = ts.ensureSearchAttributes(); err != nil {
-			return err
+			return fmt.Errorf("unable to ensure search attributes: %w", err)
 		}
 	}
 	return nil
@@ -272,7 +272,7 @@ func (ts *ConfigAndClientSuiteBase) registerNamespace() error {
 		ConnectionOptions: client.ConnectionOptions{TLS: ts.config.TLS},
 	})
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to create namespace client: %w", err)
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
 	defer cancel()
@@ -285,12 +285,12 @@ func (ts *ConfigAndClientSuiteBase) registerNamespace() error {
 		return nil
 	}
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to register namespace: %w", err)
 	}
 	time.Sleep(namespaceCacheRefreshInterval) // wait for namespace cache refresh on temporal-server
 	err = ts.InitClient()
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to create client: %w", err)
 	}
 	// below is used to guarantee namespace is ready
 	var dummyReturn string
@@ -317,7 +317,7 @@ func (ts *ConfigAndClientSuiteBase) ensureSearchAttributes() error {
 	// goroutine leak detector.
 	client, err := ts.newClient()
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to create client: %w", err)
 	}
 	defer client.Close()
 

--- a/test/test_utils_test.go
+++ b/test/test_utils_test.go
@@ -235,12 +235,11 @@ func (ts *ConfigAndClientSuiteBase) InitConfigAndNamespace() error {
 		return err
 	}
 	if ts.config.ShouldRegisterNamespace {
-		panic("Not implemented")
-		// if err = ts.registerNamespace(); err != nil {
-		// 	return fmt.Errorf("unable to register namespace: %w", err)
-		// } else if err = ts.ensureSearchAttributes(); err != nil {
-		// 	return fmt.Errorf("unable to ensure search attributes: %w", err)
-		// }
+		if err = ts.registerNamespace(); err != nil {
+			return fmt.Errorf("unable to register namespace: %w", err)
+		} else if err = ts.ensureSearchAttributes(); err != nil {
+			return fmt.Errorf("unable to ensure search attributes: %w", err)
+		}
 	}
 	return nil
 }

--- a/test/test_utils_test.go
+++ b/test/test_utils_test.go
@@ -235,11 +235,12 @@ func (ts *ConfigAndClientSuiteBase) InitConfigAndNamespace() error {
 		return err
 	}
 	if ts.config.ShouldRegisterNamespace {
-		if err = ts.registerNamespace(); err != nil {
-			return fmt.Errorf("unable to register namespace: %w", err)
-		} else if err = ts.ensureSearchAttributes(); err != nil {
-			return fmt.Errorf("unable to ensure search attributes: %w", err)
-		}
+		panic("Not implemented")
+		// if err = ts.registerNamespace(); err != nil {
+		// 	return fmt.Errorf("unable to register namespace: %w", err)
+		// } else if err = ts.ensureSearchAttributes(); err != nil {
+		// 	return fmt.Errorf("unable to ensure search attributes: %w", err)
+		// }
 	}
 	return nil
 }
@@ -255,10 +256,13 @@ func (ts *ConfigAndClientSuiteBase) InitClient() error {
 
 func (ts *ConfigAndClientSuiteBase) newClient() (client.Client, error) {
 	return client.Dial(client.Options{
-		HostPort:          ts.config.ServiceAddr,
-		Namespace:         ts.config.Namespace,
-		Logger:            ilog.NewDefaultLogger(),
-		ConnectionOptions: client.ConnectionOptions{TLS: ts.config.TLS},
+		HostPort:  ts.config.ServiceAddr,
+		Namespace: ts.config.Namespace,
+		Logger:    ilog.NewDefaultLogger(),
+		ConnectionOptions: client.ConnectionOptions{
+			TLS:                  ts.config.TLS,
+			GetSystemInfoTimeout: ctxTimeout,
+		},
 	})
 }
 

--- a/test/test_utils_test.go
+++ b/test/test_utils_test.go
@@ -285,7 +285,7 @@ func (ts *ConfigAndClientSuiteBase) registerNamespace() error {
 		return nil
 	}
 	if err != nil {
-		return fmt.Errorf("unable to register namespace: %w", err)
+		return fmt.Errorf("unable to call register namespace: %w", err)
 	}
 	time.Sleep(namespaceCacheRefreshInterval) // wait for namespace cache refresh on temporal-server
 	err = ts.InitClient()


### PR DESCRIPTION
Disable some know flaky tests. Increase some timeouts to reduce flakes

We have an issue to track https://github.com/temporalio/sdk-go/issues/1650 that we should prioritize next sprint