### PR TITLE
Fix event type typo in Nexus cancellation types test

### DIFF
--- a/test/nexus_test.go
+++ b/test/nexus_test.go
@@ -1156,7 +1156,7 @@ func TestAsyncOperationFromWorkflow_CancellationTypes(t *testing.T) {
 		for history.HasNext() {
 			event, err := history.Next()
 			require.NoError(t, err)
-			require.NotEqual(t, enumspb.EVENT_TYPE_ACTIVITY_TASK_CANCEL_REQUESTED, event.EventType)
+			require.NotEqual(t, enumspb.EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUESTED, event.EventType)
 			require.NotEqual(t, enumspb.EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUEST_COMPLETED, event.EventType)
 			require.NotEqual(t, enumspb.EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUEST_FAILED, event.EventType)
 		}


### PR DESCRIPTION
## What was changed
Test was asserting on activity cancel requested when it should have been Nexus operation cancel requested.
