### PR TITLE
Release Go SDK v1.41.1

### DIFF
--- a/internal/version.go
+++ b/internal/version.go
@@ -8,7 +8,7 @@ const (
 	// Server validates if SDKVersion fits its supported range and rejects request if it doesn't.
 	//
 	// Exposed as: [go.temporal.io/sdk/temporal.SDKVersion]
-	SDKVersion = "1.41.0"
+	SDKVersion = "1.41.1"
 
 	// SDKName represents the name of the SDK.
 	SDKName = clientNameHeaderValue


### PR DESCRIPTION
Release Go SDK v1.41.1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release bookkeeping change that only updates the advertised SDK version string used in RPC headers.
> 
> **Overview**
> Updates `internal/version.go` to bump `SDKVersion` from `1.41.0` to `1.41.1`, affecting the version metadata sent in RPC headers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eb2d1f305bf954ce232e5c2deebcbaa33a9b4a5d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->