### PR TITLE
Make search attribute type more lenient when parsing

### DIFF
--- a/internal/internal_search_attributes.go
+++ b/internal/internal_search_attributes.go
@@ -444,8 +444,9 @@ func convertToTypedSearchAttributes(logger log.Logger, attributes map[string]*co
 		if payload.Data == nil {
 			continue
 		}
-		valueType := enumspb.IndexedValueType(
-			enumspb.IndexedValueType_shorthandValue[string(payload.GetMetadata()["type"])])
+		// The type metadata is usually in PascalCase (e.g. "KeywordList") but in
+		// rare cases may be in SCREAMING_SNAKE_CASE (e.g. "INDEXED_VALUE_TYPE_KEYWORD_LIST").
+		valueType, _ := enumspb.IndexedValueTypeFromString(string(payload.GetMetadata()["type"]))
 		// For TemporalChangeVersion, we imply the value type
 		if valueType == 0 && key == TemporalChangeVersion {
 			valueType = enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST


### PR DESCRIPTION
## What was changed

There was a case in Core where we used SCREAMING_SNAKE_CASE for metadata type instead of PascalCase, see https://github.com/temporalio/features/issues/741. This adjusts Go to be a bit more lenient (but no great way to test the Core issue that's already fixed).