### PR TITLE
TestUpdateCallback UX improvement

### DIFF
--- a/internal/workflow_testsuite.go
+++ b/internal/workflow_testsuite.go
@@ -97,6 +97,8 @@ type (
 	// Tests are welcome to implement their own version of this interface if they need to test more complex
 	// update logic. This is a simple implementation to make testing basic Workflow Updates easier.
 	//
+	// Note: If any of the three fields are omitted, a no-op implementation will be used by default.
+	//
 	// Exposed as: [go.temporal.io/sdk/testsuite.TestUpdateCallback]
 	TestUpdateCallback struct {
 		OnAccept   func()
@@ -804,15 +806,21 @@ func (c *MockCallWrapper) NotBefore(calls ...*MockCallWrapper) *MockCallWrapper 
 }
 
 func (uc *TestUpdateCallback) Accept() {
-	uc.OnAccept()
+	if uc.OnAccept != nil {
+		uc.OnAccept()
+	}
 }
 
 func (uc *TestUpdateCallback) Reject(err error) {
-	uc.OnReject(err)
+	if uc.OnReject != nil {
+		uc.OnReject(err)
+	}
 }
 
 func (uc *TestUpdateCallback) Complete(success interface{}, err error) {
-	uc.OnComplete(success, err)
+	if uc.OnComplete != nil {
+		uc.OnComplete(success, err)
+	}
 }
 
 // ExecuteWorkflow executes a workflow, wait until workflow complete. It will fail the test if workflow is blocked and


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->
If any of the OnAccept/OnReject/OnCompile callbacks aren't passed in, avoid call them to avoid throwing a nil pointer error.

## Why?
<!-- Tell your future self why have you made these changes -->
Previously, if any of the OnAccept/OnReject/OnCompile callbacks weren't passed in, a nil pointer error was thrown, without any clear indicator where the error was being thrown. This should improve uer experience when writing UpdateWorkflow tests

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here --> #1860

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Added test

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
