### PR TITLE
Deprecate versioning intents

### DIFF
--- a/internal/worker_version_sets.go
+++ b/internal/worker_version_sets.go
@@ -16,6 +16,8 @@ const UnversionedBuildID = ""
 // VersioningIntent indicates whether the user intends certain commands to be run on
 // a compatible worker build ID version or not.
 //
+// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+//
 // Exposed as: [go.temporal.io/sdk/temporal.VersioningIntent]
 type VersioningIntent int
 
@@ -23,6 +25,8 @@ const (
 	// VersioningIntentUnspecified indicates that the SDK should choose the most sensible default
 	// behavior for the type of command, accounting for whether the command will be run on the same
 	// task queue as the current worker.
+	//
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
 	//
 	// Exposed as: [go.temporal.io/sdk/temporal.VersioningIntentUnspecified]
 	VersioningIntentUnspecified VersioningIntent = iota
@@ -45,11 +49,15 @@ const (
 	// Workflow triggering it, and not use Assignment Rules. (Redirect Rules are still applicable)
 	// This is the default behavior for commands running on the same Task Queue as the current worker.
 	//
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+	//
 	// Exposed as: [go.temporal.io/sdk/temporal.VersioningIntentInheritBuildID]
 	VersioningIntentInheritBuildID
 	// VersioningIntentUseAssignmentRules indicates the command should use the latest Assignment Rules
 	// to select a Build ID independently of the workflow triggering it.
 	// This is the default behavior for commands not running on the same Task Queue as the current worker.
+	//
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
 	//
 	// Exposed as: [go.temporal.io/sdk/temporal.VersioningIntentUseAssignmentRules]
 	VersioningIntentUseAssignmentRules

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -427,6 +427,9 @@ type (
 
 		// VersioningIntent specifies whether this child workflow should run on a worker with a
 		// compatible build ID or not. See VersioningIntent.
+		//
+		// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+		//
 		// WARNING: Worker versioning is currently experimental
 		VersioningIntent VersioningIntent
 

--- a/temporal/build_id_versioning.go
+++ b/temporal/build_id_versioning.go
@@ -4,14 +4,23 @@ import "go.temporal.io/sdk/internal"
 
 // VersioningIntent indicates whether the user intends certain commands to be run on
 // a compatible worker build ID version or not.
+//
+// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+//
 // WARNING: Worker versioning is currently experimental
+//
+//lint:ignore SA1019 ignore for SDK
 type VersioningIntent = internal.VersioningIntent
 
 const (
 	// VersioningIntentUnspecified indicates that the SDK should choose the most sensible default
 	// behavior for the type of command, accounting for whether the command will be run on the same
 	// task queue as the current worker.
+	//
+	// Deprecated: This has the same effect as [VersioningIntentInheritBuildID], use that instead.
+	//
 	// WARNING: Worker versioning is currently experimental
+	//lint:ignore SA1019 ignore for SDK
 	VersioningIntentUnspecified = internal.VersioningIntentUnspecified
 	// VersioningIntentCompatible indicates that the command should run on a worker with compatible
 	// version if possible. It may not be possible if the target task queue does not also have
@@ -29,11 +38,19 @@ const (
 	// VersioningIntentInheritBuildID indicates the command should inherit the current Build ID of the
 	// Workflow triggering it, and not use Assignment Rules. (Redirect Rules are still applicable)
 	// This is the default behavior for commands running on the same Task Queue as the current worker.
+	//
+	// Deprecated: This has the same effect as [VersioningIntentInheritBuildID], use that instead.
+	//
 	// WARNING: Worker versioning is currently experimental
+	//lint:ignore SA1019 ignore for SDK
 	VersioningIntentInheritBuildID = internal.VersioningIntentInheritBuildID
 	// VersioningIntentUseAssignmentRules indicates the command should use the latest Assignment Rules
 	// to select a Build ID independently of the workflow triggering it.
 	// This is the default behavior for commands not running on the same Task Queue as the current worker.
+	//
+	// Deprecated: This has the same effect as [VersioningIntentInheritBuildID], use that instead.
+	//
 	// WARNING: Worker versioning is currently experimental
+	//lint:ignore SA1019 ignore for SDK
 	VersioningIntentUseAssignmentRules = internal.VersioningIntentUseAssignmentRules
 )

--- a/workflow/workflow_options.go
+++ b/workflow/workflow_options.go
@@ -61,6 +61,8 @@ func GetChildWorkflowOptions(ctx Context) ChildWorkflowOptions {
 
 // WithWorkflowVersioningIntent is used to set the VersioningIntent before constructing a
 // ContinueAsNewError with NewContinueAsNewError.
+//
+// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
 func WithWorkflowVersioningIntent(ctx Context, intent temporal.VersioningIntent) Context {
 	return internal.WithWorkflowVersioningIntent(ctx, intent)
 }


### PR DESCRIPTION
A few more spots where old versioning approaches should've been deprecated