### PR TITLE
Clarify WithTags behaviour in metrics handler

### DIFF
--- a/internal/common/metrics/handler.go
+++ b/internal/common/metrics/handler.go
@@ -11,7 +11,8 @@ import "time"
 // handler. A handler may implement "Unwrap() Handler" if it wraps a handler.
 type Handler interface {
 	// WithTags returns a new handler with the given tags set for each metric
-	// created from it.
+	// created from it. Old tags from the previous handler are either preserved
+	// or overwritten, if an existing key is also present in the new tag set.
 	WithTags(map[string]string) Handler
 
 	// Counter obtains a counter for the given name.


### PR DESCRIPTION
This explicitly states how WithTags should work with existing tags on the handler.

## What was changed
Documentation only for the metrics handler interface.

## Why?
I had implemented a custom handler and had a hard time figuring out why some tags I needed for alerting were missing. See [slack thread](https://temporalio.slack.com/archives/CTDTU3J4T/p1749727637878739).

## Checklist
<!--- add/delete as needed --->

1. Closes

2. How was this tested:
Not needed

3. Any docs updates needed?
Not sure as I don't remember seeing this in the documentation. Honestly I figured it out by looking at how the uber-go/tally package implements it and asking on slack. I think having it in the metrics handler interface is good enough but let me know if you also want it included somewhere in the documentation.
