### PR TITLE
[DRAFT/PROPOSAL] continue-as-new-suggested reason and signal

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/nexus-rpc/sdk-go v0.3.0
 	github.com/robfig/cron v1.2.0
 	github.com/stretchr/testify v1.10.0
-	go.temporal.io/api v1.53.0
+	go.temporal.io/api v1.55.1-0.20251017163919-d527807d0d4e
 	golang.org/x/sync v0.13.0
 	golang.org/x/sys v0.32.0
 	golang.org/x/time v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -35,8 +35,8 @@ github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
-go.temporal.io/api v1.53.0 h1:6vAFpXaC584AIELa6pONV56MTpkm4Ha7gPWL2acNAjo=
-go.temporal.io/api v1.53.0/go.mod h1:iaxoP/9OXMJcQkETTECfwYq4cw/bj4nwov8b3ZLVnXM=
+go.temporal.io/api v1.55.1-0.20251017163919-d527807d0d4e h1:8Y8p3tBzobAYO3KjuoiGXjDxeKlPsrEjjDRfLlB7O7c=
+go.temporal.io/api v1.55.1-0.20251017163919-d527807d0d4e/go.mod h1:iaxoP/9OXMJcQkETTECfwYq4cw/bj4nwov8b3ZLVnXM=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=

--- a/internal/client.go
+++ b/internal/client.go
@@ -40,6 +40,9 @@ const (
 
 	// QueryTypeWorkflowMetadata is the query name for the workflow metadata.
 	QueryTypeWorkflowMetadata string = "__temporal_workflow_metadata"
+
+	// SignalTypeSuggestContinueAsNew is the signal name to set ContinueAsNewSuggested=true in the workflow env.
+	SignalTypeSuggestContinueAsNew = "__suggest_continue_as_new"
 )
 
 type (

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -69,6 +69,39 @@ const (
 	VersioningBehaviorAutoUpgrade
 )
 
+// ContinueAsNewSuggestedReason specifies why ContinueAsNewSuggested is true.
+//
+// NOTE: Experimental
+//
+// Exposed as: [go.temporal.io/sdk/workflow.ContinueAsNewSuggestedReason]
+type ContinueAsNewSuggestedReason int
+
+const (
+	// ContinueAsNewSuggestedReasonUnspecified - ContinueAsNewSuggestedReason unknown.
+	// Reason will be Unspecified if the server is not configured to suggest continue as new,
+	// if the server is not configured to provide a reason for continue as new suggested, or
+	// if continue as new is not suggested.
+	//
+	// Exposed as: [go.temporal.io/sdk/workflow.ContinueAsNewSuggestedReasonUnspecified]
+	ContinueAsNewSuggestedReasonUnspecified ContinueAsNewSuggestedReason = iota
+
+	// ContinueAsNewSuggestedReasonHistorySizeTooLarge - Workflow History size is getting too large.
+	//
+	// Exposed as: [go.temporal.io/sdk/workflow.ContinueAsNewSuggestedReasonHistorySizeTooLarge]
+	ContinueAsNewSuggestedReasonHistorySizeTooLarge
+
+	// ContinueAsNewSuggestedReasonUpdateRegistryTooLarge - Workflow Update registry is getting too large.
+	//
+	// Exposed as: [go.temporal.io/sdk/workflow.ContinueAsNewSuggestedReasonUpdateRegistryTooLarge]
+	ContinueAsNewSuggestedReasonUpdateRegistryTooLarge
+
+	// ContinueAsNewSuggestedReasonWorkerDeploymentVersionChanged - Workflow's Worker Deployment has a new Ramping
+	// Version or Current Version, and the workflow's Versioning Behavior is PinnedUntilContinueAsNew.
+	//
+	// Exposed as: [go.temporal.io/sdk/workflow.ContinueAsNewSuggestedReasonWorkerDeploymentVersionChanged]
+	ContinueAsNewSuggestedReasonWorkerDeploymentVersionChanged
+)
+
 // NexusOperationCancellationType specifies what action should be taken for a Nexus operation when the
 // caller is cancelled.
 //
@@ -1350,9 +1383,10 @@ type WorkflowInfo struct {
 	// this worker
 	currentTaskBuildID string
 
-	continueAsNewSuggested bool
-	currentHistorySize     int
-	currentHistoryLength   int
+	continueAsNewSuggested       bool
+	continueAsNewSuggestedReason ContinueAsNewSuggestedReason
+	currentHistorySize           int
+	currentHistoryLength         int
 	// currentRunID is the current run ID of the workflow task, deterministic over reset
 	currentRunID string
 }
@@ -1402,6 +1436,12 @@ func (wInfo *WorkflowInfo) GetCurrentHistorySize() int {
 // This value may change throughout the life of the workflow.
 func (wInfo *WorkflowInfo) GetContinueAsNewSuggested() bool {
 	return wInfo.continueAsNewSuggested
+}
+
+// GetContinueAsNewSuggestedReason returns the reason for ContinueAsNewSuggested if one exists.
+// This value may change throughout the life of the workflow.
+func (wInfo *WorkflowInfo) GetContinueAsNewSuggestedReason() ContinueAsNewSuggestedReason {
+	return wInfo.continueAsNewSuggestedReason
 }
 
 // GetWorkflowInfo extracts info of a current workflow from a context.

--- a/workflow/deterministic_wrappers.go
+++ b/workflow/deterministic_wrappers.go
@@ -53,6 +53,11 @@ type (
 	//
 	// NOTE: Experimental
 	AwaitOptions = internal.AwaitOptions
+
+	// ContinueAsNewSuggestedReason is the reason for ContinueAsNewSuggested
+	//
+	// NOTE: Experimental
+	ContinueAsNewSuggestedReason = internal.ContinueAsNewSuggestedReason
 )
 
 // Await blocks the calling thread until condition() returns true.


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Add a system-defined signal to set `workflowInfo.continueAsNewSuggested` to true. Add a reason enum so workflows can see why continue-as-new was suggested whether it came from a signal or from a workflow-task-started event as usual.

## Why?
So that workflows who want to upgrade their worker version via continue-as-new can find out about a new version change in their worker deployment.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expose reason for suggested continue-as-new and support a system signal to set it at runtime.
> 
> - **Workflow runtime**:
>   - Add `ContinueAsNewSuggestedReason` enum with reasons (history size, update registry, worker deployment change) and surface via `workflow.GetWorkflowInfo().GetContinueAsNewSuggestedReason()`.
>   - Extend `WorkflowInfo` with `continueAsNewSuggestedReason` and accessor; keep `continueAsNewSuggested`.
>   - Handle WFT started to populate `continueAsNewSuggested` and reason from server attributes.
> - **Signals**:
>   - Introduce system signal `__suggest_continue_as_new` that sets `continueAsNewSuggested=true` and decodes reason payload to update `WorkflowInfo`.
> - **Internal**:
>   - Add converter to map `enumspb.ContinueAsNewSuggestedReason` to SDK enum.
>   - Re-export `ContinueAsNewSuggestedReason` in `workflow/deterministic_wrappers.go`.
> - **Deps**:
>   - Bump `go.temporal.io/api` to `v1.55.1-0.20251017163919-d527807d0d4e`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4bc0d82d948ecd31b3613382532c198862e45de2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->