### PR TITLE
 Fix canceling external workflow in Selector

### DIFF
--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -2279,13 +2279,23 @@ func (env *testWorkflowEnvironmentImpl) RequestCancelChildWorkflow(_, workflowID
 
 func (env *testWorkflowEnvironmentImpl) RequestCancelExternalWorkflow(namespace, workflowID, runID string, callback ResultHandler) {
 	if env.workflowInfo.WorkflowExecution.ID == workflowID {
-		// cancel current workflow
-		env.workflowCancelHandler()
-		// check if current workflow is a child workflow
-		if env.isChildWorkflow() && env.onChildWorkflowCanceledListener != nil {
+		// cancel current workflow from within workflow context
+		if sd, ok := env.workflowDef.(*syncWorkflowDefinition); ok {
 			env.postCallback(func() {
-				env.onChildWorkflowCanceledListener(env.workflowInfo)
-			}, false)
+				sd.dispatcher.NewCoroutine(sd.rootCtx, "cancel-self", true, func(ctx Context) {
+					env.workflowCancelHandler()
+				})
+				if env.isChildWorkflow() && env.onChildWorkflowCanceledListener != nil {
+					env.onChildWorkflowCanceledListener(env.workflowInfo)
+				}
+			}, true)
+		} else {
+			env.workflowCancelHandler()
+			if env.isChildWorkflow() && env.onChildWorkflowCanceledListener != nil {
+				env.postCallback(func() {
+					env.onChildWorkflowCanceledListener(env.workflowInfo)
+				}, false)
+			}
 		}
 		return
 	} else if childHandle, ok := env.runningWorkflows[workflowID]; ok && !childHandle.handled {


### PR DESCRIPTION
## What was changed
Dispatch a new coroutine with workflow context when canceling external workflow in workflow testsuite

## Why?
Fix testsuite specific error

## Checklist

1. Closes #1961

2. How was this tested:
Added test
