### PR TITLE
Revert setting unblockSelectorSignal SDK flag by default

### DIFF
--- a/internal/internal_flags.go
+++ b/internal/internal_flags.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"math"
+	"os"
 
 	"go.temporal.io/api/workflowservice/v1"
 )
@@ -33,7 +34,7 @@ const (
 
 // unblockSelectorSignal exists to allow us to configure the default behavior of
 // SDKFlagBlockedSelectorSignalReceive. This is primarily useful with tests.
-var unblockSelectorSignal = true
+var unblockSelectorSignal = os.Getenv("UNBLOCK_SIGNAL_SELECTOR") != ""
 
 func sdkFlagFromUint(value uint32) sdkFlag {
 	switch value {


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->
Set this SDK flag to false by default. But allow users to set an ENV var if they want this flag to be true.

## Why?
<!-- Tell your future self why have you made these changes -->
Original solution is buggy, #2066. Reverting the default behavior for now, will fix the solution when the issue linked is tackled.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Turn off `unblockSelectorSignal` by default; enable it only when `UNBLOCK_SIGNAL_SELECTOR` is set.
> 
> - **Internal**
>   - **Selector Signal Unblocking**:
>     - In `internal/internal_flags.go`, set `unblockSelectorSignal` to `os.Getenv("UNBLOCK_SIGNAL_SELECTOR") != ""` (previously `true`), making it opt-in via env var.
>     - Add `os` import.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f595fd56eda93efdb588224bab2d697a7dbd4a5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->