### PR TITLE
Add support for activity pause

### DIFF
--- a/.github/workflows/docker/dynamic-config-custom.yaml
+++ b/.github/workflows/docker/dynamic-config-custom.yaml
@@ -38,3 +38,5 @@ component.callbacks.allowedAddresses:
   - value:
     - Pattern: "*"
       AllowInsecure: true
+frontend.activityAPIsEnabled:
+  - value: true

--- a/activity/activity.go
+++ b/activity/activity.go
@@ -50,7 +50,7 @@ type (
 // that could report the activity completed event to the temporal server via the Client.CompleteActivity() API.
 var ErrResultPending = internal.ErrActivityResultPending
 
-// ErrActivityPaused is returned from and activity heartbeat or the cause of an activity's context to indicate that the activity is paused.
+// ErrActivityPaused is returned from an activity heartbeat or the cause of an activity's context to indicate that the activity is paused.
 //
 // WARNING: Activity pause is currently experimental
 var ErrActivityPaused = internal.ErrActivityPaused

--- a/activity/activity.go
+++ b/activity/activity.go
@@ -26,6 +26,7 @@ package activity
 
 import (
 	"context"
+
 	"go.temporal.io/sdk/internal"
 	"go.temporal.io/sdk/internal/common/metrics"
 	"go.temporal.io/sdk/log"
@@ -49,6 +50,11 @@ type (
 // that could report the activity completed event to the temporal server via the Client.CompleteActivity() API.
 var ErrResultPending = internal.ErrActivityResultPending
 
+// ErrActivityPaused is returned from and activity heartbeat or the cause of an activity's context to indicate that the activity is paused.
+//
+// WARNING: Activity pause is currently experimental
+var ErrActivityPaused = internal.ErrActivityPaused
+
 // GetInfo returns information about the currently executing activity.
 func GetInfo(ctx context.Context) Info {
 	return internal.GetActivityInfo(ctx)
@@ -66,7 +72,18 @@ func GetMetricsHandler(ctx context.Context) metrics.Handler {
 
 // RecordHeartbeat sends a heartbeat for the currently executing activity.
 // If the activity is either canceled or the workflow/activity doesn't exist, then we would cancel
-// the context with error context.Canceled.
+// the context with error [context.Canceled]. The [context.Cause] will be set based on the reason
+// for the cancellation.
+//
+// For example, if the activity is requested to be paused by the Server:
+//
+//		func MyActivity(ctx context.Context) error {
+//			activity.RecordHeartbeat(ctx, "")
+//			// assume the activity is paused by the server
+//			activity.RecordHeartbeat(ctx, "some details")
+//			context.Cause(ctx) // Will return activity.ErrActivityPaused
+//	     	return ctx.Err() // Will return context.Canceled
+//		}
 //
 // details - The details that you provide here can be seen in the workflow when it receives TimeoutError. You
 // can check error with TimeoutType()/Details().

--- a/client/client.go
+++ b/client/client.go
@@ -998,15 +998,19 @@ type (
 
 		// RecordActivityHeartbeat records heartbeat for an activity.
 		// taskToken - is the value of the binary "TaskToken" field of the "ActivityInfo" struct retrieved inside the activity.
-		// details - is the progress you want to record along with heart beat for this activity.
-		// The errors it can return:
+		// details - is the progress you want to record along with heart beat for this activity. If the activity is canceled,
+		// the error returned will be a CanceledError. If the activity is paused by the server, the error returned will be a
+		// ErrActivityPaused.
+		// Otherwise the errors it can return:
 		//  - serviceerror.NotFound
 		//  - serviceerror.Internal
 		//  - serviceerror.Unavailable
 		RecordActivityHeartbeat(ctx context.Context, taskToken []byte, details ...interface{}) error
 
 		// RecordActivityHeartbeatByID records heartbeat for an activity.
-		// details - is the progress you want to record along with heart beat for this activity.
+		// details - is the progress you want to record along with heart beat for this activity. If the activity is canceled,
+		// the error returned will be a CanceledError. If the activity is paused by the server, the error returned will be a
+		// ErrActivityPaused.
 		// The errors it can return:
 		//  - serviceerror.NotFound
 		//  - serviceerror.Internal

--- a/internal/activity.go
+++ b/internal/activity.go
@@ -268,8 +268,6 @@ func GetWorkerStopChannel(ctx context.Context) <-chan struct{} {
 // If the activity is either canceled or workflow/activity doesn't exist, then we would cancel
 // the context with error context.Canceled.
 //
-//	TODO: we don't have a way to distinguish between the two cases when context is canceled because
-//	context doesn't support overriding value of ctx.Error.
 //	TODO: Implement automatic heartbeating with cancellation through ctx.
 //
 // details - The details that you provided here can be seen in the workflow when it receives TimeoutError. You

--- a/internal/cmd/build/main.go
+++ b/internal/cmd/build/main.go
@@ -170,6 +170,7 @@ func (b *builder) integrationTest() error {
 				"--dynamic-config-value", "matching.wv.VersionDrainageStatusVisibilityGracePeriod=10",
 				"--dynamic-config-value", "matching.wv.VersionDrainageStatusRefreshInterval=1",
 				"--dynamic-config-value", "matching.useNewMatcher=true",
+				"--dynamic-config-value", "frontend.activityAPIsEnabled=true",
 				"--http-port", "7243", // Nexus tests use the HTTP port directly
 				"--dynamic-config-value", `component.callbacks.allowedAddresses=[{"Pattern":"*","AllowInsecure":true}]`, // SDK tests use arbitrary callback URLs, permit that on the server
 				"--dynamic-config-value", `system.refreshNexusEndpointsMinWait="0s"`, // Make Nexus tests faster

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -69,7 +69,7 @@ const (
 )
 
 var (
-	// ErrActivityPaused is returned from and activity heartbeat or the cause of an activity's context to indicate that the activity is paused.
+	// ErrActivityPaused is returned from an activity heartbeat or the cause of an activity's context to indicate that the activity is paused.
 	//
 	// WARNING: Activity pause is currently experimental
 	ErrActivityPaused = errors.New("activity paused")

--- a/internal/internal_task_handlers_test.go
+++ b/internal/internal_task_handlers_test.go
@@ -2013,7 +2013,7 @@ func (t *TaskHandlersTestSuite) TestHeartBeat_NilResponseWithError() {
 	mockService.EXPECT().RecordActivityTaskHeartbeat(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, serviceerror.NewNotFound(""))
 
 	temporalInvoker := newServiceInvoker(
-		nil, "Test_Temporal_Invoker", mockService, metrics.NopHandler, func() {}, 0,
+		nil, "Test_Temporal_Invoker", mockService, metrics.NopHandler, func(err error) {}, 0,
 		make(chan struct{}), t.namespace)
 
 	ctx, err := newActivityContext(context.Background(), nil, &activityEnvironment{serviceInvoker: temporalInvoker, logger: t.logger})
@@ -2031,7 +2031,7 @@ func (t *TaskHandlersTestSuite) TestHeartBeat_NilResponseWithNamespaceNotActiveE
 	mockService.EXPECT().RecordActivityTaskHeartbeat(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, serviceerror.NewNamespaceNotActive("fake_namespace", "current_cluster", "active_cluster"))
 
 	called := false
-	cancelHandler := func() { called = true }
+	cancelHandler := func(err error) { called = true }
 
 	temporalInvoker := newServiceInvoker(
 		nil, "Test_Temporal_Invoker", mockService, metrics.NopHandler, cancelHandler,

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -1254,6 +1254,16 @@ func convertActivityResultToRespondRequest(
 				DeploymentOptions: workerDeploymentOptions,
 			}
 		}
+		if errors.Is(err, ErrActivityPaused) {
+			return &workflowservice.RespondActivityTaskCanceledRequest{
+				TaskToken:         taskToken,
+				Identity:          identity,
+				Namespace:         namespace,
+				WorkerVersion:     versionStamp,
+				Deployment:        deployment,
+				DeploymentOptions: workerDeploymentOptions,
+			}
+		}
 	}
 
 	// If a canceled error is returned but it wasn't allowed, we have to wrap in

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -1254,16 +1254,6 @@ func convertActivityResultToRespondRequest(
 				DeploymentOptions: workerDeploymentOptions,
 			}
 		}
-		if errors.Is(err, ErrActivityPaused) {
-			return &workflowservice.RespondActivityTaskCanceledRequest{
-				TaskToken:         taskToken,
-				Identity:          identity,
-				Namespace:         namespace,
-				WorkerVersion:     versionStamp,
-				Deployment:        deployment,
-				DeploymentOptions: workerDeploymentOptions,
-			}
-		}
 	}
 
 	// If a canceled error is returned but it wasn't allowed, we have to wrap in

--- a/test/activity_test.go
+++ b/test/activity_test.go
@@ -33,15 +33,14 @@ import (
 	"sync"
 	"time"
 
+	"go.opentelemetry.io/otel/baggage"
 	commonpb "go.temporal.io/api/common/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/sdk/converter"
 
 	"go.opentelemetry.io/otel/baggage"
-	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/sdk/activity"
 	"go.temporal.io/sdk/client"
-	"go.temporal.io/sdk/converter"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/worker"
 )

--- a/test/activity_test.go
+++ b/test/activity_test.go
@@ -33,6 +33,10 @@ import (
 	"sync"
 	"time"
 
+	commonpb "go.temporal.io/api/common/v1"
+	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/sdk/converter"
+
 	"go.opentelemetry.io/otel/baggage"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/sdk/activity"
@@ -94,13 +98,34 @@ func ErrorWithNextDelay(_ context.Context, delay time.Duration) error {
 	})
 }
 
-func (a *Activities) ActivityToBeCanceled(ctx context.Context) (string, error) {
-	a.append("ActivityToBeCanceled")
+func (a *Activities) ActivityToBePaused(ctx context.Context, completeOnPause bool) (string, error) {
+	a.append("ActivityToBePaused")
+	info := activity.GetInfo(ctx)
+	go func() {
+		// Pause the activity
+		activity.GetClient(ctx).WorkflowService().PauseActivity(context.Background(), &workflowservice.PauseActivityRequest{
+			Namespace: info.WorkflowNamespace,
+			Execution: &commonpb.WorkflowExecution{
+				WorkflowId: info.WorkflowExecution.ID,
+				RunId:      info.WorkflowExecution.RunID,
+			},
+			Activity: &workflowservice.PauseActivityRequest_Id{
+				Id: info.ActivityID,
+			},
+		})
+	}()
 	for {
 		select {
 		case <-time.After(1 * time.Second):
 			activity.RecordHeartbeat(ctx, "")
 		case <-ctx.Done():
+			if errors.Is(context.Cause(ctx), activity.ErrActivityPaused) {
+				if completeOnPause {
+					return "I am stopped by Pause", nil
+				}
+				return "", context.Cause(ctx)
+
+			}
 			return "I am canceled by Done", nil
 		}
 	}

--- a/test/activity_test.go
+++ b/test/activity_test.go
@@ -38,7 +38,6 @@ import (
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/sdk/converter"
 
-	"go.opentelemetry.io/otel/baggage"
 	"go.temporal.io/sdk/activity"
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/temporal"

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -635,7 +635,8 @@ func (ts *IntegrationTestSuite) TestActivityPause() {
 	ts.Len(desc.GetPendingActivities(), 1)
 	ts.Equal(desc.GetPendingActivities()[0].GetActivityType().GetName(), "ActivityToBePaused")
 	ts.Equal(desc.GetPendingActivities()[0].GetAttempt(), int32(1))
-	ts.Nil(desc.GetPendingActivities()[0].GetLastFailure()) // Verify that the activity paused successfully
+	// TODO: Update when https://github.com/temporalio/temporal/pull/7572 is released
+	ts.Nil(desc.GetPendingActivities()[0].GetLastFailure())
 	ts.True(desc.GetPendingActivities()[0].GetPaused())
 }
 


### PR DESCRIPTION
Add support for activity pause. Makes use of `context.Cause` to tell users why exactly their Activity was cancelled 

closes: https://github.com/temporalio/sdk-go/issues/1899