### PR TITLE
Expose Nexus Endpoint in Nexus Info

### DIFF
--- a/internal/internal_nexus_task_handler.go
+++ b/internal/internal_nexus_task_handler.go
@@ -450,6 +450,7 @@ func (h *nexusTaskHandler) newNexusOperationContext(response *workflowservice.Po
 
 	return &NexusOperationContext{
 		client:         h.client,
+		Endpoint:       response.GetRequest().GetEndpoint(),
 		Namespace:      h.namespace,
 		TaskQueue:      h.taskQueueName,
 		metricsHandler: metricsHandler,

--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -3568,6 +3568,7 @@ func (h *testNexusOperationHandle) newStartTask() *workflowservice.PollNexusTask
 		Request: &nexuspb.Request{
 			ScheduledTime: timestamppb.Now(),
 			Header:        h.params.nexusHeader,
+			Endpoint:      h.params.client.Endpoint(),
 			Capabilities: &nexuspb.Request_Capabilities{
 				TemporalFailureResponses: true,
 			},
@@ -3595,6 +3596,7 @@ func (h *testNexusOperationHandle) newCancelTask() *workflowservice.PollNexusTas
 		Request: &nexuspb.Request{
 			ScheduledTime: timestamppb.Now(),
 			Header:        h.params.nexusHeader,
+			Endpoint:      h.params.client.Endpoint(),
 			Capabilities: &nexuspb.Request_Capabilities{
 				TemporalFailureResponses: true,
 			},

--- a/internal/nexus_operations.go
+++ b/internal/nexus_operations.go
@@ -28,6 +28,9 @@ type NexusOperationInfo struct {
 	Namespace string
 	// The task queue of the worker handling this Nexus operation.
 	TaskQueue string
+	// The endpoint this request was addressed to before forwarding to the worker.
+	// Supported from server version 1.30.0.
+	Endpoint string
 }
 
 // NexusOperationContext is an internal only struct that holds fields used by the temporalnexus functions.
@@ -35,6 +38,7 @@ type NexusOperationContext struct {
 	client         Client
 	Namespace      string
 	TaskQueue      string
+	Endpoint       string
 	metricsHandler metrics.Handler
 	log            log.Logger
 	registry       *registry
@@ -54,6 +58,7 @@ func (nc *nexusOperationEnvironment) GetOperationInfo(ctx context.Context) Nexus
 		panic("temporalnexus GetInfo: Not a valid Nexus context")
 	}
 	return NexusOperationInfo{
+		Endpoint:  nctx.Endpoint,
 		Namespace: nctx.Namespace,
 		TaskQueue: nctx.TaskQueue,
 	}

--- a/test/nexus_test.go
+++ b/test/nexus_test.go
@@ -548,7 +548,7 @@ func TestOperationInfo(t *testing.T) {
 
 	op := nexus.NewSyncOperation("op", func(ctx context.Context, outcome string, o nexus.StartOperationOptions) (string, error) {
 		info := temporalnexus.GetOperationInfo(ctx)
-		return info.Namespace + ":" + info.TaskQueue, nil
+		return info.Endpoint + ":" + info.Namespace + ":" + info.TaskQueue, nil
 	})
 
 	wf := func(ctx workflow.Context, outcome string) (string, error) {
@@ -586,7 +586,7 @@ func TestOperationInfo(t *testing.T) {
 	require.NoError(t, err)
 	var result string
 	require.NoError(t, run.Get(ctx, &result))
-	require.Equal(t, tc.testConfig.Namespace+":"+tc.taskQueue, result)
+	require.Equal(t, tc.endpoint+":"+tc.testConfig.Namespace+":"+tc.taskQueue, result)
 }
 
 func TestSyncOperationFromWorkflow(t *testing.T) {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Expose the Nexus Endpoint to the SDK.

## Why?
So the handler knows what endpoint the request originally came from for visibility and per endpoint encryption

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

closes https://github.com/temporalio/sdk-go/issues/2290

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, additive change that plumbs a new `Endpoint` field through Nexus operation context and updates tests; no behavior changes beyond exposing extra metadata when supported by newer servers.
> 
> **Overview**
> **Expose the original Nexus endpoint on operation context/info.** The Nexus task handler now captures `Request.Endpoint` and stores it on `NexusOperationContext`, and `temporalnexus.GetOperationInfo` returns it via a new `Endpoint` field on `NexusOperationInfo` (noted as supported from server `1.30.0`).
> 
> Tests and the internal workflow test suite were updated to populate `Request.Endpoint` and assert the endpoint is included in operation info.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 556a112ca09e46fb7e7f682862932e4610553a2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->