### PR TITLE
Delete some prominent but unimportant log messages

### DIFF
--- a/internal/client.go
+++ b/internal/client.go
@@ -1095,7 +1095,6 @@ func newClient(ctx context.Context, options ClientOptions, existing Client) (Cli
 
 	if options.Logger == nil {
 		options.Logger = ilog.NewDefaultLogger()
-		options.Logger.Info("No logger configured for temporal client. Created default one.")
 	}
 
 	// Validate mutually exclusive TLS options

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -260,7 +260,6 @@ func ensureRequiredParams(params *workerExecutionParameters) {
 	if params.Logger == nil {
 		// create default logger if user does not supply one (should happen in tests only).
 		params.Logger = ilog.NewDefaultLogger()
-		params.Logger.Info("No logger configured for temporal worker. Created default one.")
 	}
 	if params.MetricsHandler == nil {
 		params.MetricsHandler = metrics.NopHandler


### PR DESCRIPTION
## What was changed
Delete some prominent but unimportant log messages.

## Why?
New users see this a lot but it is just noise.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes two informational log lines emitted when a default logger is auto-created for the client/worker, with no behavior or API changes beyond reduced log output.
> 
> **Overview**
> Removes two noisy `Info` logs that were emitted when the SDK auto-created a default logger for a Temporal `Client` and for workers (`ensureRequiredParams`).
> 
> This reduces startup log spam for new users while keeping the same default-logger fallback behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c366727301eaed3e2a41d6bfb3b1e29893559e13. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->