### PR TITLE
Fix activity cancelation check

### DIFF
--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -2308,7 +2308,7 @@ func (ath *activityTaskHandlerImpl) Execute(taskQueue string, t *workflowservice
 
 	// Cancels that don't originate from the server will have separate cancel reasons, like
 	// ErrWorkerShutdown or ErrActivityPaused
-	isActivityCanceled := ctx.Err() == context.Canceled && errors.Is(context.Cause(ctx), &CanceledError{})
+	isActivityCanceled := ctx.Err() == context.Canceled && IsCanceledError(context.Cause(ctx))
 
 	dlCancelFunc()
 	if <-ctx.Done(); ctx.Err() == context.DeadlineExceeded {

--- a/internal/session.go
+++ b/internal/session.go
@@ -419,7 +419,7 @@ func sessionCreationActivity(ctx context.Context, sessionID string) error {
 			sessionEnv.CompleteSession(sessionID)
 			// Because of how session creation configures retryPolicy, we need to wrap context cancels that don't
 			// originate from the server as non-retryable errors. See retrypolicy in createSession() above.
-			if !(ctx.Err() == context.Canceled && errors.Is(context.Cause(ctx), &CanceledError{})) {
+			if !(ctx.Err() == context.Canceled && IsCanceledError(context.Cause(ctx))) {
 				return NewApplicationErrorWithOptions(
 					"session failed due to worker shutdown", "SessionWorkerShutdown",
 					ApplicationErrorOptions{NonRetryable: true, Cause: ctx.Err()})


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->
Use `errors.As`, not `errors.Is`

## Why?
<!-- Tell your future self why have you made these changes -->
`Is` compares instances, `As` compares types

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Added test

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces CanceledError checks with IsCanceledError in activity execution and session creation, and adds a test verifying activity cancellation yields a canceled response.
> 
> - **Internal runtime**:
>   - **Cancellation handling**: Use `IsCanceledError(context.Cause(ctx))` instead of `errors.Is(..., &CanceledError{})` in `internal/internal_task_handlers.go` and `internal/session.go` to detect non-server-originated cancels.
> - **Tests**:
>   - Add `TestActivityCancellationUsesIsCanceledError` ensuring canceled activities produce `RespondActivityTaskCanceledRequest` with correct `TaskToken`, `Identity`, and `Namespace`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8cd09eba5df3b4c86d0915b86c26caef01839f26. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->