### PR TITLE
Add worker shutdown cause to context

### DIFF
--- a/internal/internal_task_handlers_test.go
+++ b/internal/internal_task_handlers_test.go
@@ -2157,10 +2157,10 @@ func (t *TaskHandlersTestSuite) TestActivityExecutionWorkerStop() {
 	mockCtrl := gomock.NewController(t.T())
 	mockService := workflowservicemock.NewMockWorkflowServiceClient(mockCtrl)
 	workerStopCh := make(chan struct{}, 1)
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancelCause(context.Background())
 	wep := t.getTestWorkerExecutionParams()
-	wep.UserContext = ctx
-	wep.UserContextCancel = cancel
+	wep.BackgroundContext = ctx
+	wep.BackgroundContextCancel = cancel
 	wep.WorkerStopChannel = workerStopCh
 	client := WorkflowClient{workflowService: mockService}
 	activityHandler := newActivityTaskHandler(&client, wep, registry)

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -164,7 +164,7 @@ type (
 	}
 
 	localActivityTaskHandler struct {
-		userContext        context.Context
+		backgroundContext  context.Context
 		metricsHandler     metrics.Handler
 		logger             log.Logger
 		dataConverter      converter.DataConverter
@@ -600,7 +600,7 @@ func newLocalActivityPoller(
 	client *WorkflowClient,
 ) *localActivityTaskPoller {
 	handler := &localActivityTaskHandler{
-		userContext:        params.UserContext,
+		backgroundContext:  params.BackgroundContext,
 		metricsHandler:     params.MetricsHandler,
 		logger:             params.Logger,
 		dataConverter:      params.DataConverter,
@@ -659,7 +659,7 @@ func (lath *localActivityTaskHandler) executeLocalActivityTask(task *localActivi
 			tagAttempt, task.attempt,
 		)
 	})
-	ctx, err := WithLocalActivityTask(lath.userContext, task, lath.logger, lath.metricsHandler,
+	ctx, err := WithLocalActivityTask(lath.backgroundContext, task, lath.logger, lath.metricsHandler,
 		lath.dataConverter, lath.interceptors, lath.client)
 	if err != nil {
 		return &localActivityResult{task: task, err: fmt.Errorf("failed building context: %w", err)}

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -2693,7 +2693,7 @@ func TestWorkerOptionDefaults(t *testing.T) {
 		Logger:                                workflowWorker.executionParameters.Logger,
 		MetricsHandler:                        workflowWorker.executionParameters.MetricsHandler,
 		Identity:                              workflowWorker.executionParameters.Identity,
-		UserContext:                           workflowWorker.executionParameters.UserContext,
+		BackgroundContext:                     workflowWorker.executionParameters.BackgroundContext,
 	}
 
 	assertWorkerExecutionParamsEqual(t, expected, workflowWorker.executionParameters)
@@ -2799,7 +2799,7 @@ func TestLocalActivityWorkerOnly(t *testing.T) {
 		Logger:                                workflowWorker.executionParameters.Logger,
 		MetricsHandler:                        workflowWorker.executionParameters.MetricsHandler,
 		Identity:                              workflowWorker.executionParameters.Identity,
-		UserContext:                           workflowWorker.executionParameters.UserContext,
+		BackgroundContext:                     workflowWorker.executionParameters.BackgroundContext,
 	}
 
 	assertWorkerExecutionParamsEqual(t, expected, workflowWorker.executionParameters)

--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -793,7 +793,7 @@ func (env *testWorkflowEnvironmentImpl) executeLocalActivity(
 		header:        params.Header,
 	}
 	taskHandler := localActivityTaskHandler{
-		userContext:        env.workerOptions.BackgroundActivityContext,
+		backgroundContext:  env.workerOptions.BackgroundActivityContext,
 		metricsHandler:     env.metricsHandler,
 		logger:             env.logger,
 		interceptors:       env.registry.interceptors,
@@ -1586,7 +1586,7 @@ func (env *testWorkflowEnvironmentImpl) ExecuteLocalActivity(params ExecuteLocal
 
 	task := newLocalActivityTask(params, callback, activityID)
 	taskHandler := localActivityTaskHandler{
-		userContext:        env.workerOptions.BackgroundActivityContext,
+		backgroundContext:  env.workerOptions.BackgroundActivityContext,
 		metricsHandler:     env.metricsHandler,
 		logger:             env.logger,
 		dataConverter:      env.dataConverter,
@@ -2095,20 +2095,20 @@ func (env *testWorkflowEnvironmentImpl) newTestActivityTaskHandler(taskQueue str
 		Identity:           env.identity,
 		MetricsHandler:     env.metricsHandler,
 		Logger:             env.logger,
-		UserContext:        env.workerOptions.BackgroundActivityContext,
+		BackgroundContext:  env.workerOptions.BackgroundActivityContext,
 		FailureConverter:   env.failureConverter,
 		DataConverter:      dataConverter,
 		WorkerStopChannel:  env.workerStopChannel,
 		ContextPropagators: env.contextPropagators,
 	}
 	ensureRequiredParams(&params)
-	if params.UserContext == nil {
-		params.UserContext = context.Background()
+	if params.BackgroundContext == nil {
+		params.BackgroundContext = context.Background()
 	}
 	if env.workerOptions.EnableSessionWorker && env.sessionEnvironment == nil {
 		env.sessionEnvironment = newTestSessionEnvironment(env, &params, env.workerOptions.MaxConcurrentSessionExecutionSize)
 	}
-	params.UserContext = context.WithValue(params.UserContext, sessionEnvironmentContextKey, env.sessionEnvironment)
+	params.BackgroundContext = context.WithValue(params.BackgroundContext, sessionEnvironmentContextKey, env.sessionEnvironment)
 	registry := env.registry
 	if len(registry.getRegisteredActivities()) == 0 {
 		panic(fmt.Sprintf("no activity is registered for taskqueue '%v'", taskQueue))

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -39,6 +39,11 @@ import (
 	"go.temporal.io/sdk/workflow"
 )
 
+var (
+	// ErrWorkerShutdown is returned when the worker is shutdown.
+	ErrWorkerShutdown = internal.ErrWorkerShutdown
+)
+
 type (
 	// Worker hosts workflow and activity implementations.
 	// Use worker.New(...) to create an instance.


### PR DESCRIPTION
Add worker shutdown cause to context. This will help users tell why their activity/local activity context was cancelled. Before this PR when an activity/local activity was shutting down at the end of the shutdown process the SDK would cancel the context, but users couldn't distinguish this cancel vs other reasons the cancel may be cancelled.