### PR TITLE
feat: use Stringer in getFunctionName when available (ExecuteActivity)

### DIFF
--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -2069,6 +2069,9 @@ func isError(inType reflect.Type) bool {
 }
 
 func getFunctionName(i interface{}) (name string, isMethod bool) {
+	if s, ok := i.(fmt.Stringer); ok {
+		return s.String(), false
+	}
 	if fullName, ok := i.(string); ok {
 		return fullName, false
 	}

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -2069,9 +2069,6 @@ func isError(inType reflect.Type) bool {
 }
 
 func getFunctionName(i interface{}) (name string, isMethod bool) {
-	if s, ok := i.(fmt.Stringer); ok {
-		return s.String(), false
-	}
 	if fullName, ok := i.(string); ok {
 		return fullName, false
 	}
@@ -2089,6 +2086,9 @@ func getFunctionName(i interface{}) (name string, isMethod bool) {
 	// var a *Activities
 	// ExecuteActivity(ctx, a.Foo)
 	// will call this function which is going to return "Foo"
+	if s, ok := i.(fmt.Stringer); ok {
+		return s.String(), false
+	}
 	return strings.TrimSuffix(shortName, "-fm"), isMethod
 }
 


### PR DESCRIPTION
closes https://github.com/temporalio/sdk-go/issues/2049

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
- Updated `getFunctionName` of `ExecuteActivity` to check if the provided value implements `fmt.Stringer`.  
- If so, it now returns the result of `String()` directly instead of inspecting the function pointer.  
- Existing behavior for raw strings and function pointers remains unchanged.

## Why?
- Allows custom types like `ActivityName` to define their activity names using `String()`.  
- Prevents incorrect behavior or panics when passing values that are `Stringer` but not functions.

### Example
```go
type ActivityName string

func (a ActivityName) String() string {
	return string(a)
}

var agentPlannerActivity ActivityName = "AgentPlannerActivity"

fut := workflow.ExecuteActivity(ctx, agentPlannerActivity, inputs{})
```

Without that, we are encountering an error, and it is difficult to comprehend the underlying reason:
```bash
3:22PM INF log/with_logger.go:45 Task processing failed with error Namespace=default TaskQueue=chat-agent WorkerID=28030@Lukas-MacBook-Pro-M4.local@ WorkerType=WorkflowWorker Error="BadScheduleActivityAttributes: ActivityType is not set on ScheduleActivityTaskCommand. ActivityID=15"
```


## Checklist
1. Closes <!-- add issue number here if one exists, otherwise leave blank -->

2. How was this tested:
- Added/ran unit tests to cover:
  - `Stringer` types (e.g. `ActivityName`)  
  - Plain strings  

3. Any docs updates needed?
- No public API change.  
- No docs updates required unless internal developer guide references `getFunctionName`.
