### PR TITLE
Include failure details in query failure. Improved gRPC-message-too-large detection. Fix flaky TestGrpcMessageTooLarge.

### DIFF
--- a/internal/common/retry/interceptor.go
+++ b/internal/common/retry/interceptor.go
@@ -191,7 +191,11 @@ func isGrpcMessageTooLargeStatus(status *status.Status) bool {
 		return false
 	}
 	message := status.Message()
+	// Source: https://github.com/search?q=repo%3Agrpc%2Fgrpc-go+ResourceExhausted&type=code
 	return strings.HasPrefix(message, "grpc: received message larger than max") ||
 		strings.HasPrefix(message, "grpc: message after decompression larger than max") ||
-		strings.HasPrefix(message, "grpc: received message after decompression larger than max")
+		strings.HasPrefix(message, "grpc: received message after decompression larger than max") ||
+		strings.HasPrefix(message, "grpc: trying to send message larger than max") ||
+		strings.HasPrefix(message, "grpc: message too large") ||
+		strings.HasPrefix(message, "trying to send message larger than max")
 }

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -1842,6 +1842,7 @@ func (wth *workflowTaskHandlerImpl) completeWorkflow(
 		if err != nil {
 			queryCompletedRequest.CompletedType = enumspb.QUERY_RESULT_TYPE_FAILED
 			queryCompletedRequest.ErrorMessage = err.Error()
+			queryCompletedRequest.Failure = wth.failureConverter.ErrorToFailure(err)
 		} else {
 			queryCompletedRequest.CompletedType = enumspb.QUERY_RESULT_TYPE_ANSWERED
 			queryCompletedRequest.QueryResult = result


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
- Query failure response now sets `RespondQueryTaskCompletedRequest.Failure` field in addition to `ErrorMessage` (except for workflow panics).
- Added more error message cases to gRPC message-too-large error detection.
- Changed `TestGrpcMessageTooLarge` to use byte arrays instead of strings to help with flakiness.

## Why?
<!-- Tell your future self why have you made these changes -->
`TestGrpcMessageTooLarge` test sometimes failed in CI because JSON encoding took too long and the deadlock detector triggered. Because byte slices don't use JSON converter, switching from a large error message string to an application failure with large byte slice in failure details avoids the problem.

Query failure handling code only set the error message in the response and not full error. To make the test fix work, it needed to be changed to set both fields. It's also a good thing to do anyway and it increases parity with other SDKs.

While fixing this issue, I discovered there are some versions of the gRPC-message-too-large error not covered by our current detection function, and so I added them.

## Checklist
<!--- add/delete as needed --->

1. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Integration tests pass.