### PR TITLE
`ResetWorkflow` workflow panic policy

### DIFF
--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -1306,10 +1306,10 @@ func (w *workflowExecutionContextImpl) applyWorkflowPanicPolicy(workflowTask *wo
 			w.getEventHandler().Complete(nil, NewApplicationError(
 				"Workflow failed on panic due to FailWorkflow workflow panic policy",
 				"", false, workflowError))
-		case RestartWorkflow:
+		case ResetWorkflow:
 			// Reset workflow execution to restart from the beginning
 			if w.wth.client == nil {
-				w.wth.logger.Error("RestartWorkflow panic policy requires client but none available",
+				w.wth.logger.Error("ResetWorkflow panic policy requires client but none available",
 					tagWorkflowType, task.WorkflowType.GetName(),
 					tagWorkflowID, task.WorkflowExecution.GetWorkflowId(),
 					tagRunID, task.WorkflowExecution.GetRunId())
@@ -1340,7 +1340,7 @@ func (w *workflowExecutionContextImpl) applyWorkflowPanicPolicy(workflowTask *wo
 					WorkflowId: workflowID,
 					RunId:      runID,
 				},
-				Reason:                    "RestartWorkflow panic policy triggered due to workflow panic",
+				Reason:                    "ResetWorkflow panic policy triggered due to workflow panic",
 				WorkflowTaskFinishEventId: resetEventId,
 			})
 			if resetErr != nil {

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -1315,7 +1315,7 @@ func (w *workflowExecutionContextImpl) applyWorkflowPanicPolicy(workflowTask *wo
 		case ResetWorkflow:
 			// Reset workflow execution to restart from the beginning
 			if w.wth.service == nil {
-				w.wth.logger.Error("ResetWorkflow panic policy requires client but none available",
+				w.wth.logger.Error("ResetWorkflow panic policy requires service but none available",
 					tagWorkflowType, task.WorkflowType.GetName(),
 					tagWorkflowID, task.WorkflowExecution.GetWorkflowId(),
 					tagRunID, task.WorkflowExecution.GetRunId())
@@ -1327,7 +1327,7 @@ func (w *workflowExecutionContextImpl) applyWorkflowPanicPolicy(workflowTask *wo
 			workflowID := task.WorkflowExecution.GetWorkflowId()
 			runID := task.WorkflowExecution.GetRunId()
 
-			resetCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			resetCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second) // Arbitrary?
 			defer cancel()
 
 			resetEventId, err := getFirstWorkflowTaskEventID(resetCtx, w.wth.service, w.wth.namespace, workflowID, runID)

--- a/internal/internal_task_handlers_test.go
+++ b/internal/internal_task_handlers_test.go
@@ -539,7 +539,7 @@ func (t *TaskHandlersTestSuite) testWorkflowTaskWorkflowExecutionStartedHelper(p
 		createTestEventWorkflowExecutionStarted(1, &historypb.WorkflowExecutionStartedEventAttributes{TaskQueue: &taskqueuepb.TaskQueue{Name: testWorkflowTaskTaskqueue}}),
 	}
 	task := createWorkflowTask(testEvents, 0, "HelloWorld_Workflow")
-	taskHandler := newWorkflowTaskHandler(params, nil, t.registry)
+	taskHandler := newWorkflowTaskHandler(params, nil, t.registry, nil)
 	wftask := workflowTask{task: task}
 	wfctx := t.mustWorkflowContextImpl(&wftask, taskHandler)
 	request, err := taskHandler.ProcessWorkflowTask(&wftask, wfctx, nil)
@@ -583,7 +583,7 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_BinaryChecksum() {
 	}
 	task := createWorkflowTask(testEvents, 8, "BinaryChecksumWorkflow")
 	params := t.getTestWorkerExecutionParams()
-	taskHandler := newWorkflowTaskHandler(params, nil, t.registry)
+	taskHandler := newWorkflowTaskHandler(params, nil, t.registry, nil)
 	wftask := workflowTask{task: task}
 	wfctx := t.mustWorkflowContextImpl(&wftask, taskHandler)
 	request, err := taskHandler.ProcessWorkflowTask(&wftask, wfctx, nil)
@@ -614,7 +614,7 @@ func (t *TaskHandlersTestSuite) TestRespondsToWFTWithWorkerBinaryID() {
 	task := createWorkflowTask(testEvents, 0, "HelloWorld_Workflow")
 	params := t.getTestWorkerExecutionParams()
 	params.WorkerBuildID = workerBuildID
-	taskHandler := newWorkflowTaskHandler(params, nil, t.registry)
+	taskHandler := newWorkflowTaskHandler(params, nil, t.registry, nil)
 	wftask := workflowTask{task: task}
 	wfctx := t.mustWorkflowContextImpl(&wftask, taskHandler)
 	request, err := taskHandler.ProcessWorkflowTask(&wftask, wfctx, nil)
@@ -637,7 +637,7 @@ func (t *TaskHandlersTestSuite) TestStickyLegacyQueryTaskOnEvictedCache() {
 	}
 	task := createWorkflowTask(testEvents, 0, "HelloWorld_Workflow")
 	params := t.getTestWorkerExecutionParams()
-	taskHandler := newWorkflowTaskHandler(params, nil, t.registry)
+	taskHandler := newWorkflowTaskHandler(params, nil, t.registry, nil)
 	wftask := workflowTask{task: task}
 	wfctx := t.mustWorkflowContextImpl(&wftask, taskHandler)
 	wfctx.Unlock(nil)
@@ -675,7 +675,7 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_ActivityTaskScheduled() {
 	}
 	task := createWorkflowTask(testEvents[0:3], 0, "HelloWorld_Workflow")
 	params := t.getTestWorkerExecutionParams()
-	taskHandler := newWorkflowTaskHandler(params, nil, t.registry)
+	taskHandler := newWorkflowTaskHandler(params, nil, t.registry, nil)
 	wftask := workflowTask{task: task}
 	wfctx := t.mustWorkflowContextImpl(&wftask, taskHandler)
 	request, err := taskHandler.ProcessWorkflowTask(&wftask, wfctx, nil)
@@ -723,7 +723,7 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_QueryWorkflow_Sticky() {
 		createTestEventActivityTaskCompleted(7, &historypb.ActivityTaskCompletedEventAttributes{ScheduledEventId: 5}),
 	}
 	params := t.getTestWorkerExecutionParams()
-	taskHandler := newWorkflowTaskHandler(params, nil, t.registry)
+	taskHandler := newWorkflowTaskHandler(params, nil, t.registry, nil)
 
 	// first make progress on the workflow
 	task := createWorkflowTask(testEvents[0:1], 0, "HelloWorld_Workflow")
@@ -773,7 +773,7 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_QueryWorkflow_NonSticky() {
 
 	// query after first workflow task (notice the previousStartEventID is always the last eventID for query task)
 	task := createQueryTask(testEvents[0:3], 3, "HelloWorld_Workflow", queryType)
-	taskHandler := newWorkflowTaskHandler(params, nil, t.registry)
+	taskHandler := newWorkflowTaskHandler(params, nil, t.registry, nil)
 	wftask := workflowTask{task: task}
 	wfctx := t.mustWorkflowContextImpl(&wftask, taskHandler)
 	response, err := taskHandler.ProcessWorkflowTask(&wftask, wfctx, nil)
@@ -782,7 +782,7 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_QueryWorkflow_NonSticky() {
 
 	// query after activity task complete but before second workflow task started
 	task = createQueryTask(testEvents[0:7], 7, "HelloWorld_Workflow", queryType)
-	taskHandler = newWorkflowTaskHandler(params, nil, t.registry)
+	taskHandler = newWorkflowTaskHandler(params, nil, t.registry, nil)
 	wftask = workflowTask{task: task}
 	wfctx = t.mustWorkflowContextImpl(&wftask, taskHandler)
 	response, _ = taskHandler.ProcessWorkflowTask(&wftask, wfctx, nil)
@@ -791,7 +791,7 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_QueryWorkflow_NonSticky() {
 
 	// query after second workflow task
 	task = createQueryTask(testEvents[0:8], 8, "HelloWorld_Workflow", queryType)
-	taskHandler = newWorkflowTaskHandler(params, nil, t.registry)
+	taskHandler = newWorkflowTaskHandler(params, nil, t.registry, nil)
 	wftask = workflowTask{task: task}
 	wfctx = t.mustWorkflowContextImpl(&wftask, taskHandler)
 	response, _ = taskHandler.ProcessWorkflowTask(&wftask, wfctx, nil)
@@ -800,7 +800,7 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_QueryWorkflow_NonSticky() {
 
 	// query after second workflow task with extra events
 	task = createQueryTask(testEvents[0:9], 9, "HelloWorld_Workflow", queryType)
-	taskHandler = newWorkflowTaskHandler(params, nil, t.registry)
+	taskHandler = newWorkflowTaskHandler(params, nil, t.registry, nil)
 	wftask = workflowTask{task: task}
 	wfctx = t.mustWorkflowContextImpl(&wftask, taskHandler)
 	response, _ = taskHandler.ProcessWorkflowTask(&wftask, wfctx, nil)
@@ -808,7 +808,7 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_QueryWorkflow_NonSticky() {
 	t.verifyQueryResult(response, "done")
 
 	task = createQueryTask(testEvents[0:9], 9, "HelloWorld_Workflow", "invalid-query-type")
-	taskHandler = newWorkflowTaskHandler(params, nil, t.registry)
+	taskHandler = newWorkflowTaskHandler(params, nil, t.registry, nil)
 	wftask = workflowTask{task: task}
 	wfctx = t.mustWorkflowContextImpl(&wftask, taskHandler)
 	response, _ = taskHandler.ProcessWorkflowTask(&wftask, wfctx, nil)
@@ -848,7 +848,7 @@ func (t *TaskHandlersTestSuite) TestCacheEvictionWhenErrorOccurs() {
 	params := t.getTestWorkerExecutionParams()
 	params.WorkflowPanicPolicy = BlockWorkflow
 
-	taskHandler := newWorkflowTaskHandler(params, nil, t.registry)
+	taskHandler := newWorkflowTaskHandler(params, nil, t.registry, nil)
 	// now change the history event so it does not match to command produced via replay
 	testEvents[4].GetActivityTaskScheduledEventAttributes().ActivityType.Name = "some-other-activity"
 	task := createWorkflowTask(testEvents, 3, "HelloWorld_Workflow")
@@ -884,7 +884,7 @@ func (t *TaskHandlersTestSuite) TestWithMissingHistoryEvents() {
 
 	for _, startEventID := range []int64{0, 3} {
 		t.Run(fmt.Sprintf("startEventID=%v", startEventID), func() {
-			taskHandler := newWorkflowTaskHandler(params, nil, t.registry)
+			taskHandler := newWorkflowTaskHandler(params, nil, t.registry, nil)
 			task := createWorkflowTask(testEvents, startEventID, "HelloWorld_Workflow")
 			// newWorkflowTaskWorkerInternal will set the laTunnel in taskHandler, without it, ProcessWorkflowTask()
 			// will fail as it can't find laTunnel in newWorkerCache().
@@ -935,7 +935,7 @@ func (t *TaskHandlersTestSuite) TestWithTruncatedHistory() {
 	for i, tc := range testCases {
 		cacheSize := params.cache.getWorkflowCache().Size()
 
-		taskHandler := newWorkflowTaskHandler(params, nil, t.registry)
+		taskHandler := newWorkflowTaskHandler(params, nil, t.registry, nil)
 		task := createWorkflowTask(testEvents, tc.previousStartedEventID, "HelloWorld_Workflow")
 		// Cut the workflow task scheduled ans started events
 		task.History.Events = task.History.Events[:len(task.History.Events)-2]
@@ -1005,7 +1005,7 @@ func (t *TaskHandlersTestSuite) testSideEffectDeferHelper(cacheSize int) {
 	params := t.getTestWorkerExecutionParams()
 	params.cache = newWorkerCache(myWorkerCachePtr, &myWorkerCacheLock, cacheSize)
 
-	taskHandler := newWorkflowTaskHandler(params, nil, t.registry)
+	taskHandler := newWorkflowTaskHandler(params, nil, t.registry, nil)
 	task := createWorkflowTask(testEvents, 0, workflowName)
 	wftask := workflowTask{task: task}
 	wfctx := t.mustWorkflowContextImpl(&wftask, taskHandler)
@@ -1041,7 +1041,7 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_NondeterministicDetection() {
 	params.WorkflowPanicPolicy = BlockWorkflow
 	params.WorkerStopChannel = stopC
 
-	taskHandler := newWorkflowTaskHandler(params, nil, t.registry)
+	taskHandler := newWorkflowTaskHandler(params, nil, t.registry, nil)
 	wftask := workflowTask{task: task}
 	wfctx := t.mustWorkflowContextImpl(&wftask, taskHandler)
 	request, err := taskHandler.ProcessWorkflowTask(&wftask, wfctx, nil)
@@ -1068,7 +1068,7 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_NondeterministicDetection() {
 	// now, create a new task handler with fail nondeterministic workflow policy
 	// and verify that it handles the mismatching history correctly.
 	params.WorkflowPanicPolicy = FailWorkflow
-	failOnNondeterminismTaskHandler := newWorkflowTaskHandler(params, nil, t.registry)
+	failOnNondeterminismTaskHandler := newWorkflowTaskHandler(params, nil, t.registry, nil)
 	task = createWorkflowTask(testEvents, 3, "HelloWorld_Workflow")
 	wftask = workflowTask{task: task}
 	wfctx = t.mustWorkflowContextImpl(&wftask, failOnNondeterminismTaskHandler)
@@ -1110,7 +1110,7 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_WorkflowReturnsPanicError() {
 	params := t.getTestWorkerExecutionParams()
 	params.WorkflowPanicPolicy = BlockWorkflow
 
-	taskHandler := newWorkflowTaskHandler(params, nil, t.registry)
+	taskHandler := newWorkflowTaskHandler(params, nil, t.registry, nil)
 	wftask := workflowTask{task: task}
 	wfctx := t.mustWorkflowContextImpl(&wftask, taskHandler)
 	request, err := taskHandler.ProcessWorkflowTask(&wftask, wfctx, nil)
@@ -1135,7 +1135,7 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_WorkflowPanics() {
 	params := t.getTestWorkerExecutionParams()
 	params.WorkflowPanicPolicy = BlockWorkflow
 
-	taskHandler := newWorkflowTaskHandler(params, nil, t.registry)
+	taskHandler := newWorkflowTaskHandler(params, nil, t.registry, nil)
 	wftask := workflowTask{task: task}
 	wfctx := t.mustWorkflowContextImpl(&wftask, taskHandler)
 	_, err := taskHandler.ProcessWorkflowTask(&wftask, wfctx, nil)
@@ -1183,7 +1183,7 @@ func (t *TaskHandlersTestSuite) TestGetWorkflowInfo() {
 	params := t.getTestWorkerExecutionParams()
 	params.WorkflowPanicPolicy = BlockWorkflow
 
-	taskHandler := newWorkflowTaskHandler(params, nil, t.registry)
+	taskHandler := newWorkflowTaskHandler(params, nil, t.registry, nil)
 	wftask := workflowTask{task: task}
 	wfctx := t.mustWorkflowContextImpl(&wftask, taskHandler)
 	request, err := taskHandler.ProcessWorkflowTask(&wftask, wfctx, nil)
@@ -1216,7 +1216,7 @@ func (t *TaskHandlersTestSuite) TestConsistentQuery_InvalidQueryTask() {
 	params := t.getTestWorkerExecutionParams()
 	params.WorkflowPanicPolicy = BlockWorkflow
 
-	taskHandler := newWorkflowTaskHandler(params, nil, t.registry)
+	taskHandler := newWorkflowTaskHandler(params, nil, t.registry, nil)
 	testEvents := []*historypb.HistoryEvent{
 		createTestEventWorkflowExecutionStarted(1, &historypb.WorkflowExecutionStartedEventAttributes{TaskQueue: &taskqueuepb.TaskQueue{Name: testWorkflowTaskTaskqueue}}),
 	}
@@ -1267,7 +1267,7 @@ func (t *TaskHandlersTestSuite) TestConsistentQuery_Success() {
 
 	params := t.getTestWorkerExecutionParams()
 
-	taskHandler := newWorkflowTaskHandler(params, nil, t.registry)
+	taskHandler := newWorkflowTaskHandler(params, nil, t.registry, nil)
 	wftask := workflowTask{task: task}
 	wfctx := t.mustWorkflowContextImpl(&wftask, taskHandler)
 	request, err := taskHandler.ProcessWorkflowTask(&wftask, wfctx, nil)
@@ -1336,7 +1336,7 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_CancelActivityBeforeSent() {
 	task := createWorkflowTask(testEvents, 0, "HelloWorld_WorkflowCancel")
 
 	params := t.getTestWorkerExecutionParams()
-	taskHandler := newWorkflowTaskHandler(params, nil, t.registry)
+	taskHandler := newWorkflowTaskHandler(params, nil, t.registry, nil)
 	wftask := workflowTask{task: task}
 	wfctx := t.mustWorkflowContextImpl(&wftask, taskHandler)
 	request, err := taskHandler.ProcessWorkflowTask(&wftask, wfctx, nil)
@@ -1371,7 +1371,7 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_PageToken() {
 			return &historypb.History{Events: nextEvents}, nil, nil
 		},
 	}
-	taskHandler := newWorkflowTaskHandler(params, nil, t.registry)
+	taskHandler := newWorkflowTaskHandler(params, nil, t.registry, nil)
 	wftask := workflowTask{task: task, historyIterator: historyIterator}
 	wfctx := t.mustWorkflowContextImpl(&wftask, taskHandler)
 	request, err := taskHandler.ProcessWorkflowTask(&wftask, wfctx, nil)
@@ -1434,7 +1434,7 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_DuplicateMessagesPanic() {
 			return &historypb.History{Events: nil}, nil, nil
 		},
 	}
-	taskHandler := newWorkflowTaskHandler(params, nil, t.registry)
+	taskHandler := newWorkflowTaskHandler(params, nil, t.registry, nil)
 	wftask := workflowTask{task: task, historyIterator: historyIterator}
 	wfctx := t.mustWorkflowContextImpl(&wftask, taskHandler)
 	request, err := taskHandler.ProcessWorkflowTask(&wftask, wfctx, nil)
@@ -1534,7 +1534,7 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_Messages() {
 			return &historypb.History{Events: nextEvents}, nil, nil
 		},
 	}
-	taskHandler := newWorkflowTaskHandler(params, nil, t.registry)
+	taskHandler := newWorkflowTaskHandler(params, nil, t.registry, nil)
 	wftask := workflowTask{task: task, historyIterator: historyIterator}
 	wfctx := t.mustWorkflowContextImpl(&wftask, taskHandler)
 	request, err := taskHandler.ProcessWorkflowTask(&wftask, wfctx, nil)
@@ -1644,7 +1644,7 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_Message_Mixed_Types() {
 	}
 
 	params := t.getTestWorkerExecutionParams()
-	taskHandler := newWorkflowTaskHandler(params, nil, t.registry)
+	taskHandler := newWorkflowTaskHandler(params, nil, t.registry, nil)
 	wftask := workflowTask{task: task}
 	wfctx := t.mustWorkflowContextImpl(&wftask, taskHandler)
 	request, err := taskHandler.ProcessWorkflowTask(&wftask, wfctx, nil)
@@ -1759,7 +1759,7 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_Message_Admitted_Paged() {
 			return &historypb.History{Events: nextEvents}, nil, nil
 		},
 	}
-	taskHandler := newWorkflowTaskHandler(params, nil, t.registry)
+	taskHandler := newWorkflowTaskHandler(params, nil, t.registry, nil)
 	wftask := workflowTask{task: task, historyIterator: historyIterator}
 	wfctx := t.mustWorkflowContextImpl(&wftask, taskHandler)
 	request, err := taskHandler.ProcessWorkflowTask(&wftask, wfctx, nil)
@@ -1821,7 +1821,7 @@ func (t *TaskHandlersTestSuite) TestLocalActivityRetry_Workflow() {
 	params.WorkerStopChannel = stopCh
 	defer close(stopCh)
 
-	taskHandler := newWorkflowTaskHandler(params, nil, t.registry)
+	taskHandler := newWorkflowTaskHandler(params, nil, t.registry, nil)
 	laStopCh := make(chan struct{})
 	defer close(laStopCh)
 	laTunnel := newLocalActivityTunnel(laStopCh)
@@ -1905,7 +1905,7 @@ func (t *TaskHandlersTestSuite) TestLocalActivityRetry_WorkflowTaskHeartbeatFail
 	params.WorkerStopChannel = stopCh
 	defer close(stopCh)
 
-	taskHandler := newWorkflowTaskHandler(params, nil, t.registry)
+	taskHandler := newWorkflowTaskHandler(params, nil, t.registry, nil)
 	laTunnel := newLocalActivityTunnel(params.WorkerStopChannel)
 	taskHandlerImpl, ok := taskHandler.(*workflowTaskHandlerImpl)
 	t.True(ok)

--- a/internal/internal_task_pollers_test.go
+++ b/internal/internal_task_pollers_test.go
@@ -52,7 +52,7 @@ func TestWFTRacePrevention(t *testing.T) {
 		ctrl             = gomock.NewController(t)
 		client           = workflowservicemock.NewMockWorkflowServiceClient(ctrl)
 		resultsChan      = make(chan error, 2)
-		innerTaskHandler = newWorkflowTaskHandler(params, nil, newRegistry())
+		innerTaskHandler = newWorkflowTaskHandler(params, nil, newRegistry(), nil)
 		taskHandler      = &countingTaskHandler{WorkflowTaskHandler: innerTaskHandler}
 		contextManager   = taskHandler
 		codec            = binary.LittleEndian
@@ -153,7 +153,7 @@ func TestWFTCorruption(t *testing.T) {
 		wfe              = commonpb.WorkflowExecution{RunId: runID, WorkflowId: wfID}
 		ctrl             = gomock.NewController(t)
 		client           = workflowservicemock.NewMockWorkflowServiceClient(ctrl)
-		innerTaskHandler = newWorkflowTaskHandler(params, nil, reg)
+		innerTaskHandler = newWorkflowTaskHandler(params, nil, reg, nil)
 		taskHandler      = &countingTaskHandler{WorkflowTaskHandler: innerTaskHandler}
 		contextManager   = taskHandler
 		completionChans  = []chan struct{}{make(chan struct{}), make(chan struct{})}
@@ -290,7 +290,7 @@ func TestWFTReset(t *testing.T) {
 		wfe              = commonpb.WorkflowExecution{RunId: runID, WorkflowId: wfID}
 		ctrl             = gomock.NewController(t)
 		client           = workflowservicemock.NewMockWorkflowServiceClient(ctrl)
-		innerTaskHandler = newWorkflowTaskHandler(params, nil, reg)
+		innerTaskHandler = newWorkflowTaskHandler(params, nil, reg, nil)
 		taskHandler      = &countingTaskHandler{WorkflowTaskHandler: innerTaskHandler}
 		contextManager   = taskHandler
 		pollResp0        = workflowservice.PollWorkflowTaskQueueResponse{
@@ -389,7 +389,7 @@ func TestWFTPanicInTaskHandler(t *testing.T) {
 		wfe              = commonpb.WorkflowExecution{RunId: runID, WorkflowId: wfID}
 		ctrl             = gomock.NewController(t)
 		client           = workflowservicemock.NewMockWorkflowServiceClient(ctrl)
-		innerTaskHandler = newWorkflowTaskHandler(params, nil, newRegistry())
+		innerTaskHandler = newWorkflowTaskHandler(params, nil, newRegistry(), nil)
 		taskHandler      = &panickingTaskHandler{WorkflowTaskHandler: innerTaskHandler}
 		contextManager   = taskHandler
 		codec            = binary.LittleEndian

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -308,7 +308,7 @@ func newWorkflowWorkerInternal(client *WorkflowClient, params workerExecutionPar
 	if overrides != nil && overrides.workflowTaskHandler != nil {
 		taskHandler = overrides.workflowTaskHandler
 	} else {
-		taskHandler = newWorkflowTaskHandler(params, ppMgr, registry, client)
+		taskHandler = newWorkflowTaskHandler(params, ppMgr, registry, client.workflowService)
 	}
 	return newWorkflowTaskWorkerInternal(taskHandler, taskHandler, client, params, workerStopChannel, registry.interceptors)
 }
@@ -1696,7 +1696,7 @@ func (aw *WorkflowReplayer) replayWorkflowHistory(logger log.Logger, service wor
 	if aw.disableDeadlockDetection {
 		params.DeadlockDetectionTimeout = math.MaxInt64
 	}
-	taskHandler := newWorkflowTaskHandler(params, nil, aw.registry, nil) // No client needed for replay
+	taskHandler := newWorkflowTaskHandler(params, nil, aw.registry, service)
 	wfctx, err := taskHandler.GetOrCreateWorkflowContext(task, iterator)
 	defer wfctx.Unlock(err)
 	if err != nil {

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -308,7 +308,7 @@ func newWorkflowWorkerInternal(client *WorkflowClient, params workerExecutionPar
 	if overrides != nil && overrides.workflowTaskHandler != nil {
 		taskHandler = overrides.workflowTaskHandler
 	} else {
-		taskHandler = newWorkflowTaskHandler(params, ppMgr, registry)
+		taskHandler = newWorkflowTaskHandler(params, ppMgr, registry, client)
 	}
 	return newWorkflowTaskWorkerInternal(taskHandler, taskHandler, client, params, workerStopChannel, registry.interceptors)
 }
@@ -1696,7 +1696,7 @@ func (aw *WorkflowReplayer) replayWorkflowHistory(logger log.Logger, service wor
 	if aw.disableDeadlockDetection {
 		params.DeadlockDetectionTimeout = math.MaxInt64
 	}
-	taskHandler := newWorkflowTaskHandler(params, nil, aw.registry)
+	taskHandler := newWorkflowTaskHandler(params, nil, aw.registry, nil) // No client needed for replay
 	wfctx, err := taskHandler.GetOrCreateWorkflowContext(task, iterator)
 	defer wfctx.Unlock(err)
 	if err != nil {

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -1622,7 +1622,7 @@ func (s *internalWorkerTestSuite) testWorkflowTaskHandlerHelper(params workerExe
 		PreviousStartedEventId: 0,
 	}
 
-	r := newWorkflowTaskHandler(params, nil, s.registry)
+	r := newWorkflowTaskHandler(params, nil, s.registry, nil)
 	wfctx, err := r.GetOrCreateWorkflowContext(task, nil)
 	s.NoError(err)
 	_, err = r.ProcessWorkflowTask(&workflowTask{task: task}, wfctx, nil)

--- a/internal/worker.go
+++ b/internal/worker.go
@@ -421,10 +421,10 @@ const (
 	//
 	// Exposed as: [go.temporal.io/sdk/worker.FailWorkflow]
 	FailWorkflow
-	// RestartWorkflow restarts workflow execution with the same workflow type and original input arguments
-	// if workflow code throws panic or detects non-determinism. The workflow will be restarted using
-	// ContinueAsNew with fresh state but identical parameters. This can be useful for recovering from
-	// transient issues while preserving the original workflow execution intent.
+	// RestartWorkflow restarts workflow execution from the beginning if workflow code throws panic or detects
+	// non-determinism. The workflow will be restarted using ResetWorkflowExecution to replay from the
+	// first workflow task with the same workflow ID but a new run ID. This can be useful for recovering from
+	// transient issues while maintaining workflow state consistency.
 	//
 	// Exposed as: [go.temporal.io/sdk/worker.RestartWorkflow]
 	RestartWorkflow

--- a/internal/worker.go
+++ b/internal/worker.go
@@ -421,6 +421,13 @@ const (
 	//
 	// Exposed as: [go.temporal.io/sdk/worker.FailWorkflow]
 	FailWorkflow
+	// RestartWorkflow restarts workflow execution with the same workflow type and original input arguments
+	// if workflow code throws panic or detects non-determinism. The workflow will be restarted using
+	// ContinueAsNew with fresh state but identical parameters. This can be useful for recovering from
+	// transient issues while preserving the original workflow execution intent.
+	//
+	// Exposed as: [go.temporal.io/sdk/worker.RestartWorkflow]
+	RestartWorkflow
 )
 
 // ReplayNamespace is namespace for replay because startEvent doesn't contain it

--- a/internal/worker.go
+++ b/internal/worker.go
@@ -421,13 +421,13 @@ const (
 	//
 	// Exposed as: [go.temporal.io/sdk/worker.FailWorkflow]
 	FailWorkflow
-	// RestartWorkflow restarts workflow execution from the beginning if workflow code throws panic or detects
-	// non-determinism. The workflow will be restarted using ResetWorkflowExecution to replay from the
+	// ResetWorkflow resets workflow execution from the beginning if workflow code throws panic or detects
+	// non-determinism. The workflow will be reset using ResetWorkflowExecution to replay from the
 	// first workflow task with the same workflow ID but a new run ID. This can be useful for recovering from
 	// transient issues while maintaining workflow state consistency.
 	//
-	// Exposed as: [go.temporal.io/sdk/worker.RestartWorkflow]
-	RestartWorkflow
+	// Exposed as: [go.temporal.io/sdk/worker.ResetWorkflow]
+	ResetWorkflow
 )
 
 // ReplayNamespace is namespace for replay because startEvent doesn't contain it

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -256,10 +256,10 @@ const (
 	// detects non-determinism. This feature is convenient during development.
 	// WARNING: enabling this in production can cause all open workflows to fail on a single bug or bad deployment.
 	FailWorkflow = internal.FailWorkflow
-	// RestartWorkflow WorkflowPanicPolicy restarts workflow execution with the same workflow type and original input arguments
-	// if workflow code throws panic or detects non-determinism. The workflow will be restarted using
-	// ContinueAsNew with fresh state but identical parameters. This can be useful for recovering from
-	// transient issues while preserving the original workflow execution intent.
+	// RestartWorkflow WorkflowPanicPolicy restarts workflow execution from the beginning if workflow code throws panic or detects
+	// non-determinism. The workflow will be restarted using ResetWorkflowExecution to replay from the
+	// first workflow task with the same workflow ID but a new run ID. This can be useful for recovering from
+	// transient issues while maintaining workflow state consistency.
 	RestartWorkflow = internal.RestartWorkflow
 )
 

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -256,11 +256,11 @@ const (
 	// detects non-determinism. This feature is convenient during development.
 	// WARNING: enabling this in production can cause all open workflows to fail on a single bug or bad deployment.
 	FailWorkflow = internal.FailWorkflow
-	// RestartWorkflow WorkflowPanicPolicy restarts workflow execution from the beginning if workflow code throws panic or detects
-	// non-determinism. The workflow will be restarted using ResetWorkflowExecution to replay from the
+	// ResetWorkflow WorkflowPanicPolicy resets workflow execution from the beginning if workflow code throws panic or detects
+	// non-determinism. The workflow will be reset using ResetWorkflowExecution to replay from the
 	// first workflow task with the same workflow ID but a new run ID. This can be useful for recovering from
 	// transient issues while maintaining workflow state consistency.
-	RestartWorkflow = internal.RestartWorkflow
+	ResetWorkflow = internal.ResetWorkflow
 )
 
 // New creates an instance of worker for managing workflow and activity executions.

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -256,6 +256,11 @@ const (
 	// detects non-determinism. This feature is convenient during development.
 	// WARNING: enabling this in production can cause all open workflows to fail on a single bug or bad deployment.
 	FailWorkflow = internal.FailWorkflow
+	// RestartWorkflow WorkflowPanicPolicy restarts workflow execution with the same workflow type and original input arguments
+	// if workflow code throws panic or detects non-determinism. The workflow will be restarted using
+	// ContinueAsNew with fresh state but identical parameters. This can be useful for recovering from
+	// transient issues while preserving the original workflow execution intent.
+	RestartWorkflow = internal.RestartWorkflow
 )
 
 // New creates an instance of worker for managing workflow and activity executions.


### PR DESCRIPTION
## What was changed
Added a new panic policy called `ResetWorkflow`, if this option is set, the workflow will be reset from the beginning.

## Why?
New panic policy to reset the workflow from the start in case of panic/non-determinism is needed for our application. Full discussion [here](https://community.temporal.io/t/catching-nondeterministicexception/5020/10?u=_elbek_khoshimjonov).

## Checklist

1. Closes https://github.com/temporalio/features/issues/417 (at least for go-sdk)

2. How was this tested: [unit test here](https://github.com/elb3k/temporal-sdk-go/commit/658ecb5d3f55c8ef21069e34b43fd38c855d8671), and using this sample workflow to test:
```golang
func Workflow(ctx workflow.Context, params string) error {
	logger := workflow.GetLogger(ctx)
	logger.Info("Starting workflow... ")

	var a *Activities
	ao := workflow.ActivityOptions{
		StartToCloseTimeout: time.Minute,
	}
	ctx = workflow.WithActivityOptions(ctx, ao)

	retryCtx := workflow.WithRetryPolicy(ctx, temporal.RetryPolicy{
		MaximumAttempts: 1,
	})

	workflow.Sleep(ctx, 1*time.Second)
	var ret int
	if err := workflow.ExecuteActivity(retryCtx, a.Rulet).Get(retryCtx, &ret); err != nil {
		return err
	}
	if ret == 3 {
		return nil
	}
	panic("error")
}

type Activities struct{}

func (*Activities) Rulet(ctx context.Context) (int, error) {
	return rand.Intn(7), nil
}
```

4. Any docs updates needed?
`ResetWorkflow` option needs to be added alongside `BlockWorkflow` and `FailWorkflow`

5. Caveats - this is a rough and simple implementation and has a few caveats:
- Any panic in the workflow will result in a restart, and if the workflow code does not handle the issue, there might be an infinite loop. (Some kind of maximum limit should be set.)
