### PR TITLE
Stop Nexus worker.

### DIFF
--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -1390,6 +1390,9 @@ func (aw *AggregatedWorker) Stop() {
 	if !util.IsInterfaceNil(aw.sessionWorker) {
 		aw.sessionWorker.Stop()
 	}
+	if !util.IsInterfaceNil(aw.nexusWorker) {
+		aw.nexusWorker.Stop()
+	}
 
 	aw.logger.Info("Stopped Worker")
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Added logic to stop the Nexus worker when AggregatedWorker stops

## Why?
<!-- Tell your future self why have you made these changes -->
We continue to see many logs despite stopping the worker:
```
2025/06/16 20:05:43 WARN  Failed to poll for task. Namespace <namespace-name> TaskQueue task-queue WorkerID 69116@mbp.lan@ WorkerType NexusWorker Error grpc: the client connection is closing
```
## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
