### PR TITLE
Remove deprecated nexus APIs

### DIFF
--- a/internal/error.go
+++ b/internal/error.go
@@ -298,10 +298,6 @@ type (
 		Service string
 		// Operation name.
 		Operation string
-		// Operation ID - may be empty if the operation completed synchronously.
-		//
-		// Deprecated: Use OperationToken instead.
-		OperationID string
 		// Operation token - may be empty if the operation completed synchronously.
 		OperationToken string
 		// Chained cause - typically an ApplicationError or a CanceledError.

--- a/internal/failure_converter.go
+++ b/internal/failure_converter.go
@@ -175,9 +175,6 @@ func (dfc *DefaultFailureConverter) ErrorToFailure(err error) *failurepb.Failure
 		failure.FailureInfo = &failurepb.Failure_ChildWorkflowExecutionFailureInfo{ChildWorkflowExecutionFailureInfo: failureInfo}
 	case *NexusOperationError:
 		var token = err.OperationToken
-		if token == "" {
-			token = err.OperationID
-		}
 		failureInfo := &failurepb.NexusOperationFailureInfo{
 			ScheduledEventId: err.ScheduledEventID,
 			Endpoint:         err.Endpoint,
@@ -309,7 +306,6 @@ func (dfc *DefaultFailureConverter) FailureToError(failure *failurepb.Failure) e
 			Service:          info.GetService(),
 			Operation:        info.GetOperation(),
 			OperationToken:   token,
-			OperationID:      token,
 		}
 	} else if info := failure.GetNexusHandlerFailureInfo(); info != nil {
 		var retryBehavior nexus.HandlerErrorRetryBehavior

--- a/internal/nexus_operations.go
+++ b/internal/nexus_operations.go
@@ -249,7 +249,7 @@ func nexusOperationFailure(params executeNexusOperationParams, token string, cau
 				Service:        params.client.Service(),
 				Operation:      params.operation,
 				OperationToken: token,
-				OperationId:    token, // Also populate ID for backwards compatiblity.
+				OperationId:    token, // Also populate ID for backwards compatibility.
 			},
 		},
 		Cause: cause,

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -2645,11 +2645,6 @@ type NexusOperationOptions struct {
 //
 // Exposed as: [go.temporal.io/sdk/workflow.NexusOperationExecution]
 type NexusOperationExecution struct {
-	// Operation ID as set by the Operation's handler. May be empty if the operation hasn't started yet or completed
-	// synchronously.
-	//
-	// Deprecated: Use OperationToken instead.
-	OperationID string
 	// Operation token as set by the Operation's handler. May be empty if the operation hasn't started yet or completed
 	// synchronously.
 	OperationToken string
@@ -2802,7 +2797,6 @@ func (wc *workflowEnvironmentInterceptor) ExecuteNexusOperation(ctx Context, inp
 	}, func(token string, e error) {
 		operationToken = token
 		executionSettable.Set(NexusOperationExecution{
-			OperationID:    operationToken,
 			OperationToken: operationToken,
 		}, e)
 	})

--- a/temporalnexus/operation.go
+++ b/temporalnexus/operation.go
@@ -69,44 +69,6 @@ func GetClient(ctx context.Context) client.Client {
 	return internal.GetNexusOperationClient(ctx)
 }
 
-type syncOperation[I, O any] struct {
-	nexus.UnimplementedOperation[I, O]
-
-	name    string
-	handler func(context.Context, client.Client, I, nexus.StartOperationOptions) (O, error)
-}
-
-// NewSyncOperation is a helper for creating a synchronous-only [nexus.Operation] from a given name and handler
-// function. The handler is passed the client that the worker was created with.
-// Sync operations are useful for exposing short-lived Temporal client requests, such as signals, queries, sync update,
-// list workflows, etc...
-//
-// Deprecated: Use nexus.NewSyncOperation and get the client via temporalnexus.GetClient
-func NewSyncOperation[I any, O any](
-	name string,
-	handler func(context.Context, client.Client, I, nexus.StartOperationOptions) (O, error),
-) nexus.Operation[I, O] {
-	if strings.HasPrefix(name, "__temporal_") {
-		panic(errors.New("temporalnexus NewSyncOperation __temporal_ is an reserved prefix"))
-	}
-	return &syncOperation[I, O]{
-		name:    name,
-		handler: handler,
-	}
-}
-
-func (o *syncOperation[I, O]) Name() string {
-	return o.name
-}
-
-func (o *syncOperation[I, O]) Start(ctx context.Context, input I, options nexus.StartOperationOptions) (nexus.HandlerStartOperationResult[O], error) {
-	out, err := o.handler(ctx, GetClient(ctx), input, options)
-	if err != nil {
-		return nil, err
-	}
-	return &nexus.HandlerStartOperationResultSync[O]{Value: out}, err
-}
-
 // WorkflowRunOperationOptions are options for [NewWorkflowRunOperationWithOptions].
 type WorkflowRunOperationOptions[I, O any] struct {
 	// Operation name.

--- a/test/nexus_test.go
+++ b/test/nexus_test.go
@@ -169,7 +169,6 @@ func (tc *testContext) newNexusClient(t *testing.T, service string) *nexus.HTTPC
 				return res, err
 			}
 		},
-		UseOperationID: true, // TODO(bergundy): Remove this after tests run against server 1.27.0.
 	})
 	require.NoError(t, err)
 	return nc


### PR DESCRIPTION
Remove deprecated nexus APIs we deprecated before GA. This is a breaking change, but these APIs were deprecated before we went GA, at the time we deprecated them with the intention to remove to give users time to migrate.
