### PR TITLE
opentelemetry: log TraceID/SpanID as hex strings (fixes #2103)

### DIFF
--- a/contrib/opentelemetry/tracing_interceptor.go
+++ b/contrib/opentelemetry/tracing_interceptor.go
@@ -223,8 +223,8 @@ func (t *tracer) GetLogger(logger log.Logger, ref interceptor.TracerSpanRef) log
 	}
 
 	logger = log.With(logger,
-		"TraceID", span.SpanContext().TraceID(),
-		"SpanID", span.SpanContext().SpanID(),
+		"TraceID", span.SpanContext().TraceID().String(),
+		"SpanID", span.SpanContext().SpanID().String(),
 	)
 
 	return logger


### PR DESCRIPTION
Fix cosmetic logging bug: ensure OpenTelemetry TraceID/SpanID are logged as hex strings instead of byte slices. Minimal change: call .String() on both.\n\nValidation: ran go test ./... successfully.\n\nAffected file: contrib/opentelemetry/tracing_interceptor.go


closes #2103 