### PR TITLE
Add nightly throughput stress

### DIFF
--- a/.github/workflows/nightly-throughput-stress.yml
+++ b/.github/workflows/nightly-throughput-stress.yml
@@ -15,7 +15,7 @@ on:
         default: '6h'
         type: string
       timeout:
-        description: 'Scenario timeout (should always be 30m more than duration)'
+        description: 'Scenario timeout (should be greater than duration)'
         required: false
         default: '6h30m'
         type: string


### PR DESCRIPTION
## What was changed
Added a nightly workflow to run Omes throughput stress scenario.

Runs throughput stress with a minimum throughput expectation.

Uploads worker logs artifacts and sends a Slack notification on failure.

## Why?
Provides basic smoke/stress testing, with a base benchmark throughput expectation.