### PR TITLE
Move Nexus operation token generation outside of callback conditional

### DIFF
--- a/temporalnexus/operation.go
+++ b/temporalnexus/operation.go
@@ -301,14 +301,13 @@ func ExecuteUntypedWorkflow[R any](
 		}
 	}
 
-	var encodedToken string
+	encodedToken, err := generateWorkflowRunOperationToken(nctx.Namespace, startWorkflowOptions.ID)
+	if err != nil {
+		return nil, err
+	}
 	if nexusOptions.CallbackURL != "" {
 		if nexusOptions.CallbackHeader == nil {
 			nexusOptions.CallbackHeader = make(nexus.Header)
-		}
-		encodedToken, err = generateWorkflowRunOperationToken(nctx.Namespace, startWorkflowOptions.ID)
-		if err != nil {
-			return nil, err
 		}
 
 		//lint:ignore SA1019 this field is expected to be populated by servers older than 1.27.0.


### PR DESCRIPTION
## What was changed
Moved Nexus operation token generation outside the conditional the checks whether a callback URL has been set.

## Why?
Callbacks are optional in the Nexus protocol and many non-workflow callers will start operations without them but still need to get the operation token.

