### PR TITLE
Add WorkflowType tag to activity log

### DIFF
--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -2229,6 +2229,7 @@ func newServiceInvoker(
 func (ath *activityTaskHandlerImpl) Execute(taskQueue string, t *workflowservice.PollActivityTaskQueueResponse) (result interface{}, err error) {
 	traceLog(func() {
 		ath.logger.Debug("Processing new activity task",
+			tagWorkflowType, t.WorkflowType.GetName(),
 			tagWorkflowID, t.WorkflowExecution.GetWorkflowId(),
 			tagRunID, t.WorkflowExecution.GetRunId(),
 			tagActivityType, t.ActivityType.GetName(),
@@ -2280,6 +2281,7 @@ func (ath *activityTaskHandlerImpl) Execute(taskQueue string, t *workflowservice
 			topLine := fmt.Sprintf("activity for %s [panic]:", ath.taskQueueName)
 			st := getStackTraceRaw(topLine, 7, 0)
 			ath.logger.Error("Activity panic.",
+				tagWorkflowType, workflowType,
 				tagWorkflowID, t.WorkflowExecution.GetWorkflowId(),
 				tagRunID, t.WorkflowExecution.GetRunId(),
 				tagActivityType, activityType,
@@ -2313,6 +2315,7 @@ func (ath *activityTaskHandlerImpl) Execute(taskQueue string, t *workflowservice
 	dlCancelFunc()
 	if <-ctx.Done(); ctx.Err() == context.DeadlineExceeded {
 		ath.logger.Info("Activity complete after timeout.",
+			tagWorkflowType, workflowType,
 			tagWorkflowID, t.WorkflowExecution.GetWorkflowId(),
 			tagRunID, t.WorkflowExecution.GetRunId(),
 			tagActivityType, activityType,
@@ -2328,6 +2331,7 @@ func (ath *activityTaskHandlerImpl) Execute(taskQueue string, t *workflowservice
 			logFunc = ath.logger.Debug // Downgrade to Debug for benign application errors
 		}
 		logFunc("Activity error.",
+			tagWorkflowType, workflowType,
 			tagWorkflowID, t.WorkflowExecution.GetWorkflowId(),
 			tagRunID, t.WorkflowExecution.GetRunId(),
 			tagActivityType, activityType,


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Add WorkflowType tag to all activity logs

## Why?
We have an activity that’s reused across multiple workflows. This tag will help us debug production issues more efficiently by allowing filtering based on workflow type.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Manually by pointing the SDK to local build.

Sample log:
```
6:33PM ERR Activity error. ActivityType=CreateJournalEntry Attempt=10429 Error="invalid_argument: validation failed: amount: value 0 is less than minimum of 1." Namespace=default RunID=d063adf7-bfc5-4803-b70c-11153049699b TaskQueue=journal WorkerID=35819@Wiliantos-MacBook-Pro.local@ WorkflowID=chargefeev2_fee_bjyopigj5n1ga8n4hleazzes56 WorkflowType=ChargeFeeWorkflow
```

3. Any docs updates needed? No
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
