### PR TITLE
💥 filter nil values from `SearchAttributes` for workflow start and continue-as-new

### DIFF
--- a/internal/internal_search_attributes.go
+++ b/internal/internal_search_attributes.go
@@ -416,6 +416,31 @@ func serializeTypedSearchAttributes(searchAttributes map[SearchAttributeKey]inte
 	return &commonpb.SearchAttributes{IndexedFields: serializedAttr}, nil
 }
 
+// Start-like requests should not carry null or unset search attributes, even
+// though workflow info may still contain them in the current run.
+func sanitizeSearchAttributesForStart(attributes *commonpb.SearchAttributes) *commonpb.SearchAttributes {
+	if attributes == nil || len(attributes.IndexedFields) == 0 {
+		return attributes
+	}
+
+	filteredAttributes := make(map[string]*commonpb.Payload, len(attributes.IndexedFields))
+	filteredAny := false
+	for key, payload := range attributes.IndexedFields {
+		if payload == nil || string(payload.GetMetadata()[converter.MetadataEncoding]) == converter.MetadataEncodingNil {
+			filteredAny = true
+			continue
+		}
+		filteredAttributes[key] = payload
+	}
+	if !filteredAny {
+		return attributes
+	}
+	if len(filteredAttributes) == 0 {
+		return nil
+	}
+	return &commonpb.SearchAttributes{IndexedFields: filteredAttributes}
+}
+
 func serializeSearchAttributes(
 	untypedAttributes map[string]interface{},
 	typedAttributes SearchAttributes,
@@ -435,7 +460,7 @@ func serializeSearchAttributes(
 			return nil, err
 		}
 	}
