### PR TITLE
More TMPRL1104 logging details

### DIFF
--- a/internal/extstore.go
+++ b/internal/extstore.go
@@ -78,7 +78,7 @@ func driversEqual(a, b converter.StorageDriver) (equal bool) {
 }
 
 type storageOperationCallback interface {
-	PayloadBatchCompleted(count int, size int64, duration time.Duration)
+	PayloadBatchCompleted(count int, size int64, duration time.Duration, driverNames []string)
 	UnconfiguredStorageReference()
 }
 
@@ -217,7 +217,7 @@ func (v *externalRetrievalVisitor) Visit(ctx *proxy.VisitPayloadsContext, payloa
 
 	if callbackValue := ctx.Value(storageOperationCallbackContextKey); callbackValue != nil {
 		if callback, isCallback := callbackValue.(storageOperationCallback); isCallback {
-			callback.PayloadBatchCompleted(externalCount, externalTotalSize, time.Since(startTime))
+			callback.PayloadBatchCompleted(externalCount, externalTotalSize, time.Since(startTime), driverOrder)
 		}
 	}
 	return result, nil
@@ -336,7 +336,7 @@ func (v *externalStorageVisitor) Visit(ctx *proxy.VisitPayloadsContext, payloads
 
 	if callbackValue := ctx.Value(storageOperationCallbackContextKey); callbackValue != nil {
 		if callback, isCallback := callbackValue.(storageOperationCallback); isCallback {
-			callback.PayloadBatchCompleted(externalCount, externalTotalSize, time.Since(startTime))
+			callback.PayloadBatchCompleted(externalCount, externalTotalSize, time.Since(startTime), driverOrder)
 		}
 	}
 	return result, nil

--- a/internal/extstore_test.go
+++ b/internal/extstore_test.go
@@ -1079,7 +1079,7 @@ type testCallback struct {
 	unconfiguredCount int
 }
 
-func (c *testCallback) PayloadBatchCompleted(count int, size int64, duration time.Duration) {
+func (c *testCallback) PayloadBatchCompleted(count int, size int64, duration time.Duration, _ []string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.count = count

--- a/internal/internal_logging_tags.go
+++ b/internal/internal_logging_tags.go
@@ -38,9 +38,11 @@ const (
 	tagPayloadDownloadCount         = "PayloadDownloadCount"
 	tagPayloadDownloadSize          = "PayloadDownloadSize"
 	tagPayloadDownloadDuration      = "PayloadDownloadDuration"
+	tagPayloadDownloadDrivers       = "PayloadDownloadDrivers"
 	tagPayloadUploadCount           = "PayloadUploadCount"
 	tagPayloadUploadSize            = "PayloadUploadSize"
 	tagPayloadUploadDuration        = "PayloadUploadDuration"
+	tagPayloadUploadDrivers         = "PayloadUploadDrivers"
 	tagPayloadSize                  = "PayloadSize"
 	tagPayloadSizeLimit             = "PayloadSizeLimit"
 )

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -636,12 +637,13 @@ func (wtp *workflowTaskProcessor) RespondTaskCompletedWithMetrics(
 
 	response, err = wtp.sendTaskCompletedRequest(taskCompletion, task)
 
+	completionEventId := task.GetStartedEventId() + 1
 	loggerDurationKeyVals := []interface{}{
 		tagWorkflowType, task.WorkflowType.GetName(),
 		tagWorkflowID, task.WorkflowExecution.GetWorkflowId(),
 		tagRunID, task.WorkflowExecution.GetRunId(),
 		tagAttempt, task.Attempt,
-		tagEventID, task.GetStartedEventId(),
+		tagEventID, completionEventId,
 		tagWorkflowTaskDuration, taskDuration,
 	}
 	if downloadPayloadMetrics.payloadCount > 0 {
@@ -649,6 +651,7 @@ func (wtp *workflowTaskProcessor) RespondTaskCompletedWithMetrics(
 			tagPayloadDownloadCount, downloadPayloadMetrics.payloadCount,
 			tagPayloadDownloadSize, downloadPayloadMetrics.totalSize,
 			tagPayloadDownloadDuration, downloadPayloadMetrics.totalDuration,
+			tagPayloadDownloadDrivers, downloadPayloadMetrics.GetDriverNames(),
 		)
 	}
 	if uploadPayloadMetrics.payloadCount > 0 {
@@ -656,15 +659,17 @@ func (wtp *workflowTaskProcessor) RespondTaskCompletedWithMetrics(
 			tagPayloadUploadCount, uploadPayloadMetrics.payloadCount,
 			tagPayloadUploadSize, uploadPayloadMetrics.totalSize,
 			tagPayloadUploadDuration, uploadPayloadMetrics.totalDuration,
+			tagPayloadUploadDrivers, uploadPayloadMetrics.GetDriverNames(),
 		)
 	}
 
+	taskID := fmt.Sprintf("%s:%d:%d", task.WorkflowExecution.GetRunId(), completionEventId, task.Attempt)
 	if taskDuration > 10*time.Second {
-		wtp.logger.Warn("[TMPRL1104] Workflow task exceeded 10 seconds.", loggerDurationKeyVals...)
+		wtp.logger.Warn("[TMPRL1104] "+taskID+" Workflow task exceeded 10 seconds.", loggerDurationKeyVals...)
 	} else if taskDuration > 5*time.Second {
-		wtp.logger.Info("[TMPRL1104] Workflow task exceeded 5 seconds.", loggerDurationKeyVals...)
+		wtp.logger.Info("[TMPRL1104] "+taskID+" Workflow task exceeded 5 seconds.", loggerDurationKeyVals...)
 	} else {
-		wtp.logger.Debug("[TMPRL1104] Workflow task duration information.", loggerDurationKeyVals...)
+		wtp.logger.Debug("[TMPRL1104] "+taskID+" Workflow task duration information.", loggerDurationKeyVals...)
 	}
 
 	var grpcMessageTooLargeErr *retry.GrpcMessageTooLargeError
@@ -872,16 +877,32 @@ type workflowTaskStorageMetrics struct {
 	payloadCount       int
 	totalSize          int64
 	totalDuration      time.Duration
+	driverNames        map[string]struct{}
 	logger             log.Logger
 	warnedUnconfigured bool
 }
 
-func (callback *workflowTaskStorageMetrics) PayloadBatchCompleted(count int, size int64, duration time.Duration) {
+func (callback *workflowTaskStorageMetrics) PayloadBatchCompleted(count int, size int64, duration time.Duration, driverNames []string) {
 	callback.mu.Lock()
 	defer callback.mu.Unlock()
 	callback.payloadCount += count
 	callback.totalSize += size
 	callback.totalDuration += duration
+	for _, name := range driverNames {
+		if callback.driverNames == nil {
+			callback.driverNames = make(map[string]struct{})
+		}
+		callback.driverNames[name] = struct{}{}
+	}
+}
+
+func (callback *workflowTaskStorageMetrics) GetDriverNames() []string {
+	names := make([]string, 0, len(callback.driverNames))
+	for name := range callback.driverNames {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
 }
 
 func (callback *workflowTaskStorageMetrics) UnconfiguredStorageReference() {

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -1615,7 +1615,7 @@ type replayStorageMetrics struct {
 	warnedUnconfigured bool
 }
 
-func (c *replayStorageMetrics) PayloadBatchCompleted(_ int, _ int64, _ time.Duration) {}
+func (c *replayStorageMetrics) PayloadBatchCompleted(_ int, _ int64, _ time.Duration, _ []string) {}
 
 func (c *replayStorageMetrics) UnconfiguredStorageReference() {
 	c.mu.Lock()


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

- Add download and update driver names to TMPRL1104 log messages.
- Add a log identifier that Temporal UI can use to refer to precise workflow task completion attempt consisting of the run ID, the completion event ID, and the attempt number.

Example log output:

> 2026/04/21 21:48:44 DEBUG [TMPRL1104] 019db381-5d58-7dd3-8adc-3c0b4879e7ff:16:1 Workflow task duration information. Namespace default TaskQueue s3-document-processing WorkerID 13319@Justins-MacBook-Pro.local@ WorkflowType Run WorkflowID doc-processing-23349da5 RunID 019db381-5d58-7dd3-8adc-3c0b4879e7ff Attempt 1 EventID 16 WorkflowTaskDuration 4.827369583s PayloadDownloadCount 2 PayloadDownloadSize 21162464 PayloadDownloadDuration 1.367541083s PayloadDownloadDrivers [aws.s3driver] PayloadUploadCount 1 PayloadUploadSize 21162356 PayloadUploadDuration 4.745379542s PayloadUploadDrivers [aws.s3driver]

## Why?

- Give customers more contextual data to better understand the precise workflow task to which the latency data is associated.
- Allow Temporal UI to easily reference a specific task completion if workflow task latency is a concern.

## Checklist
<!--- add/delete as needed --->

1. How was this tested: Existing tests and manual run
1. Any docs updates needed? No
