### PR TITLE
Release Go SDK v1.39.0

### DIFF
--- a/internal/version.go
+++ b/internal/version.go
@@ -8,7 +8,7 @@ const (
 	// Server validates if SDKVersion fits its supported range and rejects request if it doesn't.
 	//
 	// Exposed as: [go.temporal.io/sdk/temporal.SDKVersion]
-	SDKVersion = "1.38.0"
+	SDKVersion = "1.39.0"
 
 	// SDKName represents the name of the SDK.
 	SDKName = clientNameHeaderValue


### PR DESCRIPTION
Release Go SDK v1.39.0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Releases Go SDK v1.39.0.
> 
> - Updates `internal/version.go` `SDKVersion` from `1.38.0` to `1.39.0`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5463ca3c9570f8feba3dacae1321cfc50d572f38. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->