-	return searchAttr, nil
+	return sanitizeSearchAttributesForStart(searchAttr), nil
 }
 
 func convertToTypedSearchAttributes(logger log.Logger, attributes map[string]*commonpb.Payload) SearchAttributes {

--- a/internal/internal_search_attributes.go
+++ b/internal/internal_search_attributes.go
@@ -426,7 +426,7 @@ func sanitizeSearchAttributesForStart(attributes *commonpb.SearchAttributes) *co
 	filteredAttributes := make(map[string]*commonpb.Payload, len(attributes.IndexedFields))
 	filteredAny := false
 	for key, payload := range attributes.IndexedFields {
-		if payload == nil || string(payload.GetMetadata()[converter.MetadataEncoding]) == converter.MetadataEncodingNil {
+		if string(payload.GetMetadata()[converter.MetadataEncoding]) == converter.MetadataEncodingNil {
 			filteredAny = true
 			continue
 		}

--- a/internal/internal_search_attributes.go
+++ b/internal/internal_search_attributes.go
@@ -416,8 +416,9 @@ func serializeTypedSearchAttributes(searchAttributes map[SearchAttributeKey]inte
 	return &commonpb.SearchAttributes{IndexedFields: serializedAttr}, nil
 }
 
-// Start-like requests should not carry null or unset search attributes, even
-// though workflow info may still contain them in the current run.
+// sanitizeSearchAttributesForStart removes null or unset search attributes from
+// Start-like requests, even though workflow info may still contain them in the
+// current run.
 func sanitizeSearchAttributesForStart(attributes *commonpb.SearchAttributes) *commonpb.SearchAttributes {
 	indexedFields := attributes.GetIndexedFields()
 	if len(indexedFields) == 0 {

--- a/internal/internal_search_attributes.go
+++ b/internal/internal_search_attributes.go
@@ -419,7 +419,7 @@ func serializeTypedSearchAttributes(searchAttributes map[SearchAttributeKey]inte
 // Start-like requests should not carry null or unset search attributes, even
 // though workflow info may still contain them in the current run.
 func sanitizeSearchAttributesForStart(attributes *commonpb.SearchAttributes) *commonpb.SearchAttributes {
-	if attributes == nil || len(attributes.IndexedFields) == 0 {
+	if len(attributes.GetIndexedFields()) == 0 {
 		return attributes
 	}
 

--- a/internal/internal_search_attributes.go
+++ b/internal/internal_search_attributes.go
@@ -419,21 +419,27 @@ func serializeTypedSearchAttributes(searchAttributes map[SearchAttributeKey]inte
 // Start-like requests should not carry null or unset search attributes, even
 // though workflow info may still contain them in the current run.
 func sanitizeSearchAttributesForStart(attributes *commonpb.SearchAttributes) *commonpb.SearchAttributes {
-	if len(attributes.GetIndexedFields()) == 0 {
+	indexedFields := attributes.GetIndexedFields()
+	if len(indexedFields) == 0 {
 		return attributes
 	}
 
-	filteredAttributes := make(map[string]*commonpb.Payload, len(attributes.IndexedFields))
-	filteredAny := false
-	for key, payload := range attributes.IndexedFields {
+	var filteredAttributes map[string]*commonpb.Payload
+	for _, payload := range indexedFields {
 		if string(payload.GetMetadata()[converter.MetadataEncoding]) == converter.MetadataEncodingNil {
-			filteredAny = true
+			filteredAttributes = make(map[string]*commonpb.Payload, len(indexedFields)-1)
+			break
+		}
+	}
+	if filteredAttributes == nil {
+		return attributes
+	}
+
+	for key, payload := range indexedFields {
+		if string(payload.GetMetadata()[converter.MetadataEncoding]) == converter.MetadataEncodingNil {
 			continue
 		}
 		filteredAttributes[key] = payload
-	}
-	if !filteredAny {
-		return attributes
 	}
 	if len(filteredAttributes) == 0 {
 		return nil

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -1901,7 +1901,7 @@ func (wth *workflowTaskHandlerImpl) completeWorkflow(
 			WorkflowTaskTimeout:       durationpb.New(contErr.WorkflowTaskTimeout),
 			Header:                    contErr.Header,
 			Memo:                      workflowContext.workflowInfo.Memo,
-			SearchAttributes:          workflowContext.workflowInfo.SearchAttributes,
+			SearchAttributes:          sanitizeSearchAttributesForStart(workflowContext.workflowInfo.SearchAttributes),
 			RetryPolicy:               convertToPBRetryPolicy(retryPolicy),
 			InheritBuildId:            useCompat,
 			InitialVersioningBehavior: continueAsNewVersioningBehaviorToProto(contErr.InitialVersioningBehavior),

--- a/internal/internal_workflow_client_test.go
+++ b/internal/internal_workflow_client_test.go
@@ -1762,8 +1762,12 @@ func (s *workflowClientTestSuite) TestStartWorkflowWithMemoAndSearchAttr() {
 	memo := map[string]interface{}{
 		"testMemo": "memo value",
 	}
+	nilPayload, err := converter.GetDefaultDataConverter().ToPayload(nil)
+	s.NoError(err)
 	searchAttributes := map[string]interface{}{
-		"testAttr": "attr value",
+		"testAttr":       "attr value",
+		"nilAttr":        nil,
+		"nilPayloadAttr": nilPayload,
 	}
 	options := StartWorkflowOptions{
 		ID:                       workflowID,
@@ -1788,6 +1792,11 @@ func (s *workflowClientTestSuite) TestStartWorkflowWithMemoAndSearchAttr() {
 			err = converter.GetDefaultDataConverter().FromPayload(req.SearchAttributes.IndexedFields["testAttr"], &resultAttr)
 			s.NoError(err)
 			s.Equal("attr value", resultAttr)
+			s.Len(req.SearchAttributes.IndexedFields, 1)
+			_, ok := req.SearchAttributes.IndexedFields["nilAttr"]
+			s.False(ok)
+			_, ok = req.SearchAttributes.IndexedFields["nilPayloadAttr"]
+			s.False(ok)
 		})
 	_, _ = s.client.ExecuteWorkflow(context.Background(), options, wf)
 }
@@ -1796,8 +1805,12 @@ func (s *workflowClientTestSuite) TestSignalWithStartWorkflowWithMemoAndSearchAt
 	memo := map[string]interface{}{
 		"testMemo": "memo value",
 	}
+	nilPayload, err := converter.GetDefaultDataConverter().ToPayload(nil)
+	s.NoError(err)
 	searchAttributes := map[string]interface{}{
-		"testAttr": "attr value",
+		"testAttr":       "attr value",
+		"nilAttr":        nil,
+		"nilPayloadAttr": nilPayload,
 	}
 	options := StartWorkflowOptions{
 		ID:                       "wid",
@@ -1822,6 +1835,11 @@ func (s *workflowClientTestSuite) TestSignalWithStartWorkflowWithMemoAndSearchAt
 			err = converter.GetDefaultDataConverter().FromPayload(req.SearchAttributes.IndexedFields["testAttr"], &resultAttr)
 			s.NoError(err)
 			s.Equal("attr value", resultAttr)
+			s.Len(req.SearchAttributes.IndexedFields, 1)
+			_, ok := req.SearchAttributes.IndexedFields["nilAttr"]
+			s.False(ok)
+			_, ok = req.SearchAttributes.IndexedFields["nilPayloadAttr"]
+			s.False(ok)
 		})
 	_, _ = s.client.SignalWithStartWorkflow(context.Background(), "wid", "signal", "value", options, wf)
 }
@@ -2065,6 +2083,16 @@ func (s *workflowClientTestSuite) TestSerializeSearchAttributes() {
 	_ = converter.GetDefaultDataConverter().FromPayload(result3.IndexedFields["t1"], &resultString)
 	s.Equal("v1", resultString)
 
+	input1 = map[string]interface{}{
+		"nil-attr": nil,
+	}
+	resultNil, err := serializeUntypedSearchAttributes(input1)
+	s.NoError(err)
+	s.NotNil(resultNil)
+	s.Contains(resultNil.IndexedFields, "nil-attr")
+	s.NotNil(resultNil.IndexedFields["nil-attr"])
+	s.Nil(resultNil.IndexedFields["nil-attr"].GetData())
+
 	// *Payload type goes through.
 	p, err := converter.GetDefaultDataConverter().ToPayload("5eaf00d")
 	s.NoError(err)
@@ -2083,6 +2111,44 @@ func (s *workflowClientTestSuite) TestSerializeSearchAttributes() {
 	}
 	_, err = serializeUntypedSearchAttributes(input1)
 	s.Error(err)
+}
+
+func (s *workflowClientTestSuite) TestSerializeSearchAttributesOmitsNilValuesOnStart() {
+	nilPayload, err := converter.GetDefaultDataConverter().ToPayload(nil)
+	s.NoError(err)
+	payload, err := converter.GetDefaultDataConverter().ToPayload("value")
+	s.NoError(err)
+	var nilBytes []byte
+	nilBytesPayload, err := converter.GetDefaultDataConverter().ToPayload(nilBytes)
+	s.NoError(err)
+
+	result, err := serializeSearchAttributes(map[string]interface{}{
+		"realAttr":          payload,
+		"nilAttr":           nil,
+		"nilPayloadAttr":    nilPayload,
+		"nilBytesPayload":   nilBytesPayload,
+		"typedNilBytesAttr": nilBytes,
+	}, SearchAttributes{})
+	s.NoError(err)
+	s.NotNil(result)
+	s.Len(result.IndexedFields, 3)
+	_, ok := result.IndexedFields["nilAttr"]
+	s.False(ok)
+	_, ok = result.IndexedFields["nilPayloadAttr"]
+	s.False(ok)
+	s.Equal(converter.MetadataEncodingBinary, string(result.IndexedFields["nilBytesPayload"].GetMetadata()[converter.MetadataEncoding]))
+	s.Nil(result.IndexedFields["nilBytesPayload"].GetData())
+	s.Equal(converter.MetadataEncodingBinary, string(result.IndexedFields["typedNilBytesAttr"].GetMetadata()[converter.MetadataEncoding]))
+	s.Nil(result.IndexedFields["typedNilBytesAttr"].GetData())
+
+	var resultString string
+	err = converter.GetDefaultDataConverter().FromPayload(result.IndexedFields["realAttr"], &resultString)
+	s.NoError(err)
+	s.Equal("value", resultString)
+
+	result, err = serializeSearchAttributes(map[string]interface{}{"nilAttr": nil}, SearchAttributes{})
+	s.NoError(err)
+	s.Nil(result)
 }
 
 func (s *workflowClientTestSuite) TestListWorkflow() {

--- a/internal/workflow_testsuite.go
+++ b/internal/workflow_testsuite.go
@@ -1271,7 +1271,7 @@ func (e *TestWorkflowEnvironment) SetSearchAttributesOnStart(searchAttributes ma
 	if err != nil {
 		return err
 	}
-	e.impl.workflowInfo.SearchAttributes = attr
+	e.impl.workflowInfo.SearchAttributes = sanitizeSearchAttributesForStart(attr)
 	return nil
 }
 

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -695,6 +695,25 @@ func (ts *IntegrationTestSuite) TestContinueAsNewCarryOver() {
 	ts.Equal("memoVal,searchAttr,123", result)
 }
 
+func (ts *IntegrationTestSuite) TestContinueAsNewOmitsUnsetSearchAttributes() {
+	var result string
+	stringKey := temporal.NewSearchAttributeKeyString("CustomStringField")
+	keywordKey := temporal.NewSearchAttributeKeyKeyword("CustomKeywordField")
+	startOptions := ts.startWorkflowOptions("test-continueasnew-omit-unset-search-attributes")
+	startOptions.TypedSearchAttributes = temporal.NewSearchAttributes(
+		stringKey.ValueSet("carry-over"),
+		keywordKey.ValueSet("drop-me"),
+	)
+	err := ts.executeWorkflowWithOption(
+		startOptions,
+		ts.workflows.ContinueAsNewAfterUnsetSearchAttribute,
+		&result,
+		false,
+	)
+	ts.NoError(err)
+	ts.Equal("carry-over", result)
+}
+
 func (ts *IntegrationTestSuite) TestContinueAsNewWithRetryPolicy() {
 	const (
 		initialMaximumAttempts = 3

--- a/test/workflow_test.go
+++ b/test/workflow_test.go
@@ -548,6 +548,59 @@ func (w *Workflows) ContinueAsNewWithOptions(ctx workflow.Context, count int, ta
 	return "", workflow.NewContinueAsNewError(ctx, w.ContinueAsNewWithOptions, count-1, taskQueue)
 }
 
+func (w *Workflows) ContinueAsNewAfterUnsetSearchAttribute(ctx workflow.Context, continued bool) (string, error) {
+	info := workflow.GetInfo(ctx)
+	if info.SearchAttributes == nil {
+		return "", errors.New("search attributes are not present")
+	}
+
+	fields := info.SearchAttributes.GetIndexedFields()
+	stringPayload, ok := fields["CustomStringField"]
+	if !ok {
+		return "", errors.New("search attribute CustomStringField not present")
+	}
+
+	var stringValue string
+	err := converter.GetDefaultDataConverter().FromPayload(stringPayload, &stringValue)
+	if err != nil {
+		return "", errors.New("error when get CustomStringField value")
+	}
+	if stringValue != "carry-over" {
+		return "", fmt.Errorf("unexpected CustomStringField value: %s", stringValue)
+	}
+
+	keywordKey := temporal.NewSearchAttributeKeyKeyword("CustomKeywordField")
+	if !continued {
+		keywordPayload, ok := fields["CustomKeywordField"]
+		if !ok {
+			return "", errors.New("search attribute CustomKeywordField not present before unset")
+		}
+
+		var keywordValue string
+		err = converter.GetDefaultDataConverter().FromPayload(keywordPayload, &keywordValue)
+		if err != nil {
+			return "", errors.New("error when get CustomKeywordField value")
+		}
+		if keywordValue != "drop-me" {
+			return "", fmt.Errorf("unexpected CustomKeywordField value: %s", keywordValue)
+		}
+
+		err = workflow.UpsertTypedSearchAttributes(ctx, keywordKey.ValueUnset())
+		if err != nil {
+			return "", err
+		}
+		return "", workflow.NewContinueAsNewError(ctx, w.ContinueAsNewAfterUnsetSearchAttribute, true)
+	}
+
+	if _, ok := fields["CustomKeywordField"]; ok {
+		return "", errors.New("unset search attribute carried over")
+	}
+	if keywordValue, ok := workflow.GetTypedSearchAttributes(ctx).GetKeyword(keywordKey); ok || keywordValue != "" {
+		return "", errors.New("unset search attribute unexpectedly present in typed search attributes")
+	}
+	return stringValue, nil
+}
+
 func (w *Workflows) ContinueAsNewWithRetryPolicy(
 	ctx workflow.Context,
 	initialMaximumAttempts int,
@@ -3858,6 +3911,7 @@ func (w *Workflows) register(worker worker.Worker) {
 	worker.RegisterWorkflow(w.ContinueAsNew)
 	worker.RegisterWorkflow(w.UpsertSearchAttributesConditional)
 	worker.RegisterWorkflow(w.UpsertMemoConditional)
+	worker.RegisterWorkflow(w.ContinueAsNewAfterUnsetSearchAttribute)
 	worker.RegisterWorkflow(w.ContinueAsNewWithOptions)
 	worker.RegisterWorkflow(w.ContinueAsNewWithRetryPolicy)
 	worker.RegisterWorkflow(w.ContinueAsNewWithChildWF)


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
💥 Start-like requests now omit unset search attributes instead of sending `binary/null` payloads in `SearchAttributes`.

Added `sanitizeSearchAttributesForStart` and applied it to:
- workflow start serialization
- continue-as-new requests
- workflow test environment start setup

Also added regression coverage to verify that:
- `nil` / `MetadataEncodingNil` search attributes are removed from start requests
- non-nil payloads that happen to have `Data == nil` (for example `[]byte(nil)` encoded as `binary/plain`) are preserved
- continue-as-new no longer carries over a search attribute after it has been unset

## Why?
Unset search attributes are represented in workflow state as nil payloads so upserts can remove them, but start-like requests should not resend those unset values.

Without this change, a workflow that unset a search attribute and then continued as new could carry that removed attribute forward incorrectly. The sanitization is intentionally keyed to `MetadataEncodingNil` so we only drop true nil payloads and do not accidentally strip other payloads that may have `Data == nil`.

## 💥 Behavior change details
- Workflow start and signal-with-start requests now omit search attributes encoded as `MetadataEncodingNil` (`binary/null`) instead of sending them to the server.
- Continue-as-new now applies the same sanitization, so a search attribute removed in the current run is not carried into the next run.
- The filtering is based on payload encoding, not `payload.Data == nil`, so values like `[]byte(nil)` encoded as `binary/plain` are still sent.
- The workflow test environment start helpers now mirror this behavior so tests match production request construction.

## Checklist

1. Closes #2150 

2. How was this tested:
Added/updated tests in:
- `internal/internal_workflow_client_test.go`
- `test/integration_test.go`
- `test/workflow_test.go`

Ran:
```sh
go test ./internal -run 'TestWorkflowClientSuite/(TestStartWorkflowWithMemoAndSearchAttr|TestSignalWithStartWorkflowWithMemoAndSearchAttr|TestSerializeSearchAttributesOmitsNilValuesOnStart)$'
```

The broader integration suite was not run in this session.

3. Any docs updates needed?
No.
