### PR TITLE
Add warning when registering struct functions as workflows

### DIFF
--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -1147,6 +1147,10 @@ func (aw *AggregatedWorker) RegisterWorkflow(w interface{}) {
 		aw.executionParams.DefaultVersioningBehavior == VersioningBehaviorUnspecified {
 		panic("workflow type does not have a versioning behavior")
 	}
+	_, ok := w.(WorkflowDefinitionFactory)
+	if ok {
+		aw.logger.Warn("It is recommended to only use structures to define activity functions. In some cases, struct workflow functions may cause NDE errors.")
+	}
 	aw.registry.RegisterWorkflow(w)
 }
 

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -1147,9 +1147,9 @@ func (aw *AggregatedWorker) RegisterWorkflow(w interface{}) {
 		aw.executionParams.DefaultVersioningBehavior == VersioningBehaviorUnspecified {
 		panic("workflow type does not have a versioning behavior")
 	}
-	_, ok := w.(WorkflowDefinitionFactory)
-	if ok {
-		aw.logger.Warn("It is recommended to only use structures to define activity functions. In some cases, struct workflow functions may cause NDE errors.")
+	fnName := runtime.FuncForPC(reflect.ValueOf(w).Pointer()).Name()
+	if strings.HasSuffix(fnName, "-fm") {
+		aw.logger.Warn("It is recommended to only use struct methods to define activity functions. In some cases, struct methods as workflows may cause NDE errors.")
 	}
 	aw.registry.RegisterWorkflow(w)
 }

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -1149,7 +1149,7 @@ func (aw *AggregatedWorker) RegisterWorkflow(w interface{}) {
 	}
 	fnName := runtime.FuncForPC(reflect.ValueOf(w).Pointer()).Name()
 	if strings.HasSuffix(fnName, "-fm") {
-		aw.logger.Warn("Registering workflow" + fnName + ". It is recommended to only use struct methods to define activity functions. In some cases, struct methods as workflows may cause NDE errors.")
+		aw.logger.Warn("Registering workflow" + fnName + ". It is recommended to only use struct methods to define activity functions. In some cases, struct methods as workflows may cause non-deterministic errors.")
 	}
 	aw.registry.RegisterWorkflow(w)
 }

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -1149,7 +1149,7 @@ func (aw *AggregatedWorker) RegisterWorkflow(w interface{}) {
 	}
 	fnName := runtime.FuncForPC(reflect.ValueOf(w).Pointer()).Name()
 	if strings.HasSuffix(fnName, "-fm") {
-		aw.logger.Warn("It is recommended to only use struct methods to define activity functions. In some cases, struct methods as workflows may cause NDE errors.")
+		aw.logger.Warn("Registering workflow" + fnName + ". It is recommended to only use struct methods to define activity functions. In some cases, struct methods as workflows may cause NDE errors.")
 	}
 	aw.registry.RegisterWorkflow(w)
 }


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->
Added a warning log saying we suggest only using structs for activity registration

## Why?
<!-- Tell your future self why have you made these changes -->
Help prevent users from hitting potential NDEs

## Checklist
<!--- add/delete as needed --->

1. Closes #1986 

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
N/A, only added a log statement

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
