### PR TITLE
Experimental: Payload HTTP Handler for Codecs and External Storage

### DIFF
--- a/converter/codec.go
+++ b/converter/codec.go
@@ -110,9 +110,9 @@ func (*zlibCodec) Decode(payloads []*commonpb.Payload) ([]*commonpb.Payload, err
 
 func decodePayloads(payloads []*commonpb.Payload, codecs []PayloadCodec) ([]*commonpb.Payload, error) {
 	var err error
-	// Iterate backwards encoding
-	for i := len(codecs) - 1; i >= 0; i-- {
-		if payloads, err = codecs[i].Decode(payloads); err != nil {
+	// Iterate forwards decoding
+	for _, codec := range codecs {
+		if payloads, err = codec.Decode(payloads); err != nil {
 			return payloads, err
 		}
 	}
@@ -121,9 +121,9 @@ func decodePayloads(payloads []*commonpb.Payload, codecs []PayloadCodec) ([]*com
 
 func encodePayloads(payloads []*commonpb.Payload, codecs []PayloadCodec) ([]*commonpb.Payload, error) {
 	var err error
-	// Iterate forwards decoding
-	for _, codec := range codecs {
-		if payloads, err = codec.Encode(payloads); err != nil {
+	// Iterate backwards encoding
+	for i := len(codecs) - 1; i >= 0; i-- {
+		if payloads, err = codecs[i].Encode(payloads); err != nil {
 			return payloads, err
 		}
 	}

--- a/converter/codec.go
+++ b/converter/codec.go
@@ -108,6 +108,28 @@ func (*zlibCodec) Decode(payloads []*commonpb.Payload) ([]*commonpb.Payload, err
 	return result, nil
 }
 
+func decodePayloads(payloads []*commonpb.Payload, codecs []PayloadCodec) ([]*commonpb.Payload, error) {
+	var err error
+	// Iterate backwards encoding
+	for i := len(codecs) - 1; i >= 0; i-- {
+		if payloads, err = codecs[i].Decode(payloads); err != nil {
+			return payloads, err
+		}
+	}
+	return payloads, nil
+}
+
+func encodePayloads(payloads []*commonpb.Payload, codecs []PayloadCodec) ([]*commonpb.Payload, error) {
+	var err error
+	// Iterate forwards decoding
+	for _, codec := range codecs {
+		if payloads, err = codec.Encode(payloads); err != nil {
+			return payloads, err
+		}
+	}
+	return payloads, nil
+}
+
 // CodecDataConverter is a DataConverter that wraps an underlying data
 // converter and supports chained encoding of just the payload without regard
 // for serialization to/from actual types.
@@ -126,25 +148,11 @@ func NewCodecDataConverter(parent DataConverter, codecs ...PayloadCodec) DataCon
 }
 
 func (e *CodecDataConverter) encode(payloads []*commonpb.Payload) ([]*commonpb.Payload, error) {
-	var err error
-	// Iterate backwards encoding
-	for i := len(e.codecs) - 1; i >= 0; i-- {
-		if payloads, err = e.codecs[i].Encode(payloads); err != nil {
-			return payloads, err
-		}
-	}
-	return payloads, nil
+	return encodePayloads(payloads, e.codecs)
 }
 
 func (e *CodecDataConverter) decode(payloads []*commonpb.Payload) ([]*commonpb.Payload, error) {
-	var err error
-	// Iterate forwards decoding
-	for _, codec := range e.codecs {
-		if payloads, err = codec.Decode(payloads); err != nil {
-			return payloads, err
-		}
-	}
-	return payloads, nil
+	return decodePayloads(payloads, e.codecs)
 }
 
 // ToPayload implements DataConverter.ToPayload performing encoding on the
@@ -260,23 +268,11 @@ type codecHTTPHandler struct {
 }
 
 func (e *codecHTTPHandler) encode(payloads []*commonpb.Payload) ([]*commonpb.Payload, error) {
-	var err error
-	for i := len(e.codecs) - 1; i >= 0; i-- {
-		if payloads, err = e.codecs[i].Encode(payloads); err != nil {
-			return payloads, err
-		}
-	}
-	return payloads, nil
+	return encodePayloads(payloads, e.codecs)
 }
 
 func (e *codecHTTPHandler) decode(payloads []*commonpb.Payload) ([]*commonpb.Payload, error) {
-	var err error
-	for _, codec := range e.codecs {
-		if payloads, err = codec.Decode(payloads); err != nil {
-			return payloads, err
-		}
-	}
-	return payloads, nil
+	return decodePayloads(payloads, e.codecs)
 }
 
 // ServeHTTP implements the http.Handler interface.

--- a/converter/extstore.go
+++ b/converter/extstore.go
@@ -1,94 +1,46 @@
 package converter
 
-import (
-	"context"
-
-	commonpb "go.temporal.io/api/common/v1"
-)
+import "go.temporal.io/sdk/internal/extstore"
 
 // StorageDriverTargetInfo identifies the workflow or activity on whose behalf
 // a payload is being stored. Use a type switch on [StorageDriverWorkflowInfo]
 // and [StorageDriverActivityInfo] to access the concrete values.
 //
 // NOTE: Experimental
-type StorageDriverTargetInfo interface {
-	isStorageDriverTargetInfo()
-}
+type StorageDriverTargetInfo = extstore.StorageDriverTargetInfo
 
 // StorageDriverWorkflowInfo carries workflow identity for a storage operation.
 //
 // NOTE: Experimental
-type StorageDriverWorkflowInfo struct {
-	// Namespace is the Temporal namespace of the workflow execution.
-	Namespace string
-	// WorkflowType is the type name of the workflow.
-	WorkflowType string
-	// WorkflowID is the ID of the workflow execution.
-	WorkflowID string
-	// RunID is the run ID of the workflow execution.
-	RunID string
-}
-
-func (StorageDriverWorkflowInfo) isStorageDriverTargetInfo() {}
-
-var _ StorageDriverTargetInfo = StorageDriverWorkflowInfo{}
+type StorageDriverWorkflowInfo = extstore.StorageDriverWorkflowInfo
 
 // StorageDriverActivityInfo carries activity identity for a storage operation.
 // This is only used for standalone (non-workflow-bound) activities; activities
 // started by a workflow use [StorageDriverWorkflowInfo] as the target.
 //
 // NOTE: Experimental
-type StorageDriverActivityInfo struct {
-	// Namespace is the Temporal namespace of the activity execution.
-	Namespace string
-	// ActivityType is the type name of the activity.
-	ActivityType string
-	// ActivityID is the ID of the activity execution.
-	ActivityID string
-	// RunID is the run ID of the activity execution.
-	RunID string
-}
-
-func (StorageDriverActivityInfo) isStorageDriverTargetInfo() {}
-
-var _ StorageDriverTargetInfo = StorageDriverActivityInfo{}
+type StorageDriverActivityInfo = extstore.StorageDriverActivityInfo
 
 // StorageDriverStoreContext carries context passed to StorageDriver.Store and
 // StorageDriverSelector.SelectDriver operations.
 //
 // NOTE: Experimental
-type StorageDriverStoreContext struct {
-	// Context is the context of the operation that triggered the driver call.
-	// Drivers should use it to respect cancellation and to propagate deadlines
-	// and trace information to downstream calls (e.g. cloud storage SDKs).
-	Context context.Context
-	// Target identifies the workflow or activity on whose behalf payloads are
-	// being stored. Use a type switch on [StorageDriverWorkflowInfo] and
-	// [StorageDriverActivityInfo] to access the concrete values.
-	Target StorageDriverTargetInfo
-}
+type StorageDriverStoreContext = extstore.StorageDriverStoreContext
 
 // StorageDriverRetrieveContext carries context passed to StorageDriver.Retrieve
 // operations.
 //
 // NOTE: Experimental
-type StorageDriverRetrieveContext struct {
-	// Context is the context of the operation that triggered the driver call.
-	// Drivers should use it to respect cancellation and to propagate deadlines
-	// and trace information to downstream calls (e.g. cloud storage SDKs).
-	Context context.Context
-}
+type StorageDriverRetrieveContext = extstore.StorageDriverRetrieveContext
 
 // StorageDriverClaim is an opaque token returned by StorageDriver.Store that
 // identifies where a payload was stored. The SDK serializes it alongside the
 // payload metadata so that StorageDriver.Retrieve can locate the data later.
 // Drivers encode their own addressing information (e.g. a bucket name and
-// object key) into the Data map.
+// object key) into the ClaimData map.
 //
 // NOTE: Experimental
-type StorageDriverClaim struct {
-	ClaimData map[string]string `json:"claim_data"`
-}
+type StorageDriverClaim = extstore.StorageDriverClaim
 
 // StorageDriver is the interface that must be implemented to back external
 // payload storage. When a payload exceeds the configured size threshold the SDK
@@ -98,32 +50,7 @@ type StorageDriverClaim struct {
 // the data converter.
 //
 // NOTE: Experimental
-type StorageDriver interface {
-	// Name returns a stable, unique identifier for this driver instance. The
-	// name is stored in the Temporal history alongside each claim so that the
-	// correct driver is selected on the retrieval path. Multiple instances of
-	// the same driver type can be registered simultaneously under different
-	// names, allowing a DriverSelector to route payloads to different backends
-	// of the same kind. Changing the name of a deployed driver will cause
-	// retrieval to fail for any payloads that were stored under the old name.
-	Name() string
-
-	// Type identifies the driver implementation. Unlike Name, Type must be
-	// identical across all instances of the same driver type regardless of how
-	// they are configured or named.
-	Type() string
-
-	// Store persists the given payloads and returns one StorageDriverClaim per
-	// payload in the same order. The returned claims are serialized into the
-	// Temporal event and must contain enough information for Retrieve to locate
-	// the data. Store must not modify the input payloads.
-	Store(ctx StorageDriverStoreContext, payloads []*commonpb.Payload) ([]StorageDriverClaim, error)
-
-	// Retrieve fetches the payloads identified by the given claims, returning
-	// one payload per claim in the same order. It must not modify the input
-	// claims.
-	Retrieve(ctx StorageDriverRetrieveContext, claims []StorageDriverClaim) ([]*commonpb.Payload, error)
-}
+type StorageDriver = extstore.StorageDriver
 
 // StorageDriverSelector chooses which StorageDriver should store a given
 // payload, or returns nil to leave the payload inline (not stored externally).
@@ -134,9 +61,7 @@ type StorageDriver interface {
 // threshold.
 //
 // NOTE: Experimental
-type StorageDriverSelector interface {
-	SelectDriver(ctx StorageDriverStoreContext, payloads *commonpb.Payload) (StorageDriver, error)
-}
+type StorageDriverSelector = extstore.StorageDriverSelector
 
 // ExternalStorage configures external payload storage for a Temporal client or
 // worker. When set, the SDK intercepts payloads on the way to and from the
@@ -146,25 +71,4 @@ type StorageDriverSelector interface {
 // original payloads before they reach the data converter or application code.
 //
 // NOTE: Experimental
-type ExternalStorage struct {
-	// Drivers is the list of available storage drivers. At least one driver
-	// must be provided. If no DriverSelector is set, the first driver is used
-	// for all payloads that exceed the size threshold. All drivers listed here
-	// must have unique names; duplicates are rejected at client/worker
-	// construction time.
-	Drivers []StorageDriver
-
-	// DriverSelector routes each payload to a specific driver, or returns nil
-	// to leave the payload inline. When DriverSelector itself is nil, Drivers[0]
-	// is used for every oversized payload. The selector is invoked after the
-	// payload has been serialized by the data converter, so it can inspect
-	// encoding metadata and raw size to make routing decisions.
-	DriverSelector StorageDriverSelector
-
-	// PayloadSizeThreshold is the minimum serialized payload size in bytes that
-	// triggers external storage. Payloads smaller than this value are left
-	// inline in the Temporal history event. A value of zero uses the default
-	// threshold of 256 KiB. Negative values are rejected at client/worker
-	// construction time.
-	PayloadSizeThreshold int
-}
+type ExternalStorage = extstore.ExternalStorage

--- a/converter/payload_handler.go
+++ b/converter/payload_handler.go
@@ -3,11 +3,11 @@
 //
 // The handler exposes two routes:
 //
-//   - POST /ui/decode — decodes payloads through the post-storage then pre-storage
+//   - POST /decode — decodes payloads through the post-storage then pre-storage
 //     codec chains. If a payload is a storage reference after post-storage
-//     decoding it is returned as-is so the caller can resolve it via /ui/download.
+//     decoding it is returned as-is so the caller can resolve it via /download.
 //
-//   - POST /ui/download — accepts storage reference payloads, retrieves the
+//   - POST /download — accepts storage reference payloads, retrieves the
 //     original payloads from the configured storage drivers, then decodes
 //     them through the pre-storage codec chain.
 //
@@ -31,15 +31,14 @@ import (
 )
 
 const (
-	uiDecodePath   = "/ui/decode"
-	uiDownloadPath = "/ui/download"
+	downloadPath = "/download"
 )
 
-// UIPayloadHTTPHandlerOptions configures a storage and codec aware HTTP handler
+// PayloadHTTPHandlerOptions configures a storage and codec aware HTTP handler
 // for use with Temporal Web UI.
 //
 // NOTE: Experimental
-type UIPayloadHTTPHandlerOptions struct {
+type PayloadHTTPHandlerOptions struct {
 	// PostStorageCodecs are codecs applied outside the storage layer, e.g. a
 	// proxy codec that wraps the entire payload.
 	// They run last on encode (after external storage) and first on decode
@@ -56,62 +55,51 @@ type UIPayloadHTTPHandlerOptions struct {
 	// NOTE: Experimental.
 	PreStorageCodecs []PayloadCodec
 
-	// StorageDrivers provides the storage drivers used by the /download route to
+	// ExternalStorage provides the storage drivers used by the /download route to
 	// retrieve payloads identified by storage reference claims. Driver names
 	// must be unique. If no drivers are configured, /download returns HTTP 400.
 	//
 	// NOTE: Experimental.
-	StorageDrivers []StorageDriver
+	ExternalStorage ExternalStorage
 }
 
-// noopDriverSelector to satisfy the StorageDriverSelector interface when constructing
-// the retrieval visitor. It is never actually used because the visitor only performs retrieval operations.
-type noopDriverSelector struct{}
-
-func (noopDriverSelector) SelectDriver(_ StorageDriverStoreContext, _ *commonpb.Payload) (StorageDriver, error) {
-	return nil, nil
-}
-
-type uiPayloadHTTPHandler struct {
+type payloadHTTPHandler struct {
 	postStorageCodecs []PayloadCodec
 	preStorageCodecs  []PayloadCodec
-	retrievalVisitor  extstore.PayloadVisitor // nil when no drivers configured
+	retrievalVisitor  extstore.PayloadVisitor
+	storageVisitor    extstore.PayloadVisitor
 }
 
-var _ http.Handler = (*uiPayloadHTTPHandler)(nil)
+var _ http.Handler = (*payloadHTTPHandler)(nil)
 
-// NewUIPayloadHTTPHandler creates an [http.Handler] that serves /ui/decode and
-// /ui/download routes for Temporal Web UI using the provided options.
+// NewPayloadHTTPHandler creates an [http.Handler] that serves /decode, /download, and
+// /encode routes for remote payload transformations.
 //
 // NOTE: Experimental
-func NewUIPayloadHTTPHandler(options UIPayloadHTTPHandlerOptions) (http.Handler, error) {
-	h := &uiPayloadHTTPHandler{
+func NewPayloadHTTPHandler(options PayloadHTTPHandlerOptions) (http.Handler, error) {
+	params, err := extstore.ExternalStorageToParams(options.ExternalStorage)
+	if err != nil {
+		return nil, err
+	}
+	h := &payloadHTTPHandler{
 		postStorageCodecs: options.PostStorageCodecs,
 		preStorageCodecs:  options.PreStorageCodecs,
-	}
-	if len(options.StorageDrivers) > 0 {
-		params, err := extstore.ExternalStorageToParams(ExternalStorage{
-			Drivers:        options.StorageDrivers,
-			DriverSelector: noopDriverSelector{},
-		})
-		if err != nil {
-			return nil, err
-		}
-		h.retrievalVisitor = extstore.NewExternalRetrievalVisitor(params)
+		retrievalVisitor:  extstore.NewExternalRetrievalVisitor(params),
+		storageVisitor:    extstore.NewExternalStorageVisitor(params),
 	}
 	return h, nil
 }
 
 // ServeHTTP implements [http.Handler].
-func (h *uiPayloadHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func (h *payloadHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.NotFound(w, r)
 		return
 	}
 
 	path := r.URL.Path
-	if !strings.HasSuffix(path, uiDecodePath) &&
-		!strings.HasSuffix(path, uiDownloadPath) {
+	if !strings.HasSuffix(path, remotePayloadCodecDecodePath) &&
+		!strings.HasSuffix(path, downloadPath) {
 		http.NotFound(w, r)
 		return
 	}
@@ -136,9 +124,9 @@ func (h *uiPayloadHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	payloads := payloadspb.Payloads
 
 	switch {
-	case strings.HasSuffix(path, uiDecodePath):
+	case strings.HasSuffix(path, remotePayloadCodecDecodePath):
 		payloads, err = h.decode(payloads)
-	case strings.HasSuffix(path, uiDownloadPath):
+	case strings.HasSuffix(path, downloadPath):
 		payloads, err = h.download(r, payloads)
 	default:
 		http.NotFound(w, r)
@@ -158,9 +146,9 @@ func (h *uiPayloadHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 
 // decode applies post-storage codecs (first-to-last) to all payloads. Any
 // payload that is a storage reference after this step is returned as-is so
-// the caller can resolve it via /ui/download. Remaining payloads are further
+// the caller can resolve it via /download. Remaining payloads are further
 // decoded through the pre-storage codecs (first-to-last).
-func (h *uiPayloadHTTPHandler) decode(payloads []*commonpb.Payload) ([]*commonpb.Payload, error) {
+func (h *payloadHTTPHandler) decode(payloads []*commonpb.Payload) ([]*commonpb.Payload, error) {
 	var err error
 
 	// Apply post-storage codecs to all payloads.
@@ -198,7 +186,7 @@ func (h *uiPayloadHTTPHandler) decode(payloads []*commonpb.Payload) ([]*commonpb
 // download validates that every payload is a storage reference, retrieves the
 // original payloads from the registered storage drivers, then decodes them
 // through the pre-storage codec chain.
-func (h *uiPayloadHTTPHandler) download(r *http.Request, payloads []*commonpb.Payload) ([]*commonpb.Payload, error) {
+func (h *payloadHTTPHandler) download(r *http.Request, payloads []*commonpb.Payload) ([]*commonpb.Payload, error) {
 	if h.retrievalVisitor == nil {
 		return nil, errors.New("no storage drivers configured")
 	}

--- a/converter/payload_handler.go
+++ b/converter/payload_handler.go
@@ -27,6 +27,9 @@ type PayloadHTTPHandlerOptions struct {
 	// PostStorageCodecs are codecs applied after external storage from the
 	// perspective of payloads going through a encoding transformation. These are
 	// typically the codecs that would be configured in the proxy's codec chain.
+	// When encoding, the codecs are applied last to first meaning the earlier
+	// codecs wrap the later ones. When decoding, the codecs are applied first
+	// to last to reverse the effect.
 	//
 	// NOTE: Experimental.
 	PostStorageCodecs []PayloadCodec
@@ -34,7 +37,9 @@ type PayloadHTTPHandlerOptions struct {
 	// PreStorageCodecs are codecs that are applied before external storage,
 	// from the perspective of payloads going through an encoding transformation.
 	// These are typically the codecs that would be configured in the DataConverter
-	// codec chain on a Temporal client.
+	// codec chain on a Temporal client. When encoding, the codecs are applied last
+	// to first meaning the earlier codecs wrap the later ones. When decoding, the
+	// codecs are applied first to last to reverse the effect.
 	//
 	// NOTE: Experimental.
 	PreStorageCodecs []PayloadCodec

--- a/converter/payload_handler.go
+++ b/converter/payload_handler.go
@@ -1,19 +1,5 @@
-// Package converter provides an HTTP handler for a Temporal codec server that
-// understands the two-layer codec architecture used with external payload storage.
-//
-// The handler exposes two routes:
-//
-//   - POST /decode — decodes payloads through the post-storage then pre-storage
-//     codec chains. If a payload is a storage reference after post-storage
-//     decoding it is returned as-is so the caller can resolve it via /download.
-//
-//   - POST /download — accepts storage reference payloads, retrieves the
-//     original payloads from the configured storage drivers, then decodes
-//     them through the pre-storage codec chain.
-//
-// The wire format for both routes is identical to the existing
-// [NewPayloadCodecHTTPHandler]: a JSON-encoded [commonpb.Payloads] request body
-// and response body, with Content-Type application/json.
+// Package converter provides an HTTP handler for a Temporal codec server with
+// support for external payload storage.
 
 package converter
 
@@ -34,30 +20,28 @@ const (
 	downloadPath = "/download"
 )
 
-// PayloadHTTPHandlerOptions configures a storage and codec aware HTTP handler
-// for use with Temporal Web UI.
+// PayloadHTTPHandlerOptions configures a [NewPayloadHTTPHandler].
 //
 // NOTE: Experimental
 type PayloadHTTPHandlerOptions struct {
-	// PostStorageCodecs are codecs applied outside the storage layer, e.g. a
-	// proxy codec that wraps the entire payload.
-	// They run last on encode (after external storage) and first on decode
-	// (before external retrieval).
+	// PostStorageCodecs are codecs applied after external storage from the
+	// perspective of payloads going through a encoding transformation. These are
+	// typically the codecs that would be configured in the proxy's codec chain.
 	//
 	// NOTE: Experimental.
 	PostStorageCodecs []PayloadCodec
 
-	// PreStorageCodecs are worker-configured codecs that run before payloads
-	// enter external storage, e.g. encryption or compression. They run first
-	// on encode (before external storage) and last on decode (after external
-	// retrieval).
+	// PreStorageCodecs are codecs that are applied before external storage,
+	// from the perspective of payloads going through an encoding transformation.
+	// These are typically the codecs that would be configured in the DataConverter
+	// codec chain on a Temporal client.
 	//
 	// NOTE: Experimental.
 	PreStorageCodecs []PayloadCodec
 
-	// ExternalStorage provides the storage drivers used by the /download route to
-	// retrieve payloads identified by storage reference claims. Driver names
-	// must be unique. If no drivers are configured, /download returns HTTP 400.
+	// ExternalStorage configures external payload storage, allowing payloads
+	// to be stored and retrieved from external sources if they meet the size
+	// threshold and driver selection criteria.
 	//
 	// NOTE: Experimental.
 	ExternalStorage ExternalStorage
@@ -72,8 +56,8 @@ type payloadHTTPHandler struct {
 
 var _ http.Handler = (*payloadHTTPHandler)(nil)
 
-// NewPayloadHTTPHandler creates an [http.Handler] that serves /decode, /download, and
-// /encode routes for remote payload transformations.
+// NewPayloadHTTPHandler creates an [http.Handler] that serves /encode, /decode,
+// and /download routes for remote payload transformations.
 //
 // NOTE: Experimental
 func NewPayloadHTTPHandler(options PayloadHTTPHandlerOptions) (http.Handler, error) {
@@ -81,6 +65,7 @@ func NewPayloadHTTPHandler(options PayloadHTTPHandlerOptions) (http.Handler, err
 	if err != nil {
 		return nil, err
 	}
+
 	h := &payloadHTTPHandler{
 		postStorageCodecs: options.PostStorageCodecs,
 		preStorageCodecs:  options.PreStorageCodecs,
@@ -99,6 +84,7 @@ func (h *payloadHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	path := r.URL.Path
 	if !strings.HasSuffix(path, remotePayloadCodecDecodePath) &&
+		!strings.HasSuffix(path, remotePayloadCodecEncodePath) &&
 		!strings.HasSuffix(path, downloadPath) {
 		http.NotFound(w, r)
 		return
@@ -125,7 +111,9 @@ func (h *payloadHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	switch {
 	case strings.HasSuffix(path, remotePayloadCodecDecodePath):
-		payloads, err = h.decode(payloads)
+		payloads, err = h.decode(r, payloads)
+	case strings.HasSuffix(path, remotePayloadCodecEncodePath):
+		payloads, err = h.encode(r, payloads)
 	case strings.HasSuffix(path, downloadPath):
 		payloads, err = h.download(r, payloads)
 	default:
@@ -144,52 +132,31 @@ func (h *payloadHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// decode applies post-storage codecs (first-to-last) to all payloads. Any
-// payload that is a storage reference after this step is returned as-is so
-// the caller can resolve it via /download. Remaining payloads are further
-// decoded through the pre-storage codecs (first-to-last).
-func (h *payloadHTTPHandler) decode(payloads []*commonpb.Payload) ([]*commonpb.Payload, error) {
+// decode decodes payloads through the post-storage then pre-storage codec chains.
+// If returnStorageClaims=true is set in the query string, storage references are
+// returned as-is rather than being retrieved from external storage.
+func (h *payloadHTTPHandler) decode(r *http.Request, payloads []*commonpb.Payload) ([]*commonpb.Payload, error) {
 	var err error
 
-	// Apply post-storage codecs to all payloads.
-	for _, c := range h.postStorageCodecs {
-		if payloads, err = c.Decode(payloads); err != nil {
+	payloads, err = decodePayloads(payloads, h.postStorageCodecs)
+	if err != nil {
+		return nil, err
+	}
+
+	if !strings.EqualFold(r.URL.Query().Get("returnStorageClaims"), "true") {
+		vpc := &proxy.VisitPayloadsContext{Context: r.Context()}
+		payloads, err = h.retrievalVisitor.Visit(vpc, payloads)
+		if err != nil {
 			return nil, err
 		}
 	}
 
-	// Separate storage references — they cannot be pre-storage decoded yet.
-	result := make([]*commonpb.Payload, len(payloads))
-	var nonRefIdxs []int
-	var nonRefPayloads []*commonpb.Payload
-	for i, p := range payloads {
-		if extstore.IsStorageReference(p) {
-			result[i] = p
-		} else {
-			nonRefIdxs = append(nonRefIdxs, i)
-			nonRefPayloads = append(nonRefPayloads, p)
-		}
-	}
-
-	// Apply pre-storage codecs to non-reference payloads.
-	for _, c := range h.preStorageCodecs {
-		if nonRefPayloads, err = c.Decode(nonRefPayloads); err != nil {
-			return nil, err
-		}
-	}
-	for j, i := range nonRefIdxs {
-		result[i] = nonRefPayloads[j]
-	}
-	return result, nil
+	return decodeNonReferences(payloads, h.preStorageCodecs)
 }
 
-// download validates that every payload is a storage reference, retrieves the
-// original payloads from the registered storage drivers, then decodes them
-// through the pre-storage codec chain.
+// download retrieves payloads from external storage and decodes them through
+// the pre-storage codec chain. All input payloads must be storage references.
 func (h *payloadHTTPHandler) download(r *http.Request, payloads []*commonpb.Payload) ([]*commonpb.Payload, error) {
-	if h.retrievalVisitor == nil {
-		return nil, errors.New("no storage drivers configured")
-	}
 	for _, p := range payloads {
 		if !extstore.IsStorageReference(p) {
 			return nil, errors.New("all payloads must be storage references")
@@ -202,10 +169,54 @@ func (h *payloadHTTPHandler) download(r *http.Request, payloads []*commonpb.Payl
 		return nil, err
 	}
 
-	for _, c := range h.preStorageCodecs {
-		if retrieved, err = c.Decode(retrieved); err != nil {
-			return nil, err
+	return decodeNonReferences(retrieved, h.preStorageCodecs)
+}
+
+// encode encodes payloads through the pre-storage then post-storage codec chains,
+// applying external storage as configured. Storage references are returned for
+// payloads that meet the size threshold and driver selection criteria.
+func (h *payloadHTTPHandler) encode(r *http.Request, payloads []*commonpb.Payload) ([]*commonpb.Payload, error) {
+	var err error
+
+	payloads, err = encodePayloads(payloads, h.preStorageCodecs)
+	if err != nil {
+		return nil, err
+	}
+
+	vpc := &proxy.VisitPayloadsContext{Context: r.Context()}
+	payloads, err = h.storageVisitor.Visit(vpc, payloads)
+	if err != nil {
+		return nil, err
+	}
+
+	payloads, err = encodePayloads(payloads, h.postStorageCodecs)
+	if err != nil {
+		return nil, err
+	}
+
+	return payloads, nil
+}
+
+// decodeNonReferences decodes non-storage-reference payloads through the given
+// codec chain. Storage references pass through as-is.
+func decodeNonReferences(payloads []*commonpb.Payload, codecs []PayloadCodec) ([]*commonpb.Payload, error) {
+	result := make([]*commonpb.Payload, len(payloads))
+	var nonRefIdxs []int
+	var nonRefPayloads []*commonpb.Payload
+	for i, p := range payloads {
+		if extstore.IsStorageReference(p) {
+			result[i] = p
+		} else {
+			nonRefIdxs = append(nonRefIdxs, i)
+			nonRefPayloads = append(nonRefPayloads, p)
 		}
 	}
-	return retrieved, nil
+	decoded, err := decodePayloads(nonRefPayloads, codecs)
+	if err != nil {
+		return nil, err
+	}
+	for j, idx := range nonRefIdxs {
+		result[idx] = decoded[j]
+	}
+	return result, nil
 }

--- a/converter/payload_handler.go
+++ b/converter/payload_handler.go
@@ -138,7 +138,7 @@ func (h *payloadHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 // decode decodes payloads through the post-storage then pre-storage codec chains.
-// If returnStorageClaims=true is set in the query string, storage references are
+// If preserveStorageRefs=true is set in the query string, storage references are
 // returned as-is rather than being retrieved from external storage.
 func (h *payloadHTTPHandler) decode(r *http.Request, payloads []*commonpb.Payload) ([]*commonpb.Payload, error) {
 	var err error
@@ -148,7 +148,7 @@ func (h *payloadHTTPHandler) decode(r *http.Request, payloads []*commonpb.Payloa
 		return nil, err
 	}
 
-	if !strings.EqualFold(r.URL.Query().Get("returnStorageClaims"), "true") {
+	if !strings.EqualFold(r.URL.Query().Get("preserveStorageRefs"), "true") {
 		vpc := &proxy.VisitPayloadsContext{Context: r.Context()}
 		payloads, err = h.retrievalVisitor.Visit(vpc, payloads)
 		if err != nil {

--- a/converter/payload_handler_test.go
+++ b/converter/payload_handler_test.go
@@ -12,15 +12,15 @@ import (
 	"github.com/stretchr/testify/require"
 	commonpb "go.temporal.io/api/common/v1"
 	"go.temporal.io/sdk/converter"
+	"go.temporal.io/sdk/internal/extstore"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 )
 
 // ---------------------------------------------------------------------------
-// appendCodec — test codec that appends a marker byte and a suffix to the
-// encoding field on encode, and reverses both on decode. It operates on ALL
-// payloads regardless of their current encoding, which lets us verify exactly
-// which codecs were applied to which payloads by inspecting the encoding chain.
+// appendCodec — encodes unconditionally by appending a suffix to the encoding
+// field and a marker byte to the data, so tests can assert exactly which codecs
+// ran on which payloads by inspecting the encoding string.
 // ---------------------------------------------------------------------------
 
 type appendCodec struct {
@@ -61,7 +61,7 @@ func (c *appendCodec) Decode(payloads []*commonpb.Payload) ([]*commonpb.Payload,
 }
 
 // ---------------------------------------------------------------------------
-// memDriver — minimal in-memory StorageDriver for testing /download.
+// memDriver — in-memory StorageDriver.
 // ---------------------------------------------------------------------------
 
 type memDriver struct {
@@ -102,15 +102,14 @@ func (d *memDriver) Retrieve(_ converter.StorageDriverRetrieveContext, claims []
 // Helpers
 // ---------------------------------------------------------------------------
 
-// storageRefJSON mirrors the internal storageReference struct for constructing
-// test storage-reference payloads without depending on unexported types.
+// storageRefJSON mirrors the internal storageReference struct so tests can
+// construct storage-reference payloads without depending on unexported types.
 type storageRefJSON struct {
 	DriverName  string                       `json:"driver_name"`
 	DriverClaim converter.StorageDriverClaim `json:"driver_claim"`
 }
 
-// makeStorageRef creates a storage reference payload pointing to the given
-// driver and claim key. The payload format matches the internal implementation.
+// makeStorageRef creates a storage reference payload matching the internal wire format.
 func makeStorageRef(t *testing.T, driverName, key string) *commonpb.Payload {
 	t.Helper()
 	data, err := json.Marshal(storageRefJSON{
@@ -126,7 +125,6 @@ func makeStorageRef(t *testing.T, driverName, key string) *commonpb.Payload {
 	}
 }
 
-// makePayload creates a simple json/plain payload from a string value.
 func makePayload(t *testing.T, value string) *commonpb.Payload {
 	t.Helper()
 	p, err := converter.GetDefaultDataConverter().ToPayload(value)
@@ -134,15 +132,13 @@ func makePayload(t *testing.T, value string) *commonpb.Payload {
 	return p
 }
 
-// encodeRequest JSON-encodes a Payloads proto and returns a request body reader.
-func encodeRequest(t *testing.T, payloads ...*commonpb.Payload) *bytes.Reader {
+func createRequest(t *testing.T, payloads ...*commonpb.Payload) *bytes.Reader {
 	t.Helper()
 	body, err := protojson.Marshal(&commonpb.Payloads{Payloads: payloads})
 	require.NoError(t, err)
 	return bytes.NewReader(body)
 }
 
-// servePost sends a POST to path on handler and returns the recorder.
 func servePost(t *testing.T, handler http.Handler, path string, body *bytes.Reader) *httptest.ResponseRecorder {
 	t.Helper()
 	req, err := http.NewRequest(http.MethodPost, path, body)
@@ -152,8 +148,7 @@ func servePost(t *testing.T, handler http.Handler, path string, body *bytes.Read
 	return rr
 }
 
-// decodeResponse parses the handler's JSON response into a []*commonpb.Payload slice.
-func decodeResponse(t *testing.T, rr *httptest.ResponseRecorder) []*commonpb.Payload {
+func getPayloads(t *testing.T, rr *httptest.ResponseRecorder) []*commonpb.Payload {
 	t.Helper()
 	require.Equal(t, http.StatusOK, rr.Code, "response body: %s", rr.Body.String())
 	var result commonpb.Payloads
@@ -161,18 +156,14 @@ func decodeResponse(t *testing.T, rr *httptest.ResponseRecorder) []*commonpb.Pay
 	return result.Payloads
 }
 
-// encoding returns the MetadataEncoding value of a payload as a string.
 func encoding(p *commonpb.Payload) string {
 	return string(p.GetMetadata()[converter.MetadataEncoding])
 }
 
-// firstDriverSelector is a StorageDriverSelector that always routes to the
-// provided driver. Used in tests that register multiple drivers but only need
-// to satisfy the API requirement; the selector is never invoked on the
-// retrieval path.
-type firstDriverSelector struct{ driver converter.StorageDriver }
+// fixedDriverSelector always routes to the provided driver.
+type fixedDriverSelector struct{ driver converter.StorageDriver }
 
-func (s firstDriverSelector) SelectDriver(_ converter.StorageDriverStoreContext, _ *commonpb.Payload) (converter.StorageDriver, error) {
+func (s fixedDriverSelector) SelectDriver(_ converter.StorageDriverStoreContext, _ *commonpb.Payload) (converter.StorageDriver, error) {
 	return s.driver, nil
 }
 
@@ -213,7 +204,7 @@ func TestRouting_MountedAtPrefix(t *testing.T) {
 	require.NoError(t, err)
 
 	p := makePayload(t, "hello")
-	rr := servePost(t, h, "/myapp/codec/decode", encodeRequest(t, p))
+	rr := servePost(t, h, "/myapp/codec/decode", createRequest(t, p))
 	require.Equal(t, http.StatusOK, rr.Code)
 }
 
@@ -221,8 +212,6 @@ func TestRouting_MountedAtPrefix(t *testing.T) {
 // /decode
 // ---------------------------------------------------------------------------
 
-// TestDecode_AppliesPostThenPreCodecs verifies that post-storage codecs run
-// first (first-to-last) and pre-storage codecs run second on non-refs.
 func TestDecode_AppliesPostThenPreCodecs(t *testing.T) {
 	preCodec := &appendCodec{encodingSuffix: ".pre", marker: 'P'}
 	postCodec := &appendCodec{encodingSuffix: ".post", marker: 'O'}
@@ -232,7 +221,6 @@ func TestDecode_AppliesPostThenPreCodecs(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Build a payload that has been through the full encode chain (pre then post).
 	p := makePayload(t, "hello")
 	originalEncoding := encoding(p)
 	preEncoded, err := preCodec.Encode([]*commonpb.Payload{p})
@@ -240,19 +228,15 @@ func TestDecode_AppliesPostThenPreCodecs(t *testing.T) {
 	postEncoded, err := postCodec.Encode(preEncoded)
 	require.NoError(t, err)
 
-	// Decode through the handler and verify the result matches the original.
-	rr := servePost(t, h, "/decode", encodeRequest(t, postEncoded[0]))
-	result := decodeResponse(t, rr)
+	rr := servePost(t, h, "/decode", createRequest(t, postEncoded[0]))
+	result := getPayloads(t, rr)
 	require.Len(t, result, 1)
 	require.Equal(t, originalEncoding, encoding(result[0]))
 }
 
-// TestDecode_StorageRefReturnedAsIs verifies that a payload which is a storage
-// reference after post-storage decoding is returned without applying pre-storage
-// codecs (the caller should resolve it via /download).
 func TestDecode_StorageRefReturnedAsIs(t *testing.T) {
-	// Pre-storage codec that would fail if applied to a storage ref
-	// (its Decode checks for the ".pre" suffix).
+	// appendCodec.Decode would error on a storage reference because it requires
+	// the ".pre" encoding suffix — confirms pre-storage codecs are skipped.
 	preCodec := &appendCodec{encodingSuffix: ".pre", marker: 'P'}
 	postCodec := &appendCodec{encodingSuffix: ".post", marker: 'O'}
 	h, err := converter.NewPayloadHTTPHandler(converter.PayloadHTTPHandlerOptions{
@@ -261,23 +245,16 @@ func TestDecode_StorageRefReturnedAsIs(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Simulate a post-encoded storage reference (post codec was applied to a
-	// storage ref before sending it to this handler).
 	ref := makeStorageRef(t, "drv", "k1")
-	postWrapped, err := postCodec.Encode([]*commonpb.Payload{ref})
+	postEncodedRef, err := postCodec.Encode([]*commonpb.Payload{ref})
 	require.NoError(t, err)
 
-	rr := servePost(t, h, "/decode", encodeRequest(t, postWrapped[0]))
-	result := decodeResponse(t, rr)
+	rr := servePost(t, h, "/decode", createRequest(t, postEncodedRef[0]))
+	result := getPayloads(t, rr)
 	require.Len(t, result, 1)
-
-	// After post-decode we should see the original storage reference, not an error.
-	require.Equal(t, "json/external-storage-reference", encoding(result[0]))
+	require.True(t, extstore.IsStorageReference(result[0]))
 }
 
-// TestDecode_MixedBatch verifies that in a batch containing both a regular
-// payload and a storage reference, the regular payload is fully decoded while
-// the storage reference is left as-is.
 func TestDecode_MixedBatch(t *testing.T) {
 	preCodec := &appendCodec{encodingSuffix: ".pre", marker: 'P'}
 	postCodec := &appendCodec{encodingSuffix: ".post", marker: 'O'}
@@ -287,31 +264,24 @@ func TestDecode_MixedBatch(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Regular payload encoded through the full chain (pre then post).
 	regular := makePayload(t, "data")
 	originalEncoding := encoding(regular)
 	preEncoded, err := preCodec.Encode([]*commonpb.Payload{regular})
 	require.NoError(t, err)
-	encoded, err := postCodec.Encode(preEncoded)
+	postEncoded, err := postCodec.Encode(preEncoded)
 	require.NoError(t, err)
 
-	// Storage reference wrapped by the post codec only.
 	ref := makeStorageRef(t, "drv", "k1")
-	postWrappedRef, err := postCodec.Encode([]*commonpb.Payload{ref})
+	postEncodedRef, err := postCodec.Encode([]*commonpb.Payload{ref})
 	require.NoError(t, err)
 
-	rr := servePost(t, h, "/decode", encodeRequest(t, encoded[0], postWrappedRef[0]))
-	result := decodeResponse(t, rr)
+	rr := servePost(t, h, "/decode", createRequest(t, postEncoded[0], postEncodedRef[0]))
+	result := getPayloads(t, rr)
 	require.Len(t, result, 2)
-
-	// Regular payload should be fully decoded.
 	require.Equal(t, originalEncoding, encoding(result[0]))
-	// Storage reference should be left as the raw reference.
-	require.Equal(t, "json/external-storage-reference", encoding(result[1]))
+	require.True(t, extstore.IsStorageReference(result[1]))
 }
 
-// TestDecode_RoundTrip verifies that a payload encoded through the full codec
-// chain (pre then post) is restored to its original form after /decode.
 func TestDecode_RoundTrip(t *testing.T) {
 	preCodec := &appendCodec{encodingSuffix: ".pre", marker: 'P'}
 	postCodec := &appendCodec{encodingSuffix: ".post", marker: 'O'}
@@ -326,14 +296,13 @@ func TestDecode_RoundTrip(t *testing.T) {
 		makePayload(t, "second"),
 	}
 
-	// Encode through the full chain directly (pre then post).
 	preEncoded, err := preCodec.Encode(originals)
 	require.NoError(t, err)
-	encoded, err := postCodec.Encode(preEncoded)
+	postEncoded, err := postCodec.Encode(preEncoded)
 	require.NoError(t, err)
 
-	rr := servePost(t, h, "/decode", encodeRequest(t, encoded...))
-	decoded := decodeResponse(t, rr)
+	rr := servePost(t, h, "/decode", createRequest(t, postEncoded...))
+	decoded := getPayloads(t, rr)
 	require.Len(t, decoded, 2)
 
 	for i := range originals {
@@ -343,16 +312,134 @@ func TestDecode_RoundTrip(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// /decode?returnStorageClaims=true
+// ---------------------------------------------------------------------------
+
+func TestDecode_ReturnStorageClaims_AllRefs(t *testing.T) {
+	postCodec := &appendCodec{encodingSuffix: ".post", marker: 'O'}
+	h, err := converter.NewPayloadHTTPHandler(converter.PayloadHTTPHandlerOptions{
+		PostStorageCodecs: []converter.PayloadCodec{postCodec},
+	})
+	require.NoError(t, err)
+
+	ref1 := makeStorageRef(t, "drv", "k1")
+	ref2 := makeStorageRef(t, "drv", "k2")
+	postWrapped, err := postCodec.Encode([]*commonpb.Payload{ref1, ref2})
+	require.NoError(t, err)
+
+	rr := servePost(t, h, "/decode?returnStorageClaims=true", createRequest(t, postWrapped...))
+	result := getPayloads(t, rr)
+	require.Len(t, result, 2)
+	require.True(t, extstore.IsStorageReference(result[0]))
+	require.True(t, extstore.IsStorageReference(result[1]))
+}
+
+func TestDecode_ReturnStorageClaims_NoRefs(t *testing.T) {
+	preCodec := &appendCodec{encodingSuffix: ".pre", marker: 'P'}
+	postCodec := &appendCodec{encodingSuffix: ".post", marker: 'O'}
+	h, err := converter.NewPayloadHTTPHandler(converter.PayloadHTTPHandlerOptions{
+		PreStorageCodecs:  []converter.PayloadCodec{preCodec},
+		PostStorageCodecs: []converter.PayloadCodec{postCodec},
+	})
+	require.NoError(t, err)
+
+	p := makePayload(t, "hello")
+	originalEncoding := encoding(p)
+	preEncoded, err := preCodec.Encode([]*commonpb.Payload{p})
+	require.NoError(t, err)
+	postEncoded, err := postCodec.Encode(preEncoded)
+	require.NoError(t, err)
+
+	rr := servePost(t, h, "/decode?returnStorageClaims=true", createRequest(t, postEncoded[0]))
+	result := getPayloads(t, rr)
+	require.Len(t, result, 1)
+	require.Equal(t, originalEncoding, encoding(result[0]))
+}
+
+func TestDecode_ReturnStorageClaims_MixedBatch(t *testing.T) {
+	preCodec := &appendCodec{encodingSuffix: ".pre", marker: 'P'}
+	postCodec := &appendCodec{encodingSuffix: ".post", marker: 'O'}
+	h, err := converter.NewPayloadHTTPHandler(converter.PayloadHTTPHandlerOptions{
+		PreStorageCodecs:  []converter.PayloadCodec{preCodec},
+		PostStorageCodecs: []converter.PayloadCodec{postCodec},
+	})
+	require.NoError(t, err)
+
+	// Interleaved [ref, regular, ref, regular] to exercise ordering preservation.
+	ref1 := makeStorageRef(t, "drv", "k1")
+	ref2 := makeStorageRef(t, "drv", "k2")
+	regular1 := makePayload(t, "first")
+	regular2 := makePayload(t, "second")
+	originalEncoding1 := encoding(regular1)
+	originalEncoding2 := encoding(regular2)
+
+	preEncoded, err := preCodec.Encode([]*commonpb.Payload{regular1, regular2})
+	require.NoError(t, err)
+	postEncoded, err := postCodec.Encode([]*commonpb.Payload{ref1, preEncoded[0], ref2, preEncoded[1]})
+	require.NoError(t, err)
+
+	rr := servePost(t, h, "/decode?returnStorageClaims=true", createRequest(t, postEncoded...))
+	result := getPayloads(t, rr)
+	require.Len(t, result, 4)
+	require.True(t, extstore.IsStorageReference(result[0]))
+	require.Equal(t, originalEncoding1, encoding(result[1]))
+	require.True(t, extstore.IsStorageReference(result[2]))
+	require.Equal(t, originalEncoding2, encoding(result[3]))
+}
+
+func TestDecode_ReturnStorageClaims_CaseInsensitive(t *testing.T) {
+	postCodec := &appendCodec{encodingSuffix: ".post", marker: 'O'}
+	h, err := converter.NewPayloadHTTPHandler(converter.PayloadHTTPHandlerOptions{
+		PostStorageCodecs: []converter.PayloadCodec{postCodec},
+	})
+	require.NoError(t, err)
+
+	ref := makeStorageRef(t, "drv", "k1")
+	postWrapped, err := postCodec.Encode([]*commonpb.Payload{ref})
+	require.NoError(t, err)
+
+	for _, val := range []string{"TRUE", "True", "tRuE"} {
+		t.Run(val, func(t *testing.T) {
+			rr := servePost(t, h, "/decode?returnStorageClaims="+val, createRequest(t, postWrapped[0]))
+			result := getPayloads(t, rr)
+			require.Len(t, result, 1)
+			require.True(t, extstore.IsStorageReference(result[0]))
+		})
+	}
+}
+
+// TestDecode_ReturnStorageClaims_False verifies that returnStorageClaims=false
+// behaves the same as omitting the parameter — retrieval is performed.
+func TestDecode_ReturnStorageClaims_False(t *testing.T) {
+	preCodec := &appendCodec{encodingSuffix: ".pre", marker: 'P'}
+	driver := newMemDriver("drv")
+
+	stored := makePayload(t, "stored-value")
+	preEncoded, err := preCodec.Encode([]*commonpb.Payload{stored})
+	require.NoError(t, err)
+	driver.data["k1"] = proto.Clone(preEncoded[0]).(*commonpb.Payload)
+
+	h, err := converter.NewPayloadHTTPHandler(converter.PayloadHTTPHandlerOptions{
+		PreStorageCodecs: []converter.PayloadCodec{preCodec},
+		ExternalStorage:  converter.ExternalStorage{Drivers: []converter.StorageDriver{driver}},
+	})
+	require.NoError(t, err)
+
+	ref := makeStorageRef(t, "drv", "k1")
+	rr := servePost(t, h, "/decode?returnStorageClaims=false", createRequest(t, ref))
+	result := getPayloads(t, rr)
+	require.Len(t, result, 1)
+	require.True(t, proto.Equal(stored, result[0]))
+}
+
+// ---------------------------------------------------------------------------
 // /download
 // ---------------------------------------------------------------------------
 
-// TestDownload_HappyPath verifies that a storage reference is retrieved from
-// the configured driver and the result is decoded through pre-storage codecs.
-func TestDownload_HappyPath(t *testing.T) {
+func TestDownload_SingleRef(t *testing.T) {
 	preCodec := &appendCodec{encodingSuffix: ".pre", marker: 'P'}
 	driver := newMemDriver("testdrv")
 
-	// Pre-populate the driver with a pre-storage-encoded payload.
 	storedPayload := makePayload(t, "stored-value")
 	preEncoded, err := preCodec.Encode([]*commonpb.Payload{storedPayload})
 	require.NoError(t, err)
@@ -365,17 +452,13 @@ func TestDownload_HappyPath(t *testing.T) {
 	require.NoError(t, err)
 
 	ref := makeStorageRef(t, "testdrv", "my-key")
-	rr := servePost(t, h, "/download", encodeRequest(t, ref))
-	result := decodeResponse(t, rr)
+	rr := servePost(t, h, "/download", createRequest(t, ref))
+	result := getPayloads(t, rr)
 	require.Len(t, result, 1)
-
-	// The retrieved payload should have been pre-storage decoded.
 	require.True(t, proto.Equal(storedPayload, result[0]),
 		"expected %v, got %v", storedPayload, result[0])
 }
 
-// TestDownload_MultipleRefs verifies fan-out retrieval of multiple storage
-// references in a single /download request.
 func TestDownload_MultipleRefs(t *testing.T) {
 	driver := newMemDriver("drv")
 	payloads := []*commonpb.Payload{
@@ -398,16 +481,14 @@ func TestDownload_MultipleRefs(t *testing.T) {
 		refs[i] = makeStorageRef(t, "drv", fmt.Sprintf("k%d", i))
 	}
 
-	rr := servePost(t, h, "/download", encodeRequest(t, refs...))
-	result := decodeResponse(t, rr)
+	rr := servePost(t, h, "/download", createRequest(t, refs...))
+	result := getPayloads(t, rr)
 	require.Len(t, result, 3)
 	for i, p := range payloads {
 		require.True(t, proto.Equal(p, result[i]), "payload %d mismatch", i)
 	}
 }
 
-// TestDownload_NonStorageRef verifies that /download returns 400 when any
-// payload in the request is not a storage reference.
 func TestDownload_NonStorageRef(t *testing.T) {
 	driver := newMemDriver("drv")
 	h, err := converter.NewPayloadHTTPHandler(converter.PayloadHTTPHandlerOptions{
@@ -416,26 +497,21 @@ func TestDownload_NonStorageRef(t *testing.T) {
 	require.NoError(t, err)
 
 	regular := makePayload(t, "not-a-ref")
-	rr := servePost(t, h, "/download", encodeRequest(t, regular))
+	rr := servePost(t, h, "/download", createRequest(t, regular))
 	require.Equal(t, http.StatusBadRequest, rr.Code)
 }
 
-// TestDownload_NoDrivers verifies that /download with no drivers configured
-// returns the storage reference payload unresolved (the retrieval visitor leaves
-// it as-is when no driver map is present).
 func TestDownload_NoDrivers(t *testing.T) {
 	h, err := converter.NewPayloadHTTPHandler(converter.PayloadHTTPHandlerOptions{})
 	require.NoError(t, err)
 
 	ref := makeStorageRef(t, "drv", "k1")
-	rr := servePost(t, h, "/download", encodeRequest(t, ref))
-	result := decodeResponse(t, rr)
+	rr := servePost(t, h, "/download", createRequest(t, ref))
+	result := getPayloads(t, rr)
 	require.Len(t, result, 1)
-	require.Equal(t, "json/external-storage-reference", encoding(result[0]))
+	require.True(t, extstore.IsStorageReference(result[0]))
 }
 
-// TestDownload_UnknownDriver verifies that /download returns 400 when the
-// storage reference names a driver that is not registered.
 func TestDownload_UnknownDriver(t *testing.T) {
 	driver := newMemDriver("registered")
 	h, err := converter.NewPayloadHTTPHandler(converter.PayloadHTTPHandlerOptions{
@@ -444,12 +520,10 @@ func TestDownload_UnknownDriver(t *testing.T) {
 	require.NoError(t, err)
 
 	ref := makeStorageRef(t, "unregistered", "k1")
-	rr := servePost(t, h, "/download", encodeRequest(t, ref))
+	rr := servePost(t, h, "/download", createRequest(t, ref))
 	require.Equal(t, http.StatusBadRequest, rr.Code)
 }
 
-// TestDownload_MultipleDrivers verifies that multiple storage
-// drivers can be registered.
 func TestDownload_MultipleDrivers(t *testing.T) {
 	driverA := newMemDriver("driver-a")
 	driverB := newMemDriver("driver-b")
@@ -460,7 +534,7 @@ func TestDownload_MultipleDrivers(t *testing.T) {
 	h, err := converter.NewPayloadHTTPHandler(converter.PayloadHTTPHandlerOptions{
 		ExternalStorage: converter.ExternalStorage{
 			Drivers:        []converter.StorageDriver{driverA, driverB},
-			DriverSelector: firstDriverSelector{driver: driverA},
+			DriverSelector: fixedDriverSelector{driver: driverA},
 		},
 	})
 	require.NoError(t, err)
@@ -469,8 +543,8 @@ func TestDownload_MultipleDrivers(t *testing.T) {
 		makeStorageRef(t, "driver-a", "key-a"),
 		makeStorageRef(t, "driver-b", "key-b"),
 	}
-	rr := servePost(t, h, "/download", encodeRequest(t, refs...))
-	result := decodeResponse(t, rr)
+	rr := servePost(t, h, "/download", createRequest(t, refs...))
+	result := getPayloads(t, rr)
 	require.Len(t, result, 2)
 
 	var got0, got1 string
@@ -479,4 +553,114 @@ func TestDownload_MultipleDrivers(t *testing.T) {
 
 	require.NoError(t, converter.GetDefaultDataConverter().FromPayload(result[1], &got1))
 	require.Equal(t, "from-b", got1)
+}
+
+// ---------------------------------------------------------------------------
+// /encode
+// ---------------------------------------------------------------------------
+
+func TestEncode_NoCodecsNoStorage(t *testing.T) {
+	h, err := converter.NewPayloadHTTPHandler(converter.PayloadHTTPHandlerOptions{})
+	require.NoError(t, err)
+
+	p := makePayload(t, "hello")
+	rr := servePost(t, h, "/encode", createRequest(t, p))
+	result := getPayloads(t, rr)
+	require.Len(t, result, 1)
+	require.True(t, proto.Equal(p, result[0]))
+}
+
+func TestEncode_PreStorageCodecsOnly(t *testing.T) {
+	preCodec := &appendCodec{encodingSuffix: ".pre", marker: 'P'}
+	h, err := converter.NewPayloadHTTPHandler(converter.PayloadHTTPHandlerOptions{
+		PreStorageCodecs: []converter.PayloadCodec{preCodec},
+	})
+	require.NoError(t, err)
+
+	p := makePayload(t, "hello")
+	rr := servePost(t, h, "/encode", createRequest(t, p))
+	result := getPayloads(t, rr)
+	require.Len(t, result, 1)
+	require.True(t, strings.HasSuffix(encoding(result[0]), ".pre"))
+}
+
+func TestEncode_PostStorageCodecsOnly(t *testing.T) {
+	postCodec := &appendCodec{encodingSuffix: ".post", marker: 'O'}
+	h, err := converter.NewPayloadHTTPHandler(converter.PayloadHTTPHandlerOptions{
+		PostStorageCodecs: []converter.PayloadCodec{postCodec},
+	})
+	require.NoError(t, err)
+
+	p := makePayload(t, "hello")
+	rr := servePost(t, h, "/encode", createRequest(t, p))
+	result := getPayloads(t, rr)
+	require.Len(t, result, 1)
+	require.True(t, strings.HasSuffix(encoding(result[0]), ".post"))
+}
+
+func TestEncode_PreAndPostCodecs(t *testing.T) {
+	preCodec := &appendCodec{encodingSuffix: ".pre", marker: 'P'}
+	postCodec := &appendCodec{encodingSuffix: ".post", marker: 'O'}
+	h, err := converter.NewPayloadHTTPHandler(converter.PayloadHTTPHandlerOptions{
+		PreStorageCodecs:  []converter.PayloadCodec{preCodec},
+		PostStorageCodecs: []converter.PayloadCodec{postCodec},
+	})
+	require.NoError(t, err)
+
+	p := makePayload(t, "hello")
+	rr := servePost(t, h, "/encode", createRequest(t, p))
+	result := getPayloads(t, rr)
+	require.Len(t, result, 1)
+	// Pre runs first, post runs second — ".pre.post" is the expected final suffix.
+	require.True(t, strings.HasSuffix(encoding(result[0]), ".pre.post"))
+}
+
+func TestEncode_WithExternalStorage(t *testing.T) {
+	driver := newMemDriver("drv")
+	h, err := converter.NewPayloadHTTPHandler(converter.PayloadHTTPHandlerOptions{
+		ExternalStorage: converter.ExternalStorage{
+			Drivers:              []converter.StorageDriver{driver},
+			PayloadSizeThreshold: 1, // store everything
+		},
+	})
+	require.NoError(t, err)
+
+	p := makePayload(t, "hello")
+	rr := servePost(t, h, "/encode", createRequest(t, p))
+	result := getPayloads(t, rr)
+	require.Len(t, result, 1)
+	require.True(t, extstore.IsStorageReference(result[0]))
+	require.Len(t, driver.data, 1)
+}
+
+func TestEncode_DecodeRoundTrip(t *testing.T) {
+	preCodec := &appendCodec{encodingSuffix: ".pre", marker: 'P'}
+	postCodec := &appendCodec{encodingSuffix: ".post", marker: 'O'}
+	driver := newMemDriver("drv")
+
+	h, err := converter.NewPayloadHTTPHandler(converter.PayloadHTTPHandlerOptions{
+		PreStorageCodecs:  []converter.PayloadCodec{preCodec},
+		PostStorageCodecs: []converter.PayloadCodec{postCodec},
+		ExternalStorage: converter.ExternalStorage{
+			Drivers:              []converter.StorageDriver{driver},
+			PayloadSizeThreshold: 1,
+		},
+	})
+	require.NoError(t, err)
+
+	originals := []*commonpb.Payload{
+		makePayload(t, "first"),
+		makePayload(t, "second"),
+	}
+
+	encRR := servePost(t, h, "/encode", createRequest(t, originals...))
+	encoded := getPayloads(t, encRR)
+
+	decRR := servePost(t, h, "/decode", createRequest(t, encoded...))
+	decoded := getPayloads(t, decRR)
+
+	require.Len(t, decoded, len(originals))
+	for i, orig := range originals {
+		require.True(t, proto.Equal(orig, decoded[i]), "payload %d: encode→decode should be identity", i)
+	}
 }

--- a/converter/payload_handler_test.go
+++ b/converter/payload_handler_test.go
@@ -312,10 +312,10 @@ func TestDecode_RoundTrip(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// /decode?returnStorageClaims=true
+// /decode?preserveStorageRefs=true
 // ---------------------------------------------------------------------------
 
-func TestDecode_ReturnStorageClaims_AllRefs(t *testing.T) {
+func TestDecode_PreserveStorageRefs_AllRefs(t *testing.T) {
 	postCodec := &appendCodec{encodingSuffix: ".post", marker: 'O'}
 	h, err := converter.NewPayloadHTTPHandler(converter.PayloadHTTPHandlerOptions{
 		PostStorageCodecs: []converter.PayloadCodec{postCodec},
@@ -327,14 +327,14 @@ func TestDecode_ReturnStorageClaims_AllRefs(t *testing.T) {
 	postWrapped, err := postCodec.Encode([]*commonpb.Payload{ref1, ref2})
 	require.NoError(t, err)
 
-	rr := servePost(t, h, "/decode?returnStorageClaims=true", createRequest(t, postWrapped...))
+	rr := servePost(t, h, "/decode?preserveStorageRefs=true", createRequest(t, postWrapped...))
 	result := getPayloads(t, rr)
 	require.Len(t, result, 2)
 	require.True(t, extstore.IsStorageReference(result[0]))
 	require.True(t, extstore.IsStorageReference(result[1]))
 }
 
-func TestDecode_ReturnStorageClaims_NoRefs(t *testing.T) {
+func TestDecode_PreserveStorageRefs_NoRefs(t *testing.T) {
 	preCodec := &appendCodec{encodingSuffix: ".pre", marker: 'P'}
 	postCodec := &appendCodec{encodingSuffix: ".post", marker: 'O'}
 	h, err := converter.NewPayloadHTTPHandler(converter.PayloadHTTPHandlerOptions{
@@ -350,13 +350,13 @@ func TestDecode_ReturnStorageClaims_NoRefs(t *testing.T) {
 	postEncoded, err := postCodec.Encode(preEncoded)
 	require.NoError(t, err)
 
-	rr := servePost(t, h, "/decode?returnStorageClaims=true", createRequest(t, postEncoded[0]))
+	rr := servePost(t, h, "/decode?preserveStorageRefs=true", createRequest(t, postEncoded[0]))
 	result := getPayloads(t, rr)
 	require.Len(t, result, 1)
 	require.Equal(t, originalEncoding, encoding(result[0]))
 }
 
-func TestDecode_ReturnStorageClaims_MixedBatch(t *testing.T) {
+func TestDecode_PreserveStorageRefs_MixedBatch(t *testing.T) {
 	preCodec := &appendCodec{encodingSuffix: ".pre", marker: 'P'}
 	postCodec := &appendCodec{encodingSuffix: ".post", marker: 'O'}
 	h, err := converter.NewPayloadHTTPHandler(converter.PayloadHTTPHandlerOptions{
@@ -378,7 +378,7 @@ func TestDecode_ReturnStorageClaims_MixedBatch(t *testing.T) {
 	postEncoded, err := postCodec.Encode([]*commonpb.Payload{ref1, preEncoded[0], ref2, preEncoded[1]})
 	require.NoError(t, err)
 
-	rr := servePost(t, h, "/decode?returnStorageClaims=true", createRequest(t, postEncoded...))
+	rr := servePost(t, h, "/decode?preserveStorageRefs=true", createRequest(t, postEncoded...))
 	result := getPayloads(t, rr)
 	require.Len(t, result, 4)
 	require.True(t, extstore.IsStorageReference(result[0]))
@@ -387,7 +387,7 @@ func TestDecode_ReturnStorageClaims_MixedBatch(t *testing.T) {
 	require.Equal(t, originalEncoding2, encoding(result[3]))
 }
 
-func TestDecode_ReturnStorageClaims_CaseInsensitive(t *testing.T) {
+func TestDecode_PreserveStorageRefs_CaseInsensitive(t *testing.T) {
 	postCodec := &appendCodec{encodingSuffix: ".post", marker: 'O'}
 	h, err := converter.NewPayloadHTTPHandler(converter.PayloadHTTPHandlerOptions{
 		PostStorageCodecs: []converter.PayloadCodec{postCodec},
@@ -400,7 +400,7 @@ func TestDecode_ReturnStorageClaims_CaseInsensitive(t *testing.T) {
 
 	for _, val := range []string{"TRUE", "True", "tRuE"} {
 		t.Run(val, func(t *testing.T) {
-			rr := servePost(t, h, "/decode?returnStorageClaims="+val, createRequest(t, postWrapped[0]))
+			rr := servePost(t, h, "/decode?preserveStorageRefs="+val, createRequest(t, postWrapped[0]))
 			result := getPayloads(t, rr)
 			require.Len(t, result, 1)
 			require.True(t, extstore.IsStorageReference(result[0]))
@@ -408,9 +408,9 @@ func TestDecode_ReturnStorageClaims_CaseInsensitive(t *testing.T) {
 	}
 }
 
-// TestDecode_ReturnStorageClaims_False verifies that returnStorageClaims=false
+// TestDecode_PreserveStorageRefs_False verifies that preserveStorageRefs=false
 // behaves the same as omitting the parameter — retrieval is performed.
-func TestDecode_ReturnStorageClaims_False(t *testing.T) {
+func TestDecode_PreserveStorageRefs_False(t *testing.T) {
 	preCodec := &appendCodec{encodingSuffix: ".pre", marker: 'P'}
 	driver := newMemDriver("drv")
 
@@ -426,7 +426,7 @@ func TestDecode_ReturnStorageClaims_False(t *testing.T) {
 	require.NoError(t, err)
 
 	ref := makeStorageRef(t, "drv", "k1")
-	rr := servePost(t, h, "/decode?returnStorageClaims=false", createRequest(t, ref))
+	rr := servePost(t, h, "/decode?preserveStorageRefs=false", createRequest(t, ref))
 	result := getPayloads(t, rr)
 	require.Len(t, result, 1)
 	require.True(t, proto.Equal(stored, result[0]))

--- a/converter/payload_handler_test.go
+++ b/converter/payload_handler_test.go
@@ -61,7 +61,7 @@ func (c *appendCodec) Decode(payloads []*commonpb.Payload) ([]*commonpb.Payload,
 }
 
 // ---------------------------------------------------------------------------
-// memDriver — minimal in-memory StorageDriver for testing /ui/download.
+// memDriver — minimal in-memory StorageDriver for testing /download.
 // ---------------------------------------------------------------------------
 
 type memDriver struct {
@@ -166,22 +166,32 @@ func encoding(p *commonpb.Payload) string {
 	return string(p.GetMetadata()[converter.MetadataEncoding])
 }
 
+// firstDriverSelector is a StorageDriverSelector that always routes to the
+// provided driver. Used in tests that register multiple drivers but only need
+// to satisfy the API requirement; the selector is never invoked on the
+// retrieval path.
+type firstDriverSelector struct{ driver converter.StorageDriver }
+
+func (s firstDriverSelector) SelectDriver(_ converter.StorageDriverStoreContext, _ *commonpb.Payload) (converter.StorageDriver, error) {
+	return s.driver, nil
+}
+
 // ---------------------------------------------------------------------------
 // Routing
 // ---------------------------------------------------------------------------
 
 func TestRouting_WrongMethod(t *testing.T) {
-	h, err := converter.NewUIPayloadHTTPHandler(converter.UIPayloadHTTPHandlerOptions{})
+	h, err := converter.NewPayloadHTTPHandler(converter.PayloadHTTPHandlerOptions{})
 	require.NoError(t, err)
 
-	req, _ := http.NewRequest(http.MethodGet, "/ui/decode", nil)
+	req, _ := http.NewRequest(http.MethodGet, "/decode", nil)
 	rr := httptest.NewRecorder()
 	h.ServeHTTP(rr, req)
 	require.Equal(t, http.StatusNotFound, rr.Code)
 }
 
 func TestRouting_WrongPath(t *testing.T) {
-	h, err := converter.NewUIPayloadHTTPHandler(converter.UIPayloadHTTPHandlerOptions{})
+	h, err := converter.NewPayloadHTTPHandler(converter.PayloadHTTPHandlerOptions{})
 	require.NoError(t, err)
 
 	rr := servePost(t, h, "/missing", bytes.NewReader(nil))
@@ -189,26 +199,26 @@ func TestRouting_WrongPath(t *testing.T) {
 }
 
 func TestRouting_NilBody(t *testing.T) {
-	h, err := converter.NewUIPayloadHTTPHandler(converter.UIPayloadHTTPHandlerOptions{})
+	h, err := converter.NewPayloadHTTPHandler(converter.PayloadHTTPHandlerOptions{})
 	require.NoError(t, err)
 
-	req, _ := http.NewRequest(http.MethodPost, "/ui/decode", nil)
+	req, _ := http.NewRequest(http.MethodPost, "/decode", nil)
 	rr := httptest.NewRecorder()
 	h.ServeHTTP(rr, req)
 	require.Equal(t, http.StatusBadRequest, rr.Code)
 }
 
 func TestRouting_MountedAtPrefix(t *testing.T) {
-	h, err := converter.NewUIPayloadHTTPHandler(converter.UIPayloadHTTPHandlerOptions{})
+	h, err := converter.NewPayloadHTTPHandler(converter.PayloadHTTPHandlerOptions{})
 	require.NoError(t, err)
 
 	p := makePayload(t, "hello")
-	rr := servePost(t, h, "/myapp/codec/ui/decode", encodeRequest(t, p))
+	rr := servePost(t, h, "/myapp/codec/decode", encodeRequest(t, p))
 	require.Equal(t, http.StatusOK, rr.Code)
 }
 
 // ---------------------------------------------------------------------------
-// /ui/decode
+// /decode
 // ---------------------------------------------------------------------------
 
 // TestDecode_AppliesPostThenPreCodecs verifies that post-storage codecs run
@@ -216,7 +226,7 @@ func TestRouting_MountedAtPrefix(t *testing.T) {
 func TestDecode_AppliesPostThenPreCodecs(t *testing.T) {
 	preCodec := &appendCodec{encodingSuffix: ".pre", marker: 'P'}
 	postCodec := &appendCodec{encodingSuffix: ".post", marker: 'O'}
-	h, err := converter.NewUIPayloadHTTPHandler(converter.UIPayloadHTTPHandlerOptions{
+	h, err := converter.NewPayloadHTTPHandler(converter.PayloadHTTPHandlerOptions{
 		PreStorageCodecs:  []converter.PayloadCodec{preCodec},
 		PostStorageCodecs: []converter.PayloadCodec{postCodec},
 	})
@@ -231,7 +241,7 @@ func TestDecode_AppliesPostThenPreCodecs(t *testing.T) {
 	require.NoError(t, err)
 
 	// Decode through the handler and verify the result matches the original.
-	rr := servePost(t, h, "/ui/decode", encodeRequest(t, postEncoded[0]))
+	rr := servePost(t, h, "/decode", encodeRequest(t, postEncoded[0]))
 	result := decodeResponse(t, rr)
 	require.Len(t, result, 1)
 	require.Equal(t, originalEncoding, encoding(result[0]))
@@ -239,13 +249,13 @@ func TestDecode_AppliesPostThenPreCodecs(t *testing.T) {
 
 // TestDecode_StorageRefReturnedAsIs verifies that a payload which is a storage
 // reference after post-storage decoding is returned without applying pre-storage
-// codecs (the caller should resolve it via /ui/download).
+// codecs (the caller should resolve it via /download).
 func TestDecode_StorageRefReturnedAsIs(t *testing.T) {
 	// Pre-storage codec that would fail if applied to a storage ref
 	// (its Decode checks for the ".pre" suffix).
 	preCodec := &appendCodec{encodingSuffix: ".pre", marker: 'P'}
 	postCodec := &appendCodec{encodingSuffix: ".post", marker: 'O'}
-	h, err := converter.NewUIPayloadHTTPHandler(converter.UIPayloadHTTPHandlerOptions{
+	h, err := converter.NewPayloadHTTPHandler(converter.PayloadHTTPHandlerOptions{
 		PreStorageCodecs:  []converter.PayloadCodec{preCodec},
 		PostStorageCodecs: []converter.PayloadCodec{postCodec},
 	})
@@ -257,7 +267,7 @@ func TestDecode_StorageRefReturnedAsIs(t *testing.T) {
 	postWrapped, err := postCodec.Encode([]*commonpb.Payload{ref})
 	require.NoError(t, err)
 
-	rr := servePost(t, h, "/ui/decode", encodeRequest(t, postWrapped[0]))
+	rr := servePost(t, h, "/decode", encodeRequest(t, postWrapped[0]))
 	result := decodeResponse(t, rr)
 	require.Len(t, result, 1)
 
@@ -271,7 +281,7 @@ func TestDecode_StorageRefReturnedAsIs(t *testing.T) {
 func TestDecode_MixedBatch(t *testing.T) {
 	preCodec := &appendCodec{encodingSuffix: ".pre", marker: 'P'}
 	postCodec := &appendCodec{encodingSuffix: ".post", marker: 'O'}
-	h, err := converter.NewUIPayloadHTTPHandler(converter.UIPayloadHTTPHandlerOptions{
+	h, err := converter.NewPayloadHTTPHandler(converter.PayloadHTTPHandlerOptions{
 		PreStorageCodecs:  []converter.PayloadCodec{preCodec},
 		PostStorageCodecs: []converter.PayloadCodec{postCodec},
 	})
@@ -290,7 +300,7 @@ func TestDecode_MixedBatch(t *testing.T) {
 	postWrappedRef, err := postCodec.Encode([]*commonpb.Payload{ref})
 	require.NoError(t, err)
 
-	rr := servePost(t, h, "/ui/decode", encodeRequest(t, encoded[0], postWrappedRef[0]))
+	rr := servePost(t, h, "/decode", encodeRequest(t, encoded[0], postWrappedRef[0]))
 	result := decodeResponse(t, rr)
 	require.Len(t, result, 2)
 
@@ -301,11 +311,11 @@ func TestDecode_MixedBatch(t *testing.T) {
 }
 
 // TestDecode_RoundTrip verifies that a payload encoded through the full codec
-// chain (pre then post) is restored to its original form after /ui/decode.
+// chain (pre then post) is restored to its original form after /decode.
 func TestDecode_RoundTrip(t *testing.T) {
 	preCodec := &appendCodec{encodingSuffix: ".pre", marker: 'P'}
 	postCodec := &appendCodec{encodingSuffix: ".post", marker: 'O'}
-	h, err := converter.NewUIPayloadHTTPHandler(converter.UIPayloadHTTPHandlerOptions{
+	h, err := converter.NewPayloadHTTPHandler(converter.PayloadHTTPHandlerOptions{
 		PreStorageCodecs:  []converter.PayloadCodec{preCodec},
 		PostStorageCodecs: []converter.PayloadCodec{postCodec},
 	})
@@ -322,7 +332,7 @@ func TestDecode_RoundTrip(t *testing.T) {
 	encoded, err := postCodec.Encode(preEncoded)
 	require.NoError(t, err)
 
-	rr := servePost(t, h, "/ui/decode", encodeRequest(t, encoded...))
+	rr := servePost(t, h, "/decode", encodeRequest(t, encoded...))
 	decoded := decodeResponse(t, rr)
 	require.Len(t, decoded, 2)
 
@@ -333,7 +343,7 @@ func TestDecode_RoundTrip(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// /ui/download
+// /download
 // ---------------------------------------------------------------------------
 
 // TestDownload_HappyPath verifies that a storage reference is retrieved from
@@ -348,14 +358,14 @@ func TestDownload_HappyPath(t *testing.T) {
 	require.NoError(t, err)
 	driver.data["my-key"] = proto.Clone(preEncoded[0]).(*commonpb.Payload)
 
-	h, err := converter.NewUIPayloadHTTPHandler(converter.UIPayloadHTTPHandlerOptions{
+	h, err := converter.NewPayloadHTTPHandler(converter.PayloadHTTPHandlerOptions{
 		PreStorageCodecs: []converter.PayloadCodec{preCodec},
-		StorageDrivers:   []converter.StorageDriver{driver},
+		ExternalStorage:  converter.ExternalStorage{Drivers: []converter.StorageDriver{driver}},
 	})
 	require.NoError(t, err)
 
 	ref := makeStorageRef(t, "testdrv", "my-key")
-	rr := servePost(t, h, "/ui/download", encodeRequest(t, ref))
+	rr := servePost(t, h, "/download", encodeRequest(t, ref))
 	result := decodeResponse(t, rr)
 	require.Len(t, result, 1)
 
@@ -365,7 +375,7 @@ func TestDownload_HappyPath(t *testing.T) {
 }
 
 // TestDownload_MultipleRefs verifies fan-out retrieval of multiple storage
-// references in a single /ui/download request.
+// references in a single /download request.
 func TestDownload_MultipleRefs(t *testing.T) {
 	driver := newMemDriver("drv")
 	payloads := []*commonpb.Payload{
@@ -378,8 +388,8 @@ func TestDownload_MultipleRefs(t *testing.T) {
 		driver.data[key] = proto.Clone(p).(*commonpb.Payload)
 	}
 
-	h, err := converter.NewUIPayloadHTTPHandler(converter.UIPayloadHTTPHandlerOptions{
-		StorageDrivers: []converter.StorageDriver{driver},
+	h, err := converter.NewPayloadHTTPHandler(converter.PayloadHTTPHandlerOptions{
+		ExternalStorage: converter.ExternalStorage{Drivers: []converter.StorageDriver{driver}},
 	})
 	require.NoError(t, err)
 
@@ -388,7 +398,7 @@ func TestDownload_MultipleRefs(t *testing.T) {
 		refs[i] = makeStorageRef(t, "drv", fmt.Sprintf("k%d", i))
 	}
 
-	rr := servePost(t, h, "/ui/download", encodeRequest(t, refs...))
+	rr := servePost(t, h, "/download", encodeRequest(t, refs...))
 	result := decodeResponse(t, rr)
 	require.Len(t, result, 3)
 	for i, p := range payloads {
@@ -396,42 +406,45 @@ func TestDownload_MultipleRefs(t *testing.T) {
 	}
 }
 
-// TestDownload_NonStorageRef verifies that /ui/download returns 400 when any
+// TestDownload_NonStorageRef verifies that /download returns 400 when any
 // payload in the request is not a storage reference.
 func TestDownload_NonStorageRef(t *testing.T) {
 	driver := newMemDriver("drv")
-	h, err := converter.NewUIPayloadHTTPHandler(converter.UIPayloadHTTPHandlerOptions{
-		StorageDrivers: []converter.StorageDriver{driver},
+	h, err := converter.NewPayloadHTTPHandler(converter.PayloadHTTPHandlerOptions{
+		ExternalStorage: converter.ExternalStorage{Drivers: []converter.StorageDriver{driver}},
 	})
 	require.NoError(t, err)
 
 	regular := makePayload(t, "not-a-ref")
-	rr := servePost(t, h, "/ui/download", encodeRequest(t, regular))
+	rr := servePost(t, h, "/download", encodeRequest(t, regular))
 	require.Equal(t, http.StatusBadRequest, rr.Code)
 }
 
-// TestDownload_NoDrivers verifies that /ui/download returns 400 when no storage
-// drivers are configured.
+// TestDownload_NoDrivers verifies that /download with no drivers configured
+// returns the storage reference payload unresolved (the retrieval visitor leaves
+// it as-is when no driver map is present).
 func TestDownload_NoDrivers(t *testing.T) {
-	h, err := converter.NewUIPayloadHTTPHandler(converter.UIPayloadHTTPHandlerOptions{})
+	h, err := converter.NewPayloadHTTPHandler(converter.PayloadHTTPHandlerOptions{})
 	require.NoError(t, err)
 
 	ref := makeStorageRef(t, "drv", "k1")
-	rr := servePost(t, h, "/ui/download", encodeRequest(t, ref))
-	require.Equal(t, http.StatusBadRequest, rr.Code)
+	rr := servePost(t, h, "/download", encodeRequest(t, ref))
+	result := decodeResponse(t, rr)
+	require.Len(t, result, 1)
+	require.Equal(t, "json/external-storage-reference", encoding(result[0]))
 }
 
-// TestDownload_UnknownDriver verifies that /ui/download returns 400 when the
+// TestDownload_UnknownDriver verifies that /download returns 400 when the
 // storage reference names a driver that is not registered.
 func TestDownload_UnknownDriver(t *testing.T) {
 	driver := newMemDriver("registered")
-	h, err := converter.NewUIPayloadHTTPHandler(converter.UIPayloadHTTPHandlerOptions{
-		StorageDrivers: []converter.StorageDriver{driver},
+	h, err := converter.NewPayloadHTTPHandler(converter.PayloadHTTPHandlerOptions{
+		ExternalStorage: converter.ExternalStorage{Drivers: []converter.StorageDriver{driver}},
 	})
 	require.NoError(t, err)
 
 	ref := makeStorageRef(t, "unregistered", "k1")
-	rr := servePost(t, h, "/ui/download", encodeRequest(t, ref))
+	rr := servePost(t, h, "/download", encodeRequest(t, ref))
 	require.Equal(t, http.StatusBadRequest, rr.Code)
 }
 
@@ -444,8 +457,11 @@ func TestDownload_MultipleDrivers(t *testing.T) {
 	driverA.data["key-a"] = makePayload(t, "from-a")
 	driverB.data["key-b"] = makePayload(t, "from-b")
 
-	h, err := converter.NewUIPayloadHTTPHandler(converter.UIPayloadHTTPHandlerOptions{
-		StorageDrivers: []converter.StorageDriver{driverA, driverB},
+	h, err := converter.NewPayloadHTTPHandler(converter.PayloadHTTPHandlerOptions{
+		ExternalStorage: converter.ExternalStorage{
+			Drivers:        []converter.StorageDriver{driverA, driverB},
+			DriverSelector: firstDriverSelector{driver: driverA},
+		},
 	})
 	require.NoError(t, err)
 
@@ -453,7 +469,7 @@ func TestDownload_MultipleDrivers(t *testing.T) {
 		makeStorageRef(t, "driver-a", "key-a"),
 		makeStorageRef(t, "driver-b", "key-b"),
 	}
-	rr := servePost(t, h, "/ui/download", encodeRequest(t, refs...))
+	rr := servePost(t, h, "/download", encodeRequest(t, refs...))
 	result := decodeResponse(t, rr)
 	require.Len(t, result, 2)
 

--- a/converter/ui_payload_handler.go
+++ b/converter/ui_payload_handler.go
@@ -1,0 +1,210 @@
+// Package converter provides an HTTP handler for a Temporal codec server that
+// understands the two-layer codec architecture used with external payload storage.
+//
+// The handler exposes two routes:
+//
+//   - POST /ui/decode — decodes payloads through the post-storage then pre-storage
+//     codec chains. If a payload is a storage reference after post-storage
+//     decoding it is returned as-is so the caller can resolve it via /ui/download.
+//
+//   - POST /ui/download — accepts storage reference payloads, retrieves the
+//     original payloads from the configured storage drivers, then decodes
+//     them through the pre-storage codec chain.
+//
+// The wire format for both routes is identical to the existing
+// [NewPayloadCodecHTTPHandler]: a JSON-encoded [commonpb.Payloads] request body
+// and response body, with Content-Type application/json.
+
+package converter
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+
+	commonpb "go.temporal.io/api/common/v1"
+	"go.temporal.io/api/proxy"
+	"go.temporal.io/sdk/internal/extstore"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+const (
+	uiDecodePath   = "/ui/decode"
+	uiDownloadPath = "/ui/download"
+)
+
+// UIPayloadHTTPHandlerOptions configures a storage and codec aware HTTP handler
+// for use with Temporal Web UI.
+//
+// NOTE: Experimental
+type UIPayloadHTTPHandlerOptions struct {
+	// PostStorageCodecs are codecs applied outside the storage layer, e.g. a
+	// proxy codec that wraps the entire payload.
+	// They run last on encode (after external storage) and first on decode
+	// (before external retrieval).
+	//
+	// NOTE: Experimental.
+	PostStorageCodecs []PayloadCodec
+
+	// PreStorageCodecs are worker-configured codecs that run before payloads
+	// enter external storage, e.g. encryption or compression. They run first
+	// on encode (before external storage) and last on decode (after external
+	// retrieval).
+	//
+	// NOTE: Experimental.
+	PreStorageCodecs []PayloadCodec
+
+	// StorageDrivers provides the storage drivers used by the /download route to
+	// retrieve payloads identified by storage reference claims. Driver names
+	// must be unique. If no drivers are configured, /download returns HTTP 400.
+	//
+	// NOTE: Experimental.
+	StorageDrivers []StorageDriver
+}
+
+type uiPayloadHTTPHandler struct {
+	postStorageCodecs []PayloadCodec
+	preStorageCodecs  []PayloadCodec
+	retrievalVisitor  extstore.PayloadVisitor // nil when no drivers configured
+}
+
+// NewUIPayloadHTTPHandler creates an [http.Handler] that serves /ui/decode and
+// /ui/download routes for Temporal Web UI using the provided options.
+//
+// NOTE: Experimental
+func NewUIPayloadHTTPHandler(options UIPayloadHTTPHandlerOptions) (http.Handler, error) {
+	h := &uiPayloadHTTPHandler{
+		postStorageCodecs: options.PostStorageCodecs,
+		preStorageCodecs:  options.PreStorageCodecs,
+	}
+	if len(options.StorageDrivers) > 0 {
+		params, err := extstore.ExternalStorageToParams(ExternalStorage{Drivers: options.StorageDrivers})
+		if err != nil {
+			return nil, err
+		}
+		h.retrievalVisitor = extstore.NewExternalRetrievalVisitor(params)
+	}
+	return h, nil
+}
+
+// ServeHTTP implements [http.Handler].
+func (h *uiPayloadHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.NotFound(w, r)
+		return
+	}
+
+	path := r.URL.Path
+	if !strings.HasSuffix(path, uiDecodePath) &&
+		!strings.HasSuffix(path, uiDownloadPath) {
+		http.NotFound(w, r)
+		return
+	}
+
+	if r.Body == nil {
+		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+		return
+	}
+
+	bs, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	var payloadspb commonpb.Payloads
+	if err = protojson.Unmarshal(bs, &payloadspb); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	payloads := payloadspb.Payloads
+
+	switch {
+	case strings.HasSuffix(path, uiDecodePath):
+		payloads, err = h.decode(payloads)
+	case strings.HasSuffix(path, uiDownloadPath):
+		payloads, err = h.download(r, payloads)
+	default:
+		http.NotFound(w, r)
+		return
+	}
+
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err = json.NewEncoder(w).Encode(commonpb.Payloads{Payloads: payloads}); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+	}
+}
+
+// decode applies post-storage codecs (first-to-last) to all payloads. Any
+// payload that is a storage reference after this step is returned as-is so
+// the caller can resolve it via /ui/download. Remaining payloads are further
+// decoded through the pre-storage codecs (first-to-last).
+func (h *uiPayloadHTTPHandler) decode(payloads []*commonpb.Payload) ([]*commonpb.Payload, error) {
+	var err error
+
+	// Apply post-storage codecs to all payloads.
+	for _, c := range h.postStorageCodecs {
+		if payloads, err = c.Decode(payloads); err != nil {
+			return nil, err
+		}
+	}
+
+	// Separate storage references — they cannot be pre-storage decoded yet.
+	result := make([]*commonpb.Payload, len(payloads))
+	var nonRefIdxs []int
+	var nonRefPayloads []*commonpb.Payload
+	for i, p := range payloads {
+		if extstore.IsStorageReference(p) {
+			result[i] = p
+		} else {
+			nonRefIdxs = append(nonRefIdxs, i)
+			nonRefPayloads = append(nonRefPayloads, p)
+		}
+	}
+
+	// Apply pre-storage codecs to non-reference payloads.
+	for _, c := range h.preStorageCodecs {
+		if nonRefPayloads, err = c.Decode(nonRefPayloads); err != nil {
+			return nil, err
+		}
+	}
+	for j, i := range nonRefIdxs {
+		result[i] = nonRefPayloads[j]
+	}
+	return result, nil
+}
+
+// download validates that every payload is a storage reference, retrieves the
+// original payloads from the registered storage drivers, then decodes them
+// through the pre-storage codec chain.
+func (h *uiPayloadHTTPHandler) download(r *http.Request, payloads []*commonpb.Payload) ([]*commonpb.Payload, error) {
+	if h.retrievalVisitor == nil {
+		return nil, errors.New("no storage drivers configured")
+	}
+	for _, p := range payloads {
+		if !extstore.IsStorageReference(p) {
+			return nil, errors.New("all payloads must be storage references")
+		}
+	}
+
+	vpc := &proxy.VisitPayloadsContext{Context: r.Context()}
+	retrieved, err := h.retrievalVisitor.Visit(vpc, payloads)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, c := range h.preStorageCodecs {
+		if retrieved, err = c.Decode(retrieved); err != nil {
+			return nil, err
+		}
+	}
+	return retrieved, nil
+}

--- a/converter/ui_payload_handler.go
+++ b/converter/ui_payload_handler.go
@@ -64,6 +64,14 @@ type UIPayloadHTTPHandlerOptions struct {
 	StorageDrivers []StorageDriver
 }
 
+// noopDriverSelector to satisfy the StorageDriverSelector interface when constructing
+// the retrieval visitor. It is never actually used because the visitor only performs retrieval operations.
+type noopDriverSelector struct{}
+
+func (noopDriverSelector) SelectDriver(_ StorageDriverStoreContext, _ *commonpb.Payload) (StorageDriver, error) {
+	return nil, nil
+}
+
 type uiPayloadHTTPHandler struct {
 	postStorageCodecs []PayloadCodec
 	preStorageCodecs  []PayloadCodec
@@ -80,7 +88,10 @@ func NewUIPayloadHTTPHandler(options UIPayloadHTTPHandlerOptions) (http.Handler,
 		preStorageCodecs:  options.PreStorageCodecs,
 	}
 	if len(options.StorageDrivers) > 0 {
-		params, err := extstore.ExternalStorageToParams(ExternalStorage{Drivers: options.StorageDrivers})
+		params, err := extstore.ExternalStorageToParams(ExternalStorage{
+			Drivers:        options.StorageDrivers,
+			DriverSelector: noopDriverSelector{},
+		})
 		if err != nil {
 			return nil, err
 		}

--- a/converter/ui_payload_handler.go
+++ b/converter/ui_payload_handler.go
@@ -78,6 +78,8 @@ type uiPayloadHTTPHandler struct {
 	retrievalVisitor  extstore.PayloadVisitor // nil when no drivers configured
 }
 
+var _ http.Handler = (*uiPayloadHTTPHandler)(nil)
+
 // NewUIPayloadHTTPHandler creates an [http.Handler] that serves /ui/decode and
 // /ui/download routes for Temporal Web UI using the provided options.
 //

--- a/converter/ui_payload_handler_test.go
+++ b/converter/ui_payload_handler_test.go
@@ -434,3 +434,33 @@ func TestDownload_UnknownDriver(t *testing.T) {
 	rr := servePost(t, h, "/ui/download", encodeRequest(t, ref))
 	require.Equal(t, http.StatusBadRequest, rr.Code)
 }
+
+// TestDownload_MultipleDrivers verifies that multiple storage
+// drivers can be registered.
+func TestDownload_MultipleDrivers(t *testing.T) {
+	driverA := newMemDriver("driver-a")
+	driverB := newMemDriver("driver-b")
+
+	driverA.data["key-a"] = makePayload(t, "from-a")
+	driverB.data["key-b"] = makePayload(t, "from-b")
+
+	h, err := converter.NewUIPayloadHTTPHandler(converter.UIPayloadHTTPHandlerOptions{
+		StorageDrivers: []converter.StorageDriver{driverA, driverB},
+	})
+	require.NoError(t, err)
+
+	refs := []*commonpb.Payload{
+		makeStorageRef(t, "driver-a", "key-a"),
+		makeStorageRef(t, "driver-b", "key-b"),
+	}
+	rr := servePost(t, h, "/ui/download", encodeRequest(t, refs...))
+	result := decodeResponse(t, rr)
+	require.Len(t, result, 2)
+
+	var got0, got1 string
+	require.NoError(t, converter.GetDefaultDataConverter().FromPayload(result[0], &got0))
+	require.Equal(t, "from-a", got0)
+
+	require.NoError(t, converter.GetDefaultDataConverter().FromPayload(result[1], &got1))
+	require.Equal(t, "from-b", got1)
+}

--- a/converter/ui_payload_handler_test.go
+++ b/converter/ui_payload_handler_test.go
@@ -1,0 +1,436 @@
+package converter_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	commonpb "go.temporal.io/api/common/v1"
+	"go.temporal.io/sdk/converter"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+)
+
+// ---------------------------------------------------------------------------
+// appendCodec — test codec that appends a marker byte and a suffix to the
+// encoding field on encode, and reverses both on decode. It operates on ALL
+// payloads regardless of their current encoding, which lets us verify exactly
+// which codecs were applied to which payloads by inspecting the encoding chain.
+// ---------------------------------------------------------------------------
+
+type appendCodec struct {
+	encodingSuffix string
+	marker         byte
+}
+
+func (c *appendCodec) Encode(payloads []*commonpb.Payload) ([]*commonpb.Payload, error) {
+	result := make([]*commonpb.Payload, len(payloads))
+	for i, p := range payloads {
+		enc := string(p.GetMetadata()[converter.MetadataEncoding]) + c.encodingSuffix
+		data := append(append([]byte(nil), p.GetData()...), c.marker)
+		result[i] = &commonpb.Payload{
+			Metadata: map[string][]byte{converter.MetadataEncoding: []byte(enc)},
+			Data:     data,
+		}
+	}
+	return result, nil
+}
+
+func (c *appendCodec) Decode(payloads []*commonpb.Payload) ([]*commonpb.Payload, error) {
+	result := make([]*commonpb.Payload, len(payloads))
+	for i, p := range payloads {
+		enc := string(p.GetMetadata()[converter.MetadataEncoding])
+		if !strings.HasSuffix(enc, c.encodingSuffix) {
+			return nil, fmt.Errorf("appendCodec.Decode: encoding %q does not have expected suffix %q", enc, c.encodingSuffix)
+		}
+		data := p.GetData()
+		if len(data) == 0 || data[len(data)-1] != c.marker {
+			return nil, fmt.Errorf("appendCodec.Decode: expected trailing marker byte %d", c.marker)
+		}
+		result[i] = &commonpb.Payload{
+			Metadata: map[string][]byte{converter.MetadataEncoding: []byte(strings.TrimSuffix(enc, c.encodingSuffix))},
+			Data:     data[:len(data)-1],
+		}
+	}
+	return result, nil
+}
+
+// ---------------------------------------------------------------------------
+// memDriver — minimal in-memory StorageDriver for testing /ui/download.
+// ---------------------------------------------------------------------------
+
+type memDriver struct {
+	name string
+	data map[string]*commonpb.Payload
+}
+
+func newMemDriver(name string) *memDriver {
+	return &memDriver{name: name, data: map[string]*commonpb.Payload{}}
+}
+
+func (d *memDriver) Name() string { return d.name }
+func (d *memDriver) Type() string { return "mem" }
+
+func (d *memDriver) Store(_ converter.StorageDriverStoreContext, payloads []*commonpb.Payload) ([]converter.StorageDriverClaim, error) {
+	claims := make([]converter.StorageDriverClaim, len(payloads))
+	for i, p := range payloads {
+		key := fmt.Sprintf("key-%d-%d", i, len(d.data))
+		d.data[key] = proto.Clone(p).(*commonpb.Payload)
+		claims[i] = converter.StorageDriverClaim{ClaimData: map[string]string{"key": key}}
+	}
+	return claims, nil
+}
+
+func (d *memDriver) Retrieve(_ converter.StorageDriverRetrieveContext, claims []converter.StorageDriverClaim) ([]*commonpb.Payload, error) {
+	payloads := make([]*commonpb.Payload, len(claims))
+	for i, c := range claims {
+		p, ok := d.data[c.ClaimData["key"]]
+		if !ok {
+			return nil, fmt.Errorf("memDriver: key not found: %q", c.ClaimData["key"])
+		}
+		payloads[i] = proto.Clone(p).(*commonpb.Payload)
+	}
+	return payloads, nil
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// storageRefJSON mirrors the internal storageReference struct for constructing
+// test storage-reference payloads without depending on unexported types.
+type storageRefJSON struct {
+	DriverName  string                       `json:"driver_name"`
+	DriverClaim converter.StorageDriverClaim `json:"driver_claim"`
+}
+
+// makeStorageRef creates a storage reference payload pointing to the given
+// driver and claim key. The payload format matches the internal implementation.
+func makeStorageRef(t *testing.T, driverName, key string) *commonpb.Payload {
+	t.Helper()
+	data, err := json.Marshal(storageRefJSON{
+		DriverName:  driverName,
+		DriverClaim: converter.StorageDriverClaim{ClaimData: map[string]string{"key": key}},
+	})
+	require.NoError(t, err)
+	return &commonpb.Payload{
+		Metadata: map[string][]byte{
+			converter.MetadataEncoding: []byte("json/external-storage-reference"),
+		},
+		Data: data,
+	}
+}
+
+// makePayload creates a simple json/plain payload from a string value.
+func makePayload(t *testing.T, value string) *commonpb.Payload {
+	t.Helper()
+	p, err := converter.GetDefaultDataConverter().ToPayload(value)
+	require.NoError(t, err)
+	return p
+}
+
+// encodeRequest JSON-encodes a Payloads proto and returns a request body reader.
+func encodeRequest(t *testing.T, payloads ...*commonpb.Payload) *bytes.Reader {
+	t.Helper()
+	body, err := protojson.Marshal(&commonpb.Payloads{Payloads: payloads})
+	require.NoError(t, err)
+	return bytes.NewReader(body)
+}
+
+// servePost sends a POST to path on handler and returns the recorder.
+func servePost(t *testing.T, handler http.Handler, path string, body *bytes.Reader) *httptest.ResponseRecorder {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, path, body)
+	require.NoError(t, err)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	return rr
+}
+
+// decodeResponse parses the handler's JSON response into a []*commonpb.Payload slice.
+func decodeResponse(t *testing.T, rr *httptest.ResponseRecorder) []*commonpb.Payload {
+	t.Helper()
+	require.Equal(t, http.StatusOK, rr.Code, "response body: %s", rr.Body.String())
+	var result commonpb.Payloads
+	require.NoError(t, protojson.Unmarshal(rr.Body.Bytes(), &result))
+	return result.Payloads
+}
+
+// encoding returns the MetadataEncoding value of a payload as a string.
+func encoding(p *commonpb.Payload) string {
+	return string(p.GetMetadata()[converter.MetadataEncoding])
+}
+
+// ---------------------------------------------------------------------------
+// Routing
+// ---------------------------------------------------------------------------
+
+func TestRouting_WrongMethod(t *testing.T) {
+	h, err := converter.NewUIPayloadHTTPHandler(converter.UIPayloadHTTPHandlerOptions{})
+	require.NoError(t, err)
+
+	req, _ := http.NewRequest(http.MethodGet, "/ui/decode", nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusNotFound, rr.Code)
+}
+
+func TestRouting_WrongPath(t *testing.T) {
+	h, err := converter.NewUIPayloadHTTPHandler(converter.UIPayloadHTTPHandlerOptions{})
+	require.NoError(t, err)
+
+	rr := servePost(t, h, "/missing", bytes.NewReader(nil))
+	require.Equal(t, http.StatusNotFound, rr.Code)
+}
+
+func TestRouting_NilBody(t *testing.T) {
+	h, err := converter.NewUIPayloadHTTPHandler(converter.UIPayloadHTTPHandlerOptions{})
+	require.NoError(t, err)
+
+	req, _ := http.NewRequest(http.MethodPost, "/ui/decode", nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestRouting_MountedAtPrefix(t *testing.T) {
+	h, err := converter.NewUIPayloadHTTPHandler(converter.UIPayloadHTTPHandlerOptions{})
+	require.NoError(t, err)
+
+	p := makePayload(t, "hello")
+	rr := servePost(t, h, "/myapp/codec/ui/decode", encodeRequest(t, p))
+	require.Equal(t, http.StatusOK, rr.Code)
+}
+
+// ---------------------------------------------------------------------------
+// /ui/decode
+// ---------------------------------------------------------------------------
+
+// TestDecode_AppliesPostThenPreCodecs verifies that post-storage codecs run
+// first (first-to-last) and pre-storage codecs run second on non-refs.
+func TestDecode_AppliesPostThenPreCodecs(t *testing.T) {
+	preCodec := &appendCodec{encodingSuffix: ".pre", marker: 'P'}
+	postCodec := &appendCodec{encodingSuffix: ".post", marker: 'O'}
+	h, err := converter.NewUIPayloadHTTPHandler(converter.UIPayloadHTTPHandlerOptions{
+		PreStorageCodecs:  []converter.PayloadCodec{preCodec},
+		PostStorageCodecs: []converter.PayloadCodec{postCodec},
+	})
+	require.NoError(t, err)
+
+	// Build a payload that has been through the full encode chain (pre then post).
+	p := makePayload(t, "hello")
+	originalEncoding := encoding(p)
+	preEncoded, err := preCodec.Encode([]*commonpb.Payload{p})
+	require.NoError(t, err)
+	postEncoded, err := postCodec.Encode(preEncoded)
+	require.NoError(t, err)
+
+	// Decode through the handler and verify the result matches the original.
+	rr := servePost(t, h, "/ui/decode", encodeRequest(t, postEncoded[0]))
+	result := decodeResponse(t, rr)
+	require.Len(t, result, 1)
+	require.Equal(t, originalEncoding, encoding(result[0]))
+}
+
+// TestDecode_StorageRefReturnedAsIs verifies that a payload which is a storage
+// reference after post-storage decoding is returned without applying pre-storage
+// codecs (the caller should resolve it via /ui/download).
+func TestDecode_StorageRefReturnedAsIs(t *testing.T) {
+	// Pre-storage codec that would fail if applied to a storage ref
+	// (its Decode checks for the ".pre" suffix).
+	preCodec := &appendCodec{encodingSuffix: ".pre", marker: 'P'}
+	postCodec := &appendCodec{encodingSuffix: ".post", marker: 'O'}
+	h, err := converter.NewUIPayloadHTTPHandler(converter.UIPayloadHTTPHandlerOptions{
+		PreStorageCodecs:  []converter.PayloadCodec{preCodec},
+		PostStorageCodecs: []converter.PayloadCodec{postCodec},
+	})
+	require.NoError(t, err)
+
+	// Simulate a post-encoded storage reference (post codec was applied to a
+	// storage ref before sending it to this handler).
+	ref := makeStorageRef(t, "drv", "k1")
+	postWrapped, err := postCodec.Encode([]*commonpb.Payload{ref})
+	require.NoError(t, err)
+
+	rr := servePost(t, h, "/ui/decode", encodeRequest(t, postWrapped[0]))
+	result := decodeResponse(t, rr)
+	require.Len(t, result, 1)
+
+	// After post-decode we should see the original storage reference, not an error.
+	require.Equal(t, "json/external-storage-reference", encoding(result[0]))
+}
+
+// TestDecode_MixedBatch verifies that in a batch containing both a regular
+// payload and a storage reference, the regular payload is fully decoded while
+// the storage reference is left as-is.
+func TestDecode_MixedBatch(t *testing.T) {
+	preCodec := &appendCodec{encodingSuffix: ".pre", marker: 'P'}
+	postCodec := &appendCodec{encodingSuffix: ".post", marker: 'O'}
+	h, err := converter.NewUIPayloadHTTPHandler(converter.UIPayloadHTTPHandlerOptions{
+		PreStorageCodecs:  []converter.PayloadCodec{preCodec},
+		PostStorageCodecs: []converter.PayloadCodec{postCodec},
+	})
+	require.NoError(t, err)
+
+	// Regular payload encoded through the full chain (pre then post).
+	regular := makePayload(t, "data")
+	originalEncoding := encoding(regular)
+	preEncoded, err := preCodec.Encode([]*commonpb.Payload{regular})
+	require.NoError(t, err)
+	encoded, err := postCodec.Encode(preEncoded)
+	require.NoError(t, err)
+
+	// Storage reference wrapped by the post codec only.
+	ref := makeStorageRef(t, "drv", "k1")
+	postWrappedRef, err := postCodec.Encode([]*commonpb.Payload{ref})
+	require.NoError(t, err)
+
+	rr := servePost(t, h, "/ui/decode", encodeRequest(t, encoded[0], postWrappedRef[0]))
+	result := decodeResponse(t, rr)
+	require.Len(t, result, 2)
+
+	// Regular payload should be fully decoded.
+	require.Equal(t, originalEncoding, encoding(result[0]))
+	// Storage reference should be left as the raw reference.
+	require.Equal(t, "json/external-storage-reference", encoding(result[1]))
+}
+
+// TestDecode_RoundTrip verifies that a payload encoded through the full codec
+// chain (pre then post) is restored to its original form after /ui/decode.
+func TestDecode_RoundTrip(t *testing.T) {
+	preCodec := &appendCodec{encodingSuffix: ".pre", marker: 'P'}
+	postCodec := &appendCodec{encodingSuffix: ".post", marker: 'O'}
+	h, err := converter.NewUIPayloadHTTPHandler(converter.UIPayloadHTTPHandlerOptions{
+		PreStorageCodecs:  []converter.PayloadCodec{preCodec},
+		PostStorageCodecs: []converter.PayloadCodec{postCodec},
+	})
+	require.NoError(t, err)
+
+	originals := []*commonpb.Payload{
+		makePayload(t, "first"),
+		makePayload(t, "second"),
+	}
+
+	// Encode through the full chain directly (pre then post).
+	preEncoded, err := preCodec.Encode(originals)
+	require.NoError(t, err)
+	encoded, err := postCodec.Encode(preEncoded)
+	require.NoError(t, err)
+
+	rr := servePost(t, h, "/ui/decode", encodeRequest(t, encoded...))
+	decoded := decodeResponse(t, rr)
+	require.Len(t, decoded, 2)
+
+	for i := range originals {
+		require.True(t, proto.Equal(originals[i], decoded[i]),
+			"payload %d: encode→decode should be identity", i)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// /ui/download
+// ---------------------------------------------------------------------------
+
+// TestDownload_HappyPath verifies that a storage reference is retrieved from
+// the configured driver and the result is decoded through pre-storage codecs.
+func TestDownload_HappyPath(t *testing.T) {
+	preCodec := &appendCodec{encodingSuffix: ".pre", marker: 'P'}
+	driver := newMemDriver("testdrv")
+
+	// Pre-populate the driver with a pre-storage-encoded payload.
+	storedPayload := makePayload(t, "stored-value")
+	preEncoded, err := preCodec.Encode([]*commonpb.Payload{storedPayload})
+	require.NoError(t, err)
+	driver.data["my-key"] = proto.Clone(preEncoded[0]).(*commonpb.Payload)
+
+	h, err := converter.NewUIPayloadHTTPHandler(converter.UIPayloadHTTPHandlerOptions{
+		PreStorageCodecs: []converter.PayloadCodec{preCodec},
+		StorageDrivers:   []converter.StorageDriver{driver},
+	})
+	require.NoError(t, err)
+
+	ref := makeStorageRef(t, "testdrv", "my-key")
+	rr := servePost(t, h, "/ui/download", encodeRequest(t, ref))
+	result := decodeResponse(t, rr)
+	require.Len(t, result, 1)
+
+	// The retrieved payload should have been pre-storage decoded.
+	require.True(t, proto.Equal(storedPayload, result[0]),
+		"expected %v, got %v", storedPayload, result[0])
+}
+
+// TestDownload_MultipleRefs verifies fan-out retrieval of multiple storage
+// references in a single /ui/download request.
+func TestDownload_MultipleRefs(t *testing.T) {
+	driver := newMemDriver("drv")
+	payloads := []*commonpb.Payload{
+		makePayload(t, "alpha"),
+		makePayload(t, "beta"),
+		makePayload(t, "gamma"),
+	}
+	for i, p := range payloads {
+		key := fmt.Sprintf("k%d", i)
+		driver.data[key] = proto.Clone(p).(*commonpb.Payload)
+	}
+
+	h, err := converter.NewUIPayloadHTTPHandler(converter.UIPayloadHTTPHandlerOptions{
+		StorageDrivers: []converter.StorageDriver{driver},
+	})
+	require.NoError(t, err)
+
+	refs := make([]*commonpb.Payload, len(payloads))
+	for i := range payloads {
+		refs[i] = makeStorageRef(t, "drv", fmt.Sprintf("k%d", i))
+	}
+
+	rr := servePost(t, h, "/ui/download", encodeRequest(t, refs...))
+	result := decodeResponse(t, rr)
+	require.Len(t, result, 3)
+	for i, p := range payloads {
+		require.True(t, proto.Equal(p, result[i]), "payload %d mismatch", i)
+	}
+}
+
+// TestDownload_NonStorageRef verifies that /ui/download returns 400 when any
+// payload in the request is not a storage reference.
+func TestDownload_NonStorageRef(t *testing.T) {
+	driver := newMemDriver("drv")
+	h, err := converter.NewUIPayloadHTTPHandler(converter.UIPayloadHTTPHandlerOptions{
+		StorageDrivers: []converter.StorageDriver{driver},
+	})
+	require.NoError(t, err)
+
+	regular := makePayload(t, "not-a-ref")
+	rr := servePost(t, h, "/ui/download", encodeRequest(t, regular))
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+// TestDownload_NoDrivers verifies that /ui/download returns 400 when no storage
+// drivers are configured.
+func TestDownload_NoDrivers(t *testing.T) {
+	h, err := converter.NewUIPayloadHTTPHandler(converter.UIPayloadHTTPHandlerOptions{})
+	require.NoError(t, err)
+
+	ref := makeStorageRef(t, "drv", "k1")
+	rr := servePost(t, h, "/ui/download", encodeRequest(t, ref))
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+// TestDownload_UnknownDriver verifies that /ui/download returns 400 when the
+// storage reference names a driver that is not registered.
+func TestDownload_UnknownDriver(t *testing.T) {
+	driver := newMemDriver("registered")
+	h, err := converter.NewUIPayloadHTTPHandler(converter.UIPayloadHTTPHandlerOptions{
+		StorageDrivers: []converter.StorageDriver{driver},
+	})
+	require.NoError(t, err)
+
+	ref := makeStorageRef(t, "unregistered", "k1")
+	rr := servePost(t, h, "/ui/download", encodeRequest(t, ref))
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+}

--- a/internal/client.go
+++ b/internal/client.go
@@ -17,6 +17,7 @@ import (
 	"google.golang.org/grpc/metadata"
 
 	"go.temporal.io/sdk/converter"
+	"go.temporal.io/sdk/internal/extstore"
 	"go.temporal.io/sdk/internal/common/metrics"
 	ilog "go.temporal.io/sdk/internal/log"
 	"go.temporal.io/sdk/log"
@@ -1399,7 +1400,7 @@ func NewServiceClient(workflowServiceClient workflowservice.WorkflowServiceClien
 		heartbeatInterval = options.WorkerHeartbeatInterval
 	}
 
-	storageParams, err := ExternalStorageToParams(options.ExternalStorage)
+	storageParams, err := extstore.ExternalStorageToParams(options.ExternalStorage)
 	if err != nil {
 		panic(fmt.Sprintf("invalid ExternalStorage options: %v", err))
 	}
@@ -1427,8 +1428,8 @@ func NewServiceClient(workflowServiceClient workflowservice.WorkflowServiceClien
 		getSystemInfoTimeout:    options.ConnectionOptions.GetSystemInfoTimeout,
 		workerHeartbeatInterval: heartbeatInterval,
 		workerGroupingKey:       uuid.NewString(),
-		inboundPayloadVisitor:   NewExternalRetrievalVisitor(storageParams),
-		outboundPayloadVisitor:  NewExternalStorageVisitor(storageParams),
+		inboundPayloadVisitor:   extstore.NewExternalRetrievalVisitor(storageParams),
+		outboundPayloadVisitor:  extstore.NewExternalStorageVisitor(storageParams),
 		storageDriverTypes:      storageDriverTypes,
 	}
 

--- a/internal/extstore/extstore.go
+++ b/internal/extstore/extstore.go
@@ -1,0 +1,181 @@
+// Package extstore provides external payload storage types and implementations
+// for the Temporal Go SDK. It is a sub-package of internal/ so that both
+// converter/ and internal/ can import it without creating a circular dependency.
+package extstore
+
+import (
+	"context"
+
+	commonpb "go.temporal.io/api/common/v1"
+	"go.temporal.io/api/proxy"
+)
+
+// StorageDriverTargetInfo identifies the workflow or activity on whose behalf
+// a payload is being stored. Use a type switch on [StorageDriverWorkflowInfo]
+// and [StorageDriverActivityInfo] to access the concrete values.
+//
+// NOTE: Experimental
+type StorageDriverTargetInfo interface {
+	isStorageDriverTargetInfo()
+}
+
+// StorageDriverWorkflowInfo carries workflow identity for a storage operation.
+//
+// NOTE: Experimental
+type StorageDriverWorkflowInfo struct {
+	// Namespace is the Temporal namespace of the workflow execution.
+	Namespace string
+	// WorkflowType is the type name of the workflow.
+	WorkflowType string
+	// WorkflowID is the ID of the workflow execution.
+	WorkflowID string
+	// RunID is the run ID of the workflow execution.
+	RunID string
+}
+
+func (StorageDriverWorkflowInfo) isStorageDriverTargetInfo() {}
+
+var _ StorageDriverTargetInfo = StorageDriverWorkflowInfo{}
+
+// StorageDriverActivityInfo carries activity identity for a storage operation.
+// This is only used for standalone (non-workflow-bound) activities; activities
+// started by a workflow use [StorageDriverWorkflowInfo] as the target.
+//
+// NOTE: Experimental
+type StorageDriverActivityInfo struct {
+	// Namespace is the Temporal namespace of the activity execution.
+	Namespace string
+	// ActivityType is the type name of the activity.
+	ActivityType string
+	// ActivityID is the ID of the activity execution.
+	ActivityID string
+	// RunID is the run ID of the activity execution.
+	RunID string
+}
+
+func (StorageDriverActivityInfo) isStorageDriverTargetInfo() {}
+
+var _ StorageDriverTargetInfo = StorageDriverActivityInfo{}
+
+// StorageDriverStoreContext carries context passed to StorageDriver.Store and
+// StorageDriverSelector.SelectDriver operations.
+//
+// NOTE: Experimental
+type StorageDriverStoreContext struct {
+	// Context is the context of the operation that triggered the driver call.
+	// Drivers should use it to respect cancellation and to propagate deadlines
+	// and trace information to downstream calls (e.g. cloud storage SDKs).
+	Context context.Context
+	// Target identifies the workflow or activity on whose behalf payloads are
+	// being stored. Use a type switch on [StorageDriverWorkflowInfo] and
+	// [StorageDriverActivityInfo] to access the concrete values.
+	Target StorageDriverTargetInfo
+}
+
+// StorageDriverRetrieveContext carries context passed to StorageDriver.Retrieve
+// operations.
+//
+// NOTE: Experimental
+type StorageDriverRetrieveContext struct {
+	// Context is the context of the operation that triggered the driver call.
+	// Drivers should use it to respect cancellation and to propagate deadlines
+	// and trace information to downstream calls (e.g. cloud storage SDKs).
+	Context context.Context
+}
+
+// StorageDriverClaim is an opaque token returned by StorageDriver.Store that
+// identifies where a payload was stored. The SDK serializes it alongside the
+// payload metadata so that StorageDriver.Retrieve can locate the data later.
+// Drivers encode their own addressing information (e.g. a bucket name and
+// object key) into the Data map.
+//
+// NOTE: Experimental
+type StorageDriverClaim struct {
+	ClaimData map[string]string `json:"claim_data"`
+}
+
+// StorageDriver is the interface that must be implemented to back external
+// payload storage. When a payload exceeds the configured size threshold the SDK
+// calls Store instead of embedding it in the Temporal history event. On the
+// read path the SDK calls Retrieve using the claim that was persisted with the
+// event, transparently restoring the original payload before it is decoded by
+// the data converter.
+//
+// NOTE: Experimental
+type StorageDriver interface {
+	// Name returns a stable, unique identifier for this driver instance. The
+	// name is stored in the Temporal history alongside each claim so that the
+	// correct driver is selected on the retrieval path. Multiple instances of
+	// the same driver type can be registered simultaneously under different
+	// names, allowing a DriverSelector to route payloads to different backends
+	// of the same kind. Changing the name of a deployed driver will cause
+	// retrieval to fail for any payloads that were stored under the old name.
+	Name() string
+
+	// Type identifies the driver implementation. Unlike Name, Type must be
+	// identical across all instances of the same driver type regardless of how
+	// they are configured or named.
+	Type() string
+
+	// Store persists the given payloads and returns one StorageDriverClaim per
+	// payload in the same order. The returned claims are serialized into the
+	// Temporal event and must contain enough information for Retrieve to locate
+	// the data. Store must not modify the input payloads.
+	Store(ctx StorageDriverStoreContext, payloads []*commonpb.Payload) ([]StorageDriverClaim, error)
+
+	// Retrieve fetches the payloads identified by the given claims, returning
+	// one payload per claim in the same order. It must not modify the input
+	// claims.
+	Retrieve(ctx StorageDriverRetrieveContext, claims []StorageDriverClaim) ([]*commonpb.Payload, error)
+}
+
+// StorageDriverSelector chooses which StorageDriver should store a given
+// payload, or returns nil to leave the payload inline (not stored externally).
+// Use this when different payloads should be routed to different backends. For
+// example, routing large binary blobs to object storage while keeping small
+// JSON payloads inline. If no selector is set, the first driver in
+// ExternalStorage.Drivers is used for every payload that exceeds the size
+// threshold.
+//
+// NOTE: Experimental
+type StorageDriverSelector interface {
+	SelectDriver(ctx StorageDriverStoreContext, payload *commonpb.Payload) (StorageDriver, error)
+}
+
+// ExternalStorage configures external payload storage for a Temporal client or
+// worker. When set, the SDK intercepts payloads on the way to and from the
+// Temporal server: payloads that exceed PayloadSizeThreshold are offloaded to
+// an external store by the configured driver(s), and storage references are
+// substituted in the history event. The references are resolved back to the
+// original payloads before they reach the data converter or application code.
+//
+// NOTE: Experimental
+type ExternalStorage struct {
+	// Drivers is the list of available storage drivers. At least one driver
+	// must be provided. If no DriverSelector is set, the first driver is used
+	// for all payloads that exceed the size threshold. All drivers listed here
+	// must have unique names; duplicates are rejected at client/worker
+	// construction time.
+	Drivers []StorageDriver
+
+	// DriverSelector routes each payload to a specific driver, or returns nil
+	// to leave the payload inline. When DriverSelector itself is nil, Drivers[0]
+	// is used for every oversized payload. The selector is invoked after the
+	// payload has been serialized by the data converter, so it can inspect
+	// encoding metadata and raw size to make routing decisions.
+	DriverSelector StorageDriverSelector
+
+	// PayloadSizeThreshold is the minimum serialized payload size in bytes that
+	// triggers external storage. Payloads smaller than this value are left
+	// inline in the Temporal history event. A value of zero uses the default
+	// threshold of 256 KiB. Negative values are rejected at client/worker
+	// construction time.
+	PayloadSizeThreshold int
+}
+
+// PayloadVisitor is implemented by types that can transform a slice of payloads
+// in the context of a proxy.VisitPayloads traversal.
+type PayloadVisitor interface {
+	Visit(ctx *proxy.VisitPayloadsContext, payloads []*commonpb.Payload) ([]*commonpb.Payload, error)
+}
+

--- a/internal/extstore/extstore_test.go
+++ b/internal/extstore/extstore_test.go
@@ -1,7 +1,8 @@
-package internal
+package extstore
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sync"
@@ -12,7 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 	commonpb "go.temporal.io/api/common/v1"
 	"go.temporal.io/api/proxy"
-	"go.temporal.io/sdk/converter"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 )
@@ -42,7 +42,7 @@ func newTestDriver(name string) *testStorageDriver {
 func (d *testStorageDriver) Name() string { return d.name }
 func (d *testStorageDriver) Type() string { return "test" }
 
-func (d *testStorageDriver) Store(_ converter.StorageDriverStoreContext, payloads []*commonpb.Payload) ([]converter.StorageDriverClaim, error) {
+func (d *testStorageDriver) Store(_ StorageDriverStoreContext, payloads []*commonpb.Payload) ([]StorageDriverClaim, error) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	d.storeCount++
@@ -57,16 +57,16 @@ func (d *testStorageDriver) Store(_ converter.StorageDriverStoreContext, payload
 	if d.storeErr != nil {
 		return nil, d.storeErr
 	}
-	claims := make([]converter.StorageDriverClaim, len(payloads))
+	claims := make([]StorageDriverClaim, len(payloads))
 	for i, p := range payloads {
 		key := uuid.NewString()
 		d.data[key] = proto.Clone(p).(*commonpb.Payload)
-		claims[i] = converter.StorageDriverClaim{ClaimData: map[string]string{"key": key}}
+		claims[i] = StorageDriverClaim{ClaimData: map[string]string{"key": key}}
 	}
 	return claims, nil
 }
 
-func (d *testStorageDriver) Retrieve(_ converter.StorageDriverRetrieveContext, claims []converter.StorageDriverClaim) ([]*commonpb.Payload, error) {
+func (d *testStorageDriver) Retrieve(_ StorageDriverRetrieveContext, claims []StorageDriverClaim) ([]*commonpb.Payload, error) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	d.retrieveCount++
@@ -98,9 +98,12 @@ func (d *testStorageDriver) Retrieve(_ converter.StorageDriverRetrieveContext, c
 
 func makePayload(t *testing.T, data string) *commonpb.Payload {
 	t.Helper()
-	p, err := converter.GetDefaultDataConverter().ToPayload(data)
+	jsonBytes, err := json.Marshal(data)
 	require.NoError(t, err)
-	return p
+	return &commonpb.Payload{
+		Metadata: map[string][]byte{metadataEncoding: []byte("json/plain")},
+		Data:     jsonBytes,
+	}
 }
 
 // makeOversizedPayload returns a payload whose proto.Size() is >= threshold.
@@ -123,8 +126,8 @@ func visitPayloads(ctx context.Context, visitor PayloadVisitor, payloads []*comm
 // ---------------------------------------------------------------------------
 
 func TestExternalStorageToParams_NegativeThreshold(t *testing.T) {
-	_, err := ExternalStorageToParams(converter.ExternalStorage{
-		Drivers:              []converter.StorageDriver{newTestDriver("d")},
+	_, err := ExternalStorageToParams(ExternalStorage{
+		Drivers:              []StorageDriver{newTestDriver("d")},
 		PayloadSizeThreshold: -1,
 	})
 	require.Error(t, err)
@@ -132,16 +135,16 @@ func TestExternalStorageToParams_NegativeThreshold(t *testing.T) {
 }
 
 func TestExternalStorageToParams_ZeroThresholdUsesDefault(t *testing.T) {
-	params, err := ExternalStorageToParams(converter.ExternalStorage{
-		Drivers: []converter.StorageDriver{newTestDriver("d")},
+	params, err := ExternalStorageToParams(ExternalStorage{
+		Drivers: []StorageDriver{newTestDriver("d")},
 	})
 	require.NoError(t, err)
 	require.Equal(t, defaultPayloadSizeThreshold, params.payloadSizeThreshold)
 }
 
 func TestExternalStorageToParams_ExplicitThreshold(t *testing.T) {
-	params, err := ExternalStorageToParams(converter.ExternalStorage{
-		Drivers:              []converter.StorageDriver{newTestDriver("d")},
+	params, err := ExternalStorageToParams(ExternalStorage{
+		Drivers:              []StorageDriver{newTestDriver("d")},
 		PayloadSizeThreshold: 1024,
 	})
 	require.NoError(t, err)
@@ -149,15 +152,15 @@ func TestExternalStorageToParams_ExplicitThreshold(t *testing.T) {
 }
 
 func TestExternalStorageToParams_MultipleDriversRequireSelector(t *testing.T) {
-	_, err := ExternalStorageToParams(converter.ExternalStorage{
-		Drivers: []converter.StorageDriver{newTestDriver("a"), newTestDriver("b")},
+	_, err := ExternalStorageToParams(ExternalStorage{
+		Drivers: []StorageDriver{newTestDriver("a"), newTestDriver("b")},
 	})
 	require.EqualError(t, err, "DriverSelector must be set when more than one driver is provided")
 }
 
 func TestExternalStorageToParams_DuplicateDriverNames(t *testing.T) {
-	_, err := ExternalStorageToParams(converter.ExternalStorage{
-		Drivers: []converter.StorageDriver{newTestDriver("same"), newTestDriver("same")},
+	_, err := ExternalStorageToParams(ExternalStorage{
+		Drivers: []StorageDriver{newTestDriver("same"), newTestDriver("same")},
 	})
 	require.EqualError(t, err, `duplicate storage driver name: "same"`)
 }
@@ -171,11 +174,11 @@ func TestExternalStorageToParams_PointerAndValueReceiverDrivers(t *testing.T) {
 	//valDriver := valueReceiverDriver{name: "val-driver"}
 	valDriver := newValDriver("val-driver")
 
-	selector := &funcDriverSelector{fn: func(_ converter.StorageDriverStoreContext, _ *commonpb.Payload) (converter.StorageDriver, error) {
+	selector := &funcDriverSelector{fn: func(_ StorageDriverStoreContext, _ *commonpb.Payload) (StorageDriver, error) {
 		return ptrDriver, nil
 	}}
-	params, err := ExternalStorageToParams(converter.ExternalStorage{
-		Drivers:              []converter.StorageDriver{ptrDriver, valDriver},
+	params, err := ExternalStorageToParams(ExternalStorage{
+		Drivers:              []StorageDriver{ptrDriver, valDriver},
 		DriverSelector:       selector,
 		PayloadSizeThreshold: 1, // store everything
 	})
@@ -185,19 +188,19 @@ func TestExternalStorageToParams_PointerAndValueReceiverDrivers(t *testing.T) {
 }
 
 func TestExternalStorageToParams_EmptyDrivers(t *testing.T) {
-	params, err := ExternalStorageToParams(converter.ExternalStorage{})
+	params, err := ExternalStorageToParams(ExternalStorage{})
 	require.NoError(t, err)
 	require.Nil(t, params.driverSelector)
 }
 
 func TestExternalStorageToParams_SingleDriverSynthesizesSelector(t *testing.T) {
 	driver := newTestDriver("d")
-	params, err := ExternalStorageToParams(converter.ExternalStorage{
-		Drivers: []converter.StorageDriver{driver},
+	params, err := ExternalStorageToParams(ExternalStorage{
+		Drivers: []StorageDriver{driver},
 	})
 	require.NoError(t, err)
 	require.NotNil(t, params.driverSelector)
-	selected, err := params.driverSelector.SelectDriver(converter.StorageDriverStoreContext{Context: context.Background()}, nil)
+	selected, err := params.driverSelector.SelectDriver(StorageDriverStoreContext{Context: context.Background()}, nil)
 	require.NoError(t, err)
 	require.Equal(t, driver, selected)
 }
@@ -209,11 +212,11 @@ func TestExternalStorageToParams_SingleDriverSynthesizesSelector(t *testing.T) {
 func TestStorageReferenceRoundTrip(t *testing.T) {
 	ref := storageReference{
 		DriverName:  "mydriver",
-		DriverClaim: converter.StorageDriverClaim{ClaimData: map[string]string{"key": "abc123"}},
+		DriverClaim: StorageDriverClaim{ClaimData: map[string]string{"key": "abc123"}},
 	}
 	p, err := storageReferenceToPayload(ref, 512)
 	require.NoError(t, err)
-	require.Equal(t, metadataEncodingStorageRef, string(p.Metadata[converter.MetadataEncoding]))
+	require.Equal(t, metadataEncodingStorageRef, string(p.Metadata[metadataEncoding]))
 	require.Len(t, p.ExternalPayloads, 1)
 	require.Equal(t, int64(512), p.ExternalPayloads[0].SizeBytes)
 
@@ -225,7 +228,7 @@ func TestStorageReferenceRoundTrip(t *testing.T) {
 
 func TestPayloadToStorageReference_WrongEncoding(t *testing.T) {
 	p := &commonpb.Payload{
-		Metadata: map[string][]byte{converter.MetadataEncoding: []byte("json/plain")},
+		Metadata: map[string][]byte{metadataEncoding: []byte("json/plain")},
 		Data:     []byte(`{}`),
 	}
 	_, err := payloadToStorageReference(p)
@@ -234,7 +237,7 @@ func TestPayloadToStorageReference_WrongEncoding(t *testing.T) {
 
 func TestPayloadToStorageReference_CorruptJSON(t *testing.T) {
 	p := &commonpb.Payload{
-		Metadata: map[string][]byte{converter.MetadataEncoding: []byte(metadataEncodingStorageRef)},
+		Metadata: map[string][]byte{metadataEncoding: []byte(metadataEncodingStorageRef)},
 		Data:     []byte(`not json`),
 	}
 	_, err := payloadToStorageReference(p)
@@ -246,7 +249,7 @@ func TestPayloadToStorageReference_CorruptJSON(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestStoreVisitor_NoDriverNoop(t *testing.T) {
-	params, err := ExternalStorageToParams(converter.ExternalStorage{})
+	params, err := ExternalStorageToParams(ExternalStorage{})
 	require.NoError(t, err)
 	visitor := NewExternalStorageVisitor(params)
 
@@ -259,8 +262,8 @@ func TestStoreVisitor_NoDriverNoop(t *testing.T) {
 func TestStoreVisitor_BelowThreshold_NotStored(t *testing.T) {
 	driver := newTestDriver("d")
 	// Use a large threshold so the payload stays inline.
-	params, err := ExternalStorageToParams(converter.ExternalStorage{
-		Drivers:              []converter.StorageDriver{driver},
+	params, err := ExternalStorageToParams(ExternalStorage{
+		Drivers:              []StorageDriver{driver},
 		PayloadSizeThreshold: 1 << 20, // 1 MiB
 	})
 	require.NoError(t, err)
@@ -276,8 +279,8 @@ func TestStoreVisitor_BelowThreshold_NotStored(t *testing.T) {
 func TestStoreVisitor_AtThreshold_Stored(t *testing.T) {
 	const threshold = 100
 	driver := newTestDriver("d")
-	params, err := ExternalStorageToParams(converter.ExternalStorage{
-		Drivers:              []converter.StorageDriver{driver},
+	params, err := ExternalStorageToParams(ExternalStorage{
+		Drivers:              []StorageDriver{driver},
 		PayloadSizeThreshold: threshold,
 	})
 	require.NoError(t, err)
@@ -288,15 +291,15 @@ func TestStoreVisitor_AtThreshold_Stored(t *testing.T) {
 
 	result, err := visitPayloads(context.Background(), visitor, []*commonpb.Payload{p})
 	require.NoError(t, err)
-	require.Equal(t, metadataEncodingStorageRef, string(result[0].Metadata[converter.MetadataEncoding]))
+	require.Equal(t, metadataEncodingStorageRef, string(result[0].Metadata[metadataEncoding]))
 	require.Equal(t, 1, driver.storeCount)
 }
 
 func TestStoreVisitor_AboveThreshold_Stored(t *testing.T) {
 	const threshold = 10
 	driver := newTestDriver("d")
-	params, err := ExternalStorageToParams(converter.ExternalStorage{
-		Drivers:              []converter.StorageDriver{driver},
+	params, err := ExternalStorageToParams(ExternalStorage{
+		Drivers:              []StorageDriver{driver},
 		PayloadSizeThreshold: threshold,
 	})
 	require.NoError(t, err)
@@ -305,15 +308,15 @@ func TestStoreVisitor_AboveThreshold_Stored(t *testing.T) {
 	p := makeOversizedPayload(t, threshold+1)
 	result, err := visitPayloads(context.Background(), visitor, []*commonpb.Payload{p})
 	require.NoError(t, err)
-	require.Equal(t, metadataEncodingStorageRef, string(result[0].Metadata[converter.MetadataEncoding]))
+	require.Equal(t, metadataEncodingStorageRef, string(result[0].Metadata[metadataEncoding]))
 	require.Equal(t, 1, driver.storeCount)
 }
 
 func TestStoreVisitor_MultiplePayloads_Batched(t *testing.T) {
 	const threshold = 500
 	driver := newTestDriver("d")
-	params, err := ExternalStorageToParams(converter.ExternalStorage{
-		Drivers:              []converter.StorageDriver{driver},
+	params, err := ExternalStorageToParams(ExternalStorage{
+		Drivers:              []StorageDriver{driver},
 		PayloadSizeThreshold: threshold,
 	})
 	require.NoError(t, err)
@@ -326,8 +329,8 @@ func TestStoreVisitor_MultiplePayloads_Batched(t *testing.T) {
 	result, err := visitPayloads(context.Background(), visitor, []*commonpb.Payload{big1, small, big2})
 	require.NoError(t, err)
 	require.Len(t, result, 3)
-	require.Equal(t, metadataEncodingStorageRef, string(result[0].Metadata[converter.MetadataEncoding]))
-	require.Equal(t, metadataEncodingStorageRef, string(result[2].Metadata[converter.MetadataEncoding]))
+	require.Equal(t, metadataEncodingStorageRef, string(result[0].Metadata[metadataEncoding]))
+	require.Equal(t, metadataEncodingStorageRef, string(result[2].Metadata[metadataEncoding]))
 	// small payload is inline
 	require.Empty(t, result[1].ExternalPayloads)
 	// both big payloads batched in a single Store call
@@ -336,11 +339,11 @@ func TestStoreVisitor_MultiplePayloads_Batched(t *testing.T) {
 
 func TestStoreVisitor_SelectorNil_PayloadInline(t *testing.T) {
 	driver := newTestDriver("d")
-	selector := &funcDriverSelector{fn: func(_ converter.StorageDriverStoreContext, _ *commonpb.Payload) (converter.StorageDriver, error) {
+	selector := &funcDriverSelector{fn: func(_ StorageDriverStoreContext, _ *commonpb.Payload) (StorageDriver, error) {
 		return nil, nil
 	}}
-	params, err := ExternalStorageToParams(converter.ExternalStorage{
-		Drivers:        []converter.StorageDriver{driver},
+	params, err := ExternalStorageToParams(ExternalStorage{
+		Drivers:        []StorageDriver{driver},
 		DriverSelector: selector,
 	})
 	require.NoError(t, err)
@@ -356,12 +359,12 @@ func TestStoreVisitor_SelectorNil_PayloadInline(t *testing.T) {
 func TestStoreVisitor_SelectorBelowThreshold_NotCalled(t *testing.T) {
 	driver := newTestDriver("d")
 	selectorCalled := false
-	selector := &funcDriverSelector{fn: func(_ converter.StorageDriverStoreContext, _ *commonpb.Payload) (converter.StorageDriver, error) {
+	selector := &funcDriverSelector{fn: func(_ StorageDriverStoreContext, _ *commonpb.Payload) (StorageDriver, error) {
 		selectorCalled = true
 		return driver, nil
 	}}
-	params, err := ExternalStorageToParams(converter.ExternalStorage{
-		Drivers:              []converter.StorageDriver{driver},
+	params, err := ExternalStorageToParams(ExternalStorage{
+		Drivers:              []StorageDriver{driver},
 		DriverSelector:       selector,
 		PayloadSizeThreshold: 1 << 20, // 1 MiB
 	})
@@ -380,15 +383,15 @@ func TestStoreVisitor_SelectorRoutes_TwoDrivers(t *testing.T) {
 	d1 := newTestDriver("d1")
 	d2 := newTestDriver("d2")
 	i := 0
-	selector := &funcDriverSelector{fn: func(_ converter.StorageDriverStoreContext, _ *commonpb.Payload) (converter.StorageDriver, error) {
+	selector := &funcDriverSelector{fn: func(_ StorageDriverStoreContext, _ *commonpb.Payload) (StorageDriver, error) {
 		defer func() { i++ }()
 		if i%2 == 0 {
 			return d1, nil
 		}
 		return d2, nil
 	}}
-	params, err := ExternalStorageToParams(converter.ExternalStorage{
-		Drivers:              []converter.StorageDriver{d1, d2},
+	params, err := ExternalStorageToParams(ExternalStorage{
+		Drivers:              []StorageDriver{d1, d2},
 		DriverSelector:       selector,
 		PayloadSizeThreshold: 1,
 	})
@@ -405,11 +408,11 @@ func TestStoreVisitor_SelectorRoutes_TwoDrivers(t *testing.T) {
 
 func TestStoreVisitor_SelectorUnregisteredDriver(t *testing.T) {
 	unregistered := newTestDriver("my-unregistered-driver")
-	selector := &funcDriverSelector{fn: func(_ converter.StorageDriverStoreContext, _ *commonpb.Payload) (converter.StorageDriver, error) {
+	selector := &funcDriverSelector{fn: func(_ StorageDriverStoreContext, _ *commonpb.Payload) (StorageDriver, error) {
 		return unregistered, nil
 	}}
-	params, err := ExternalStorageToParams(converter.ExternalStorage{
-		Drivers:              []converter.StorageDriver{newTestDriver("registered")},
+	params, err := ExternalStorageToParams(ExternalStorage{
+		Drivers:              []StorageDriver{newTestDriver("registered")},
 		DriverSelector:       selector,
 		PayloadSizeThreshold: 1,
 	})
@@ -422,11 +425,11 @@ func TestStoreVisitor_SelectorUnregisteredDriver(t *testing.T) {
 }
 
 func TestStoreVisitor_SelectorError(t *testing.T) {
-	selector := &funcDriverSelector{fn: func(_ converter.StorageDriverStoreContext, _ *commonpb.Payload) (converter.StorageDriver, error) {
+	selector := &funcDriverSelector{fn: func(_ StorageDriverStoreContext, _ *commonpb.Payload) (StorageDriver, error) {
 		return nil, errors.New("selector error")
 	}}
-	params, err := ExternalStorageToParams(converter.ExternalStorage{
-		Drivers:              []converter.StorageDriver{newTestDriver("d")},
+	params, err := ExternalStorageToParams(ExternalStorage{
+		Drivers:              []StorageDriver{newTestDriver("d")},
 		DriverSelector:       selector,
 		PayloadSizeThreshold: 1,
 	})
@@ -440,8 +443,8 @@ func TestStoreVisitor_SelectorError(t *testing.T) {
 
 func TestStoreVisitor_WrongClaimCount(t *testing.T) {
 	driver := &badCountDriver{name: "my-bad-count-driver"}
-	params, err := ExternalStorageToParams(converter.ExternalStorage{
-		Drivers:              []converter.StorageDriver{driver},
+	params, err := ExternalStorageToParams(ExternalStorage{
+		Drivers:              []StorageDriver{driver},
 		PayloadSizeThreshold: 1,
 	})
 	require.NoError(t, err)
@@ -455,8 +458,8 @@ func TestStoreVisitor_WrongClaimCount(t *testing.T) {
 func TestStoreVisitor_StoreError(t *testing.T) {
 	driver := newTestDriver("my-bad-error-driver")
 	driver.storeErr = errors.New("store failed")
-	params, err := ExternalStorageToParams(converter.ExternalStorage{
-		Drivers:              []converter.StorageDriver{driver},
+	params, err := ExternalStorageToParams(ExternalStorage{
+		Drivers:              []StorageDriver{driver},
 		PayloadSizeThreshold: 1,
 	})
 	require.NoError(t, err)
@@ -470,8 +473,8 @@ func TestStoreVisitor_StoreError(t *testing.T) {
 
 func TestStoreVisitor_StorePanic(t *testing.T) {
 	driver := &panicDriver{name: "my-panic-store-driver", panicOnStore: true}
-	params, err := ExternalStorageToParams(converter.ExternalStorage{
-		Drivers:              []converter.StorageDriver{driver},
+	params, err := ExternalStorageToParams(ExternalStorage{
+		Drivers:              []StorageDriver{driver},
 		PayloadSizeThreshold: 1,
 	})
 	require.NoError(t, err)
@@ -490,15 +493,15 @@ func TestStoreVisitor_CancelOnError(t *testing.T) {
 	errD.storeGate = blockD.startedCh
 
 	i := 0
-	selector := &funcDriverSelector{fn: func(_ converter.StorageDriverStoreContext, _ *commonpb.Payload) (converter.StorageDriver, error) {
+	selector := &funcDriverSelector{fn: func(_ StorageDriverStoreContext, _ *commonpb.Payload) (StorageDriver, error) {
 		defer func() { i++ }()
 		if i%2 == 0 {
 			return errD, nil
 		}
 		return blockD, nil
 	}}
-	params, err := ExternalStorageToParams(converter.ExternalStorage{
-		Drivers:              []converter.StorageDriver{errD, blockD},
+	params, err := ExternalStorageToParams(ExternalStorage{
+		Drivers:              []StorageDriver{errD, blockD},
 		DriverSelector:       selector,
 		PayloadSizeThreshold: 1,
 	})
@@ -520,15 +523,15 @@ func TestStoreVisitor_CancelOnError(t *testing.T) {
 func TestStoreVisitor_Callback(t *testing.T) {
 	driver := newTestDriver("d")
 	driver.storeDelay = time.Millisecond
-	params, err := ExternalStorageToParams(converter.ExternalStorage{
-		Drivers:              []converter.StorageDriver{driver},
+	params, err := ExternalStorageToParams(ExternalStorage{
+		Drivers:              []StorageDriver{driver},
 		PayloadSizeThreshold: 1,
 	})
 	require.NoError(t, err)
 	visitor := NewExternalStorageVisitor(params)
 
 	cb := &testCallback{}
-	ctx := context.WithValue(context.Background(), storageOperationCallbackContextKey, cb)
+	ctx := WithStorageOperationCallback(context.Background(), cb)
 	_, err = visitPayloads(ctx, visitor, []*commonpb.Payload{makePayload(t, "x"), makePayload(t, "y")})
 	require.NoError(t, err)
 	require.Equal(t, 2, cb.count)
@@ -539,8 +542,8 @@ func TestStoreVisitor_Callback(t *testing.T) {
 func TestStoreVisitor_Callback_ExternalCountOnly(t *testing.T) {
 	const threshold = 50
 	driver := newTestDriver("d")
-	params, err := ExternalStorageToParams(converter.ExternalStorage{
-		Drivers:              []converter.StorageDriver{driver},
+	params, err := ExternalStorageToParams(ExternalStorage{
+		Drivers:              []StorageDriver{driver},
 		PayloadSizeThreshold: threshold,
 	})
 	require.NoError(t, err)
@@ -551,7 +554,7 @@ func TestStoreVisitor_Callback_ExternalCountOnly(t *testing.T) {
 	big2 := makeOversizedPayload(t, threshold)
 
 	cb := &testCallback{}
-	ctx := context.WithValue(context.Background(), storageOperationCallbackContextKey, cb)
+	ctx := WithStorageOperationCallback(context.Background(), cb)
 	_, err = visitPayloads(ctx, visitor, []*commonpb.Payload{small, big1, big2})
 	require.NoError(t, err)
 	require.Equal(t, 2, cb.count)
@@ -563,8 +566,8 @@ func TestStoreVisitor_Callback_ExternalCountOnly(t *testing.T) {
 
 func TestRetrievalVisitor_InlinePassthrough(t *testing.T) {
 	driver := newTestDriver("d")
-	params, err := ExternalStorageToParams(converter.ExternalStorage{
-		Drivers: []converter.StorageDriver{driver},
+	params, err := ExternalStorageToParams(ExternalStorage{
+		Drivers: []StorageDriver{driver},
 	})
 	require.NoError(t, err)
 	visitor := NewExternalRetrievalVisitor(params)
@@ -578,8 +581,8 @@ func TestRetrievalVisitor_InlinePassthrough(t *testing.T) {
 
 func TestRetrievalVisitor_Mixed(t *testing.T) {
 	driver := newTestDriver("d")
-	storeParams, err := ExternalStorageToParams(converter.ExternalStorage{
-		Drivers:              []converter.StorageDriver{driver},
+	storeParams, err := ExternalStorageToParams(ExternalStorage{
+		Drivers:              []StorageDriver{driver},
 		PayloadSizeThreshold: 1,
 	})
 	require.NoError(t, err)
@@ -601,8 +604,8 @@ func TestRetrievalVisitor_Mixed(t *testing.T) {
 
 func TestRetrievalVisitor_BatchedByDriver(t *testing.T) {
 	driver := newTestDriver("d")
-	params, err := ExternalStorageToParams(converter.ExternalStorage{
-		Drivers:              []converter.StorageDriver{driver},
+	params, err := ExternalStorageToParams(ExternalStorage{
+		Drivers:              []StorageDriver{driver},
 		PayloadSizeThreshold: 1,
 	})
 	require.NoError(t, err)
@@ -625,15 +628,15 @@ func TestRetrievalVisitor_MultiDriver(t *testing.T) {
 	d1 := newTestDriver("d1")
 	d2 := newTestDriver("d2")
 	i := 0
-	selector := &funcDriverSelector{fn: func(_ converter.StorageDriverStoreContext, _ *commonpb.Payload) (converter.StorageDriver, error) {
+	selector := &funcDriverSelector{fn: func(_ StorageDriverStoreContext, _ *commonpb.Payload) (StorageDriver, error) {
 		defer func() { i++ }()
 		if i == 0 {
 			return d1, nil
 		}
 		return d2, nil
 	}}
-	params, err := ExternalStorageToParams(converter.ExternalStorage{
-		Drivers:              []converter.StorageDriver{d1, d2},
+	params, err := ExternalStorageToParams(ExternalStorage{
+		Drivers:              []StorageDriver{d1, d2},
 		DriverSelector:       selector,
 		PayloadSizeThreshold: 1,
 	})
@@ -654,15 +657,15 @@ func TestRetrievalVisitor_MultiDriver(t *testing.T) {
 }
 
 func TestRetrievalVisitor_UnknownDriver(t *testing.T) {
-	params, err := ExternalStorageToParams(converter.ExternalStorage{
-		Drivers: []converter.StorageDriver{newTestDriver("registered")},
+	params, err := ExternalStorageToParams(ExternalStorage{
+		Drivers: []StorageDriver{newTestDriver("registered")},
 	})
 	require.NoError(t, err)
 	visitor := NewExternalRetrievalVisitor(params)
 
 	ref, err := storageReferenceToPayload(storageReference{
 		DriverName:  "unregistered-driver",
-		DriverClaim: converter.StorageDriverClaim{ClaimData: map[string]string{"key": "k"}},
+		DriverClaim: StorageDriverClaim{ClaimData: map[string]string{"key": "k"}},
 	}, 10)
 	require.NoError(t, err)
 
@@ -674,8 +677,8 @@ func TestRetrievalVisitor_UnknownDriver(t *testing.T) {
 func TestRetrievalVisitor_RetrieveError(t *testing.T) {
 	driver := newTestDriver("my-bad-error-driver")
 	driver.retrieveErr = errors.New("retrieve error")
-	params, err := ExternalStorageToParams(converter.ExternalStorage{
-		Drivers:              []converter.StorageDriver{driver},
+	params, err := ExternalStorageToParams(ExternalStorage{
+		Drivers:              []StorageDriver{driver},
 		PayloadSizeThreshold: 1,
 	})
 	require.NoError(t, err)
@@ -693,15 +696,15 @@ func TestRetrievalVisitor_RetrieveError(t *testing.T) {
 
 func TestRetrievalVisitor_RetrievePanic(t *testing.T) {
 	driver := &panicDriver{name: "my-panic-retrieve-driver", panicOnRetrieve: true}
-	params, err := ExternalStorageToParams(converter.ExternalStorage{
-		Drivers: []converter.StorageDriver{driver},
+	params, err := ExternalStorageToParams(ExternalStorage{
+		Drivers: []StorageDriver{driver},
 	})
 	require.NoError(t, err)
 	visitor := NewExternalRetrievalVisitor(params)
 
 	ref, err := storageReferenceToPayload(storageReference{
 		DriverName:  "my-panic-retrieve-driver",
-		DriverClaim: converter.StorageDriverClaim{ClaimData: map[string]string{"key": "k"}},
+		DriverClaim: StorageDriverClaim{ClaimData: map[string]string{"key": "k"}},
 	}, 10)
 	require.NoError(t, err)
 
@@ -719,8 +722,8 @@ func TestRetrievalVisitor_CancelOnError(t *testing.T) {
 
 	// Store via errD so we get a real reference for errD, then hand-craft a
 	// reference for blockD.
-	storeParams, err := ExternalStorageToParams(converter.ExternalStorage{
-		Drivers:              []converter.StorageDriver{errD},
+	storeParams, err := ExternalStorageToParams(ExternalStorage{
+		Drivers:              []StorageDriver{errD},
 		PayloadSizeThreshold: 1,
 	})
 	require.NoError(t, err)
@@ -731,13 +734,13 @@ func TestRetrievalVisitor_CancelOnError(t *testing.T) {
 
 	blockRef, err := storageReferenceToPayload(storageReference{
 		DriverName:  "block-driver",
-		DriverClaim: converter.StorageDriverClaim{ClaimData: map[string]string{"key": "k"}},
+		DriverClaim: StorageDriverClaim{ClaimData: map[string]string{"key": "k"}},
 	}, 10)
 	require.NoError(t, err)
 
-	retrieveParams, err := ExternalStorageToParams(converter.ExternalStorage{
-		Drivers: []converter.StorageDriver{errD, blockD},
-		DriverSelector: &funcDriverSelector{fn: func(_ converter.StorageDriverStoreContext, _ *commonpb.Payload) (converter.StorageDriver, error) {
+	retrieveParams, err := ExternalStorageToParams(ExternalStorage{
+		Drivers: []StorageDriver{errD, blockD},
+		DriverSelector: &funcDriverSelector{fn: func(_ StorageDriverStoreContext, _ *commonpb.Payload) (StorageDriver, error) {
 			return errD, nil
 		}},
 	})
@@ -757,15 +760,15 @@ func TestRetrievalVisitor_CancelOnError(t *testing.T) {
 
 func TestRetrievalVisitor_WrongPayloadCount(t *testing.T) {
 	driver := &badCountRetrieveDriver{name: "my-bad-count-driver"}
-	params, err := ExternalStorageToParams(converter.ExternalStorage{
-		Drivers: []converter.StorageDriver{driver},
+	params, err := ExternalStorageToParams(ExternalStorage{
+		Drivers: []StorageDriver{driver},
 	})
 	require.NoError(t, err)
 	visitor := NewExternalRetrievalVisitor(params)
 
 	ref, err := storageReferenceToPayload(storageReference{
 		DriverName:  "my-bad-count-driver",
-		DriverClaim: converter.StorageDriverClaim{ClaimData: map[string]string{"key": "k"}},
+		DriverClaim: StorageDriverClaim{ClaimData: map[string]string{"key": "k"}},
 	}, 10)
 	require.NoError(t, err)
 
@@ -777,8 +780,8 @@ func TestRetrievalVisitor_WrongPayloadCount(t *testing.T) {
 func TestRetrievalVisitor_Callback(t *testing.T) {
 	driver := newTestDriver("d")
 	driver.retrieveDelay = time.Millisecond
-	params, err := ExternalStorageToParams(converter.ExternalStorage{
-		Drivers:              []converter.StorageDriver{driver},
+	params, err := ExternalStorageToParams(ExternalStorage{
+		Drivers:              []StorageDriver{driver},
 		PayloadSizeThreshold: 1,
 	})
 	require.NoError(t, err)
@@ -789,7 +792,7 @@ func TestRetrievalVisitor_Callback(t *testing.T) {
 	require.NoError(t, err)
 
 	cb := &testCallback{}
-	ctx := context.WithValue(context.Background(), storageOperationCallbackContextKey, cb)
+	ctx := WithStorageOperationCallback(context.Background(), cb)
 	_, err = visitPayloads(ctx, retrieveVisitor, refs)
 	require.NoError(t, err)
 	require.Greater(t, cb.duration, time.Duration(0))
@@ -798,8 +801,8 @@ func TestRetrievalVisitor_Callback(t *testing.T) {
 func TestRetrievalVisitor_Callback_ExternalCountOnly(t *testing.T) {
 	const threshold = 50
 	driver := newTestDriver("d")
-	params, err := ExternalStorageToParams(converter.ExternalStorage{
-		Drivers:              []converter.StorageDriver{driver},
+	params, err := ExternalStorageToParams(ExternalStorage{
+		Drivers:              []StorageDriver{driver},
 		PayloadSizeThreshold: threshold,
 	})
 	require.NoError(t, err)
@@ -815,7 +818,7 @@ func TestRetrievalVisitor_Callback_ExternalCountOnly(t *testing.T) {
 	batch := []*commonpb.Payload{inline, refs[0], refs[1]}
 
 	cb := &testCallback{}
-	ctx := context.WithValue(context.Background(), storageOperationCallbackContextKey, cb)
+	ctx := WithStorageOperationCallback(context.Background(), cb)
 	_, err = visitPayloads(ctx, retrieveVisitor, batch)
 	require.NoError(t, err)
 	require.Equal(t, 2, cb.count)
@@ -848,7 +851,7 @@ func TestClaimDeserialization(t *testing.T) {
 
 	ref, err := payloadToStorageReference(refPayload)
 	require.NoError(t, err)
-	require.Equal(t, metadataEncodingStorageRef, string(refPayload.GetMetadata()[converter.MetadataEncoding]))
+	require.Equal(t, metadataEncodingStorageRef, string(refPayload.GetMetadata()[metadataEncoding]))
 	require.Equal(t, 1, len(refPayload.ExternalPayloads))
 	require.Equal(t, int64(385), refPayload.ExternalPayloads[0].SizeBytes)
 	require.Equal(t, "temporalio:driver:s3", ref.DriverName)
@@ -862,8 +865,8 @@ func TestClaimDeserialization(t *testing.T) {
 
 func TestStoreRetrieveRoundTrip_Single(t *testing.T) {
 	driver := newTestDriver("d")
-	params, err := ExternalStorageToParams(converter.ExternalStorage{
-		Drivers:              []converter.StorageDriver{driver},
+	params, err := ExternalStorageToParams(ExternalStorage{
+		Drivers:              []StorageDriver{driver},
 		PayloadSizeThreshold: 1,
 	})
 	require.NoError(t, err)
@@ -873,7 +876,7 @@ func TestStoreRetrieveRoundTrip_Single(t *testing.T) {
 	original := makePayload(t, "round-trip value")
 	refs, err := visitPayloads(context.Background(), storeVisitor, []*commonpb.Payload{original})
 	require.NoError(t, err)
-	require.Equal(t, metadataEncodingStorageRef, string(refs[0].Metadata[converter.MetadataEncoding]))
+	require.Equal(t, metadataEncodingStorageRef, string(refs[0].Metadata[metadataEncoding]))
 
 	restored, err := visitPayloads(context.Background(), retrieveVisitor, refs)
 	require.NoError(t, err)
@@ -883,8 +886,8 @@ func TestStoreRetrieveRoundTrip_Single(t *testing.T) {
 func TestStoreRetrieveRoundTrip_MixedInline(t *testing.T) {
 	const threshold = 50
 	driver := newTestDriver("d")
-	params, err := ExternalStorageToParams(converter.ExternalStorage{
-		Drivers:              []converter.StorageDriver{driver},
+	params, err := ExternalStorageToParams(ExternalStorage{
+		Drivers:              []StorageDriver{driver},
 		PayloadSizeThreshold: threshold,
 	})
 	require.NoError(t, err)
@@ -909,7 +912,7 @@ func TestStoreRetrieveRoundTrip_PointerAndValueReceiverDrivers(t *testing.T) {
 
 	// Route the first payload to ptrDriver and the second to valDriver.
 	i := 0
-	selector := &funcDriverSelector{fn: func(_ converter.StorageDriverStoreContext, _ *commonpb.Payload) (converter.StorageDriver, error) {
+	selector := &funcDriverSelector{fn: func(_ StorageDriverStoreContext, _ *commonpb.Payload) (StorageDriver, error) {
 		defer func() { i++ }()
 		if i == 0 {
 			return ptrDriver, nil
@@ -917,8 +920,8 @@ func TestStoreRetrieveRoundTrip_PointerAndValueReceiverDrivers(t *testing.T) {
 		return valDriver, nil
 	}}
 
-	params, err := ExternalStorageToParams(converter.ExternalStorage{
-		Drivers:              []converter.StorageDriver{ptrDriver, valDriver},
+	params, err := ExternalStorageToParams(ExternalStorage{
+		Drivers:              []StorageDriver{ptrDriver, valDriver},
 		DriverSelector:       selector,
 		PayloadSizeThreshold: 1, // store everything
 	})
@@ -961,13 +964,13 @@ type panicDriver struct {
 
 func (d *panicDriver) Name() string { return d.name }
 func (d *panicDriver) Type() string { return "panic" }
-func (d *panicDriver) Store(_ converter.StorageDriverStoreContext, _ []*commonpb.Payload) ([]converter.StorageDriverClaim, error) {
+func (d *panicDriver) Store(_ StorageDriverStoreContext, _ []*commonpb.Payload) ([]StorageDriverClaim, error) {
 	if d.panicOnStore {
 		panic("store panic")
 	}
 	return nil, nil
 }
-func (d *panicDriver) Retrieve(_ converter.StorageDriverRetrieveContext, _ []converter.StorageDriverClaim) ([]*commonpb.Payload, error) {
+func (d *panicDriver) Retrieve(_ StorageDriverRetrieveContext, _ []StorageDriverClaim) ([]*commonpb.Payload, error) {
 	if d.panicOnRetrieve {
 		panic("retrieve panic")
 	}
@@ -986,7 +989,7 @@ type blockingDriver struct {
 
 func (d *blockingDriver) Name() string { return d.name }
 func (d *blockingDriver) Type() string { return "blocking" }
-func (d *blockingDriver) Store(ctx converter.StorageDriverStoreContext, _ []*commonpb.Payload) ([]converter.StorageDriverClaim, error) {
+func (d *blockingDriver) Store(ctx StorageDriverStoreContext, _ []*commonpb.Payload) ([]StorageDriverClaim, error) {
 	if d.startedCh != nil {
 		close(d.startedCh)
 	}
@@ -994,7 +997,7 @@ func (d *blockingDriver) Store(ctx converter.StorageDriverStoreContext, _ []*com
 	close(d.cancelledCh)
 	return nil, ctx.Context.Err()
 }
-func (d *blockingDriver) Retrieve(ctx converter.StorageDriverRetrieveContext, _ []converter.StorageDriverClaim) ([]*commonpb.Payload, error) {
+func (d *blockingDriver) Retrieve(ctx StorageDriverRetrieveContext, _ []StorageDriverClaim) ([]*commonpb.Payload, error) {
 	close(d.startedCh)
 	<-ctx.Context.Done()
 	close(d.cancelledCh)
@@ -1002,10 +1005,10 @@ func (d *blockingDriver) Retrieve(ctx converter.StorageDriverRetrieveContext, _ 
 }
 
 type funcDriverSelector struct {
-	fn func(converter.StorageDriverStoreContext, *commonpb.Payload) (converter.StorageDriver, error)
+	fn func(StorageDriverStoreContext, *commonpb.Payload) (StorageDriver, error)
 }
 
-func (s *funcDriverSelector) SelectDriver(ctx converter.StorageDriverStoreContext, p *commonpb.Payload) (converter.StorageDriver, error) {
+func (s *funcDriverSelector) SelectDriver(ctx StorageDriverStoreContext, p *commonpb.Payload) (StorageDriver, error) {
 	return s.fn(ctx, p)
 }
 
@@ -1013,10 +1016,10 @@ type badCountDriver struct{ name string }
 
 func (d *badCountDriver) Name() string { return d.name }
 func (d *badCountDriver) Type() string { return "bad" }
-func (d *badCountDriver) Store(_ converter.StorageDriverStoreContext, _ []*commonpb.Payload) ([]converter.StorageDriverClaim, error) {
-	return []converter.StorageDriverClaim{}, nil // returns 0 claims instead of 1
+func (d *badCountDriver) Store(_ StorageDriverStoreContext, _ []*commonpb.Payload) ([]StorageDriverClaim, error) {
+	return []StorageDriverClaim{}, nil // returns 0 claims instead of 1
 }
-func (d *badCountDriver) Retrieve(_ converter.StorageDriverRetrieveContext, _ []converter.StorageDriverClaim) ([]*commonpb.Payload, error) {
+func (d *badCountDriver) Retrieve(_ StorageDriverRetrieveContext, _ []StorageDriverClaim) ([]*commonpb.Payload, error) {
 	return nil, nil
 }
 
@@ -1024,14 +1027,14 @@ type badCountRetrieveDriver struct{ name string }
 
 func (d *badCountRetrieveDriver) Name() string { return d.name }
 func (d *badCountRetrieveDriver) Type() string { return "bad" }
-func (d *badCountRetrieveDriver) Store(_ converter.StorageDriverStoreContext, payloads []*commonpb.Payload) ([]converter.StorageDriverClaim, error) {
-	claims := make([]converter.StorageDriverClaim, len(payloads))
+func (d *badCountRetrieveDriver) Store(_ StorageDriverStoreContext, payloads []*commonpb.Payload) ([]StorageDriverClaim, error) {
+	claims := make([]StorageDriverClaim, len(payloads))
 	for i := range claims {
-		claims[i] = converter.StorageDriverClaim{ClaimData: map[string]string{"key": "k"}}
+		claims[i] = StorageDriverClaim{ClaimData: map[string]string{"key": "k"}}
 	}
 	return claims, nil
 }
-func (d *badCountRetrieveDriver) Retrieve(_ converter.StorageDriverRetrieveContext, _ []converter.StorageDriverClaim) ([]*commonpb.Payload, error) {
+func (d *badCountRetrieveDriver) Retrieve(_ StorageDriverRetrieveContext, _ []StorageDriverClaim) ([]*commonpb.Payload, error) {
 	return []*commonpb.Payload{}, nil // returns 0 payloads instead of 1
 }
 
@@ -1046,16 +1049,16 @@ type valueReceiverDriver struct {
 
 func (d valueReceiverDriver) Name() string { return d.name }
 func (d valueReceiverDriver) Type() string { return "value" }
-func (d valueReceiverDriver) Store(_ converter.StorageDriverStoreContext, payloads []*commonpb.Payload) ([]converter.StorageDriverClaim, error) {
-	claims := make([]converter.StorageDriverClaim, len(payloads))
+func (d valueReceiverDriver) Store(_ StorageDriverStoreContext, payloads []*commonpb.Payload) ([]StorageDriverClaim, error) {
+	claims := make([]StorageDriverClaim, len(payloads))
 	for i, p := range payloads {
 		key := uuid.NewString()
 		d.data[key] = proto.Clone(p).(*commonpb.Payload)
-		claims[i] = converter.StorageDriverClaim{ClaimData: map[string]string{"key": key}}
+		claims[i] = StorageDriverClaim{ClaimData: map[string]string{"key": key}}
 	}
 	return claims, nil
 }
-func (d valueReceiverDriver) Retrieve(_ converter.StorageDriverRetrieveContext, claims []converter.StorageDriverClaim) ([]*commonpb.Payload, error) {
+func (d valueReceiverDriver) Retrieve(_ StorageDriverRetrieveContext, claims []StorageDriverClaim) ([]*commonpb.Payload, error) {
 	payloads := make([]*commonpb.Payload, len(claims))
 	for i, c := range claims {
 		p, ok := d.data[c.ClaimData["key"]]
@@ -1067,7 +1070,7 @@ func (d valueReceiverDriver) Retrieve(_ converter.StorageDriverRetrieveContext, 
 	return payloads, nil
 }
 
-func newValDriver(name string) converter.StorageDriver {
+func newValDriver(name string) StorageDriver {
 	return valueReceiverDriver{name: name, data: map[string]*commonpb.Payload{}}
 }
 

--- a/internal/extstore/internal_extstore.go
+++ b/internal/extstore/internal_extstore.go
@@ -1,4 +1,4 @@
-package internal
+package extstore
 
 import (
 	"context"
@@ -8,34 +8,41 @@ import (
 
 	commonpb "go.temporal.io/api/common/v1"
 	"go.temporal.io/api/proxy"
-	"go.temporal.io/sdk/converter"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/protobuf/proto"
 )
 
 const defaultPayloadSizeThreshold = 256 * 1024
 
-type storageParameters struct {
-	driverMap            map[string]converter.StorageDriver
-	driverSelector       converter.StorageDriverSelector
+// StorageParameters holds the validated, ready-to-use storage configuration
+// built from a [ExternalStorage] value via [ExternalStorageToParams].
+type StorageParameters struct {
+	driverMap            map[string]StorageDriver
+	driverSelector       StorageDriverSelector
 	payloadSizeThreshold int
 }
 
-func ExternalStorageToParams(options converter.ExternalStorage) (storageParameters, error) {
+// IsStorageReference reports whether p is an external-storage reference payload
+// (i.e. its encoding metadata equals the internal storage-reference marker).
+func IsStorageReference(p *commonpb.Payload) bool {
+	return string(p.GetMetadata()[metadataEncoding]) == metadataEncodingStorageRef
+}
+
+func ExternalStorageToParams(options ExternalStorage) (StorageParameters, error) {
 	if options.PayloadSizeThreshold < 0 {
-		return storageParameters{}, fmt.Errorf("PayloadSizeThreshold must not be negative")
+		return StorageParameters{}, fmt.Errorf("PayloadSizeThreshold must not be negative")
 	}
 
-	driverMap := make(map[string]converter.StorageDriver, len(options.Drivers))
+	driverMap := make(map[string]StorageDriver, len(options.Drivers))
 	for _, d := range options.Drivers {
 		if _, exists := driverMap[d.Name()]; exists {
-			return storageParameters{}, fmt.Errorf("duplicate storage driver name: %q", d.Name())
+			return StorageParameters{}, fmt.Errorf("duplicate storage driver name: %q", d.Name())
 		}
 		driverMap[d.Name()] = d
 	}
 
 	if len(options.Drivers) > 1 && options.DriverSelector == nil {
-		return storageParameters{}, fmt.Errorf("DriverSelector must be set when more than one driver is provided")
+		return StorageParameters{}, fmt.Errorf("DriverSelector must be set when more than one driver is provided")
 	}
 
 	selector := options.DriverSelector
@@ -48,7 +55,7 @@ func ExternalStorageToParams(options converter.ExternalStorage) (storageParamete
 		sizeThreshold = defaultPayloadSizeThreshold
 	}
 
-	return storageParameters{
+	return StorageParameters{
 		driverMap:            driverMap,
 		driverSelector:       selector,
 		payloadSizeThreshold: sizeThreshold,
@@ -57,10 +64,10 @@ func ExternalStorageToParams(options converter.ExternalStorage) (storageParamete
 
 // singleDriverSelector is a StorageDriverSelector that always returns the same driver.
 type singleDriverSelector struct {
-	driver converter.StorageDriver
+	driver StorageDriver
 }
 
-func (s singleDriverSelector) SelectDriver(_ converter.StorageDriverStoreContext, _ *commonpb.Payload) (converter.StorageDriver, error) {
+func (s singleDriverSelector) SelectDriver(_ StorageDriverStoreContext, _ *commonpb.Payload) (StorageDriver, error) {
 	return s.driver, nil
 }
 
@@ -68,7 +75,7 @@ func (s singleDriverSelector) SelectDriver(_ converter.StorageDriverStoreContext
 // the dynamic type is comparable (pointer types, simple value types) and
 // falls back to name equality for non-comparable value types (e.g. structs
 // with map fields).
-func driversEqual(a, b converter.StorageDriver) (equal bool) {
+func driversEqual(a, b StorageDriver) (equal bool) {
 	defer func() {
 		if recover() != nil {
 			equal = a.Name() == b.Name()
@@ -77,21 +84,41 @@ func driversEqual(a, b converter.StorageDriver) (equal bool) {
 	return a == b
 }
 
-type storageOperationCallback interface {
+type StorageOperationCallback interface {
 	PayloadBatchCompleted(count int, size int64, duration time.Duration)
 	UnconfiguredStorageReference()
 }
 
+type contextKey string
+
 const storageOperationCallbackContextKey contextKey = "storageOperationCallback"
+
+func WithStorageOperationCallback(ctx context.Context, cb StorageOperationCallback) context.Context {
+	return context.WithValue(ctx, storageOperationCallbackContextKey, cb)
+}
+
 const storageTargetContextKey contextKey = "storageTarget"
+
+func WithStorageTarget(ctx context.Context, target StorageDriverTargetInfo) context.Context {
+	return context.WithValue(ctx, storageTargetContextKey, target)
+}
+
+func StorageTargetFromContext(ctx context.Context) StorageDriverTargetInfo {
+	t, _ := ctx.Value(storageTargetContextKey).(StorageDriverTargetInfo)
+	return t
+}
+
+// metadataEncoding is the key used in payload metadata to identify the encoding
+// format. Mirrors converter.MetadataEncoding without importing converter package.
+const metadataEncoding = "encoding"
 
 // metadataEncodingStorageRef is the metadata encoding value used to identify
 // payloads that are storage references rather than actual data.
 const metadataEncodingStorageRef = "json/external-storage-reference"
 
 type storageReference struct {
-	DriverName  string                       `json:"driver_name"`
-	DriverClaim converter.StorageDriverClaim `json:"driver_claim"`
+	DriverName  string             `json:"driver_name"`
+	DriverClaim StorageDriverClaim `json:"driver_claim"`
 }
 
 func storageReferenceToPayload(ref storageReference, storedSizeBytes int64) (*commonpb.Payload, error) {
@@ -101,7 +128,7 @@ func storageReferenceToPayload(ref storageReference, storedSizeBytes int64) (*co
 	}
 	return &commonpb.Payload{
 		Metadata: map[string][]byte{
-			converter.MetadataEncoding: []byte(metadataEncodingStorageRef),
+			metadataEncoding: []byte(metadataEncodingStorageRef),
 		},
 		Data: data,
 		ExternalPayloads: []*commonpb.Payload_ExternalPayloadDetails{
@@ -112,8 +139,8 @@ func storageReferenceToPayload(ref storageReference, storedSizeBytes int64) (*co
 
 // payloadToStorageReference decodes a storage reference from a payload.
 func payloadToStorageReference(p *commonpb.Payload) (storageReference, error) {
-	if string(p.GetMetadata()[converter.MetadataEncoding]) != metadataEncodingStorageRef {
-		return storageReference{}, fmt.Errorf("payload is not a storage reference: unexpected encoding %q", string(p.GetMetadata()[converter.MetadataEncoding]))
+	if string(p.GetMetadata()[metadataEncoding]) != metadataEncodingStorageRef {
+		return storageReference{}, fmt.Errorf("payload is not a storage reference: unexpected encoding %q", string(p.GetMetadata()[metadataEncoding]))
 	}
 	var ref storageReference
 	if err := json.Unmarshal(p.Data, &ref); err != nil {
@@ -123,7 +150,7 @@ func payloadToStorageReference(p *commonpb.Payload) (storageReference, error) {
 }
 
 type externalRetrievalVisitor struct {
-	params storageParameters
+	params StorageParameters
 }
 
 func (v *externalRetrievalVisitor) Visit(ctx *proxy.VisitPayloadsContext, payloads []*commonpb.Payload) ([]*commonpb.Payload, error) {
@@ -131,9 +158,9 @@ func (v *externalRetrievalVisitor) Visit(ctx *proxy.VisitPayloadsContext, payloa
 
 	// Identify which payloads are storage references and group them by driver.
 	type driverBatch struct {
-		driver  converter.StorageDriver
+		driver  StorageDriver
 		indices []int
-		claims  []converter.StorageDriverClaim
+		claims  []StorageDriverClaim
 	}
 	var driverOrder []string
 	driverBatches := map[string]*driverBatch{}
@@ -141,7 +168,7 @@ func (v *externalRetrievalVisitor) Visit(ctx *proxy.VisitPayloadsContext, payloa
 	result := make([]*commonpb.Payload, len(payloads))
 
 	for i, p := range payloads {
-		if string(p.GetMetadata()[converter.MetadataEncoding]) != metadataEncodingStorageRef {
+		if string(p.GetMetadata()[metadataEncoding]) != metadataEncodingStorageRef {
 			result[i] = p
 			continue
 		}
@@ -149,7 +176,7 @@ func (v *externalRetrievalVisitor) Visit(ctx *proxy.VisitPayloadsContext, payloa
 		// No storage drivers configured at all. Notify the caller and leave the
 		// payload unresolved so downstream code can surface a clear error.
 		if len(v.params.driverMap) == 0 {
-			if cb, ok := ctx.Value(storageOperationCallbackContextKey).(storageOperationCallback); ok {
+			if cb, ok := ctx.Value(storageOperationCallbackContextKey).(StorageOperationCallback); ok {
 				cb.UnconfiguredStorageReference()
 			}
 			result[i] = p
@@ -182,7 +209,7 @@ func (v *externalRetrievalVisitor) Visit(ctx *proxy.VisitPayloadsContext, payloa
 	// information for determing how to retrieve payloads. Drivers should only use information
 	// from the StorageDriverClaim to retrieve payloads.
 	eg, egCtx := errgroup.WithContext(context.Background())
-	driverCtx := converter.StorageDriverRetrieveContext{Context: egCtx}
+	driverCtx := StorageDriverRetrieveContext{Context: egCtx}
 	sizes := make([]int64, len(driverOrder))
 
 	externalCount := 0
@@ -216,19 +243,19 @@ func (v *externalRetrievalVisitor) Visit(ctx *proxy.VisitPayloadsContext, payloa
 	}
 
 	if callbackValue := ctx.Value(storageOperationCallbackContextKey); callbackValue != nil {
-		if callback, isCallback := callbackValue.(storageOperationCallback); isCallback {
+		if callback, isCallback := callbackValue.(StorageOperationCallback); isCallback {
 			callback.PayloadBatchCompleted(externalCount, externalTotalSize, time.Since(startTime))
 		}
 	}
 	return result, nil
 }
 
-func NewExternalRetrievalVisitor(params storageParameters) PayloadVisitor {
+func NewExternalRetrievalVisitor(params StorageParameters) PayloadVisitor {
 	return &externalRetrievalVisitor{params: params}
 }
 
 type externalStorageVisitor struct {
-	params storageParameters
+	params StorageParameters
 }
 
 func (v *externalStorageVisitor) Visit(ctx *proxy.VisitPayloadsContext, payloads []*commonpb.Payload) ([]*commonpb.Payload, error) {
@@ -240,7 +267,7 @@ func (v *externalStorageVisitor) Visit(ctx *proxy.VisitPayloadsContext, payloads
 
 	// Determine which driver (if any) should store each payload.
 	type driverBatch struct {
-		driver   converter.StorageDriver
+		driver   StorageDriver
 		indices  []int
 		payloads []*commonpb.Payload
 	}
@@ -248,11 +275,8 @@ func (v *externalStorageVisitor) Visit(ctx *proxy.VisitPayloadsContext, payloads
 	driverBatches := map[string]*driverBatch{}
 
 	result := make([]*commonpb.Payload, len(payloads))
-	var target converter.StorageDriverTargetInfo
-	if t, ok := ctx.Context.Value(storageTargetContextKey).(converter.StorageDriverTargetInfo); ok {
-		target = t
-	}
-	driverCtx := converter.StorageDriverStoreContext{Context: ctx.Context, Target: target}
+	target := StorageTargetFromContext(ctx.Context)
+	driverCtx := StorageDriverStoreContext{Context: ctx.Context, Target: target}
 
 	for i, p := range payloads {
 		if proto.Size(p) < v.params.payloadSizeThreshold {
@@ -264,7 +288,7 @@ func (v *externalStorageVisitor) Visit(ctx *proxy.VisitPayloadsContext, payloads
 		if err != nil {
 			return nil, fmt.Errorf("storage driver selector failed: %w", err)
 		}
-		var driver converter.StorageDriver
+		var driver StorageDriver
 		if selected != nil {
 			registered, ok := v.params.driverMap[selected.Name()]
 			if !ok || !driversEqual(registered, selected) {
@@ -292,7 +316,7 @@ func (v *externalStorageVisitor) Visit(ctx *proxy.VisitPayloadsContext, payloads
 	// Fan out to each driver concurrently. The errgroup context is used as the
 	// StorageDriverStoreContext so a failing driver cancels in-flight siblings.
 	eg, egCtx := errgroup.WithContext(ctx.Context)
-	storeDrCtx := converter.StorageDriverStoreContext{Context: egCtx, Target: target}
+	storeDrCtx := StorageDriverStoreContext{Context: egCtx, Target: target}
 	sizes := make([]int64, len(driverOrder))
 
 	externalCount := 0
@@ -335,18 +359,18 @@ func (v *externalStorageVisitor) Visit(ctx *proxy.VisitPayloadsContext, payloads
 	}
 
 	if callbackValue := ctx.Value(storageOperationCallbackContextKey); callbackValue != nil {
-		if callback, isCallback := callbackValue.(storageOperationCallback); isCallback {
+		if callback, isCallback := callbackValue.(StorageOperationCallback); isCallback {
 			callback.PayloadBatchCompleted(externalCount, externalTotalSize, time.Since(startTime))
 		}
 	}
 	return result, nil
 }
 
-func NewExternalStorageVisitor(params storageParameters) PayloadVisitor {
+func NewExternalStorageVisitor(params StorageParameters) PayloadVisitor {
 	return &externalStorageVisitor{params: params}
 }
 
-func callDriverSelector(s converter.StorageDriverSelector, ctx converter.StorageDriverStoreContext, p *commonpb.Payload) (driver converter.StorageDriver, err error) {
+func callDriverSelector(s StorageDriverSelector, ctx StorageDriverStoreContext, p *commonpb.Payload) (driver StorageDriver, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			err = fmt.Errorf("panicked: %v", r)
@@ -355,7 +379,7 @@ func callDriverSelector(s converter.StorageDriverSelector, ctx converter.Storage
 	return s.SelectDriver(ctx, p)
 }
 
-func callDriverStore(d converter.StorageDriver, ctx converter.StorageDriverStoreContext, payloads []*commonpb.Payload) (claims []converter.StorageDriverClaim, err error) {
+func callDriverStore(d StorageDriver, ctx StorageDriverStoreContext, payloads []*commonpb.Payload) (claims []StorageDriverClaim, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			err = fmt.Errorf("panicked: %v", r)
@@ -364,7 +388,7 @@ func callDriverStore(d converter.StorageDriver, ctx converter.StorageDriverStore
 	return d.Store(ctx, payloads)
 }
 
-func callDriverRetrieve(d converter.StorageDriver, ctx converter.StorageDriverRetrieveContext, claims []converter.StorageDriverClaim) (payloads []*commonpb.Payload, err error) {
+func callDriverRetrieve(d StorageDriver, ctx StorageDriverRetrieveContext, claims []StorageDriverClaim) (payloads []*commonpb.Payload, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			err = fmt.Errorf("panicked: %v", r)

--- a/internal/internal_activity_client.go
+++ b/internal/internal_activity_client.go
@@ -14,6 +14,7 @@ import (
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/sdk/converter"
+	"go.temporal.io/sdk/internal/extstore"
 	"google.golang.org/protobuf/types/known/durationpb"
 )
 
@@ -587,7 +588,7 @@ func (w *workflowClientInterceptor) ExecuteActivity(
 		return nil, err
 	}
 
-	storeCtx := context.WithValue(ctx, storageTargetContextKey, converter.StorageDriverActivityInfo{
+	storeCtx := extstore.WithStorageTarget(ctx, extstore.StorageDriverActivityInfo{
 		Namespace:    w.client.namespace,
 		ActivityID:   request.ActivityId,
 		ActivityType: in.ActivityType,

--- a/internal/internal_schedule_client.go
+++ b/internal/internal_schedule_client.go
@@ -18,6 +18,7 @@ import (
 	workflowpb "go.temporal.io/api/workflow/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/sdk/converter"
+	"go.temporal.io/sdk/internal/extstore"
 	"go.temporal.io/sdk/log"
 )
 
@@ -131,7 +132,7 @@ func (w *workflowClientInterceptor) CreateSchedule(ctx context.Context, in *Sche
 		SearchAttributes: searchAttr,
 	}
 
-	storeCtx := context.WithValue(ctx, storageTargetContextKey, converter.StorageDriverWorkflowInfo{
+	storeCtx := extstore.WithStorageTarget(ctx, extstore.StorageDriverWorkflowInfo{
 		Namespace:    w.client.namespace,
 		WorkflowID:   action.GetStartWorkflow().GetWorkflowId(),
 		WorkflowType: action.GetStartWorkflow().GetWorkflowType().GetName(),
@@ -302,7 +303,7 @@ func (scheduleHandle *scheduleHandleImpl) Update(ctx context.Context, options Sc
 		SearchAttributes: newSA,
 	}
 
-	storeCtx := context.WithValue(ctx, storageTargetContextKey, converter.StorageDriverWorkflowInfo{
+	storeCtx := extstore.WithStorageTarget(ctx, extstore.StorageDriverWorkflowInfo{
 		Namespace:    scheduleHandle.client.namespace,
 		WorkflowID:   newSchedulePB.GetAction().GetStartWorkflow().GetWorkflowId(),
 		WorkflowType: newSchedulePB.GetAction().GetStartWorkflow().GetWorkflowType().GetName(),

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -24,6 +24,7 @@ import (
 	"go.temporal.io/api/workflowservice/v1"
 
 	"go.temporal.io/sdk/converter"
+	"go.temporal.io/sdk/internal/extstore"
 	"go.temporal.io/sdk/internal/common/metrics"
 	"go.temporal.io/sdk/internal/common/serializer"
 	"go.temporal.io/sdk/log"
@@ -461,7 +462,7 @@ func (wtp *workflowTaskProcessor) processWorkflowTask(task *workflowTask) (retEr
 	defer close(doneCh)
 
 	downloadPayloadMetrics := &workflowTaskStorageMetrics{logger: wtp.logger}
-	ctx := context.WithValue(context.Background(), storageOperationCallbackContextKey, downloadPayloadMetrics)
+	ctx := extstore.WithStorageOperationCallback(context.Background(), downloadPayloadMetrics)
 	if err := visitProtoPayloads(ctx, wtp.inboundPayloadVisitor, task.task); err != nil {
 		// Submit an explicit WFT failure so the server records the error immediately
 		// rather than waiting for the task to time out.
@@ -568,16 +569,16 @@ func (wtp *workflowTaskProcessor) processWorkflowTask(task *workflowTask) (retEr
 // payload visitation. info is the WorkflowInfo for the current execution.
 func (wtp *workflowTaskProcessor) commandAwareContextHook(info *WorkflowInfo) func(context.Context, proto.Message) (context.Context, error) {
 	return func(ctx context.Context, msg proto.Message) (context.Context, error) {
-		var target converter.StorageDriverTargetInfo
+		var target extstore.StorageDriverTargetInfo
 		switch attrs := msg.(type) {
 		case *commandpb.StartChildWorkflowExecutionCommandAttributes:
-			target = converter.StorageDriverWorkflowInfo{
+			target = extstore.StorageDriverWorkflowInfo{
 				Namespace:    wtp.namespace,
 				WorkflowType: attrs.WorkflowType.GetName(),
 				WorkflowID:   attrs.WorkflowId,
 			}
 		case *commandpb.SignalExternalWorkflowExecutionCommandAttributes:
-			target = converter.StorageDriverWorkflowInfo{
+			target = extstore.StorageDriverWorkflowInfo{
 				Namespace:  wtp.namespace,
 				WorkflowID: attrs.Execution.GetWorkflowId(),
 				RunID:      attrs.Execution.GetRunId(),
@@ -586,12 +587,12 @@ func (wtp *workflowTaskProcessor) commandAwareContextHook(info *WorkflowInfo) fu
 			// The new run keeps the same workflow ID. WorkflowType comes from the
 			// command if specified (type change), otherwise falls back to the current
 			// type already in context. RunID is omitted — the new run hasn't started.
-			current, _ := ctx.Value(storageTargetContextKey).(converter.StorageDriverWorkflowInfo)
+			current, _ := extstore.StorageTargetFromContext(ctx).(extstore.StorageDriverWorkflowInfo)
 			wfType := attrs.WorkflowType.GetName()
 			if wfType == "" {
 				wfType = current.WorkflowType
 			}
-			target = converter.StorageDriverWorkflowInfo{
+			target = extstore.StorageDriverWorkflowInfo{
 				Namespace:    current.Namespace,
 				WorkflowID:   current.WorkflowID,
 				WorkflowType: wfType,
@@ -604,7 +605,7 @@ func (wtp *workflowTaskProcessor) commandAwareContextHook(info *WorkflowInfo) fu
 			if ns == "" {
 				ns = wtp.namespace
 			}
-			target = converter.StorageDriverWorkflowInfo{
+			target = extstore.StorageDriverWorkflowInfo{
 				Namespace:  ns,
 				WorkflowID: info.ParentWorkflowExecution.ID,
 				RunID:      info.ParentWorkflowExecution.RunID,
@@ -612,7 +613,7 @@ func (wtp *workflowTaskProcessor) commandAwareContextHook(info *WorkflowInfo) fu
 		default:
 			return ctx, nil
 		}
-		return context.WithValue(ctx, storageTargetContextKey, target), nil
+		return extstore.WithStorageTarget(ctx, target), nil
 	}
 }
 
@@ -645,8 +646,8 @@ func (wtp *workflowTaskProcessor) RespondTaskCompletedWithMetrics(
 	}
 
 	uploadPayloadMetrics := &workflowTaskStorageMetrics{}
-	ctx := context.WithValue(context.Background(), storageOperationCallbackContextKey, uploadPayloadMetrics)
-	ctx = context.WithValue(ctx, storageTargetContextKey, converter.StorageDriverWorkflowInfo{
+	ctx := extstore.WithStorageOperationCallback(context.Background(), uploadPayloadMetrics)
+	ctx = extstore.WithStorageTarget(ctx, extstore.StorageDriverWorkflowInfo{
 		Namespace:    wtp.namespace,
 		WorkflowID:   task.WorkflowExecution.GetWorkflowId(),
 		RunID:        task.WorkflowExecution.GetRunId(),
@@ -1476,24 +1477,24 @@ func (atp *activityTaskPoller) ProcessTask(task interface{}) error {
 	}
 
 	if msg, ok := request.(proto.Message); ok {
-		var storageTarget converter.StorageDriverTargetInfo
+		var storageTarget extstore.StorageDriverTargetInfo
 		t := activityTask.task
 		if t.WorkflowExecution.GetWorkflowId() != "" {
-			storageTarget = converter.StorageDriverWorkflowInfo{
+			storageTarget = extstore.StorageDriverWorkflowInfo{
 				Namespace:    atp.namespace,
 				WorkflowID:   t.WorkflowExecution.GetWorkflowId(),
 				RunID:        t.WorkflowExecution.GetRunId(),
 				WorkflowType: t.WorkflowType.GetName(),
 			}
 		} else {
-			storageTarget = converter.StorageDriverActivityInfo{
+			storageTarget = extstore.StorageDriverActivityInfo{
 				Namespace:    atp.namespace,
 				ActivityID:   t.ActivityId,
 				RunID:        t.ActivityRunId,
 				ActivityType: t.ActivityType.GetName(),
 			}
 		}
-		outboundCtx := context.WithValue(context.Background(), storageTargetContextKey, storageTarget)
+		outboundCtx := extstore.WithStorageTarget(context.Background(), storageTarget)
 		if err := visitProtoPayloads(outboundCtx, atp.outboundPayloadVisitor, msg); err != nil {
 			return err
 		}

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -35,6 +35,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"go.temporal.io/sdk/converter"
+	"go.temporal.io/sdk/internal/extstore"
 	"go.temporal.io/sdk/internal/common/metrics"
 	"go.temporal.io/sdk/internal/common/serializer"
 	"go.temporal.io/sdk/internal/common/util"
@@ -1700,7 +1701,7 @@ func NewWorkflowReplayer(options WorkflowReplayerOptions) (*WorkflowReplayer, er
 		}
 	}
 
-	storageParams, err := ExternalStorageToParams(options.ExternalStorage)
+	storageParams, err := extstore.ExternalStorageToParams(options.ExternalStorage)
 	if err != nil {
 		return nil, fmt.Errorf("invalid ExternalStorage options: %w", err)
 	}
@@ -1714,7 +1715,7 @@ func NewWorkflowReplayer(options WorkflowReplayerOptions) (*WorkflowReplayer, er
 		contextPropagators:          options.ContextPropagators,
 		enableLoggingInReplay:       options.EnableLoggingInReplay,
 		disableDeadlockDetection:    options.DisableDeadlockDetection,
-		inboundPayloadVisitor:       NewExternalRetrievalVisitor(storageParams),
+		inboundPayloadVisitor:       extstore.NewExternalRetrievalVisitor(storageParams),
 		workflowExecutionResults:    make(map[string]*commonpb.Payloads),
 		workflowReplayerInstanceKey: workflowReplayerInstanceKey,
 		plugins:                     options.Plugins,
@@ -1978,7 +1979,7 @@ func (aw *WorkflowReplayer) replayWorkflowHistoryRoot(
 	// Resolve externally stored payloads in the history before passing to the
 	// task handler. This mirrors what processWorkflowTask does for live workers.
 	replayStorageCb := &replayStorageMetrics{logger: logger}
-	inboundPayloadVisitorCtx := context.WithValue(context.Background(), storageOperationCallbackContextKey, replayStorageCb)
+	inboundPayloadVisitorCtx := extstore.WithStorageOperationCallback(context.Background(), replayStorageCb)
 	if err := visitProtoPayloads(inboundPayloadVisitorCtx, aw.inboundPayloadVisitor, task); err != nil {
 		return err
 	}

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -34,6 +34,7 @@ import (
 	"go.temporal.io/api/workflowservice/v1"
 
 	"go.temporal.io/sdk/converter"
+	"go.temporal.io/sdk/internal/extstore"
 	"go.temporal.io/sdk/internal/common/metrics"
 	"go.temporal.io/sdk/internal/common/retry"
 	"go.temporal.io/sdk/internal/common/serializer"
@@ -516,7 +517,7 @@ func (wc *WorkflowClient) CompleteActivityWithOptions(ctx context.Context, opts 
 	request := convertActivityResultToRespondRequest(wc.identity, opts.TaskToken,
 		data, opts.Err, dataConverter, failureConverter, wc.namespace, cancelAllowed, nil, nil, nil)
 	if msg, ok := request.(proto.Message); ok {
-		storeCtx := context.WithValue(ctx, storageTargetContextKey, converter.StorageDriverWorkflowInfo{
+		storeCtx := extstore.WithStorageTarget(ctx, extstore.StorageDriverWorkflowInfo{
 			Namespace:    cmp.Or(opts.Namespace, wc.namespace),
 			WorkflowID:   opts.WorkflowID,
 			WorkflowType: opts.WorkflowType,
@@ -577,7 +578,7 @@ func (wc *WorkflowClient) CompleteActivityByIDWithOptions(ctx context.Context, o
 	request := convertActivityResultToRespondRequestByID(wc.identity, opts.Namespace, opts.WorkflowID, opts.RunID, opts.ActivityID,
 		data, opts.Err, dataConverter, failureConverter, cancelAllowed)
 	if msg, ok := request.(proto.Message); ok {
-		storeCtx := context.WithValue(ctx, storageTargetContextKey, converter.StorageDriverWorkflowInfo{
+		storeCtx := extstore.WithStorageTarget(ctx, extstore.StorageDriverWorkflowInfo{
 			Namespace:    opts.Namespace,
 			WorkflowID:   opts.WorkflowID,
 			RunID:        opts.RunID,
@@ -633,7 +634,7 @@ func (wc *WorkflowClient) CompleteActivityByActivityIDWithOptions(ctx context.Co
 	request := convertActivityResultToRespondRequestByID(wc.identity, opts.Namespace, "", opts.ActivityRunID, opts.ActivityID,
 		data, opts.Err, dataConverter, failureConverter, cancelAllowed)
 	if msg, ok := request.(proto.Message); ok {
-		storeCtx := context.WithValue(ctx, storageTargetContextKey, converter.StorageDriverActivityInfo{
+		storeCtx := extstore.WithStorageTarget(ctx, extstore.StorageDriverActivityInfo{
 			Namespace:    opts.Namespace,
 			ActivityID:   opts.ActivityID,
 			RunID:        opts.ActivityRunID,
@@ -2074,7 +2075,7 @@ func (w *workflowClientInterceptor) ExecuteWorkflow(
 		eagerExecutor = w.client.eagerDispatcher.applyToRequest(startRequest)
 	}
 
-	storeCtx := context.WithValue(ctx, storageTargetContextKey, converter.StorageDriverWorkflowInfo{
+	storeCtx := extstore.WithStorageTarget(ctx, extstore.StorageDriverWorkflowInfo{
 		Namespace:    w.client.namespace,
 		WorkflowID:   startRequest.WorkflowId,
 		WorkflowType: in.WorkflowType,
@@ -2239,7 +2240,7 @@ func (w *workflowClientInterceptor) updateWithStartWorkflow(
 		},
 	}
 
-	storeCtx := context.WithValue(ctx, storageTargetContextKey, converter.StorageDriverWorkflowInfo{
+	storeCtx := extstore.WithStorageTarget(ctx, extstore.StorageDriverWorkflowInfo{
 		Namespace:    w.client.namespace,
 		WorkflowID:   startRequest.WorkflowId,
 		WorkflowType: startRequest.WorkflowType.GetName(),
@@ -2389,7 +2390,7 @@ func (w *workflowClientInterceptor) SignalWorkflow(ctx context.Context, in *Clie
 		request.RequestId = uuid.NewString()
 	}
 
-	storeCtx := context.WithValue(ctx, storageTargetContextKey, converter.StorageDriverWorkflowInfo{
+	storeCtx := extstore.WithStorageTarget(ctx, extstore.StorageDriverWorkflowInfo{
 		Namespace:  w.client.namespace,
 		WorkflowID: in.WorkflowID,
 		RunID:      in.RunID,
@@ -2477,7 +2478,7 @@ func (w *workflowClientInterceptor) SignalWithStartWorkflow(
 		return nil, err
 	}
 
-	storeCtx := context.WithValue(ctx, storageTargetContextKey, converter.StorageDriverWorkflowInfo{
+	storeCtx := extstore.WithStorageTarget(ctx, extstore.StorageDriverWorkflowInfo{
 		Namespace:    w.client.namespace,
 		WorkflowID:   in.Options.ID,
 		WorkflowType: in.WorkflowType,
@@ -2559,7 +2560,7 @@ func (w *workflowClientInterceptor) TerminateWorkflow(ctx context.Context, in *C
 		Details:  detailsPayload,
 	}
 
-	storeCtx := context.WithValue(ctx, storageTargetContextKey, converter.StorageDriverWorkflowInfo{
+	storeCtx := extstore.WithStorageTarget(ctx, extstore.StorageDriverWorkflowInfo{
 		Namespace:  w.client.namespace,
 		WorkflowID: in.WorkflowID,
 		RunID:      in.RunID,
@@ -2694,7 +2695,7 @@ func (w *workflowClientInterceptor) QueryWorkflow(
 		QueryRejectCondition: in.QueryRejectCondition,
 	}
 
-	storeCtx := context.WithValue(ctx, storageTargetContextKey, converter.StorageDriverWorkflowInfo{
+	storeCtx := extstore.WithStorageTarget(ctx, extstore.StorageDriverWorkflowInfo{
 		Namespace:  w.client.namespace,
 		WorkflowID: in.WorkflowID,
 		RunID:      in.RunID,
@@ -2733,7 +2734,7 @@ func (w *workflowClientInterceptor) UpdateWorkflow(
 		return nil, err
 	}
 
-	storeCtx := context.WithValue(ctx, storageTargetContextKey, converter.StorageDriverWorkflowInfo{
+	storeCtx := extstore.WithStorageTarget(ctx, extstore.StorageDriverWorkflowInfo{
 		Namespace:  w.client.namespace,
 		WorkflowID: in.WorkflowID,
 		RunID:      in.RunID,


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

- Move all external storage types, implementations, and algorithms to `internal/extstore` package. Re-export public types via the `converter` package. Necessary so the implementation and algorithms can be shared internally with `converter` package.
- Add `NewPayloadHTTPHandler` and `PayloadHTTPHandlerOptions` to allow Web UI and CLI to encode, decode, and download payloads when external storage is enabled. The handler is fully backward compatible for Web UI and CLI use, but should not be used as the target of a remote codec without careful consideration to the fact that it does more than applying a single list of codecs as the existing codec HTTP handlers do.

## Why?

The ordering of payload operations is inconsistent under different customer configurations when external storage is enabled. The introduction of the new HTTP handler allows the Web UI and CLI to encode, decode, and optionally download externally stored payloads without having to understand the order of operations itself.

Examples of customer scenarios (showing only the encode path):
- Customer has encryption and external storage configured in worker: `Codecs (in DataConverter) -> External Storage`
- Customer has external storage configured in worker and encryption in proxy: `External Storage -> Codecs (in proxy)`
- Customer has compression and external storage configured in worker and encryption in proxy: `Codecs (in DataConverter) -> External Storage -> Codecs (in proxy)`

## Checklist
<!--- add/delete as needed --->

1. How was this tested: Tests
1. Any docs updates needed? Yes
