### PR TITLE
chore: Remove redundant activityInterceptorContextKey assignment

### DIFF
--- a/internal/activity.go
+++ b/internal/activity.go
@@ -424,7 +424,6 @@ func newActivityContext(
 	envInterceptor.inboundInterceptor = envInterceptor
 	envInterceptor.outboundInterceptor = envInterceptor
 	ctx = context.WithValue(ctx, activityEnvInterceptorContextKey, envInterceptor)
-	ctx = context.WithValue(ctx, activityInterceptorContextKey, envInterceptor.outboundInterceptor)
 
 	// Intercept, run init, and put the new outbound interceptor on the context
 	for i := len(interceptors) - 1; i >= 0; i-- {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Removes redundant activityInterceptorContextKey assignment in newActivityContext.

## Why?
<!-- Tell your future self why have you made these changes -->
Noticed that it's redundant with line 437.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
go run . unit-test
(TestIsActivity)

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
No