### PR TITLE
Handle links from ExecuteWorkflow in Nexus WorkflowRunOperation

### DIFF
--- a/internal/client.go
+++ b/internal/client.go
@@ -762,6 +762,10 @@ type (
 		// WARNING: Task queue priority is currently experimental.
 		Priority Priority
 
+		// responseInfo - Optional pointer to store information of StartWorkflowExecution response.
+		// Only settable by the SDK - e.g. [temporalnexus.workflowRunOperation].
+		responseInfo *startWorkflowResponseInfo
+
 		// request ID. Only settable by the SDK - e.g. [temporalnexus.workflowRunOperation].
 		requestID string
 		// workflow completion callback. Only settable by the SDK - e.g. [temporalnexus.workflowRunOperation].
@@ -776,6 +780,13 @@ type (
 		//
 		// NOTE: Only settable by the SDK -- e.g. [temporalnexus.workflowRunOperation].
 		onConflictOptions *OnConflictOptions
+	}
+
+	// startWorkflowResponseInfo can be passed to StartWorkflowOptions to receive additional information
+	// of StartWorkflowExecution response.
+	startWorkflowResponseInfo struct {
+		// Link to the workflow event.
+		Link *commonpb.Link
 	}
 
 	// WithStartWorkflowOperation defines how to start a workflow when using UpdateWithStartWorkflow.
@@ -1275,4 +1286,14 @@ func SetOnConflictOptionsOnStartWorkflowOptions(opts *StartWorkflowOptions) {
 		AttachCompletionCallbacks: true,
 		AttachLinks:               true,
 	}
+}
+
+// SetResponseInfoOnStartWorkflowOptions is an internal only method for setting start workflow
+// response info object pointer on StartWorkflowOptions and return the object pointer.
+// StartWorkflowResponseInfo is purposefully not exposed to users for the time being.
+func SetResponseInfoOnStartWorkflowOptions(opts *StartWorkflowOptions) *startWorkflowResponseInfo {
+	if opts.responseInfo == nil {
+		opts.responseInfo = &startWorkflowResponseInfo{}
+	}
+	return opts.responseInfo
 }

--- a/internal/cmd/build/main.go
+++ b/internal/cmd/build/main.go
@@ -113,7 +113,7 @@ func (b *builder) integrationTest() error {
 	if *devServerFlag {
 		devServer, err := testsuite.StartDevServer(context.Background(), testsuite.DevServerOptions{
 			CachedDownload: testsuite.CachedDownload{
-				Version: "v1.3.1-nexus-cancellation.0",
+				Version: "v1.3.1-nexus-links.0",
 			},
 			ClientOptions: &client.Options{
 				HostPort:  "127.0.0.1:7233",
@@ -147,6 +147,7 @@ func (b *builder) integrationTest() error {
 				"--dynamic-config-value", `component.callbacks.allowedAddresses=[{"Pattern":"*","AllowInsecure":true}]`, // SDK tests use arbitrary callback URLs, permit that on the server
 				"--dynamic-config-value", `system.refreshNexusEndpointsMinWait="0s"`, // Make Nexus tests faster
 				"--dynamic-config-value", `component.nexusoperations.recordCancelRequestCompletionEvents=true`, // Defaults to false until after OSS 1.28 is released
+				"--dynamic-config-value", `history.enableRequestIdRefLinks=true`,
 			},
 		})
 		if err != nil {

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -1798,6 +1798,10 @@ func (w *workflowClientInterceptor) ExecuteWorkflow(
 		runID = response.RunId
 	}
 
+	if responseInfo := in.Options.responseInfo; responseInfo != nil {
+		responseInfo.Link = response.GetLink()
+	}
+
 	iterFn := func(fnCtx context.Context, fnRunID string) HistoryEventIterator {
 		metricsHandler := w.client.metricsHandler.WithTags(metrics.RPCTags(in.WorkflowType,
 			metrics.NoneTagValue, in.Options.TaskQueue))


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Introduce `StartWorkflowResponseInfo` to `StartWorkflowOptions`.
Handle links from `ExecuteWorkflow` in Nexus `WorkflowRunOperation`.

## Why?
<!-- Tell your future self why have you made these changes -->
Be able to pass information from `StartWorkflowExecutionResponse` to `ExecuteWorkflow` call through `StartWorkflowOptions`.
Use the link from the server instead of generating one in `WorkflowRunOperation`.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
