### PR TITLE
Handle activity cancel due to worker shutdown properly

### DIFF
--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -500,7 +500,7 @@ func (wc *WorkflowClient) CompleteActivity(ctx context.Context, taskToken []byte
 	// We do allow canceled error to be passed here
 	cancelAllowed := true
 	request := convertActivityResultToRespondRequest(wc.identity, taskToken,
-		data, err, wc.dataConverter, wc.failureConverter, wc.namespace, cancelAllowed, nil, nil, nil)
+		data, err, wc.dataConverter, wc.failureConverter, wc.namespace, cancelAllowed, nil, nil, nil, false)
 	return reportActivityComplete(ctx, wc.workflowService, request, wc.metricsHandler)
 }
 

--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -1199,7 +1199,7 @@ func (env *testWorkflowEnvironmentImpl) CompleteActivity(taskToken []byte, resul
 		// We do allow canceled error to be passed here
 		cancelAllowed := true
 		request := convertActivityResultToRespondRequest("test-identity", taskToken, data, err,
-			env.GetDataConverter(), env.GetFailureConverter(), defaultTestNamespace, cancelAllowed, nil, nil, nil)
+			env.GetDataConverter(), env.GetFailureConverter(), defaultTestNamespace, cancelAllowed, nil, nil, nil, false)
 		env.handleActivityResult(activityID, request, activityHandle.activityType, env.GetDataConverter())
 	}, false /* do not auto schedule workflow task, because activity might be still pending */)
 

--- a/test/activity_test.go
+++ b/test/activity_test.go
@@ -462,3 +462,12 @@ func (a *Activities) RawValueActivity(ctx context.Context, value converter.RawVa
 	activity.GetLogger(ctx).Info("RawValue value", value.Payload())
 	return value, nil
 }
+
+func (a *Activities) ReactToCancel(ctx context.Context) error {
+	select {
+	case <-time.After(1 * time.Second):
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}


### PR DESCRIPTION
## What was changed
Stop sending activity cancellation due to worker shutdown. Now we send an Application error, allowing for another worker to retry the activity.

## Why?
<!-- Tell your future self why have you made these changes -->
align behavior with core SDKs

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here --> #1156

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Added integration test, shutdown worker in the middle of activity, and start a new worker to see the workflow complete.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
