### PR TITLE
Fix data converter ToPayload error management

### DIFF
--- a/converter/codec.go
+++ b/converter/codec.go
@@ -157,7 +157,7 @@ func (e *CodecDataConverter) ToPayload(value interface{}) (*commonpb.Payload, er
 
 	encodedPayloads, err := e.encode([]*commonpb.Payload{payload})
 	if err != nil {
-		return payload, nil
+		return payload, err
 	}
 	if len(encodedPayloads) != 1 {
 		return payload, fmt.Errorf("received %d payloads from codec, expected 1", len(encodedPayloads))


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->   
Returns error is codec `encode` method error in ToPayload

## Why?
<!-- Tell your future self why have you made these changes -->    
If codec failed to encode data, the error was silent and the non-encoded payload was return. An error management is missing because an error was expected in this case.

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-go/issues/1999

2. How was this tested: unit test
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed? No
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
