### PR TITLE
Use system time as started time

### DIFF
--- a/internal/activity.go
+++ b/internal/activity.go
@@ -287,7 +287,7 @@ func WithActivityTask(
 	client *WorkflowClient,
 ) (context.Context, error) {
 	scheduled := task.GetScheduledTime().AsTime()
-	started := task.GetStartedTime().AsTime()
+	started := time.Now()
 	scheduleToCloseTimeout := task.GetScheduleToCloseTimeout().AsDuration()
 	startToCloseTimeout := task.GetStartToCloseTimeout().AsDuration()
 	heartbeatTimeout := task.GetHeartbeatTimeout().AsDuration()


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Use system time as started time

## Why?
<!-- Tell your future self why have you made these changes -->
Have implicit activity context timeout start-to-close be relative to system time not server time

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->
#1930
2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
The time is not consistent across hosts in the construct cluster.
The local time of the host on which the construct executes the activity has exceeded the timeout set by the server.
#1912

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
N/A