### PR TITLE
Add TestNilContextWorkflow for safety with nil context

### DIFF
--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -7741,3 +7741,23 @@ func (ts *IntegrationTestSuite) TestLocalActivitySummary() {
 	}
 	ts.Equal(summaryStr, summary)
 }
+
+func (ts *IntegrationTestSuite) TestNilContextWorkflow() {
+    w := &Workflows{}
+    w.register(ts.worker)
+
+    err := ts.worker.Start()
+    ts.NoError(err)
+    defer ts.worker.Stop()
+
+    ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+    defer cancel()
+
+    run, err := ts.client.ExecuteWorkflow(ctx, ts.startWorkflowOptions("test-nil-context"), w.NilContextWorkflow)
+    ts.NoError(err)
+
+    var result string
+    err = run.Get(ctx, &result)
+    ts.NoError(err)
+    ts.Equal("ok", result)
+}

--- a/test/workflow_test.go
+++ b/test/workflow_test.go
@@ -3529,6 +3529,24 @@ func (w *Workflows) WorkflowReactToCancel(ctx workflow.Context, localActivity bo
 	return nil
 }
 
+// NilContextWorkflow calls ExecuteActivity with a nil context to ensure safety.
+func (w *Workflows) NilContextWorkflow(ctx workflow.Context) (string, error) {
+    var a Activities
+    var nilCtx workflow.Context = nil
+    future := workflow.ExecuteActivity(nilCtx, a.SimpleActivity)
+    var result string
+    err := future.Get(ctx, &result)
+    if err != nil {
+        return "", err
+    }
+    return result, nil
+}
+
+// SimpleActivity is a minimal Activity that returns "ok".
+func (a *Activities) SimpleActivity() (string, error) {
+    return "ok", nil
+}
+
 func (w *Workflows) register(worker worker.Worker) {
 	worker.RegisterWorkflow(w.ActivityCancelRepro)
 	worker.RegisterWorkflow(w.ActivityCompletionUsingID)
@@ -3678,6 +3696,7 @@ func (w *Workflows) register(worker worker.Worker) {
 	worker.RegisterWorkflow(w.WorkflowTemporalPrefixSignal)
 	worker.RegisterWorkflow(w.WorkflowRawValue)
 	worker.RegisterWorkflow(w.WorkflowReactToCancel)
+	worker.RegisterWorkflow(w.NilContextWorkflow)
 }
 
 func (w *Workflows) defaultActivityOptions() workflow.ActivityOptions {


### PR DESCRIPTION
### What
Add an integration test for NilContextWorkflow to ensure safety when executing activities with a nil context.

### Why
To cover a potential edge case where a workflow calls an activity with a nil context, ensuring the SDK behaves safely and returns expected results.

### How
- Added NilContextWorkflow to the Workflows struct
- Added integration test in test directory using TestNilContextWorkflow
- Registered the workflow in worker

### Verification
- Run `go test ./test/... -run TestNilContextWorkflow -v` to confirm the workflow executes without error
