### PR TITLE
Improve docs on NexusOperationCancellationTypeTryCancel

### DIFF
--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -85,7 +85,8 @@ const (
 	NexusOperationCancellationTypeAbandon
 
 	// NexusOperationCancellationTypeTryCancel - Initiate a cancellation request for the Nexus operation and immediately report cancellation
-	// to the caller.
+	// to the caller. Note that it doesn't guarantee that cancellation is delivered to the operation if calling workflow exits before the delivery is done.
+	// If you want to ensure that cancellation is delivered to the operation, use NexusOperationCancellationTypeWaitRequested.
 	NexusOperationCancellationTypeTryCancel
 
 	// NexusOperationCancellationTypeWaitRequested - Request cancellation of the Nexus operation and wait for confirmation that the request was received.


### PR DESCRIPTION
Improve docs on `NexusOperationCancellationTypeTryCancel `to clarify if the cancellation may not be delivered if the workflow completes before it is delivered.
