### PR TITLE
Deprecate v1 and v2 versioning worker options and versioning intent

### DIFF
--- a/internal/activity.go
+++ b/internal/activity.go
@@ -146,7 +146,8 @@ type (
 
 		// VersioningIntent - Specifies whether this activity should run on a worker with a compatible
 		// build ID or not. See temporal.VersioningIntent.
-		// WARNING: Worker versioning is currently experimental
+		//
+		// Deprecated: Use Worker Deployment Versioning instead. See https://docs.temporal.io/worker-versioning
 		VersioningIntent VersioningIntent
 
 		// Summary is a single-line summary for this activity that will appear in UI/CLI. This can be

--- a/internal/error.go
+++ b/internal/error.go
@@ -191,6 +191,8 @@ type (
 
 		// VersioningIntent specifies whether the continued workflow should run on a worker with a
 		// compatible build ID or not. See VersioningIntent.
+		//
+		// Deprecated: Use Worker Deployment Versioning instead. See https://docs.temporal.io/worker-versioning
 		VersioningIntent VersioningIntent
 
 		// This is by default nil but may be overridden using NewContinueAsNewErrorWithOptions.

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -134,9 +134,13 @@ type (
 		Identity string
 
 		// The worker's build ID used for versioning, if one was set.
+		//
+		// Deprecated: use DeploymentOptions.Version for versioning instead.
 		WorkerBuildID string
 
 		// If true the worker is opting in to build ID based versioning.
+		//
+		// Deprecated: use DeploymentOptions.UseVersioning for versioning instead.
 		UseBuildIDForVersioning bool
 
 		// Worker deployment options containing all deployment versioning configuration.


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Deprecate v1 and v2 versioning worker options and versioning intent

## Why?
These have already been deprecated at the API level for some time.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only deprecation annotations with no functional logic changes; minimal risk aside from downstream tooling that treats deprecations as warnings/errors.
> 
> **Overview**
> Updates public/internal option structs to **formally deprecate legacy build-ID versioning fields**.
> 
> Specifically, adds `Deprecated:` doc comments pointing users to Worker Deployment Versioning for `ActivityOptions.VersioningIntent`, `ContinueAsNewError.VersioningIntent`, and worker execution fields `WorkerBuildID`/`UseBuildIDForVersioning` (redirecting to `DeploymentOptions`). No runtime behavior changes; this is a documentation/API-signal change only.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 01537d2ad2857db4bce7fd6bb15d9df713613659. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->