### PR TITLE
fix: use 127.0.0.1 instead of localhost as default HostPort for IPv4 consistency

### DIFF
--- a/internal/grpc_dialer.go
+++ b/internal/grpc_dialer.go
@@ -32,7 +32,7 @@ const (
 	// LocalHostPort is a default host:port for worker and client to connect to.
 	//
 	// Exposed as: [go.temporal.io/sdk/client.DefaultHostPort]
-	LocalHostPort = "localhost:7233"
+	LocalHostPort = "127.0.0.1:7233"
 
 	// defaultServiceConfig is a default gRPC connection service config which enables DNS round-robin between IPs.
 	defaultServiceConfig = `{"loadBalancingConfig": [{"round_robin":{}}]}`


### PR DESCRIPTION
## What was changed
Updated the `defaultHostPort` constant in `internal/grpc_dialer.go` from:
```go
const defaultHostPort = "localhost:7233"
```
to:
```go
const defaultHostPort = "127.0.0.1:7233"
```
to ensure consistent and reliable connectivity in local development environments across platforms.

## Why?
The default HostPort value used when connecting to the Temporal server is set to "localhost:7233". However, "localhost" may resolve to ::1 (IPv6) on some systems, while temporal server start-dev binds only to 127.0.0.1 (IPv4). 

This mismatch leads to errors like:
> failed reaching server: context deadline exceeded