### PR TITLE
fix: set RootWorkflowExecution in child workflow env when testing

### DIFF
--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -468,7 +468,7 @@ func (env *testWorkflowEnvironmentImpl) newTestWorkflowEnvironmentForChild(
 	if env.workflowInfo.RootWorkflowExecution == nil {
 		childEnv.workflowInfo.RootWorkflowExecution = &env.workflowInfo.WorkflowExecution
 	} else {
-		childEnv.workflowInfo.ParentWorkflowExecution = env.workflowInfo.RootWorkflowExecution
+		childEnv.workflowInfo.RootWorkflowExecution = env.workflowInfo.RootWorkflowExecution
 	}
 
 	searchAttrs, err := serializeSearchAttributes(params.SearchAttributes, params.TypedSearchAttributes)


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Fixes a bug introduced in https://github.com/temporalio/sdk-go/pull/1923. When running child workflows that are not direct descendants from a root workflow in a test environment, the child workflow's parent info is incorrectly overwritten by the root workflow. This leads to issues when, for example, the child workflow tries to signal to its parent workflow and instead signals to the root workflow, leading to an `UnknownExternalWorkflowExecutionError`.

The fix changes this branch to update the child workflow's root info instead of the child workflow's parent info when the root info is not null.

## Why?
<!-- Tell your future self why have you made these changes -->
This fix allows users of the `sdk-go` package to test child workflows that are at least one step removed from their parent workflow.

## Checklist
<!--- add/delete as needed --->

### How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
The PR adds one test (`Test_NestedChildWorkflow_RootWorkflowExecution`) that fails before this change and passes afterwards. It expects the root ID to be the same for both workflows.

Test failure:
```
$ go test ./internal -run TestUnitTestSuite/Test_NestedChildWorkflow_RootWorkflowExecution -v
=== RUN   TestUnitTestSuite
=== RUN   TestUnitTestSuite/Test_NestedChildWorkflow_RootWorkflowExecution
2026/01/28 14:33:37 INFO  ExecuteChildWorkflow WorkflowType func3
2026/01/28 14:33:37 INFO  ExecuteChildWorkflow WorkflowType func2
    internal_workflow_testsuite_test.go:1123: 
        	Error Trace:	/Users/pbrowne/work/sdk-go/internal/internal_workflow_testsuite_test.go:1123
        	Error:      	Not equal: 
        	            	expected: "default-test-workflow-id"
        	            	actual  : ""
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1 +1 @@
        	            	-default-test-workflow-id
        	            	+
        	Test:       	TestUnitTestSuite/Test_NestedChildWorkflow_RootWorkflowExecution
        	Messages:   	Grandchild's RootWorkflowExecution should point to root (parent), not child
--- FAIL: TestUnitTestSuite (0.00s)
    --- FAIL: TestUnitTestSuite/Test_NestedChildWorkflow_RootWorkflowExecution (0.00s)
FAIL
FAIL	go.temporal.io/sdk/internal	0.884s
FAIL
```
