### PR TITLE
Add `ErrGroup` and `Once` types

### DIFF
--- a/internal/internal_workflow.go
+++ b/internal/internal_workflow.go
@@ -78,8 +78,8 @@ type (
 		errOnce    Once
 		err        error
 		mu         Mutex
-		panicValue any  // = PanicError | PanicValue; non-nil if some Group.Go coroutine panicked.
-		abnormal   bool // some Group.Go coroutine terminated abnormally (panic or goexit).
+		panicValue any  // = PanicError | PanicValue; non-nil if some ErrGroup.Go coroutine panicked.
+		abnormal   bool // some ErrGroup.Go coroutine terminated abnormally (panic or goexit).
 	}
 
 	token struct{}
@@ -92,8 +92,8 @@ type (
 	}
 
 	// PanicValue wraps a value that does not implement the error interface,
-	// recovered from an unhandled panic when calling a function passed to Go or
-	// TryGo.
+	// recovered from an unhandled panic when calling a function passed to ErrGroup.Go or
+	// ErrGroup.TryGo.
 	panicValue struct {
 		Recovered any
 		Stack     []byte // result of call to [debug.Stack]

--- a/workflow/deterministic_wrappers.go
+++ b/workflow/deterministic_wrappers.go
@@ -35,6 +35,13 @@ type (
 	// coroutines to finish
 	WaitGroup = internal.WaitGroup
 
+	// WaitGroup is used to wait for a collection of
+	// fallible coroutines to finish, stopping on the first error.
+	ErrGroup = internal.ErrGroup
+
+	// Once is used run a function just once.
+	Once = internal.Once
+
 	// Mutex is a mutual exclusion lock.
 	// Mutex must be used instead of native go mutex by workflow code.
 	// Use [workflow.NewMutex] method to create a Mutex instance.
@@ -143,6 +150,16 @@ func NewNamedSelector(ctx Context, name string) Selector {
 // NewWaitGroup creates a new WaitGroup instance.
 func NewWaitGroup(ctx Context) WaitGroup {
 	return internal.NewWaitGroup(ctx)
+}
+
+// NewWaitGroup creates a new WaitGroup instance.
+func NewErrGroup(ctx Context) (ErrGroup, Context) {
+	return internal.NewErrGroup(ctx)
+}
+
+// NewChannel creates a new Once instance
+func NewOnce(ctx Context) Once {
+	return internal.NewOnce(ctx)
 }
 
 // NewMutex creates a new Mutex instance. A mutex can be used


### PR DESCRIPTION
## What was changed
- Adds `ErrGroup` and `Once` types
  - `ErrGroup` ported from [`x/sync.Group`](https://cs.opensource.google/go/x/sync/+/refs/tags/v0.15.0:errgroup/errgroup.go) v0.15.0
  - `Once` ported from [`sync.Once`](https://cs.opensource.google/go/go/+/refs/tags/go1.24.4:src/sync/once.go) v1.24.4
- Adds `workflow.NewErrGroup` and `workflow.NewOnce`

## Why?
- Because `WaitGroup` can't handle errors and has no concurrency limits

## Checklist
1. How was this tested:
- All the original tests were ported