### PR TITLE
Cancellation of child cancelers is non-deterministic

### DIFF
--- a/internal/context_test.go
+++ b/internal/context_test.go
@@ -1,0 +1,43 @@
+package internal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCancelerChildInteractions(t *testing.T) {
+	t.Parallel()
+	// Previously, cancellation propagation was handled using a map, which meant that the order of cancellation was random per run (due to map iteration order randomisation)
+	// Switched to a slice to maintain order, so this test ensures that the order is maintained as expected
+
+	// Kinda rough setup, but enough to test the child management logic
+	rootCtx := &cancelCtx{done: &channelImpl{}}
+	childOne := &cancelCtx{}
+	childTwo := &cancelCtx{}
+	childThree := &cancelCtx{}
+
+	propagateCancel(rootCtx, childOne)
+	assert.Equal(t, rootCtx.children, []canceler{childOne})
+
+	// Should not add the same child twice
+	propagateCancel(rootCtx, childOne)
+	assert.Equal(t, rootCtx.children, []canceler{childOne})
+
+	propagateCancel(rootCtx, childTwo)
+	assert.Equal(t, rootCtx.children, []canceler{childOne, childTwo})
+
+	// Removing a child that hasn't been added should be a no-op
+	removeChild(rootCtx, childThree)
+	assert.Equal(t, rootCtx.children, []canceler{childOne, childTwo})
+
+	propagateCancel(rootCtx, childThree)
+	assert.Equal(t, rootCtx.children, []canceler{childOne, childTwo, childThree})
+
+	// Remove and re-add childTwo to ensure order is maintained
+	removeChild(rootCtx, childTwo)
+	assert.Equal(t, rootCtx.children, []canceler{childOne, childThree})
+
+	propagateCancel(rootCtx, childTwo)
+	assert.Equal(t, rootCtx.children, []canceler{childOne, childThree, childTwo})
+}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Moved from using a map internally to represent child contexts to cancel, moved to using a slice (but added similar functionality for checking existing items aren't added twice)

## Why?
We had noticed one of our replay tests failing intermittently, so had a closer look. The replay was specifically to do with cancellation of a workflow.
In having a deeper dive, I realised that the order in which child contexts are cancelled is non-deterministic (due to map iteration). I had thought of iterating the map in an ordered fashion, but wasn't sure how we would want to order the cancelers, so instead went with a slice so we can keep order based on the order in which they appear in the slice.

[Replay file](https://github.com/user-attachments/files/22373001/41ee787c-f851-4fe0-aee4-ecbd6d20689b_events.json)
I've attached an event history from a simple reproduction of the issue I created with some modifications of the cancellation example in samples-go:
```
func YourWorkflow(ctx workflow.Context) error {
	ao := workflow.ActivityOptions{
		StartToCloseTimeout: 30 * time.Minute,
		HeartbeatTimeout:    5 * time.Second,
		WaitForCancellation: true,
	}
	ctx = workflow.WithActivityOptions(ctx, ao)
	logger := workflow.GetLogger(ctx)
	logger.Info("cancel workflow started")
	var a *Activities // Used to call Activities by function pointer
	defer func() {

		if !errors.Is(ctx.Err(), workflow.ErrCanceled) {
			return
		}

		// When the Workflow is canceled, it has to get a new disconnected context to execute any Activities
		newCtx, _ := workflow.NewDisconnectedContext(ctx)
		err := workflow.ExecuteActivity(newCtx, a.CleanupActivity).Get(ctx, nil)
		if err != nil {
			logger.Error("CleanupActivity failed", "Error", err)
		}
	}()

	// My changes - BEGIN
	selector := workflow.NewSelector(ctx)
	timer1Ctx, _ := workflow.WithCancel(ctx)
	// Create two new timers
	selector.AddFuture(workflow.NewTimer(timer1Ctx, time.Hour), func(f workflow.Future) {
		logger.Info("Timer 1 completed")
	})
	timer2Ctx, _ := workflow.WithCancel(ctx)
	selector.AddFuture(workflow.NewTimer(timer2Ctx, 2*time.Hour), func(f workflow.Future) {
		logger.Info("Timer 2 completed")
	})
	selector.Select(ctx)
	// My changes - END

	err := workflow.ExecuteActivity(ctx, a.ActivityToBeSkipped).Get(ctx, nil)
	logger.Error("Error from ActivityToBeSkipped", "Error", err)

	logger.Info("Workflow Execution complete.")

	return nil
}
```
Running the replay with the following code on repeat will encounter failures, without the fix in this PR:
```
func TestReplay(t *testing.T) {
	replayOpts := worker.WorkflowReplayerOptions{
		EnableLoggingInReplay: true,
	}
	replayer, err := worker.NewWorkflowReplayerWithOptions(replayOpts)
	assert.NoError(t, err)
	replayer.RegisterWorkflow(YourWorkflow)

	f, err := os.Open("41ee787c-f851-4fe0-aee4-ecbd6d20689b_events.json")
	require.NoError(t, err, "failed to open file")
	defer f.Close()

	h, err := client.HistoryFromJSON(f, client.HistoryJSONOptions{})
	require.NoError(t, err, "failed to parse history from JSON")

	err = replayer.ReplayWorkflowHistory(nil, h)

	assert.NoError(t, err)
}
```

## Checklist

1. How was this tested:
Unit tests cover the changes, and I have ran the code over our intermittently failing replay tests and it resolves the failures.

2. Any docs updates needed?
I don't believe so? This is likely not documented, since it's internal code
