### PR TITLE
Do not require resource tuner for heartbeat CPU/mem metrics

### DIFF
--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -2365,11 +2365,23 @@ func NewAggregatedWorker(client *WorkflowClient, taskQueue string, options Worke
 		})
 	}
 
-	// Get SysInfoProvider from tuner's slot supplier if it implements HasSysInfoProvider.
-	// If not available, heartbeats will report 0 for CPU/memory usage.
+	// Resolve the SysInfoProvider used for worker heartbeats. Prefer the explicit
+	// WorkerOptions.SysInfoProvider; otherwise fall back to the tuner's slot supplier if it
+	// implements HasSysInfoProvider. If both are set to different providers, that's a config
+	// error. If neither is set, heartbeats report 0 for CPU/memory usage.
 	var sysInfoProvider SysInfoProvider
+	var tunerSysInfoProvider SysInfoProvider
 	if sis, ok := options.Tuner.GetWorkflowTaskSlotSupplier().(HasSysInfoProvider); ok {
-		sysInfoProvider = sis.SysInfoProvider()
+		tunerSysInfoProvider = sis.SysInfoProvider()
+	}
+	switch {
+	case options.SysInfoProvider != nil && tunerSysInfoProvider != nil && options.SysInfoProvider != tunerSysInfoProvider:
+		panic("WorkerOptions.SysInfoProvider conflicts with the SysInfoProvider exposed by the Tuner; " +
+			"set only one, or set both to the same instance")
+	case options.SysInfoProvider != nil:
+		sysInfoProvider = options.SysInfoProvider
+	default:
+		sysInfoProvider = tunerSysInfoProvider
 	}
 
 	var heartbeatCallback func() *workerpb.WorkerHeartbeat

--- a/internal/worker.go
+++ b/internal/worker.go
@@ -357,6 +357,17 @@ type (
 		// NOTE: Experimental
 		Tuner WorkerTuner
 
+		// Optional: If set, provides CPU and memory usage information for worker heartbeats.
+		// Use contrib/sysinfo.SysInfoProvider() for a gopsutil-based implementation, or provide
+		// your own. When unset, the worker will use the Tuner's SysInfoProvider if it exposes one
+		// (e.g. a resource-based tuner); otherwise heartbeats report 0 for CPU/memory usage.
+		//
+		// It is an error to provide a SysInfoProvider here that differs from the one used by the
+		// Tuner.
+		//
+		// NOTE: Experimental
+		SysInfoProvider SysInfoProvider
+
 		// Optional: If set, the worker will use the provided poller behavior when polling for workflow tasks.
 		// This is mutually exclusive with MaxConcurrentWorkflowTaskPollers.
 		//

--- a/test/worker_heartbeat_test.go
+++ b/test/worker_heartbeat_test.go
@@ -856,6 +856,53 @@ func (ts *WorkerHeartbeatTestSuite) TestWorkerHeartbeatResourceBasedTuner() {
 	ts.True(workerInfo.ActivityPollerInfo.IsAutoscaling)
 }
 
+// TestWorkerHeartbeatSysInfoProviderWithoutResourceTuner verifies that a worker using a
+// fixed-size tuner (not resource-based) still reports CPU/memory in heartbeats when the user
+// wires a SysInfoProvider into WorkerOptions directly.
+func (ts *WorkerHeartbeatTestSuite) TestWorkerHeartbeatSysInfoProviderWithoutResourceTuner() {
+	ctx := context.Background()
+
+	sysInfoWorkflow := func(ctx workflow.Context) error {
+		ao := workflow.ActivityOptions{StartToCloseTimeout: 10 * time.Second}
+		return workflow.ExecuteActivity(workflow.WithActivityOptions(ctx, ao), "sysInfoActivity").Get(ctx, nil)
+	}
+	sysInfoActivity := func(ctx context.Context) error { return nil }
+
+	ts.worker = worker.New(ts.client, ts.taskQueueName, worker.Options{
+		MaxConcurrentWorkflowTaskExecutionSize: 5,
+		MaxConcurrentActivityExecutionSize:     5,
+		SysInfoProvider:                        sysinfo.SysInfoProvider(),
+	})
+	ts.worker.RegisterWorkflowWithOptions(sysInfoWorkflow, workflow.RegisterOptions{Name: "sysInfoWorkflow"})
+	ts.worker.RegisterActivityWithOptions(sysInfoActivity, activity.RegisterOptions{Name: "sysInfoActivity"})
+	ts.NoError(ts.worker.Start())
+
+	workflowOptions := client.StartWorkflowOptions{
+		ID:        "test-sysinfo-no-resource-tuner-" + uuid.NewString(),
+		TaskQueue: ts.taskQueueName,
+	}
+	run, err := ts.client.ExecuteWorkflow(ctx, workflowOptions, "sysInfoWorkflow")
+	ts.NoError(err)
+	ts.NoError(run.Get(ctx, nil))
+
+	// Wait for a heartbeat that reports populated memory usage. Memory usage from sysinfo should
+	// always be > 0 on a running Go process; CPU may be near zero on an idle host, so we only
+	// gate on memory for the Eventually condition.
+	var workerInfo *workerpb.WorkerHeartbeat
+	ts.Eventually(func() bool {
+		workerInfo = ts.getWorkerInfo(ctx, ts.taskQueueName)
+		return workerInfo != nil && workerInfo.HostInfo != nil &&
+			workerInfo.HostInfo.CurrentHostMemUsage > 0
+	}, 5*time.Second, 200*time.Millisecond, "Heartbeat should report non-zero memory usage")
+
+	// Confirm we're exercising the non-resource-based path.
+	ts.NotNil(workerInfo.WorkflowTaskSlotsInfo)
+	ts.Equal("Fixed", workerInfo.WorkflowTaskSlotsInfo.SlotSupplierKind)
+
+	ts.Greater(workerInfo.HostInfo.CurrentHostMemUsage, float32(0.0))
+	ts.GreaterOrEqual(workerInfo.HostInfo.CurrentHostCpuUsage, float32(0.0))
+}
+
 func (ts *WorkerHeartbeatTestSuite) TestWorkerHeartbeatPlugins() {
 	ctx := context.Background()
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Before this PR users _had_ to be using a resource based tuner for CPU/mem to get reported in worker heartbeats. That's undesirable. Now they can enable it by setting a `SysInfoProvider` without using the tuner.

## Why?
Heartbeating shouldn't be coupled to the resource tuner.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
Added test

3. Any docs updates needed?
