### PR TITLE
Remove flag for cancelling worker polls on shutdown

### DIFF
--- a/internal/cmd/build/main.go
+++ b/internal/cmd/build/main.go
@@ -161,7 +161,6 @@ func (b *builder) integrationTest() error {
 				"--dynamic-config-value", `component.nexusoperations.useSystemCallbackURL=false`,
 				"--dynamic-config-value", `component.nexusoperations.callback.endpoint.template="http://localhost:7243/namespaces/{{.NamespaceName}}/nexus/callback"`,
 				"--dynamic-config-value", "frontend.ListWorkersEnabled=true",
-				"--dynamic-config-value", "frontend.enableCancelWorkerPollsOnShutdown=true",
 			},
 		})
 		if err != nil {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Remove the `frontend.enableCancelWorkerPollsOnShutdown` server flag.

## Why?

The flag is not needed until https://github.com/temporalio/temporal/pull/9545 is rolled out and available.

## Checklist
<!--- add/delete as needed --->
1. How was this tested: Existing tests
1. Any docs updates needed? No
