### PR TITLE
Release Go SDK v1.41.0

### DIFF
--- a/test/worker_versioning_test.go
+++ b/test/worker_versioning_test.go
@@ -861,7 +861,7 @@ func (ts *WorkerVersioningTestSuite) TestTaskQueueStats() {
 
 			assert.Greater(t, taskQueueInfo.VersionsInfo[""].TypesInfo[client.TaskQueueTypeWorkflow].Stats.ApproximateBacklogCount, int64(0))
 		},
-		5*time.Second, 100*time.Millisecond,
+		time.Second, 100*time.Millisecond,
 	)
 
 	// no workers yet, so only workflow should have a backlog


### PR DESCRIPTION
Release Go SDK v1.41.0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates the embedded `SDKVersion` string used in RPC headers, with no functional or behavioral code changes.
> 
> **Overview**
> Updates the Temporal Go SDK release metadata by bumping `internal.SDKVersion` from `1.40.0` to `1.41.0`, which is sent in RPC request headers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c1942e812a80ceb66b962d6fdaed773ee1e10d7b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->