### PR TITLE
Adds envconfig fields ahead of adding a `--grpc-authority` flag to the `temporal` cli

### DIFF
--- a/contrib/envconfig/client_config.go
+++ b/contrib/envconfig/client_config.go
@@ -39,6 +39,10 @@ type ClientConfigProfile struct {
 	TLS *ClientConfigTLS
 	// Optional client codec config.
 	Codec *ClientConfigCodec
+	// GRPCAuthority will set the :authority pseudoheader the grpc clients.
+	//
+	// This is useful in situations where you might need to route through an intermediate proxy.
+	GRPCAuthority string
 	// Client gRPC metadata (aka headers). When loading from TOML and env var, or writing to TOML, the keys are
 	// lowercased and hyphens are replaced with underscores. This is used for deduplicating/overriding too, so manually
 	// set values that are not normalized may not get overridden with [ClientConfigProfile.ApplyEnvVars].
@@ -123,6 +127,9 @@ func (c *ClientConfigProfile) ToClientOptions(options ToClientOptionsRequest) (c
 		if opts.DataConverter, err = c.Codec.toDataConverter(c.Namespace); err != nil {
 			return client.Options{}, fmt.Errorf("invalid codec: %w", err)
 		}
+	}
+	if c.GRPCAuthority != "" {
+		opts.ConnectionOptions.Authority = c.GRPCAuthority
 	}
 	if len(c.GRPCMeta) > 0 {
 		opts.HeadersProvider = fixedHeaders(c.GRPCMeta)

--- a/contrib/envconfig/client_config.go
+++ b/contrib/envconfig/client_config.go
@@ -39,7 +39,7 @@ type ClientConfigProfile struct {
 	TLS *ClientConfigTLS
 	// Optional client codec config.
 	Codec *ClientConfigCodec
-	// GRPCAuthority will set the :authority pseudoheader the grpc clients.
+	// GRPCAuthority will set the :authority pseudoheader on grpc clients.
 	//
 	// This is useful in situations where you might need to route through an intermediate proxy.
 	GRPCAuthority string

--- a/contrib/envconfig/client_config_load.go
+++ b/contrib/envconfig/client_config_load.go
@@ -362,6 +362,10 @@ func (c *ClientConfigProfile) ApplyEnvVars(env EnvLookup) error {
 		c.Codec.Auth = s
 	}
 
+	if s, ok := env.LookupEnv("TEMPORAL_GRPC_AUTHORITY"); ok {
+		c.GRPCAuthority = s
+	}
+
 	// GRPC meta requires crawling the envs to find
 	for _, v := range env.Environ() {
 		if strings.HasPrefix(v, "TEMPORAL_GRPC_META_") {


### PR DESCRIPTION
## What was changed
Sets up (a) required field to add a `--grpc-authority` flag to the `temporal` clie.

## Why?
We will need this to generate the command flags file in github.com/temporalio/cli.

## Checklist
<!--- add/delete as needed --->

1. Flagged in support channel (2025-08-26)

2. How was this tested:
Ran local tests, and redirected the mod in the /cli repo and validated the client options file contains the new field.

3. Any docs updates needed?

Eventually we'll want to update (once we also land a PR to temporalio/cli)
- https://docs.temporal.io/develop/environment-configuration we likely need to add the new environment variable here
- https://docs.temporal.io/cli/cmd-options#address as well we will want to add the flag here
