### PR TITLE
Fix SAA header propagation

### DIFF
--- a/internal/internal_activity_client.go
+++ b/internal/internal_activity_client.go
@@ -461,6 +461,9 @@ func (wc *WorkflowClient) ExecuteActivity(ctx context.Context, options ClientSta
 		return nil, err
 	}
 
+	// Set header before interceptor run so interceptors can access it
+	ctx = contextWithNewHeader(ctx)
+
 	return wc.interceptor.ExecuteActivity(ctx, &ClientExecuteActivityInput{
 		Options:      &options,
 		ActivityType: activityType.Name,
@@ -562,7 +565,6 @@ func (w *workflowClientInterceptor) ExecuteActivity(
 	ctx context.Context,
 	in *ClientExecuteActivityInput,
 ) (ClientActivityHandle, error) {
-	ctx = contextWithNewHeader(ctx)
 	dataConverter := WithContext(ctx, w.client.dataConverter)
 	if dataConverter == nil {
 		dataConverter = converter.GetDefaultDataConverter()

--- a/internal/internal_activity_client_test.go
+++ b/internal/internal_activity_client_test.go
@@ -1,0 +1,65 @@
+package internal
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/api/workflowservice/v1"
+)
+
+// headerCheckInterceptor is a ClientInterceptor that verifies the header is
+// present on the context when ExecuteActivity is called. This ensures that
+// contextWithNewHeader is called before the interceptor chain runs, so
+// interceptors (like the tracing interceptor) can read/write headers.
+type headerCheckInterceptor struct {
+	ClientInterceptorBase
+	headerWasPresent bool
+}
+
+func (h *headerCheckInterceptor) InterceptClient(next ClientOutboundInterceptor) ClientOutboundInterceptor {
+	return &headerCheckOutbound{
+		ClientOutboundInterceptorBase: ClientOutboundInterceptorBase{Next: next},
+		parent:                        h,
+	}
+}
+
+type headerCheckOutbound struct {
+	ClientOutboundInterceptorBase
+	parent *headerCheckInterceptor
+}
+
+func (h *headerCheckOutbound) ExecuteActivity(
+	ctx context.Context,
+	in *ClientExecuteActivityInput,
+) (ClientActivityHandle, error) {
+	h.parent.headerWasPresent = Header(ctx) != nil
+	// Return an error to short-circuit the rest of the chain (avoids needing a
+	// real gRPC connection for the base interceptor).
+	return nil, fmt.Errorf("short-circuit")
+}
+
+func TestExecuteActivityHeaderAvailableToInterceptors(t *testing.T) {
+	interceptor := &headerCheckInterceptor{}
+
+	client := NewServiceClient(nil, nil, ClientOptions{
+		Interceptors: []ClientInterceptor{interceptor},
+	})
+	// Pre-set capabilities so ensureInitialized doesn't make a gRPC call.
+	client.capabilities = &workflowservice.GetSystemInfoResponse_Capabilities{}
+
+	// Register a dummy activity so getValidatedActivityFunction succeeds.
+	dummyActivity := func(ctx context.Context) error { return nil }
+	client.registry.RegisterActivityWithOptions(dummyActivity, RegisterActivityOptions{})
+
+	_, err := client.ExecuteActivity(context.Background(), ClientStartActivityOptions{
+		TaskQueue:           "test-tq",
+		ID:                  "test-activity-id",
+		StartToCloseTimeout: 1,
+	}, dummyActivity)
+	// We expect the short-circuit error from our interceptor.
+	require.ErrorContains(t, err, "short-circuit")
+	require.True(t, interceptor.headerWasPresent,
+		"Header should be set on context before interceptor chain runs")
+}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Move `contextWithNewHeader` to before the interceptor chain instead of after.

## Why?
Fixes SAA header propagation so interceptors can access and modify headers.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `ExecuteActivity` context setup so interceptors can read/write headers, which can affect tracing/propagation behavior for all standalone activity starts. Low code surface area but impacts interceptor-visible request metadata.
> 
> **Overview**
> Fixes standalone activity header propagation by moving `contextWithNewHeader` from the base `workflowClientInterceptor.ExecuteActivity` into `WorkflowClient.ExecuteActivity`, ensuring the header exists *before* the client interceptor chain executes.
> 
> Adds `TestExecuteActivityHeaderAvailableToInterceptors` to assert `Header(ctx)` is non-nil within an interceptor during `ExecuteActivity`, guarding against regressions in interceptor-based header/tracing behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0b8664efb76eee1dea60150c952d507bf6016550. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->