### PR TITLE
Update grpc interceptor to preserve external payload details

### DIFF
--- a/converter/grpc_interceptor.go
+++ b/converter/grpc_interceptor.go
@@ -27,10 +27,34 @@ func NewPayloadCodecGRPCClientInterceptor(options PayloadCodecGRPCClientIntercep
 	return proxy.NewPayloadVisitorInterceptor(proxy.PayloadVisitorInterceptorOptions{
 		Outbound: &proxy.VisitPayloadsOptions{
 			Visitor: func(vpc *proxy.VisitPayloadsContext, payloads []*commonpb.Payload) ([]*commonpb.Payload, error) {
+				inputExternal := make([][]*commonpb.Payload_ExternalPayloadDetails, len(payloads))
+				for i, p := range payloads {
+					inputExternal[i] = p.GetExternalPayloads()
+				}
+
 				var err error
 				for i := len(options.Codecs) - 1; i >= 0; i-- {
 					if payloads, err = options.Codecs[i].Encode(payloads); err != nil {
 						return payloads, err
+					}
+				}
+
+				// Best effort: preserve external size information after encoding
+				if len(payloads) == len(inputExternal) {
+					for i, ext := range inputExternal {
+						if len(ext) > 0 {
+							payloads[i].ExternalPayloads = ext
+						}
+					}
+				} else if len(payloads) == 1 && len(inputExternal) > 1 {
+					var total int64
+					for _, extSlice := range inputExternal {
+						for _, d := range extSlice {
+							total += d.GetSizeBytes()
+						}
+					}
+					if total > 0 {
+						payloads[0].ExternalPayloads = []*commonpb.Payload_ExternalPayloadDetails{{SizeBytes: total}}
 					}
 				}
 

--- a/converter/grpc_interceptor_test.go
+++ b/converter/grpc_interceptor_test.go
@@ -128,6 +128,171 @@ func TestFailureGRPCClientInterceptor(t *testing.T) {
 	require.Equal("internal_file:12", f.StackTrace)
 }
 
+// testOneToOneCodec returns the same number of payloads but strips ExternalPayloads.
+type testOneToOneCodec struct{}
+
+func (c *testOneToOneCodec) Encode(payloads []*commonpb.Payload) ([]*commonpb.Payload, error) {
+	out := make([]*commonpb.Payload, len(payloads))
+	for i, p := range payloads {
+		out[i] = &commonpb.Payload{Metadata: p.Metadata, Data: p.Data}
+	}
+	return out, nil
+}
+
+func (c *testOneToOneCodec) Decode(payloads []*commonpb.Payload) ([]*commonpb.Payload, error) {
+	return payloads, nil
+}
+
+// testManyToOneCodec merges all input payloads into a single payload.
+type testManyToOneCodec struct{}
+
+func (c *testManyToOneCodec) Encode(payloads []*commonpb.Payload) ([]*commonpb.Payload, error) {
+	return []*commonpb.Payload{{Metadata: map[string][]byte{MetadataEncoding: []byte("binary/merged")}}}, nil
+}
+
+func (c *testManyToOneCodec) Decode(payloads []*commonpb.Payload) ([]*commonpb.Payload, error) {
+	return payloads, nil
+}
+
+// testOneToManyCodec expands a single payload into multiple payloads.
+type testOneToManyCodec struct{ count int }
+
+func (c *testOneToManyCodec) Encode(payloads []*commonpb.Payload) ([]*commonpb.Payload, error) {
+	out := make([]*commonpb.Payload, c.count)
+	for i := range out {
+		out[i] = &commonpb.Payload{Metadata: map[string][]byte{MetadataEncoding: []byte("binary/split")}}
+	}
+	return out, nil
+}
+
+func (c *testOneToManyCodec) Decode(payloads []*commonpb.Payload) ([]*commonpb.Payload, error) {
+	return payloads, nil
+}
+
+func payloadsWithExternalDetails(sizesBytes ...int64) *commonpb.Payloads {
+	ps := make([]*commonpb.Payload, len(sizesBytes))
+	for i, sz := range sizesBytes {
+		ps[i] = &commonpb.Payload{
+			Metadata: map[string][]byte{MetadataEncoding: []byte(MetadataEncodingJSON)},
+			ExternalPayloads: []*commonpb.Payload_ExternalPayloadDetails{
+				{SizeBytes: sz},
+			},
+		}
+	}
+	return &commonpb.Payloads{Payloads: ps}
+}
+
+// Test that the interceptor preserves ExternalPayloadDetails when the number of output payloads
+// matches the number of input payloads, even if the codec doesn't preserve the details.
+func TestPayloadCodecGRPCClientInterceptor_PreservesExternalPayloadDetails_OneToOne(t *testing.T) {
+	require := require.New(t)
+
+	server, err := startTestGRPCServer()
+	require.NoError(err)
+
+	interceptor, err := NewPayloadCodecGRPCClientInterceptor(
+		PayloadCodecGRPCClientInterceptorOptions{
+			Codecs: []PayloadCodec{&testOneToOneCodec{}},
+		},
+	)
+	require.NoError(err)
+
+	c, err := grpc.NewClient(
+		server.addr,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithChainUnaryInterceptor(interceptor),
+	)
+	require.NoError(err)
+
+	client := workflowservice.NewWorkflowServiceClient(c)
+	_, err = client.StartWorkflowExecution(
+		context.Background(),
+		&workflowservice.StartWorkflowExecutionRequest{
+			Input: payloadsWithExternalDetails(1234),
+		},
+	)
+	require.NoError(err)
+
+	got := server.startWorkflowExecutionRequest.Input.Payloads
+	require.Len(got, 1)
+	require.Len(got[0].ExternalPayloads, 1)
+	require.Equal(int64(1234), got[0].ExternalPayloads[0].SizeBytes)
+}
+
+// Test that the interceptor sums ExternalPayloadDetails sizes when the codec merges multiple payloads into one.
+func TestPayloadCodecGRPCClientInterceptor_PreservesExternalPayloadDetails_ManyToOne(t *testing.T) {
+	require := require.New(t)
+
+	server, err := startTestGRPCServer()
+	require.NoError(err)
+
+	interceptor, err := NewPayloadCodecGRPCClientInterceptor(
+		PayloadCodecGRPCClientInterceptorOptions{
+			Codecs: []PayloadCodec{&testManyToOneCodec{}},
+		},
+	)
+	require.NoError(err)
+
+	c, err := grpc.NewClient(
+		server.addr,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithChainUnaryInterceptor(interceptor),
+	)
+	require.NoError(err)
+
+	client := workflowservice.NewWorkflowServiceClient(c)
+	_, err = client.StartWorkflowExecution(
+		context.Background(),
+		&workflowservice.StartWorkflowExecutionRequest{
+			Input: payloadsWithExternalDetails(7, 40, 500),
+		},
+	)
+	require.NoError(err)
+
+	got := server.startWorkflowExecutionRequest.Input.Payloads
+	require.Len(got, 1)
+	require.Len(got[0].ExternalPayloads, 1)
+	require.Equal(int64(547), got[0].ExternalPayloads[0].SizeBytes)
+}
+
+// Test that the interceptor does not preserve ExternalPayloadDetails when the codec changes the number of payloads
+// in a way that doesn't allow for a clear mapping.
+func TestPayloadCodecGRPCClientInterceptor_PreservesExternalPayloadDetails_OtherMismatch(t *testing.T) {
+	require := require.New(t)
+
+	server, err := startTestGRPCServer()
+	require.NoError(err)
+
+	interceptor, err := NewPayloadCodecGRPCClientInterceptor(
+		PayloadCodecGRPCClientInterceptorOptions{
+			Codecs: []PayloadCodec{&testOneToManyCodec{count: 3}},
+		},
+	)
+	require.NoError(err)
+
+	c, err := grpc.NewClient(
+		server.addr,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithChainUnaryInterceptor(interceptor),
+	)
+	require.NoError(err)
+
+	client := workflowservice.NewWorkflowServiceClient(c)
+	_, err = client.StartWorkflowExecution(
+		context.Background(),
+		&workflowservice.StartWorkflowExecutionRequest{
+			Input: payloadsWithExternalDetails(500, 30),
+		},
+	)
+	require.NoError(err)
+
+	got := server.startWorkflowExecutionRequest.Input.Payloads
+	require.Len(got, 3)
+	for _, p := range got {
+		require.Empty(p.ExternalPayloads)
+	}
+}
+
 type testGRPCServer struct {
 	workflowservice.UnimplementedWorkflowServiceServer
 	*grpc.Server


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Preserve external payload details across the codec application in the gRPC proxy.

## Why?

Assists Temporal UI in determining when to enable download via the codec server.

## Checklist
<!--- add/delete as needed --->

1. How was this tested: Unit tests
1. Any docs updates needed? No
