### PR TITLE
add Namespace method to Client interface

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1261,6 +1261,9 @@ type (
 		// underlying connection. Only the final close of all existing clients will
 		// close the underlying connection.
 		Close()
+
+		// Namespace returns the configured namespace of the Temporal client
+		Namespace() string
 	}
 
 	// NamespaceClient is the client for managing operations on the namespace.

--- a/internal/client.go
+++ b/internal/client.go
@@ -452,6 +452,9 @@ type (
 
 		// Close client and clean up underlying resources.
 		Close()
+
+		// Namespace returns the configured namespace of the Temporal client
+		Namespace() string
 	}
 
 	// ClientOptions are optional parameters for Client creation.

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -1365,6 +1365,11 @@ func (wc *WorkflowClient) Close() {
 	}
 }
 
+// Namespace returns the configured namespace of the Temporal client
+func (wc *WorkflowClient) Namespace() string {
+	return wc.namespace
+}
+
 // Register a namespace with temporal server
 // The errors it can throw:
 //   - NamespaceAlreadyExistsError

--- a/internal/internal_workflow_client_test.go
+++ b/internal/internal_workflow_client_test.go
@@ -2478,3 +2478,11 @@ func TestUpdate(t *testing.T) {
 		require.NoError(t, err)
 	})
 }
+
+func (s *workflowClientTestSuite) TestNamespace() {
+	dc := NewContextAwareDataConverter(converter.GetDefaultDataConverter())
+	s.client = NewServiceClient(s.service, nil, ClientOptions{DataConverter: dc})
+	client, ok := s.client.(*WorkflowClient)
+	s.Require().True(ok)
+	s.Equal(DefaultNamespace, client.Namespace())
+}

--- a/internal/nexus_operations.go
+++ b/internal/nexus_operations.go
@@ -698,6 +698,11 @@ func (t *testSuiteClientForNexusOperations) UpdateWorkflowExecutionOptions(ctx c
 	panic("not implemented in the test environment")
 }
 
+// Namespace returns the default testing namespace, ie. "default-test-namespace"
+func (t *testSuiteClientForNexusOperations) Namespace() string {
+	return t.env.workflowInfo.Namespace
+}
+
 var _ Client = &testSuiteClientForNexusOperations{}
 
 // testEnvWorkflowRunForNexusOperations is a partial [WorkflowRun] implementation for the test workflow environment used

--- a/mocks/Client.go
+++ b/mocks/Client.go
@@ -1112,6 +1112,26 @@ func (_m *Client) WorkflowService() workflowservice.WorkflowServiceClient {
 	return r0
 }
 
+// Namespace provides a mock function with given fields:
+func (_m *Client) Namespace() string {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for Namespace")
+	}
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(string)
+		}
+	}
+
+	return r0
+}
+
 // NewClient creates a new instance of Client. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewClient(t interface {


### PR DESCRIPTION
## What was changed
Added `Namespace() string` method to `Client` interface and its various implementors.

## Why?
- Primary motivation: I want to be able to pass a Temporal client into a function that retrieves the workflow history of a workflow.
ie.
```go
func ExtractUnhandledFailure(ctx context.Context, temporalClient client.Client, workflowId string, innerErr error) error {
	// ... -- more code above --- ...

	// NOTE(jae): 2025-03-21
	// Query in reverse and just get last event. With local testing the difference in performance is
	// - ~16 milliseconds to iterate over each history event for ~200 events
	// - ~1 millisecond to get last event for ~200 events
	resp, err := temporalClient.WorkflowService().GetWorkflowExecutionHistoryReverse(ctx, &workflowservice.GetWorkflowExecutionHistoryReverseRequest{
		// I want the ability to pass the Namespace() parameter into the WorkflowService() call
		Namespace:       temporalClient.Namespace(),
		MaximumPageSize: 1,
		Execution: &common.WorkflowExecution{
			WorkflowId: workflowId,
			RunId:      "",
		},
	})

	// ... -- more code below --- ...
}
```

- Secondary motivation: We have multiple of our own Temporal struct wrappers that hold the "namespace" value. It would be more convenient if we could just retrieve it from the interface directly.

## Checklist

1. Closes: N/A

3. How was this tested:
- Added a unit test and asserted that it returns the default namespace

4. Any docs updates needed? N/A