### PR TITLE
Make sure schedule Update treats CatchupWindow properly

### DIFF
--- a/internal/internal_schedule_client.go
+++ b/internal/internal_schedule_client.go
@@ -547,8 +547,7 @@ func convertToPBSchedule(ctx context.Context, client *WorkflowClient, schedule *
 
 	var catchupWindow *durationpb.Duration
 	if schedule.Policy.CatchupWindow != 0 {
-		// Convert to nil so the server uses the default
-		// catchup window.
+		// Only convert non-zero CatchWindow so server treats 0 as nil and uses the default catchup window.
 		catchupWindow = durationpb.New(schedule.Policy.CatchupWindow)
 	}
 

--- a/internal/internal_schedule_client.go
+++ b/internal/internal_schedule_client.go
@@ -544,12 +544,20 @@ func convertToPBSchedule(ctx context.Context, client *WorkflowClient, schedule *
 	if err != nil {
 		return nil, err
 	}
+
+	var catchupWindow *durationpb.Duration
+	if schedule.Policy.CatchupWindow != 0 {
+		// Convert to nil so the server uses the default
+		// catchup window.
+		catchupWindow = durationpb.New(schedule.Policy.CatchupWindow)
+	}
+
 	return &schedulepb.Schedule{
 		Spec:   convertToPBScheduleSpec(schedule.Spec),
 		Action: action,
 		Policies: &schedulepb.SchedulePolicies{
 			OverlapPolicy:  schedule.Policy.Overlap,
-			CatchupWindow:  durationpb.New(schedule.Policy.CatchupWindow),
+			CatchupWindow:  catchupWindow,
 			PauseOnFailure: schedule.Policy.PauseOnFailure,
 		},
 		State: &schedulepb.ScheduleState{

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -6230,6 +6230,8 @@ func (ts *IntegrationTestSuite) TestScheduleUpdate() {
 	)
 
 	updateFunc := func(input client.ScheduleUpdateInput) (*client.ScheduleUpdate, error) {
+		// Set the catchup window to 0 to verify that update treats zero as unset.
+		input.Description.Schedule.Policy.CatchupWindow = 0 * time.Second
 		return &client.ScheduleUpdate{
 			Schedule:              &input.Description.Schedule,
 			TypedSearchAttributes: &sa,
@@ -6237,6 +6239,8 @@ func (ts *IntegrationTestSuite) TestScheduleUpdate() {
 	}
 	description, err := handle.Describe(ctx)
 	ts.NoError(err)
+	// Since the CatchupWindow was set to 0, the server should set it to the default value.
+	ts.Equal(365*24*time.Hour, description.Schedule.Policy.CatchupWindow)
 
 	err = handle.Update(ctx, client.ScheduleUpdateOptions{
 		DoUpdate: updateFunc,


### PR DESCRIPTION
Make sure schedule Update treats CatchupWindow properly. When we create a schedule we treat a `CatchupWindow=0` as unset, so we pass `nil` which tells the server to use the default value. On update we forgot to convert `CatchupWindow=0` causing the server to use the min. value of `10s` instead.


https://github.com/temporalio/sdk-go/blob/31c4c30812adcd53554f08dfc5ca917df718ceae/internal/internal_schedule_client.go#L124