### PR TITLE
Add missing `actions: read` to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  actions: read
 
 jobs:
   build-and-test:


### PR DESCRIPTION
## What was changed

Following the same fix done here:
https://github.com/temporalio/sdk-dotnet/pull/556

## Why?

To fix CI workflow runs.

## Checklist

1. Closes: n/a

2. How was this tested: this PR.

3. Any docs updates needed?: no.
