### PR TITLE
Release Go SDK v1.37.0

### DIFF
--- a/internal/version.go
+++ b/internal/version.go
@@ -8,7 +8,7 @@ const (
 	// Server validates if SDKVersion fits its supported range and rejects request if it doesn't.
 	//
 	// Exposed as: [go.temporal.io/sdk/temporal.SDKVersion]
-	SDKVersion = "1.36.0"
+	SDKVersion = "1.37.0"
 
 	// SDKName represents the name of the SDK.
 	SDKName = clientNameHeaderValue


### PR DESCRIPTION
Release Go SDK v1.37.0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps `SDKVersion` to 1.37.0 in `internal/version.go`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 92850de3a9a01219ae912b5ab0f219b8b1fdad6b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->