### PR TITLE
Add explicit bucket boundaries for MetricsHandler timer in contrib/op…

### DIFF
--- a/contrib/opentelemetry/handler.go
+++ b/contrib/opentelemetry/handler.go
@@ -118,7 +118,11 @@ func (m MetricsHandler) Gauge(name string) client.MetricsGauge {
 }
 
 func (m MetricsHandler) Timer(name string) client.MetricsTimer {
-	h, err := m.meter.Float64Histogram(name, metric.WithUnit("s"))
+	h, err := m.meter.Float64Histogram(name, metric.WithUnit("s"), metric.WithExplicitBucketBoundaries(
+		0.001, 0.002, 0.005, 0.010, 0.020, 0.050,
+		0.100, 0.200, 0.300, 0.400, 0.500, 0.600, 0.700, 0.800, 0.900,
+		1.000, 1.500, 2.000, 3.000, 4.000, 5.000, 7.000, 10.000,
+	))
 	if err != nil {
 		m.onError(err)
 		return client.MetricsNopHandler.Timer(name)


### PR DESCRIPTION
## What was changed

Added **explicit bucket boundaries** for `MetricsHandler` timers in `contrib/opentelemetry/handler.go`.
Previously, histograms relied on the default OpenTelemetry buckets. Now, we explicitly define latency buckets for better accuracy and consistency.

## Why?

* With recent OpenTelemetry updates, histogram buckets must be specified **at creation time** instead of being inferred.
* Without explicit buckets, the metrics fell back to defaults, which are not suitable for timing in seconds.
* Example of current output (cut for brevity):

```
le="0"} 0
le="5"} 2151
le="10"} 2151
le="25"} 2151
le="50"} 2151
le="75"} 2151
le="100"} 2151
le="250"} 2151
le="500"} 2151
le="750"} 2151
le="1000"} 2151
le="2500"} 2151
le="5000"} 2151
le="7500"} 2151
le="10000"} 2151
le="+Inf"} 2151
```

Here, the minimum bucket starts at `5` (seconds), while our metrics are recorded in much smaller values (e.g., `0.01s`). This made the histogram distribution meaningless.

By explicitly setting fine-grained buckets (`0.001s` up to `10s`), latency distributions are now represented correctly.

## Checklist

1. Closes N/A (no issue filed, but improves metrics correctness).
2. **How was this tested**:

   * Built the SDK and verified no compile/runtime errors.
   * Checked that histograms now expose expected fine-grained bucket boundaries.
3. **Docs updates**:

   * No changes needed in README/docs since this is an internal metrics improvement.
