### PR TITLE
fix: IsWorkflowExecutionAlreadyStartedError now unwraps WorkflowExecutionAlreadyStarted

### DIFF
--- a/temporal/error.go
+++ b/temporal/error.go
@@ -5,6 +5,7 @@ import (
 
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
+
 	"go.temporal.io/sdk/internal"
 )
 

--- a/temporal/error.go
+++ b/temporal/error.go
@@ -5,7 +5,6 @@ import (
 
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
-
 	"go.temporal.io/sdk/internal"
 )
 
@@ -210,9 +209,8 @@ func IsApplicationError(err error) bool {
 	return errors.As(err, &applicationError)
 }
 
-// IsWorkflowExecutionAlreadyStartedError return if the err is a
-// WorkflowExecutionAlreadyStartedError or if an error in the chain is a
-// ChildWorkflowExecutionAlreadyStartedError.
+// IsWorkflowExecutionAlreadyStartedError returns true if an error in the chain
+// is a WorkflowExecutionAlreadyStartedError or ChildWorkflowExecutionAlreadyStartedError.
 func IsWorkflowExecutionAlreadyStartedError(err error) bool {
 	var alreadyStartedError *serviceerror.WorkflowExecutionAlreadyStarted
 	if errors.As(err, &alreadyStartedError) {

--- a/temporal/error.go
+++ b/temporal/error.go
@@ -214,8 +214,9 @@ func IsApplicationError(err error) bool {
 // WorkflowExecutionAlreadyStartedError or if an error in the chain is a
 // ChildWorkflowExecutionAlreadyStartedError.
 func IsWorkflowExecutionAlreadyStartedError(err error) bool {
-	if _, ok := err.(*serviceerror.WorkflowExecutionAlreadyStarted); ok {
-		return ok
+	var alreadyStartedError *serviceerror.WorkflowExecutionAlreadyStarted
+	if errors.As(err, &alreadyStartedError) {
+		return true
 	}
 	var childError *ChildWorkflowExecutionAlreadyStartedError
 	return errors.As(err, &childError)


### PR DESCRIPTION
## What was changed
Fixed `IsWorkflowExecutionAlreadyStartedError` to consistently unwrap errors for both 
`WorkflowExecutionAlreadyStarted` and `ChildWorkflowExecutionAlreadyStartedError` detection.

## Why?
The original implementation used a direct type assertion for `WorkflowExecutionAlreadyStarted` 
(no unwrapping) but `errors.As` for `ChildWorkflowExecutionAlreadyStartedError` (with unwrapping), 
making the behavior inconsistent. If `WorkflowExecutionAlreadyStarted` is wrapped in another error, 
the function would incorrectly return `false`.

## Checklist
1. Any docs updates needed? No