### PR TITLE
Deprecate more old versioning APIs

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -734,47 +734,61 @@ type (
 	WorkerVersionCapabilities = internal.WorkerVersionCapabilities
 
 	// UpdateWorkerVersioningRulesOptions is the input to [client.Client.UpdateWorkerVersioningRules].
+	//
 	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+	//
 	// WARNING: Worker versioning is currently experimental.
-	UpdateWorkerVersioningRulesOptions = internal.UpdateWorkerVersioningRulesOptions
+	UpdateWorkerVersioningRulesOptions = internal.UpdateWorkerVersioningRulesOptions //lint:ignore SA1019 transitioning to Worker Deployments
 
 	// VersioningConflictToken is a conflict token to serialize calls to [client.Client.UpdateWorkerVersioningRules].
 	// An update with an old token fails with `serviceerror.FailedPrecondition`.
 	// The current token can be obtained with [client.Client.GetWorkerVersioningRules],
 	// or returned by a successful [client.Client.UpdateWorkerVersioningRules].
+	//
 	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+	//
 	// WARNING: Worker versioning is currently experimental.
-	VersioningConflictToken = internal.VersioningConflictToken
+	VersioningConflictToken = internal.VersioningConflictToken //lint:ignore SA1019 transitioning to Worker Deployments
 
 	// VersioningRampByPercentage is a VersionRamp that sends a proportion of the traffic
 	// to the target Build ID.
+	//
 	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+	//
 	// WARNING: Worker versioning is currently experimental.
 	VersioningRampByPercentage = internal.VersioningRampByPercentage
 
 	// VersioningAssignmentRule is a BuildID  assigment rule for a task queue.
 	// Assignment rules only affect new workflows.
+	//
 	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+	//
 	// WARNING: Worker versioning is currently experimental.
 	VersioningAssignmentRule = internal.VersioningAssignmentRule
 
 	// VersioningAssignmentRuleWithTimestamp contains an assignment rule annotated
 	// by the server with its creation time.
+	//
 	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+	//
 	// WARNING: Worker versioning is currently experimental.
-	VersioningAssignmentRuleWithTimestamp = internal.VersioningAssignmentRuleWithTimestamp
+	VersioningAssignmentRuleWithTimestamp = internal.VersioningAssignmentRuleWithTimestamp //lint:ignore SA1019 transitioning to Worker Deployments
 
 	// VersioningAssignmentRule is a BuildID redirect rule for a task queue.
 	// It changes the behavior of currently running workflows and new ones.
+	//
 	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+	//
 	// WARNING: Worker versioning is currently experimental.
-	VersioningRedirectRule = internal.VersioningRedirectRule
+	VersioningRedirectRule = internal.VersioningRedirectRule //lint:ignore SA1019 transitioning to Worker Deployments
 
 	// VersioningRedirectRuleWithTimestamp contains a redirect rule annotated
 	// by the server with its creation time.
+	//
 	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+	//
 	// WARNING: Worker versioning is currently experimental.
-	VersioningRedirectRuleWithTimestamp = internal.VersioningRedirectRuleWithTimestamp
+	VersioningRedirectRuleWithTimestamp = internal.VersioningRedirectRuleWithTimestamp //lint:ignore SA1019 transitioning to Worker Deployments
 
 	// VersioningOperationInsertAssignmentRule is an operation for UpdateWorkerVersioningRulesOptions
 	// that inserts the rule to the list of assignment rules for this Task Queue.
@@ -783,46 +797,58 @@ type (
 	// By default, the new rule is inserted at the beginning of the list
 	// (index 0). If the given index is too larger the rule will be
 	// inserted at the end of the list.
+	//
 	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+	//
 	// WARNING: Worker versioning is currently experimental.
-	VersioningOperationInsertAssignmentRule = internal.VersioningOperationInsertAssignmentRule
+	VersioningOperationInsertAssignmentRule = internal.VersioningOperationInsertAssignmentRule //lint:ignore SA1019 transitioning to Worker Deployments
 
 	// VersioningOperationReplaceAssignmentRule is an operation for UpdateWorkerVersioningRulesOptions
 	// that replaces the assignment rule at a given index. By default presence of one
 	// unconditional rule, i.e., no hint filter or ramp, is enforced, otherwise
 	// the delete operation will be rejected. Set `force` to true to
 	// bypass this validation.
+	//
 	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+	//
 	// WARNING: Worker versioning is currently experimental.
-	VersioningOperationReplaceAssignmentRule = internal.VersioningOperationReplaceAssignmentRule
+	VersioningOperationReplaceAssignmentRule = internal.VersioningOperationReplaceAssignmentRule //lint:ignore SA1019 transitioning to Worker Deployments
 
 	// VersioningOperationDeleteAssignmentRule is an operation for UpdateWorkerVersioningRulesOptions
 	// that deletes the assignment rule at a given index. By default presence of one
 	// unconditional rule, i.e., no hint filter or ramp, is enforced, otherwise
 	// the delete operation will be rejected. Set `force` to true to
 	// bypass this validation.
+	//
 	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+	//
 	// WARNING: Worker versioning is currently experimental.
-	VersioningOperationDeleteAssignmentRule = internal.VersioningOperationDeleteAssignmentRule
+	VersioningOperationDeleteAssignmentRule = internal.VersioningOperationDeleteAssignmentRule //lint:ignore SA1019 transitioning to Worker Deployments
 
 	// VersioningOperationAddRedirectRule is an operation for UpdateWorkerVersioningRulesOptions
 	// that adds the rule to the list of redirect rules for this Task Queue. There
 	// can be at most one redirect rule for each distinct Source BuildID.
+	//
 	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+	//
 	// WARNING: Worker versioning is currently experimental.
-	VersioningOperationAddRedirectRule = internal.VersioningOperationAddRedirectRule
+	VersioningOperationAddRedirectRule = internal.VersioningOperationAddRedirectRule //lint:ignore SA1019 transitioning to Worker Deployments
 
 	// VersioningOperationReplaceRedirectRule is an operation for UpdateWorkerVersioningRulesOptions
 	// that replaces the routing rule with the given source BuildID.
+	//
 	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+	//
 	// WARNING: Worker versioning is currently experimental.
-	VersioningOperationReplaceRedirectRule = internal.VersioningOperationReplaceRedirectRule
+	VersioningOperationReplaceRedirectRule = internal.VersioningOperationReplaceRedirectRule //lint:ignore SA1019 transitioning to Worker Deployments
 
 	// VersioningOperationDeleteRedirectRule is an operation for UpdateWorkerVersioningRulesOptions
 	// that deletes the routing rule with the given source Build ID.
+	//
 	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+	//
 	// WARNING: Worker versioning is currently experimental.
-	VersioningOperationDeleteRedirectRule = internal.VersioningOperationDeleteRedirectRule
+	VersioningOperationDeleteRedirectRule = internal.VersioningOperationDeleteRedirectRule //lint:ignore SA1019 transitioning to Worker Deployments
 
 	// VersioningOperationCommitBuildID is an operation for UpdateWorkerVersioningRulesOptions
 	// that completes  the rollout of a BuildID and cleanup unnecessary rules possibly
@@ -837,19 +863,25 @@ type (
 	// To prevent committing invalid Build IDs, we reject the request if no
 	// pollers have been seen recently for this Build ID. Use the `force`
 	// option to disable this validation.
+	//
 	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+	//
 	// WARNING: Worker versioning is currently experimental.
-	VersioningOperationCommitBuildID = internal.VersioningOperationCommitBuildID
+	VersioningOperationCommitBuildID = internal.VersioningOperationCommitBuildID //lint:ignore SA1019 transitioning to Worker Deployments
 
 	// GetWorkerVersioningOptions is the input to [client.Client.GetWorkerVersioningRules].
+	//
 	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+	//
 	// WARNING: Worker versioning is currently experimental.
-	GetWorkerVersioningOptions = internal.GetWorkerVersioningOptions
+	GetWorkerVersioningOptions = internal.GetWorkerVersioningOptions //lint:ignore SA1019 transitioning to Worker Deployments
 
 	// WorkerVersioningRules is the response for [client.Client.GetWorkerVersioningRules].
+	//
 	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+	//
 	// WARNING: Worker versioning is currently experimental.
-	WorkerVersioningRules = internal.WorkerVersioningRules
+	WorkerVersioningRules = internal.WorkerVersioningRules //lint:ignore SA1019 transitioning to Worker Deployments
 
 	// WorkflowUpdateServiceTimeoutOrCanceledError is an error that occurs when an update call times out or is cancelled.
 	//
@@ -1211,6 +1243,7 @@ type (
 		//  - serviceerror.FailedPrecondition when the conflict token is invalid
 		//
 		// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+		//
 		// WARNING: Worker versioning is currently experimental, and requires server 1.24+
 		UpdateWorkerVersioningRules(ctx context.Context, options UpdateWorkerVersioningRulesOptions) (*WorkerVersioningRules, error)
 
@@ -1218,6 +1251,7 @@ type (
 		// Returns the worker-build-id assignment and redirect rules for a task queue.
 		//
 		// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+		//
 		// WARNING: Worker versioning is currently experimental, and requires server 1.24+
 		GetWorkerVersioningRules(ctx context.Context, options GetWorkerVersioningOptions) (*WorkerVersioningRules, error)
 

--- a/client/client.go
+++ b/client/client.go
@@ -756,7 +756,7 @@ type (
 	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
 	//
 	// WARNING: Worker versioning is currently experimental.
-	VersioningRampByPercentage = internal.VersioningRampByPercentage
+	VersioningRampByPercentage = internal.VersioningRampByPercentage //lint:ignore SA1019 transitioning to Worker Deployments
 
 	// VersioningAssignmentRule is a BuildID  assigment rule for a task queue.
 	// Assignment rules only affect new workflows.
@@ -764,7 +764,7 @@ type (
 	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
 	//
 	// WARNING: Worker versioning is currently experimental.
-	VersioningAssignmentRule = internal.VersioningAssignmentRule
+	VersioningAssignmentRule = internal.VersioningAssignmentRule //lint:ignore SA1019 transitioning to Worker Deployments
 
 	// VersioningAssignmentRuleWithTimestamp contains an assignment rule annotated
 	// by the server with its creation time.

--- a/client/client.go
+++ b/client/client.go
@@ -734,6 +734,7 @@ type (
 	WorkerVersionCapabilities = internal.WorkerVersionCapabilities
 
 	// UpdateWorkerVersioningRulesOptions is the input to [client.Client.UpdateWorkerVersioningRules].
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
 	// WARNING: Worker versioning is currently experimental.
 	UpdateWorkerVersioningRulesOptions = internal.UpdateWorkerVersioningRulesOptions
 
@@ -741,31 +742,37 @@ type (
 	// An update with an old token fails with `serviceerror.FailedPrecondition`.
 	// The current token can be obtained with [client.Client.GetWorkerVersioningRules],
 	// or returned by a successful [client.Client.UpdateWorkerVersioningRules].
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
 	// WARNING: Worker versioning is currently experimental.
 	VersioningConflictToken = internal.VersioningConflictToken
 
 	// VersioningRampByPercentage is a VersionRamp that sends a proportion of the traffic
 	// to the target Build ID.
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
 	// WARNING: Worker versioning is currently experimental.
 	VersioningRampByPercentage = internal.VersioningRampByPercentage
 
 	// VersioningAssignmentRule is a BuildID  assigment rule for a task queue.
 	// Assignment rules only affect new workflows.
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
 	// WARNING: Worker versioning is currently experimental.
 	VersioningAssignmentRule = internal.VersioningAssignmentRule
 
 	// VersioningAssignmentRuleWithTimestamp contains an assignment rule annotated
 	// by the server with its creation time.
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
 	// WARNING: Worker versioning is currently experimental.
 	VersioningAssignmentRuleWithTimestamp = internal.VersioningAssignmentRuleWithTimestamp
 
 	// VersioningAssignmentRule is a BuildID redirect rule for a task queue.
 	// It changes the behavior of currently running workflows and new ones.
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
 	// WARNING: Worker versioning is currently experimental.
 	VersioningRedirectRule = internal.VersioningRedirectRule
 
 	// VersioningRedirectRuleWithTimestamp contains a redirect rule annotated
 	// by the server with its creation time.
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
 	// WARNING: Worker versioning is currently experimental.
 	VersioningRedirectRuleWithTimestamp = internal.VersioningRedirectRuleWithTimestamp
 
@@ -776,6 +783,7 @@ type (
 	// By default, the new rule is inserted at the beginning of the list
 	// (index 0). If the given index is too larger the rule will be
 	// inserted at the end of the list.
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
 	// WARNING: Worker versioning is currently experimental.
 	VersioningOperationInsertAssignmentRule = internal.VersioningOperationInsertAssignmentRule
 
@@ -784,6 +792,7 @@ type (
 	// unconditional rule, i.e., no hint filter or ramp, is enforced, otherwise
 	// the delete operation will be rejected. Set `force` to true to
 	// bypass this validation.
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
 	// WARNING: Worker versioning is currently experimental.
 	VersioningOperationReplaceAssignmentRule = internal.VersioningOperationReplaceAssignmentRule
 
@@ -792,22 +801,26 @@ type (
 	// unconditional rule, i.e., no hint filter or ramp, is enforced, otherwise
 	// the delete operation will be rejected. Set `force` to true to
 	// bypass this validation.
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
 	// WARNING: Worker versioning is currently experimental.
 	VersioningOperationDeleteAssignmentRule = internal.VersioningOperationDeleteAssignmentRule
 
 	// VersioningOperationAddRedirectRule is an operation for UpdateWorkerVersioningRulesOptions
 	// that adds the rule to the list of redirect rules for this Task Queue. There
 	// can be at most one redirect rule for each distinct Source BuildID.
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
 	// WARNING: Worker versioning is currently experimental.
 	VersioningOperationAddRedirectRule = internal.VersioningOperationAddRedirectRule
 
 	// VersioningOperationReplaceRedirectRule is an operation for UpdateWorkerVersioningRulesOptions
 	// that replaces the routing rule with the given source BuildID.
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
 	// WARNING: Worker versioning is currently experimental.
 	VersioningOperationReplaceRedirectRule = internal.VersioningOperationReplaceRedirectRule
 
 	// VersioningOperationDeleteRedirectRule is an operation for UpdateWorkerVersioningRulesOptions
 	// that deletes the routing rule with the given source Build ID.
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
 	// WARNING: Worker versioning is currently experimental.
 	VersioningOperationDeleteRedirectRule = internal.VersioningOperationDeleteRedirectRule
 
@@ -824,14 +837,17 @@ type (
 	// To prevent committing invalid Build IDs, we reject the request if no
 	// pollers have been seen recently for this Build ID. Use the `force`
 	// option to disable this validation.
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
 	// WARNING: Worker versioning is currently experimental.
 	VersioningOperationCommitBuildID = internal.VersioningOperationCommitBuildID
 
 	// GetWorkerVersioningOptions is the input to [client.Client.GetWorkerVersioningRules].
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
 	// WARNING: Worker versioning is currently experimental.
 	GetWorkerVersioningOptions = internal.GetWorkerVersioningOptions
 
 	// WorkerVersioningRules is the response for [client.Client.GetWorkerVersioningRules].
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
 	// WARNING: Worker versioning is currently experimental.
 	WorkerVersioningRules = internal.WorkerVersioningRules
 
@@ -1193,11 +1209,15 @@ type (
 		// conjunction with workers who specify their build id and thus opt into the feature.
 		// The errors it can return:
 		//  - serviceerror.FailedPrecondition when the conflict token is invalid
+		//
+		// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
 		// WARNING: Worker versioning is currently experimental, and requires server 1.24+
 		UpdateWorkerVersioningRules(ctx context.Context, options UpdateWorkerVersioningRulesOptions) (*WorkerVersioningRules, error)
 
 		// GetWorkerVersioningRules
 		// Returns the worker-build-id assignment and redirect rules for a task queue.
+		//
+		// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
 		// WARNING: Worker versioning is currently experimental, and requires server 1.24+
 		GetWorkerVersioningRules(ctx context.Context, options GetWorkerVersioningOptions) (*WorkerVersioningRules, error)
 

--- a/client/client.go
+++ b/client/client.go
@@ -735,7 +735,7 @@ type (
 
 	// UpdateWorkerVersioningRulesOptions is the input to [client.Client.UpdateWorkerVersioningRules].
 	//
-	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning and will be removed soon.
 	//
 	// WARNING: Worker versioning is currently experimental.
 	UpdateWorkerVersioningRulesOptions = internal.UpdateWorkerVersioningRulesOptions //lint:ignore SA1019 transitioning to Worker Deployments
@@ -745,7 +745,7 @@ type (
 	// The current token can be obtained with [client.Client.GetWorkerVersioningRules],
 	// or returned by a successful [client.Client.UpdateWorkerVersioningRules].
 	//
-	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning and will be removed soon.
 	//
 	// WARNING: Worker versioning is currently experimental.
 	VersioningConflictToken = internal.VersioningConflictToken //lint:ignore SA1019 transitioning to Worker Deployments
@@ -753,7 +753,7 @@ type (
 	// VersioningRampByPercentage is a VersionRamp that sends a proportion of the traffic
 	// to the target Build ID.
 	//
-	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning and will be removed soon.
 	//
 	// WARNING: Worker versioning is currently experimental.
 	VersioningRampByPercentage = internal.VersioningRampByPercentage //lint:ignore SA1019 transitioning to Worker Deployments
@@ -761,7 +761,7 @@ type (
 	// VersioningAssignmentRule is a BuildID  assigment rule for a task queue.
 	// Assignment rules only affect new workflows.
 	//
-	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning and will be removed soon.
 	//
 	// WARNING: Worker versioning is currently experimental.
 	VersioningAssignmentRule = internal.VersioningAssignmentRule //lint:ignore SA1019 transitioning to Worker Deployments
@@ -769,7 +769,7 @@ type (
 	// VersioningAssignmentRuleWithTimestamp contains an assignment rule annotated
 	// by the server with its creation time.
 	//
-	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning and will be removed soon.
 	//
 	// WARNING: Worker versioning is currently experimental.
 	VersioningAssignmentRuleWithTimestamp = internal.VersioningAssignmentRuleWithTimestamp //lint:ignore SA1019 transitioning to Worker Deployments
@@ -777,7 +777,7 @@ type (
 	// VersioningAssignmentRule is a BuildID redirect rule for a task queue.
 	// It changes the behavior of currently running workflows and new ones.
 	//
-	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning and will be removed soon.
 	//
 	// WARNING: Worker versioning is currently experimental.
 	VersioningRedirectRule = internal.VersioningRedirectRule //lint:ignore SA1019 transitioning to Worker Deployments
@@ -785,7 +785,7 @@ type (
 	// VersioningRedirectRuleWithTimestamp contains a redirect rule annotated
 	// by the server with its creation time.
 	//
-	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning and will be removed soon.
 	//
 	// WARNING: Worker versioning is currently experimental.
 	VersioningRedirectRuleWithTimestamp = internal.VersioningRedirectRuleWithTimestamp //lint:ignore SA1019 transitioning to Worker Deployments
@@ -798,7 +798,7 @@ type (
 	// (index 0). If the given index is too larger the rule will be
 	// inserted at the end of the list.
 	//
-	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning and will be removed soon.
 	//
 	// WARNING: Worker versioning is currently experimental.
 	VersioningOperationInsertAssignmentRule = internal.VersioningOperationInsertAssignmentRule //lint:ignore SA1019 transitioning to Worker Deployments
@@ -809,7 +809,7 @@ type (
 	// the delete operation will be rejected. Set `force` to true to
 	// bypass this validation.
 	//
-	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning and will be removed soon.
 	//
 	// WARNING: Worker versioning is currently experimental.
 	VersioningOperationReplaceAssignmentRule = internal.VersioningOperationReplaceAssignmentRule //lint:ignore SA1019 transitioning to Worker Deployments
@@ -820,7 +820,7 @@ type (
 	// the delete operation will be rejected. Set `force` to true to
 	// bypass this validation.
 	//
-	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning and will be removed soon.
 	//
 	// WARNING: Worker versioning is currently experimental.
 	VersioningOperationDeleteAssignmentRule = internal.VersioningOperationDeleteAssignmentRule //lint:ignore SA1019 transitioning to Worker Deployments
@@ -829,7 +829,7 @@ type (
 	// that adds the rule to the list of redirect rules for this Task Queue. There
 	// can be at most one redirect rule for each distinct Source BuildID.
 	//
-	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning and will be removed soon.
 	//
 	// WARNING: Worker versioning is currently experimental.
 	VersioningOperationAddRedirectRule = internal.VersioningOperationAddRedirectRule //lint:ignore SA1019 transitioning to Worker Deployments
@@ -837,7 +837,7 @@ type (
 	// VersioningOperationReplaceRedirectRule is an operation for UpdateWorkerVersioningRulesOptions
 	// that replaces the routing rule with the given source BuildID.
 	//
-	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning and will be removed soon.
 	//
 	// WARNING: Worker versioning is currently experimental.
 	VersioningOperationReplaceRedirectRule = internal.VersioningOperationReplaceRedirectRule //lint:ignore SA1019 transitioning to Worker Deployments
@@ -845,7 +845,7 @@ type (
 	// VersioningOperationDeleteRedirectRule is an operation for UpdateWorkerVersioningRulesOptions
 	// that deletes the routing rule with the given source Build ID.
 	//
-	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning and will be removed soon.
 	//
 	// WARNING: Worker versioning is currently experimental.
 	VersioningOperationDeleteRedirectRule = internal.VersioningOperationDeleteRedirectRule //lint:ignore SA1019 transitioning to Worker Deployments
@@ -864,21 +864,21 @@ type (
 	// pollers have been seen recently for this Build ID. Use the `force`
 	// option to disable this validation.
 	//
-	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning and will be removed soon.
 	//
 	// WARNING: Worker versioning is currently experimental.
 	VersioningOperationCommitBuildID = internal.VersioningOperationCommitBuildID //lint:ignore SA1019 transitioning to Worker Deployments
 
 	// GetWorkerVersioningOptions is the input to [client.Client.GetWorkerVersioningRules].
 	//
-	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning and will be removed soon.
 	//
 	// WARNING: Worker versioning is currently experimental.
 	GetWorkerVersioningOptions = internal.GetWorkerVersioningOptions //lint:ignore SA1019 transitioning to Worker Deployments
 
 	// WorkerVersioningRules is the response for [client.Client.GetWorkerVersioningRules].
 	//
-	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning and will be removed soon.
 	//
 	// WARNING: Worker versioning is currently experimental.
 	WorkerVersioningRules = internal.WorkerVersioningRules //lint:ignore SA1019 transitioning to Worker Deployments
@@ -1242,7 +1242,7 @@ type (
 		// The errors it can return:
 		//  - serviceerror.FailedPrecondition when the conflict token is invalid
 		//
-		// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+		// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning and will be removed soon.
 		//
 		// WARNING: Worker versioning is currently experimental, and requires server 1.24+
 		UpdateWorkerVersioningRules(ctx context.Context, options UpdateWorkerVersioningRulesOptions) (*WorkerVersioningRules, error)
@@ -1250,7 +1250,7 @@ type (
 		// GetWorkerVersioningRules
 		// Returns the worker-build-id assignment and redirect rules for a task queue.
 		//
-		// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+		// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning and will be removed soon.
 		//
 		// WARNING: Worker versioning is currently experimental, and requires server 1.24+
 		GetWorkerVersioningRules(ctx context.Context, options GetWorkerVersioningOptions) (*WorkerVersioningRules, error)

--- a/internal/worker_version_sets.go
+++ b/internal/worker_version_sets.go
@@ -16,7 +16,7 @@ const UnversionedBuildID = ""
 // VersioningIntent indicates whether the user intends certain commands to be run on
 // a compatible worker build ID version or not.
 //
-// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning and will be removed soon.
 //
 // Exposed as: [go.temporal.io/sdk/temporal.VersioningIntent]
 type VersioningIntent int
@@ -26,7 +26,7 @@ const (
 	// behavior for the type of command, accounting for whether the command will be run on the same
 	// task queue as the current worker.
 	//
-	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning and will be removed soon.
 	//
 	// Exposed as: [go.temporal.io/sdk/temporal.VersioningIntentUnspecified]
 	VersioningIntentUnspecified VersioningIntent = iota
@@ -49,7 +49,7 @@ const (
 	// Workflow triggering it, and not use Assignment Rules. (Redirect Rules are still applicable)
 	// This is the default behavior for commands running on the same Task Queue as the current worker.
 	//
-	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning and will be removed soon.
 	//
 	// Exposed as: [go.temporal.io/sdk/temporal.VersioningIntentInheritBuildID]
 	VersioningIntentInheritBuildID
@@ -57,7 +57,7 @@ const (
 	// to select a Build ID independently of the workflow triggering it.
 	// This is the default behavior for commands not running on the same Task Queue as the current worker.
 	//
-	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning and will be removed soon.
 	//
 	// Exposed as: [go.temporal.io/sdk/temporal.VersioningIntentUseAssignmentRules]
 	VersioningIntentUseAssignmentRules

--- a/internal/worker_versioning_rules.go
+++ b/internal/worker_versioning_rules.go
@@ -16,8 +16,8 @@ type (
 	}
 
 	// VersioningRampByPercentage sends a proportion of the traffic to the target Build ID.
-         //
-	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+	//
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning and will be removed soon.
 	//
 	// WARNING: Worker versioning is currently experimental
 	//
@@ -29,8 +29,8 @@ type (
 
 	// VersioningAssignmentRule is a BuildID assigment rule for a task queue.
 	// Assignment rules only affect new workflows.
-         //
-	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+	//
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning and will be removed soon.
 	//
 	// WARNING: Worker versioning is currently experimental
 	//
@@ -45,7 +45,7 @@ type (
 	// VersioningAssignmentRuleWithTimestamp contains an assignment rule annotated
 	// by the server with its creation time.
 	//
-	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning and will be removed soon.
 	//
 	// WARNING: Worker versioning is currently experimental
 	//
@@ -59,7 +59,7 @@ type (
 	// VersioningAssignmentRule is a BuildID redirect rule for a task queue.
 	// It changes the behavior of currently running workflows and new ones.
 	//
-	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning and will be removed soon.
 	//
 	// WARNING: Worker versioning is currently experimental
 	//
@@ -73,7 +73,7 @@ type (
 	// by the server with its creation time.
 	// WARNING: Worker versioning is currently experimental
 	//
-	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning and will be removed soon.
 	//
 	// Exposed as: [go.temporal.io/sdk/client.VersioningRedirectRuleWithTimestamp]
 	VersioningRedirectRuleWithTimestamp struct {
@@ -86,7 +86,7 @@ type (
 	// An update with an old token fails with `serviceerror.FailedPrecondition`.
 	// The current token can be obtained with [GetWorkerVersioningRules], or returned by a successful [UpdateWorkerVersioningRules].
 	//
-	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning and will be removed soon.
 	//
 	// WARNING: Worker versioning is currently experimental
 	//
@@ -97,7 +97,7 @@ type (
 
 	// UpdateWorkerVersioningRulesOptions is the input to [Client.UpdateWorkerVersioningRules].
 	//
-	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning and will be removed soon.
 	//
 	// WARNING: Worker versioning is currently experimental
 	//
@@ -122,7 +122,7 @@ type (
 	//   - [VersioningOperationDeleteRedirectRule]
 	//   - [VersioningOperationCommitBuildID]
 	//
-	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning and will be removed soon.
 	VersioningOperation interface {
 		validateOp() error
 	}
@@ -135,7 +135,7 @@ type (
 	// (index 0). If the given index is too larger the rule will be
 	// inserted at the end of the list.
 	//
-	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning and will be removed soon.
 	//
 	// WARNING: Worker versioning is currently experimental
 	//
@@ -151,7 +151,7 @@ type (
 	// the delete operation will be rejected. Set `force` to true to
 	// bypass this validation.
 	//
-	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning and will be removed soon.
 	//
 	// WARNING: Worker versioning is currently experimental
 	//
@@ -168,7 +168,7 @@ type (
 	// the delete operation will be rejected. Set `force` to true to
 	// bypass this validation.
 	//
-	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning and will be removed soon.
 	//
 	// WARNING: Worker versioning is currently experimental
 	//
@@ -182,7 +182,7 @@ type (
 	// that adds the rule to the list of redirect rules for this Task Queue. There
 	// can be at most one redirect rule for each distinct Source BuildID.
 	//
-	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning and will be removed soon.
 	//
 	// WARNING: Worker versioning is currently experimental
 	//
@@ -194,7 +194,7 @@ type (
 	// VersioningOperationReplaceRedirectRule is an operation for UpdateWorkerVersioningRulesOptions
 	// that replaces the routing rule with the given source BuildID.
 	//
-	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning and will be removed soon.
 	//
 	// WARNING: Worker versioning is currently experimental
 	//
@@ -206,7 +206,7 @@ type (
 	// VersioningOperationDeleteRedirectRule is an operation for UpdateWorkerVersioningRulesOptions
 	// that deletes the routing rule with the given source Build ID.
 	//
-	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning and will be removed soon.
 	//
 	// WARNING: Worker versioning is currently experimental
 	//
@@ -229,7 +229,7 @@ type (
 	// pollers have been seen recently for this Build ID. Use the `force`
 	// option to disable this validation.
 	//
-	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning and will be removed soon.
 	//
 	// WARNING: Worker versioning is currently experimental
 	//
@@ -243,7 +243,7 @@ type (
 // Token
 // Returns an internal representation of this token, mostly for debugging purposes.
 //
-// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning and will be removed soon.
 //
 // WARNING: Worker versioning is currently experimental
 func (c *VersioningConflictToken) Token() []byte {
@@ -323,7 +323,7 @@ func (uw *UpdateWorkerVersioningRulesOptions) validateAndConvertToProto(namespac
 
 // GetWorkerVersioningOptions is the input to [Client.GetWorkerVersioningRules].
 //
-// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning and will be removed soon.
 //
 // WARNING: Worker versioning is currently experimental
 //
@@ -351,7 +351,7 @@ func (gw *GetWorkerVersioningOptions) validateAndConvertToProto(namespace string
 
 // WorkerVersioningRules is the response for [Client.GetWorkerVersioningRules].
 //
-// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning and will be removed soon.
 //
 // WARNING: Worker versioning is currently experimental
 //

--- a/internal/worker_versioning_rules.go
+++ b/internal/worker_versioning_rules.go
@@ -16,6 +16,7 @@ type (
 	}
 
 	// VersioningRampByPercentage sends a proportion of the traffic to the target Build ID.
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
 	// WARNING: Worker versioning is currently experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.VersioningRampByPercentage]
@@ -26,6 +27,7 @@ type (
 
 	// VersioningAssignmentRule is a BuildID assigment rule for a task queue.
 	// Assignment rules only affect new workflows.
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
 	// WARNING: Worker versioning is currently experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.VersioningAssignmentRule]
@@ -38,6 +40,7 @@ type (
 
 	// VersioningAssignmentRuleWithTimestamp contains an assignment rule annotated
 	// by the server with its creation time.
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
 	// WARNING: Worker versioning is currently experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.VersioningAssignmentRuleWithTimestamp]
@@ -49,6 +52,7 @@ type (
 
 	// VersioningAssignmentRule is a BuildID redirect rule for a task queue.
 	// It changes the behavior of currently running workflows and new ones.
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
 	// WARNING: Worker versioning is currently experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.VersioningRedirectRule]
@@ -68,9 +72,10 @@ type (
 		CreateTime time.Time
 	}
 
-	//VersioningConflictToken is a conflict token to serialize updates.
+	// VersioningConflictToken is a conflict token to serialize updates.
 	// An update with an old token fails with `serviceerror.FailedPrecondition`.
 	// The current token can be obtained with [GetWorkerVersioningRules], or returned by a successful [UpdateWorkerVersioningRules].
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
 	// WARNING: Worker versioning is currently experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.VersioningConflictToken]
@@ -79,6 +84,7 @@ type (
 	}
 
 	// UpdateWorkerVersioningRulesOptions is the input to [Client.UpdateWorkerVersioningRules].
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
 	// WARNING: Worker versioning is currently experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.UpdateWorkerVersioningRulesOptions]
@@ -101,6 +107,8 @@ type (
 	//   - [VersioningOperationReplaceRedirectRule]
 	//   - [VersioningOperationDeleteRedirectRule]
 	//   - [VersioningOperationCommitBuildID]
+	//
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
 	VersioningOperation interface {
 		validateOp() error
 	}
@@ -112,6 +120,7 @@ type (
 	// By default, the new rule is inserted at the beginning of the list
 	// (index 0). If the given index is too larger the rule will be
 	// inserted at the end of the list.
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
 	// WARNING: Worker versioning is currently experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.VersioningOperationInsertAssignmentRule]
@@ -125,6 +134,7 @@ type (
 	// unconditional rule, i.e., no hint filter or ramp, is enforced, otherwise
 	// the delete operation will be rejected. Set `force` to true to
 	// bypass this validation.
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
 	// WARNING: Worker versioning is currently experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.VersioningOperationReplaceAssignmentRule]
@@ -139,6 +149,7 @@ type (
 	// unconditional rule, i.e., no hint filter or ramp, is enforced, otherwise
 	// the delete operation will be rejected. Set `force` to true to
 	// bypass this validation.
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
 	// WARNING: Worker versioning is currently experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.VersioningOperationDeleteAssignmentRule]
@@ -150,6 +161,7 @@ type (
 	// VersioningOperationAddRedirectRule is an operation for UpdateWorkerVersioningRulesOptions
 	// that adds the rule to the list of redirect rules for this Task Queue. There
 	// can be at most one redirect rule for each distinct Source BuildID.
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
 	// WARNING: Worker versioning is currently experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.VersioningOperationAddRedirectRule]
@@ -159,6 +171,7 @@ type (
 
 	// VersioningOperationReplaceRedirectRule is an operation for UpdateWorkerVersioningRulesOptions
 	// that replaces the routing rule with the given source BuildID.
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
 	// WARNING: Worker versioning is currently experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.VersioningOperationReplaceRedirectRule]
@@ -168,6 +181,7 @@ type (
 
 	// VersioningOperationDeleteRedirectRule is an operation for UpdateWorkerVersioningRulesOptions
 	// that deletes the routing rule with the given source Build ID.
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
 	// WARNING: Worker versioning is currently experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.VersioningOperationDeleteRedirectRule]
@@ -188,6 +202,7 @@ type (
 	// To prevent committing invalid Build IDs, we reject the request if no
 	// pollers have been seen recently for this Build ID. Use the `force`
 	// option to disable this validation.
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
 	// WARNING: Worker versioning is currently experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.VersioningOperationCommitBuildID]
@@ -199,6 +214,7 @@ type (
 
 // Token
 // Returns an internal representation of this token, mostly for debugging purposes.
+// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
 // WARNING: Worker versioning is currently experimental
 func (c *VersioningConflictToken) Token() []byte {
 	return c.token
@@ -276,6 +292,7 @@ func (uw *UpdateWorkerVersioningRulesOptions) validateAndConvertToProto(namespac
 }
 
 // GetWorkerVersioningOptions is the input to [Client.GetWorkerVersioningRules].
+// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
 // WARNING: Worker versioning is currently experimental
 //
 // Exposed as: [go.temporal.io/sdk/client.GetWorkerVersioningOptions]
@@ -301,6 +318,7 @@ func (gw *GetWorkerVersioningOptions) validateAndConvertToProto(namespace string
 }
 
 // WorkerVersioningRules is the response for [Client.GetWorkerVersioningRules].
+// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
 // WARNING: Worker versioning is currently experimental
 //
 // Exposed as: [go.temporal.io/sdk/client.WorkerVersioningRules]

--- a/internal/worker_versioning_rules.go
+++ b/internal/worker_versioning_rules.go
@@ -16,7 +16,9 @@ type (
 	}
 
 	// VersioningRampByPercentage sends a proportion of the traffic to the target Build ID.
+         //
 	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+	//
 	// WARNING: Worker versioning is currently experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.VersioningRampByPercentage]
@@ -27,7 +29,9 @@ type (
 
 	// VersioningAssignmentRule is a BuildID assigment rule for a task queue.
 	// Assignment rules only affect new workflows.
+         //
 	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+	//
 	// WARNING: Worker versioning is currently experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.VersioningAssignmentRule]

--- a/internal/worker_versioning_rules.go
+++ b/internal/worker_versioning_rules.go
@@ -40,7 +40,9 @@ type (
 
 	// VersioningAssignmentRuleWithTimestamp contains an assignment rule annotated
 	// by the server with its creation time.
+	//
 	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+	//
 	// WARNING: Worker versioning is currently experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.VersioningAssignmentRuleWithTimestamp]
@@ -52,7 +54,9 @@ type (
 
 	// VersioningAssignmentRule is a BuildID redirect rule for a task queue.
 	// It changes the behavior of currently running workflows and new ones.
+	//
 	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+	//
 	// WARNING: Worker versioning is currently experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.VersioningRedirectRule]
@@ -65,6 +69,8 @@ type (
 	// by the server with its creation time.
 	// WARNING: Worker versioning is currently experimental
 	//
+	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+	//
 	// Exposed as: [go.temporal.io/sdk/client.VersioningRedirectRuleWithTimestamp]
 	VersioningRedirectRuleWithTimestamp struct {
 		Rule VersioningRedirectRule
@@ -75,7 +81,9 @@ type (
 	// VersioningConflictToken is a conflict token to serialize updates.
 	// An update with an old token fails with `serviceerror.FailedPrecondition`.
 	// The current token can be obtained with [GetWorkerVersioningRules], or returned by a successful [UpdateWorkerVersioningRules].
+	//
 	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+	//
 	// WARNING: Worker versioning is currently experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.VersioningConflictToken]
@@ -84,7 +92,9 @@ type (
 	}
 
 	// UpdateWorkerVersioningRulesOptions is the input to [Client.UpdateWorkerVersioningRules].
+	//
 	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+	//
 	// WARNING: Worker versioning is currently experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.UpdateWorkerVersioningRulesOptions]
@@ -120,7 +130,9 @@ type (
 	// By default, the new rule is inserted at the beginning of the list
 	// (index 0). If the given index is too larger the rule will be
 	// inserted at the end of the list.
+	//
 	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+	//
 	// WARNING: Worker versioning is currently experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.VersioningOperationInsertAssignmentRule]
@@ -134,7 +146,9 @@ type (
 	// unconditional rule, i.e., no hint filter or ramp, is enforced, otherwise
 	// the delete operation will be rejected. Set `force` to true to
 	// bypass this validation.
+	//
 	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+	//
 	// WARNING: Worker versioning is currently experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.VersioningOperationReplaceAssignmentRule]
@@ -149,7 +163,9 @@ type (
 	// unconditional rule, i.e., no hint filter or ramp, is enforced, otherwise
 	// the delete operation will be rejected. Set `force` to true to
 	// bypass this validation.
+	//
 	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+	//
 	// WARNING: Worker versioning is currently experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.VersioningOperationDeleteAssignmentRule]
@@ -161,7 +177,9 @@ type (
 	// VersioningOperationAddRedirectRule is an operation for UpdateWorkerVersioningRulesOptions
 	// that adds the rule to the list of redirect rules for this Task Queue. There
 	// can be at most one redirect rule for each distinct Source BuildID.
+	//
 	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+	//
 	// WARNING: Worker versioning is currently experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.VersioningOperationAddRedirectRule]
@@ -171,7 +189,9 @@ type (
 
 	// VersioningOperationReplaceRedirectRule is an operation for UpdateWorkerVersioningRulesOptions
 	// that replaces the routing rule with the given source BuildID.
+	//
 	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+	//
 	// WARNING: Worker versioning is currently experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.VersioningOperationReplaceRedirectRule]
@@ -181,7 +201,9 @@ type (
 
 	// VersioningOperationDeleteRedirectRule is an operation for UpdateWorkerVersioningRulesOptions
 	// that deletes the routing rule with the given source Build ID.
+	//
 	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+	//
 	// WARNING: Worker versioning is currently experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.VersioningOperationDeleteRedirectRule]
@@ -202,7 +224,9 @@ type (
 	// To prevent committing invalid Build IDs, we reject the request if no
 	// pollers have been seen recently for this Build ID. Use the `force`
 	// option to disable this validation.
+	//
 	// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+	//
 	// WARNING: Worker versioning is currently experimental
 	//
 	// Exposed as: [go.temporal.io/sdk/client.VersioningOperationCommitBuildID]
@@ -214,7 +238,9 @@ type (
 
 // Token
 // Returns an internal representation of this token, mostly for debugging purposes.
+//
 // Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+//
 // WARNING: Worker versioning is currently experimental
 func (c *VersioningConflictToken) Token() []byte {
 	return c.token
@@ -292,7 +318,9 @@ func (uw *UpdateWorkerVersioningRulesOptions) validateAndConvertToProto(namespac
 }
 
 // GetWorkerVersioningOptions is the input to [Client.GetWorkerVersioningRules].
+//
 // Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+//
 // WARNING: Worker versioning is currently experimental
 //
 // Exposed as: [go.temporal.io/sdk/client.GetWorkerVersioningOptions]
@@ -318,7 +346,9 @@ func (gw *GetWorkerVersioningOptions) validateAndConvertToProto(namespace string
 }
 
 // WorkerVersioningRules is the response for [Client.GetWorkerVersioningRules].
+//
 // Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+//
 // WARNING: Worker versioning is currently experimental
 //
 // Exposed as: [go.temporal.io/sdk/client.WorkerVersioningRules]

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -428,7 +428,7 @@ type (
 		// VersioningIntent specifies whether this child workflow should run on a worker with a
 		// compatible build ID or not. See VersioningIntent.
 		//
-		// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+		// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning and will be removed soon.
 		//
 		// WARNING: Worker versioning is currently experimental
 		VersioningIntent VersioningIntent

--- a/mocks/Client.go
+++ b/mocks/Client.go
@@ -393,6 +393,8 @@ func (_m *Client) GetWorkerTaskReachability(ctx context.Context, options *client
 }
 
 // GetWorkerVersioningRules provides a mock function with given fields: ctx, options
+//
+//lint:ignore SA1019 ignore for SDK mocks
 func (_m *Client) GetWorkerVersioningRules(ctx context.Context, options client.GetWorkerVersioningOptions) (*client.WorkerVersioningRules, error) {
 	ret := _m.Called(ctx, options)
 
@@ -400,19 +402,24 @@ func (_m *Client) GetWorkerVersioningRules(ctx context.Context, options client.G
 		panic("no return value specified for GetWorkerVersioningRules")
 	}
 
+	//lint:ignore SA1019 ignore for SDK mocks
 	var r0 *client.WorkerVersioningRules
 	var r1 error
+	//lint:ignore SA1019 ignore for SDK mocks
 	if rf, ok := ret.Get(0).(func(context.Context, client.GetWorkerVersioningOptions) (*client.WorkerVersioningRules, error)); ok {
 		return rf(ctx, options)
 	}
+	//lint:ignore SA1019 ignore for SDK mocks
 	if rf, ok := ret.Get(0).(func(context.Context, client.GetWorkerVersioningOptions) *client.WorkerVersioningRules); ok {
 		r0 = rf(ctx, options)
 	} else {
 		if ret.Get(0) != nil {
+			//lint:ignore SA1019 ignore for SDK mocks
 			r0 = ret.Get(0).(*client.WorkerVersioningRules)
 		}
 	}
 
+	//lint:ignore SA1019 ignore for SDK mocks
 	if rf, ok := ret.Get(1).(func(context.Context, client.GetWorkerVersioningOptions) error); ok {
 		r1 = rf(ctx, options)
 	} else {
@@ -961,6 +968,8 @@ func (_m *Client) UpdateWorkerBuildIdCompatibility(ctx context.Context, options 
 }
 
 // UpdateWorkerVersioningRules provides a mock function with given fields: ctx, options
+//
+//lint:ignore SA1019 ignore for SDK mocks
 func (_m *Client) UpdateWorkerVersioningRules(ctx context.Context, options client.UpdateWorkerVersioningRulesOptions) (*client.WorkerVersioningRules, error) {
 	ret := _m.Called(ctx, options)
 
@@ -968,19 +977,24 @@ func (_m *Client) UpdateWorkerVersioningRules(ctx context.Context, options clien
 		panic("no return value specified for UpdateWorkerVersioningRules")
 	}
 
+	//lint:ignore SA1019 ignore for SDK mocks
 	var r0 *client.WorkerVersioningRules
 	var r1 error
+	//lint:ignore SA1019 ignore for SDK mocks
 	if rf, ok := ret.Get(0).(func(context.Context, client.UpdateWorkerVersioningRulesOptions) (*client.WorkerVersioningRules, error)); ok {
 		return rf(ctx, options)
 	}
+	//lint:ignore SA1019 ignore for SDK mocks
 	if rf, ok := ret.Get(0).(func(context.Context, client.UpdateWorkerVersioningRulesOptions) *client.WorkerVersioningRules); ok {
 		r0 = rf(ctx, options)
 	} else {
 		if ret.Get(0) != nil {
+			//lint:ignore SA1019 ignore for SDK mocks
 			r0 = ret.Get(0).(*client.WorkerVersioningRules)
 		}
 	}
 
+	//lint:ignore SA1019 ignore for SDK mocks
 	if rf, ok := ret.Get(1).(func(context.Context, client.UpdateWorkerVersioningRulesOptions) error); ok {
 		r1 = rf(ctx, options)
 	} else {

--- a/temporal/build_id_versioning.go
+++ b/temporal/build_id_versioning.go
@@ -5,7 +5,7 @@ import "go.temporal.io/sdk/internal"
 // VersioningIntent indicates whether the user intends certain commands to be run on
 // a compatible worker build ID version or not.
 //
-// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning and will be removed soon.
 //
 // WARNING: Worker versioning is currently experimental
 //

--- a/workflow/workflow_options.go
+++ b/workflow/workflow_options.go
@@ -62,7 +62,7 @@ func GetChildWorkflowOptions(ctx Context) ChildWorkflowOptions {
 // WithWorkflowVersioningIntent is used to set the VersioningIntent before constructing a
 // ContinueAsNewError with NewContinueAsNewError.
 //
-// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning
+// Deprecated: Build-id based versioning is deprecated in favor of worker deployment based versioning and will be removed soon.
 func WithWorkflowVersioningIntent(ctx Context, intent temporal.VersioningIntent) Context {
 	return internal.WithWorkflowVersioningIntent(ctx, intent)
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Deprecated more of the penultimate versioning API surface

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
