### PR TITLE
Make poller scaling log trace

### DIFF
--- a/internal/internal_worker_base.go
+++ b/internal/internal_worker_base.go
@@ -772,7 +772,9 @@ func (prh *pollScalerReportHandle) updateTarget(f func(int64) int64) {
 	}
 	permits := int(newTarget)
 	if prh.scaleCallback != nil {
-		prh.logger.Debug("Updating number of permits", "permits", permits)
+		traceLog(func() {
+			prh.logger.Debug("Updating number of permits", "permits", permits)
+		})
 		prh.scaleCallback(permits)
 	}
 }


### PR DESCRIPTION
Make poller scaling log trace since it is quite noisy, but can be useful to debug poller scaling decisions.