### PR TITLE
Add keep-original-workflow-id to schedule policy

### DIFF
--- a/internal/internal_schedule_client.go
+++ b/internal/internal_schedule_client.go
@@ -114,9 +114,10 @@ func (w *workflowClientInterceptor) CreateSchedule(ctx context.Context, in *Sche
 			Spec:   convertToPBScheduleSpec(&in.Options.Spec),
 			Action: action,
 			Policies: &schedulepb.SchedulePolicies{
-				OverlapPolicy:  in.Options.Overlap,
-				CatchupWindow:  catchupWindow,
-				PauseOnFailure: in.Options.PauseOnFailure,
+				OverlapPolicy:          in.Options.Overlap,
+				CatchupWindow:          catchupWindow,
+				PauseOnFailure:         in.Options.PauseOnFailure,
+				KeepOriginalWorkflowId: in.Options.KeepOriginalWorkflowID,
 			},
 			State: &schedulepb.ScheduleState{
 				Notes:            in.Options.Note,
@@ -487,9 +488,10 @@ func scheduleDescriptionFromPB(
 			Action: actionDescription,
 			Spec:   convertFromPBScheduleSpec(describeResponse.Schedule.Spec),
 			Policy: &SchedulePolicies{
-				Overlap:        describeResponse.Schedule.Policies.GetOverlapPolicy(),
-				CatchupWindow:  describeResponse.Schedule.Policies.GetCatchupWindow().AsDuration(),
-				PauseOnFailure: describeResponse.Schedule.Policies.GetPauseOnFailure(),
+				Overlap:                describeResponse.Schedule.Policies.GetOverlapPolicy(),
+				CatchupWindow:          describeResponse.Schedule.Policies.GetCatchupWindow().AsDuration(),
+				PauseOnFailure:         describeResponse.Schedule.Policies.GetPauseOnFailure(),
+				KeepOriginalWorkflowID: describeResponse.Schedule.Policies.GetKeepOriginalWorkflowId(),
 			},
 			State: &ScheduleState{
 				Note:             describeResponse.Schedule.State.GetNotes(),
@@ -533,9 +535,10 @@ func convertToPBSchedule(ctx context.Context, client *WorkflowClient, schedule *
 		Spec:   convertToPBScheduleSpec(schedule.Spec),
 		Action: action,
 		Policies: &schedulepb.SchedulePolicies{
-			OverlapPolicy:  schedule.Policy.Overlap,
-			CatchupWindow:  catchupWindow,
-			PauseOnFailure: schedule.Policy.PauseOnFailure,
+			OverlapPolicy:          schedule.Policy.Overlap,
+			CatchupWindow:          catchupWindow,
+			PauseOnFailure:         schedule.Policy.PauseOnFailure,
+			KeepOriginalWorkflowId: schedule.Policy.KeepOriginalWorkflowID,
 		},
 		State: &schedulepb.ScheduleState{
 			Notes:            schedule.State.Note,

--- a/internal/schedule_client.go
+++ b/internal/schedule_client.go
@@ -349,6 +349,13 @@ type (
 		// Optional: defaulted to false
 		PauseOnFailure bool
 
+		// KeepOriginalWorkflowID - Whether to keep the Action's workflow ID exactly as configured.
+		//
+		// When false, Temporal Server may append a timestamp suffix for uniqueness.
+		//
+		// Optional: defaulted to false
+		KeepOriginalWorkflowID bool
+
 		// Note - Informative human-readable message with contextual notes, e.g. the reason
 		// a Schedule is paused. The system may overwrite this message on certain
 		// conditions, e.g. when pause-on-failure happens.
@@ -485,6 +492,9 @@ type (
 
 		// PauseOnFailure - When an Action times out or reaches the end of its Retry Policy.
 		PauseOnFailure bool
+
+		// KeepOriginalWorkflowID - Whether started workflow executions keep the Action workflow ID exactly as configured.
+		KeepOriginalWorkflowID bool
 	}
 
 	// ScheduleState describes the current state of a schedule.


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Add field to allow keeping the original workflow id on a schedule.

1. Part of https://github.com/temporalio/features/issues/727

2. How was this tested:
integration test

3. Any docs updates needed?
no
