### PR TITLE
Add actions-read permission to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  actions: read
 
 jobs:
   build-and-test:


### PR DESCRIPTION
Add actions-read permission to CI workflow

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Grant GitHub Actions "actions: read" permission in the CI workflow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f3aed59a6ae7a4ad71592ea7394cd2c1a4f59e20. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->