### PR TITLE
Fix CA cert config validation

### DIFF
--- a/contrib/envconfig/client_config.go
+++ b/contrib/envconfig/client_config.go
@@ -168,7 +168,7 @@ func (c *ClientConfigTLS) toTLSConfig() (*tls.Config, error) {
 			if serverCAData, err = os.ReadFile(c.ServerCACertPath); err != nil {
 				return nil, fmt.Errorf("failed reading server CA cert path: %w", err)
 			}
-		} else if c.ServerCACertPath == "" {
+		} else if c.ServerCACertPath != "" {
 			return nil, fmt.Errorf("cannot have server CA cert path with data")
 		}
 		if !pool.AppendCertsFromPEM(serverCAData) {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Changed the check in `client_config.go` from:

```
		} else if c.ServerCACertPath == "" {
			return nil, fmt.Errorf("cannot have server CA cert path with data")
		}
```

to 

```
		} else if c.ServerCACertPath != "" {
			return nil, fmt.Errorf("cannot have server CA cert path with data")
		}
```

## Why?
The current check was causing the error to be thrown incorrectly when CA cert data was provided but CA cert path was NOT.