### PR TITLE
VLN-490: Set explicit permissions for GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     strategy:
@@ -23,6 +26,10 @@ jobs:
             runsOn: macos-15-intel
           - os: macos-arm
             runsOn: macos-14
+    permissions:
+      contents: read
+      checks: write
+      statuses: write
     runs-on: ${{ matrix.runsOn || matrix.os }}
     steps:
       - name: Checkout repository

--- a/.github/workflows/nightly-throughput-stress.yml
+++ b/.github/workflows/nightly-throughput-stress.yml
@@ -25,6 +25,9 @@ on:
         default: 420
         type: number
 
+permissions:
+  contents: read
+
 env:
   # Workflow configuration
   TEST_DURATION: ${{ inputs.duration || vars.NIGHTLY_TEST_DURATION || '6h' }}
@@ -42,6 +45,9 @@ jobs:
   throughput-stress:
     runs-on: ubuntu-latest-4-cores
     timeout-minutes: ${{ fromJSON(inputs.job_timeout_minutes || (vars.NIGHTLY_JOB_TIMEOUT_MINUTES || '420')) }}
+    permissions:
+      contents: read
+      actions: write
 
     steps:
       - name: Print test configuration

--- a/.github/workflows/omes.yml
+++ b/.github/workflows/omes.yml
@@ -4,8 +4,14 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   omes-image-build:
+    permissions:
+      contents: read
+      packages: write
     uses: temporalio/omes/.github/workflows/docker-images.yml@main
     secrets: inherit
     with:


### PR DESCRIPTION
## Summary

- `.github/workflows/ci.yml`: Added a workflow-level `contents: read` scope and tightened the `build-and-test` job to only request the additional `checks: write` and `statuses: write` permissions needed for Coveralls status reporting.
- `.github/workflows/nightly-throughput-stress.yml`: Set workflow permissions to `contents: read` and granted the lone job `actions: write` so it can upload artifacts while keeping other scopes read-only.
- `.github/workflows/omes.yml`: Established a workflow-level `contents: read` default and allowed the reusable image-build job to push images by adding `packages: write`.