### PR TITLE
💥 Experimental: Memo limit validation

### DIFF
--- a/internal/internal_logging_tags.go
+++ b/internal/internal_logging_tags.go
@@ -45,4 +45,6 @@ const (
 	tagPayloadUploadDrivers         = "PayloadUploadDrivers"
 	tagPayloadSize                  = "PayloadSize"
 	tagPayloadSizeLimit             = "PayloadSizeLimit"
+	tagMemoSize                     = "MemoSize"
+	tagMemoSizeLimit                = "MemoSizeLimit"
 )

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -231,7 +231,7 @@ type (
 
 		payloadVisitorConcurrency int
 
-		setPayloadErrorLimits func(*payloadLimits)
+		setErrorLimits func(*payloadLimits)
 	}
 
 	// HistoryJSONOptions are options for HistoryFromJSON.
@@ -1305,13 +1305,18 @@ func (aw *AggregatedWorker) start() error {
 		return err
 	}
 
-	if aw.executionParams.setPayloadErrorLimits != nil {
+	if aw.executionParams.setErrorLimits != nil {
 		payloadSizeError := int64(0)
 		if nsData.limits.BlobSizeLimitError > 0 {
 			payloadSizeError = nsData.limits.BlobSizeLimitError
 		}
-		aw.executionParams.setPayloadErrorLimits(&payloadLimits{
+		memoSizeError := int64(0)
+		if nsData.limits.MemoSizeLimitError > 0 {
+			memoSizeError = nsData.limits.MemoSizeLimitError
+		}
+		aw.executionParams.setErrorLimits(&payloadLimits{
 			payloadSize: payloadSizeError,
+			memoSize:    memoSizeError,
 		})
 	}
 
@@ -2242,7 +2247,7 @@ func NewAggregatedWorker(client *WorkflowClient, taskQueue string, options Worke
 		)
 	}
 
-	payloadLimitVisitor, setPayloadErrorLimits := newPayloadLimitsVisitor(client.payloadWarningLimits, logger)
+	payloadLimitVisitor, setErrorLimits := newPayloadLimitsVisitor(client.payloadWarningLimits, logger)
 
 	cache := NewWorkerCache()
 	workerPollCompleteOnShutdown := &atomic.Bool{}
@@ -2289,9 +2294,9 @@ func NewAggregatedWorker(client *WorkflowClient, taskQueue string, options Worke
 			payloadLimitVisitor,
 		),
 		payloadVisitorConcurrency: options.MaxConcurrentWorkflowTaskExternalStorageVisits,
-		setPayloadErrorLimits: func(limits *payloadLimits) {
+		setErrorLimits: func(limits *payloadLimits) {
 			if !options.DisablePayloadErrorLimit {
-				setPayloadErrorLimits(limits)
+				setErrorLimits(limits)
 			}
 		},
 	}

--- a/internal/payload_limits.go
+++ b/internal/payload_limits.go
@@ -113,7 +113,7 @@ func (v *payloadLimitsVisitorImpl) Visit(ctx *proxy.VisitPayloadsContext, payloa
 		size = int64((&commonpb.Payloads{Payloads: payloads}).Size())
 	}
 
-	err := v.checkPayloadSize(size, !skipErrorLimit, !skipWarningLimit)
+	err := v.checkPayloadSize(size, skipErrorLimit, skipWarningLimit)
 	if err != nil {
 		return nil, err
 	}
@@ -127,7 +127,7 @@ func (v *payloadLimitsVisitorImpl) ContextHook(ctx context.Context, msg proto.Me
 	// RecordMarkerCommandAttributes.Details is a map[string]Payloads
 	// Server has specialized size checking for map[string]Payloads for this field.
 	case *commandpb.RecordMarkerCommandAttributes:
-		err := v.checkPayloadSize(v.getPayloadsMapSize(msg.Details), true, true)
+		err := v.checkPayloadSize(v.getPayloadsMapSize(msg.Details), false, false)
 		if err != nil {
 			return nil, err
 		}
@@ -135,7 +135,7 @@ func (v *payloadLimitsVisitorImpl) ContextHook(ctx context.Context, msg proto.Me
 	// UpsertWorkflowSearchAttributesCommandAttributes.SearchAttributes is a map[string]Payload
 	// Server has specialized size checking for map[string]Payload (that are not Memo fields).
 	case *commandpb.UpsertWorkflowSearchAttributesCommandAttributes:
-		err := v.checkPayloadSize(v.getPayloadMapSize(msg.GetSearchAttributes().GetIndexedFields()), true, true)
+		err := v.checkPayloadSize(v.getPayloadMapSize(msg.GetSearchAttributes().GetIndexedFields()), false, false)
 		if err != nil {
 			return nil, err
 		}
@@ -143,7 +143,7 @@ func (v *payloadLimitsVisitorImpl) ContextHook(ctx context.Context, msg proto.Me
 	// ModifyWorkflowPropertiesCommandAttributes.Properties is a map[string]Payload
 	// Server has specialized size checking for map[string]Payload (that are not Memo fields).
 	case *commandpb.ModifyWorkflowPropertiesCommandAttributes:
-		err := v.checkPayloadSize(v.getPayloadMapSize(msg.GetUpsertedMemo().GetFields()), true, true)
+		err := v.checkPayloadSize(v.getPayloadMapSize(msg.GetUpsertedMemo().GetFields()), false, false)
 		if err != nil {
 			return nil, err
 		}
@@ -151,13 +151,13 @@ func (v *payloadLimitsVisitorImpl) ContextHook(ctx context.Context, msg proto.Me
 	case *commonpb.Memo:
 		skipErrorLimit := ctx.Value(skipMemoErrorLimitKey{}) == true
 		skipWarningLimit := ctx.Value(skipMemoWarningLimitKey{}) == true
-		err := v.checkMemoSize(int64(msg.Size()), !skipErrorLimit, !skipWarningLimit)
+		err := v.checkMemoSize(int64(msg.Size()), skipErrorLimit, skipWarningLimit)
 		if err != nil {
 			return nil, err
 		}
 		ctx = withSkipPayloadErrorLimit(withSkipPayloadWarningLimit(ctx))
 	case *querypb.WorkflowQueryResult:
-		err := v.checkPayloadSize(int64(msg.GetAnswer().Size()), true, true)
+		err := v.checkPayloadSize(int64(msg.GetAnswer().Size()), false, false)
 		// Server translates too large results into failed query results
 		if err != nil {
 			msg.Answer = nil
@@ -166,7 +166,7 @@ func (v *payloadLimitsVisitorImpl) ContextHook(ctx context.Context, msg proto.Me
 		}
 		ctx = withSkipPayloadErrorLimit(withSkipPayloadWarningLimit(ctx))
 	case *workflowservice.RespondQueryTaskCompletedRequest:
-		err := v.checkPayloadSize(int64(msg.GetQueryResult().Size()), true, true)
+		err := v.checkPayloadSize(int64(msg.GetQueryResult().Size()), false, false)
 		// Server translates too large results into failed query results
 		if err != nil {
 			msg.ErrorMessage = err.Error()
@@ -179,7 +179,7 @@ func (v *payloadLimitsVisitorImpl) ContextHook(ctx context.Context, msg proto.Me
 		// Server only supports StartWorkflow action; skip if not StartWorkflow and let the server handle it.
 		if action, ok := msg.GetSchedule().GetAction().GetAction().(*schedulepb.ScheduleAction_StartWorkflow); ok {
 			size := int64(msg.GetMemo().Size()) + int64(action.StartWorkflow.GetInput().Size())
-			err := v.checkPayloadSize(size, true, true)
+			err := v.checkPayloadSize(size, false, false)
 			if err != nil {
 				return nil, err
 			}
@@ -212,8 +212,8 @@ func (v *payloadLimitsVisitorImpl) ContextHook(ctx context.Context, msg proto.Me
 	return ctx, nil
 }
 
-func (v *payloadLimitsVisitorImpl) checkPayloadSize(size int64, checkErrorLimits bool, checkWarningLimits bool) error {
-	if checkErrorLimits {
+func (v *payloadLimitsVisitorImpl) checkPayloadSize(size int64, skipErrorLimits bool, skipWarningLimits bool) error {
+	if !skipErrorLimits {
 		errorLimits := v.errorLimits.Load()
 		if errorLimits != nil && errorLimits.payloadSize > 0 && size > errorLimits.payloadSize {
 			return payloadSizeError{
@@ -223,7 +223,7 @@ func (v *payloadLimitsVisitorImpl) checkPayloadSize(size int64, checkErrorLimits
 			}
 		}
 	}
-	if checkWarningLimits && v.warningLimits.payloadSize > 0 && size > v.warningLimits.payloadSize && v.logger != nil {
+	if !skipWarningLimits && v.warningLimits.payloadSize > 0 && size > v.warningLimits.payloadSize && v.logger != nil {
 		v.logger.Warn(
 			"[TMPRL1103] Attempted to upload payloads with size that exceeded the warning limit.",
 			tagPayloadSize, size,
@@ -233,8 +233,8 @@ func (v *payloadLimitsVisitorImpl) checkPayloadSize(size int64, checkErrorLimits
 	return nil
 }
 
-func (v *payloadLimitsVisitorImpl) checkMemoSize(size int64, checkErrorLimits bool, checkWarningLimits bool) error {
-	if checkErrorLimits {
+func (v *payloadLimitsVisitorImpl) checkMemoSize(size int64, skipErrorLimits bool, skipWarningLimits bool) error {
+	if !skipErrorLimits {
 		errorLimits := v.errorLimits.Load()
 		if errorLimits != nil && errorLimits.memoSize > 0 && size > errorLimits.memoSize {
 			return payloadSizeError{
@@ -244,7 +244,7 @@ func (v *payloadLimitsVisitorImpl) checkMemoSize(size int64, checkErrorLimits bo
 			}
 		}
 	}
-	if checkWarningLimits && v.warningLimits.memoSize > 0 && size > v.warningLimits.memoSize && v.logger != nil {
+	if !skipWarningLimits && v.warningLimits.memoSize > 0 && size > v.warningLimits.memoSize && v.logger != nil {
 		v.logger.Warn(
 			"[TMPRL1103] Attempted to upload memo with size that exceeded the warning limit.",
 			tagMemoSize, size,

--- a/internal/payload_limits.go
+++ b/internal/payload_limits.go
@@ -10,6 +10,7 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/proxy"
 	querypb "go.temporal.io/api/query/v1"
+	schedulepb "go.temporal.io/api/schedule/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/sdk/log"
 	"google.golang.org/protobuf/proto"
@@ -24,17 +25,30 @@ type PayloadLimitOptions struct {
 	// The limit (in bytes) at which a payload size warning is logged.
 	// If unspecified or zero, defaults to 512 KiB.
 	PayloadSizeWarning int
+	// The limit (in bytes) at which an aggregate memo size warning is logged.
+	// If unspecified or zero, defaults to 512 KiB.
+	MemoSizeWarning int
 }
 
 type skipErrorLimitKey struct{}
 type skipWarningLimitKey struct{}
+type skipMemoErrorLimitKey struct{}
+type skipMemoWarningLimitKey struct{}
 
-func withSkipErrorLimit(ctx context.Context) context.Context {
+func withSkipPayloadErrorLimit(ctx context.Context) context.Context {
 	return context.WithValue(ctx, skipErrorLimitKey{}, true)
 }
 
-func withSkipWarningLimit(ctx context.Context) context.Context {
+func withSkipPayloadWarningLimit(ctx context.Context) context.Context {
 	return context.WithValue(ctx, skipWarningLimitKey{}, true)
+}
+
+func withSkipMemoErrorLimit(ctx context.Context) context.Context {
+	return context.WithValue(ctx, skipMemoErrorLimitKey{}, true)
+}
+
+func withSkipMemoWarningLimit(ctx context.Context) context.Context {
+	return context.WithValue(ctx, skipMemoWarningLimitKey{}, true)
 }
 
 type payloadSizeError struct {
@@ -49,6 +63,7 @@ func (e payloadSizeError) Error() string {
 
 type payloadLimits struct {
 	payloadSize int64
+	memoSize    int64
 }
 
 func payloadLimitOptionsToLimits(options PayloadLimitOptions) (payloadLimits, error) {
@@ -59,8 +74,16 @@ func payloadLimitOptionsToLimits(options PayloadLimitOptions) (payloadLimits, er
 	if payloadSizeWarning == 0 {
 		payloadSizeWarning = 512 * 1024
 	}
+	memoSizeWarning := int64(options.MemoSizeWarning)
+	if memoSizeWarning < 0 {
+		return payloadLimits{}, errors.New("MemoSizeWarning must be greater than or equal to zero")
+	}
+	if memoSizeWarning == 0 {
+		memoSizeWarning = 2 * 1024
+	}
 	return payloadLimits{
 		payloadSize: payloadSizeWarning,
+		memoSize:    memoSizeWarning,
 	}, nil
 }
 
@@ -108,7 +131,7 @@ func (v *payloadLimitsVisitorImpl) ContextHook(ctx context.Context, msg proto.Me
 		if err != nil {
 			return nil, err
 		}
-		ctx = withSkipErrorLimit(withSkipWarningLimit(ctx))
+		ctx = withSkipPayloadErrorLimit(withSkipPayloadWarningLimit(ctx))
 	// UpsertWorkflowSearchAttributesCommandAttributes.SearchAttributes is a map[string]Payload
 	// Server has specialized size checking for map[string]Payload (that are not Memo fields).
 	case *commandpb.UpsertWorkflowSearchAttributesCommandAttributes:
@@ -116,7 +139,7 @@ func (v *payloadLimitsVisitorImpl) ContextHook(ctx context.Context, msg proto.Me
 		if err != nil {
 			return nil, err
 		}
-		ctx = withSkipErrorLimit(withSkipWarningLimit(ctx))
+		ctx = withSkipPayloadErrorLimit(withSkipPayloadWarningLimit(ctx))
 	// ModifyWorkflowPropertiesCommandAttributes.Properties is a map[string]Payload
 	// Server has specialized size checking for map[string]Payload (that are not Memo fields).
 	case *commandpb.ModifyWorkflowPropertiesCommandAttributes:
@@ -124,7 +147,15 @@ func (v *payloadLimitsVisitorImpl) ContextHook(ctx context.Context, msg proto.Me
 		if err != nil {
 			return nil, err
 		}
-		ctx = withSkipErrorLimit(withSkipWarningLimit(ctx))
+		ctx = withSkipPayloadErrorLimit(withSkipPayloadWarningLimit(ctx))
+	case *commonpb.Memo:
+		skipErrorLimit := ctx.Value(skipMemoErrorLimitKey{}) == true
+		skipWarningLimit := ctx.Value(skipMemoWarningLimitKey{}) == true
+		err := v.checkMemoSize(int64(msg.Size()), !skipErrorLimit, !skipWarningLimit)
+		if err != nil {
+			return nil, err
+		}
+		ctx = withSkipPayloadErrorLimit(withSkipPayloadWarningLimit(ctx))
 	case *querypb.WorkflowQueryResult:
 		err := v.checkPayloadSize(int64(msg.GetAnswer().Size()), true, true)
 		// Server translates too large results into failed query results
@@ -133,7 +164,7 @@ func (v *payloadLimitsVisitorImpl) ContextHook(ctx context.Context, msg proto.Me
 			msg.ErrorMessage = err.Error()
 			msg.ResultType = enumspb.QUERY_RESULT_TYPE_FAILED
 		}
-		ctx = withSkipErrorLimit(withSkipWarningLimit(ctx))
+		ctx = withSkipPayloadErrorLimit(withSkipPayloadWarningLimit(ctx))
 	case *workflowservice.RespondQueryTaskCompletedRequest:
 		err := v.checkPayloadSize(int64(msg.GetQueryResult().Size()), true, true)
 		// Server translates too large results into failed query results
@@ -142,16 +173,42 @@ func (v *payloadLimitsVisitorImpl) ContextHook(ctx context.Context, msg proto.Me
 			msg.QueryResult = nil
 			msg.CompletedType = enumspb.QUERY_RESULT_TYPE_FAILED
 		}
-		ctx = withSkipErrorLimit(withSkipWarningLimit(ctx))
+		ctx = withSkipPayloadErrorLimit(withSkipPayloadWarningLimit(ctx))
+	// CreateScheduleRequest has a custom size checking algorithm checked against the payload size limit.
+	case *workflowservice.CreateScheduleRequest:
+		// Server only supports StartWorkflow action; skip if not StartWorkflow and let the server handle it.
+		if action, ok := msg.GetSchedule().GetAction().GetAction().(*schedulepb.ScheduleAction_StartWorkflow); ok {
+			size := int64(msg.GetMemo().Size()) + int64(action.StartWorkflow.GetInput().Size())
+			err := v.checkPayloadSize(size, true, true)
+			if err != nil {
+				return nil, err
+			}
+		}
+		ctx = withSkipMemoErrorLimit(withSkipMemoWarningLimit(ctx))
+		ctx = withSkipPayloadErrorLimit(withSkipPayloadWarningLimit(ctx))
+	// UpdateScheduleRequest.Memo is not validated by the server against memo size limits.
+	case *workflowservice.UpdateScheduleRequest:
+		ctx = withSkipMemoErrorLimit(ctx)
 	// Failures are passed through to server which will append failure details instead of failing the workflow.
 	// Skip error checking these to allow the server to receive the failures.
 	case *workflowservice.RespondActivityTaskFailedRequest:
-		ctx = withSkipErrorLimit(ctx)
+		ctx = withSkipPayloadErrorLimit(ctx)
 	case *workflowservice.RespondActivityTaskFailedByIdRequest:
-		ctx = withSkipErrorLimit(ctx)
+		ctx = withSkipPayloadErrorLimit(ctx)
 	case *workflowservice.RespondWorkflowTaskFailedRequest:
-		ctx = withSkipErrorLimit(ctx)
+		ctx = withSkipPayloadErrorLimit(ctx)
 	}
+	// These are the additional protos that server checks that the SDK does not currently check:
+	// - UpsertWorkflowSearchAttributesCommandAttributes has another SearchAttributes size check that combines execution info,
+	//   which is not available in the SDK. Violating the limit will terminate the workflow.
+	// - ModifyWorkflowPropertiesCommandAttributes has another SearchAttributes size check that combines execution info,
+	//   which is not available in the SDK. Violating the limit will terminate the workflow.
+	// - UpdateScheduleRequest has a complicated payload sizing algorithm that combines multiple fields into another proto,
+	//   proto-preferred encodes them, and checks against the payload size limit. Violating the limit returns an error to the client.
+	// - PatchScheduleRequest has a Patch field that is proto-preferred encoded and checked against the payload size limit.
+	//   Violating the limit returns an error to the client.
+	// - ListScheduleMatchingTimesRequest is proto-preferred encoded and checked against the payload size limit.
+	//   Violating the limit returns an error to the client.
 	return ctx, nil
 }
 
@@ -171,6 +228,27 @@ func (v *payloadLimitsVisitorImpl) checkPayloadSize(size int64, checkErrorLimits
 			"[TMPRL1103] Attempted to upload payloads with size that exceeded the warning limit.",
 			tagPayloadSize, size,
 			tagPayloadSizeLimit, v.warningLimits.payloadSize,
+		)
+	}
+	return nil
+}
+
+func (v *payloadLimitsVisitorImpl) checkMemoSize(size int64, checkErrorLimits bool, checkWarningLimits bool) error {
+	if checkErrorLimits {
+		errorLimits := v.errorLimits.Load()
+		if errorLimits != nil && errorLimits.memoSize > 0 && size > errorLimits.memoSize {
+			return payloadSizeError{
+				message: "[TMPRL1103] Attempted to upload memo with size that exceeded the error limit.",
+				size:    size,
+				limit:   errorLimits.memoSize,
+			}
+		}
+	}
+	if checkWarningLimits && v.warningLimits.memoSize > 0 && size > v.warningLimits.memoSize && v.logger != nil {
+		v.logger.Warn(
+			"[TMPRL1103] Attempted to upload memo with size that exceeded the warning limit.",
+			tagMemoSize, size,
+			tagMemoSizeLimit, v.warningLimits.memoSize,
 		)
 	}
 	return nil

--- a/internal/payload_limits.go
+++ b/internal/payload_limits.go
@@ -192,11 +192,11 @@ func (v *payloadLimitsVisitorImpl) ContextHook(ctx context.Context, msg proto.Me
 	// Failures are passed through to server which will append failure details instead of failing the workflow.
 	// Skip error checking these to allow the server to receive the failures.
 	case *workflowservice.RespondActivityTaskFailedRequest:
-		ctx = withSkipPayloadErrorLimit(ctx)
+		ctx = withSkipPayloadErrorLimit(withSkipMemoErrorLimit(ctx))
 	case *workflowservice.RespondActivityTaskFailedByIdRequest:
-		ctx = withSkipPayloadErrorLimit(ctx)
+		ctx = withSkipPayloadErrorLimit(withSkipMemoErrorLimit(ctx))
 	case *workflowservice.RespondWorkflowTaskFailedRequest:
-		ctx = withSkipPayloadErrorLimit(ctx)
+		ctx = withSkipPayloadErrorLimit(withSkipMemoErrorLimit(ctx))
 	}
 	// These are the additional protos that server checks that the SDK does not currently check:
 	// - UpsertWorkflowSearchAttributesCommandAttributes has another SearchAttributes size check that combines execution info,

--- a/internal/payload_limits.go
+++ b/internal/payload_limits.go
@@ -30,26 +30,43 @@ type PayloadLimitOptions struct {
 	MemoSizeWarning int
 }
 
-type skipErrorLimitKey struct{}
-type skipWarningLimitKey struct{}
-type skipMemoErrorLimitKey struct{}
-type skipMemoWarningLimitKey struct{}
+type payloadLimitCheckKey struct{}
+type memoLimitCheckKey struct{}
 
-func withSkipPayloadErrorLimit(ctx context.Context) context.Context {
-	return context.WithValue(ctx, skipErrorLimitKey{}, true)
+func withPayloadLimitChecks(ctx context.Context, checks limitCheck) context.Context {
+	return context.WithValue(ctx, payloadLimitCheckKey{}, checks)
 }
 
-func withSkipPayloadWarningLimit(ctx context.Context) context.Context {
-	return context.WithValue(ctx, skipWarningLimitKey{}, true)
+func withMemoLimitChecks(ctx context.Context, checks limitCheck) context.Context {
+	return context.WithValue(ctx, memoLimitCheckKey{}, checks)
 }
 
-func withSkipMemoErrorLimit(ctx context.Context) context.Context {
-	return context.WithValue(ctx, skipMemoErrorLimitKey{}, true)
+func getPayloadLimitChecks(ctx context.Context) limitCheck {
+	if ctx != nil {
+		if v, ok := ctx.Value(payloadLimitCheckKey{}).(limitCheck); ok {
+			return v
+		}
+	}
+	return limitCheckAll
 }
 
-func withSkipMemoWarningLimit(ctx context.Context) context.Context {
-	return context.WithValue(ctx, skipMemoWarningLimitKey{}, true)
+func getMemoLimitChecks(ctx context.Context) limitCheck {
+	if ctx != nil {
+		if v, ok := ctx.Value(memoLimitCheckKey{}).(limitCheck); ok {
+			return v
+		}
+	}
+	return limitCheckAll
 }
+
+type limitCheck uint8
+
+const (
+	limitCheckNone    limitCheck = 0
+	limitCheckError   limitCheck = 1 << 0
+	limitCheckWarning limitCheck = 1 << 1
+	limitCheckAll                = limitCheckError | limitCheckWarning
+)
 
 type payloadSizeError struct {
 	message string
@@ -97,9 +114,6 @@ var _ PayloadVisitor = (*payloadLimitsVisitorImpl)(nil)
 var _ PayloadVisitorWithContextHook = (*payloadLimitsVisitorImpl)(nil)
 
 func (v *payloadLimitsVisitorImpl) Visit(ctx *proxy.VisitPayloadsContext, payloads []*commonpb.Payload) ([]*commonpb.Payload, error) {
-	skipErrorLimit := ctx.Context != nil && ctx.Context.Value(skipErrorLimitKey{}) == true
-	skipWarningLimit := ctx.Context != nil && ctx.Context.Value(skipWarningLimitKey{}) == true
-
 	size := int64(0)
 	if ctx.SinglePayloadRequired {
 		if _, ok := ctx.Parent.(*commandpb.ScheduleNexusOperationCommandAttributes); !ok {
@@ -113,7 +127,7 @@ func (v *payloadLimitsVisitorImpl) Visit(ctx *proxy.VisitPayloadsContext, payloa
 		size = int64((&commonpb.Payloads{Payloads: payloads}).Size())
 	}
 
-	err := v.checkPayloadSize(size, skipErrorLimit, skipWarningLimit)
+	err := v.checkPayloadSize(size, getPayloadLimitChecks(ctx.Context))
 	if err != nil {
 		return nil, err
 	}
@@ -127,76 +141,77 @@ func (v *payloadLimitsVisitorImpl) ContextHook(ctx context.Context, msg proto.Me
 	// RecordMarkerCommandAttributes.Details is a map[string]Payloads
 	// Server has specialized size checking for map[string]Payloads for this field.
 	case *commandpb.RecordMarkerCommandAttributes:
-		err := v.checkPayloadSize(v.getPayloadsMapSize(msg.Details), false, false)
+		err := v.checkPayloadSize(v.getPayloadsMapSize(msg.Details), limitCheckAll)
 		if err != nil {
 			return nil, err
 		}
-		ctx = withSkipPayloadErrorLimit(withSkipPayloadWarningLimit(ctx))
+		ctx = withPayloadLimitChecks(ctx, limitCheckNone)
 	// UpsertWorkflowSearchAttributesCommandAttributes.SearchAttributes is a map[string]Payload
 	// Server has specialized size checking for map[string]Payload (that are not Memo fields).
 	case *commandpb.UpsertWorkflowSearchAttributesCommandAttributes:
-		err := v.checkPayloadSize(v.getPayloadMapSize(msg.GetSearchAttributes().GetIndexedFields()), false, false)
+		err := v.checkPayloadSize(v.getPayloadMapSize(msg.GetSearchAttributes().GetIndexedFields()), limitCheckAll)
 		if err != nil {
 			return nil, err
 		}
-		ctx = withSkipPayloadErrorLimit(withSkipPayloadWarningLimit(ctx))
+		ctx = withPayloadLimitChecks(ctx, limitCheckNone)
 	// ModifyWorkflowPropertiesCommandAttributes.Properties is a map[string]Payload
 	// Server has specialized size checking for map[string]Payload (that are not Memo fields).
 	case *commandpb.ModifyWorkflowPropertiesCommandAttributes:
-		err := v.checkPayloadSize(v.getPayloadMapSize(msg.GetUpsertedMemo().GetFields()), false, false)
+		err := v.checkPayloadSize(v.getPayloadMapSize(msg.GetUpsertedMemo().GetFields()), limitCheckAll)
 		if err != nil {
 			return nil, err
 		}
-		ctx = withSkipPayloadErrorLimit(withSkipPayloadWarningLimit(ctx))
+		ctx = withPayloadLimitChecks(ctx, limitCheckNone)
 	case *commonpb.Memo:
-		skipErrorLimit := ctx.Value(skipMemoErrorLimitKey{}) == true
-		skipWarningLimit := ctx.Value(skipMemoWarningLimitKey{}) == true
-		err := v.checkMemoSize(int64(msg.Size()), skipErrorLimit, skipWarningLimit)
+		err := v.checkMemoSize(int64(msg.Size()), getMemoLimitChecks(ctx))
 		if err != nil {
 			return nil, err
 		}
-		ctx = withSkipPayloadErrorLimit(withSkipPayloadWarningLimit(ctx))
+		ctx = withPayloadLimitChecks(ctx, limitCheckNone)
 	case *querypb.WorkflowQueryResult:
-		err := v.checkPayloadSize(int64(msg.GetAnswer().Size()), false, false)
+		err := v.checkPayloadSize(int64(msg.GetAnswer().Size()), limitCheckAll)
 		// Server translates too large results into failed query results
 		if err != nil {
 			msg.Answer = nil
 			msg.ErrorMessage = err.Error()
 			msg.ResultType = enumspb.QUERY_RESULT_TYPE_FAILED
 		}
-		ctx = withSkipPayloadErrorLimit(withSkipPayloadWarningLimit(ctx))
+		ctx = withPayloadLimitChecks(ctx, limitCheckNone)
 	case *workflowservice.RespondQueryTaskCompletedRequest:
-		err := v.checkPayloadSize(int64(msg.GetQueryResult().Size()), false, false)
+		err := v.checkPayloadSize(int64(msg.GetQueryResult().Size()), limitCheckAll)
 		// Server translates too large results into failed query results
 		if err != nil {
 			msg.ErrorMessage = err.Error()
 			msg.QueryResult = nil
 			msg.CompletedType = enumspb.QUERY_RESULT_TYPE_FAILED
 		}
-		ctx = withSkipPayloadErrorLimit(withSkipPayloadWarningLimit(ctx))
+		ctx = withPayloadLimitChecks(ctx, limitCheckNone)
 	// CreateScheduleRequest has a custom size checking algorithm checked against the payload size limit.
 	case *workflowservice.CreateScheduleRequest:
 		// Server only supports StartWorkflow action; skip if not StartWorkflow and let the server handle it.
 		if action, ok := msg.GetSchedule().GetAction().GetAction().(*schedulepb.ScheduleAction_StartWorkflow); ok {
 			size := int64(msg.GetMemo().Size()) + int64(action.StartWorkflow.GetInput().Size())
-			err := v.checkPayloadSize(size, false, false)
+			err := v.checkPayloadSize(size, limitCheckAll)
 			if err != nil {
 				return nil, err
 			}
 		}
-		ctx = withSkipMemoErrorLimit(withSkipMemoWarningLimit(ctx))
-		ctx = withSkipPayloadErrorLimit(withSkipPayloadWarningLimit(ctx))
+		ctx = withMemoLimitChecks(ctx, limitCheckNone)
+		ctx = withPayloadLimitChecks(ctx, limitCheckNone)
 	// UpdateScheduleRequest.Memo is not validated by the server against memo size limits.
 	case *workflowservice.UpdateScheduleRequest:
-		ctx = withSkipMemoErrorLimit(ctx)
+		ctx = withMemoLimitChecks(ctx, limitCheckWarning)
 	// Failures are passed through to server which will append failure details instead of failing the workflow.
 	// Skip error checking these to allow the server to receive the failures.
 	case *workflowservice.RespondActivityTaskFailedRequest:
-		ctx = withSkipPayloadErrorLimit(withSkipMemoErrorLimit(ctx))
+		ctx = withPayloadLimitChecks(ctx, limitCheckWarning)
+		ctx = withMemoLimitChecks(ctx, limitCheckWarning)
 	case *workflowservice.RespondActivityTaskFailedByIdRequest:
-		ctx = withSkipPayloadErrorLimit(withSkipMemoErrorLimit(ctx))
+		ctx = withPayloadLimitChecks(ctx, limitCheckWarning)
+		ctx = withMemoLimitChecks(ctx, limitCheckWarning)
 	case *workflowservice.RespondWorkflowTaskFailedRequest:
-		ctx = withSkipPayloadErrorLimit(withSkipMemoErrorLimit(ctx))
+		ctx = withPayloadLimitChecks(ctx, limitCheckWarning)
+		ctx = withMemoLimitChecks(ctx, limitCheckWarning)
 	}
 	// These are the additional protos that server checks that the SDK does not currently check:
 	// - UpsertWorkflowSearchAttributesCommandAttributes has another SearchAttributes size check that combines execution info,
@@ -212,8 +227,8 @@ func (v *payloadLimitsVisitorImpl) ContextHook(ctx context.Context, msg proto.Me
 	return ctx, nil
 }
 
-func (v *payloadLimitsVisitorImpl) checkPayloadSize(size int64, skipErrorLimits bool, skipWarningLimits bool) error {
-	if !skipErrorLimits {
+func (v *payloadLimitsVisitorImpl) checkPayloadSize(size int64, checks limitCheck) error {
+	if checks&limitCheckError != 0 {
 		errorLimits := v.errorLimits.Load()
 		if errorLimits != nil && errorLimits.payloadSize > 0 && size > errorLimits.payloadSize {
 			return payloadSizeError{
@@ -223,7 +238,7 @@ func (v *payloadLimitsVisitorImpl) checkPayloadSize(size int64, skipErrorLimits 
 			}
 		}
 	}
-	if !skipWarningLimits && v.warningLimits.payloadSize > 0 && size > v.warningLimits.payloadSize && v.logger != nil {
+	if checks&limitCheckWarning != 0 && v.warningLimits.payloadSize > 0 && size > v.warningLimits.payloadSize && v.logger != nil {
 		v.logger.Warn(
 			"[TMPRL1103] Attempted to upload payloads with size that exceeded the warning limit.",
 			tagPayloadSize, size,
@@ -233,8 +248,8 @@ func (v *payloadLimitsVisitorImpl) checkPayloadSize(size int64, skipErrorLimits 
 	return nil
 }
 
-func (v *payloadLimitsVisitorImpl) checkMemoSize(size int64, skipErrorLimits bool, skipWarningLimits bool) error {
-	if !skipErrorLimits {
+func (v *payloadLimitsVisitorImpl) checkMemoSize(size int64, checks limitCheck) error {
+	if checks&limitCheckError != 0 {
 		errorLimits := v.errorLimits.Load()
 		if errorLimits != nil && errorLimits.memoSize > 0 && size > errorLimits.memoSize {
 			return payloadSizeError{
@@ -244,7 +259,7 @@ func (v *payloadLimitsVisitorImpl) checkMemoSize(size int64, skipErrorLimits boo
 			}
 		}
 	}
-	if !skipWarningLimits && v.warningLimits.memoSize > 0 && size > v.warningLimits.memoSize && v.logger != nil {
+	if checks&limitCheckWarning != 0 && v.warningLimits.memoSize > 0 && size > v.warningLimits.memoSize && v.logger != nil {
 		v.logger.Warn(
 			"[TMPRL1103] Attempted to upload memo with size that exceeded the warning limit.",
 			tagMemoSize, size,

--- a/internal/payload_limits_test.go
+++ b/internal/payload_limits_test.go
@@ -431,10 +431,10 @@ func TestPayloadLimitsVisitorSpecializations(t *testing.T) {
 
 	for _, tc := range skipErrorOnlyTypes {
 		tc := tc
-		t.Run(tc.name+" skips error limit but not warning", func(t *testing.T) {
+		t.Run(tc.name+" skips payload and memo error limits but not warning", func(t *testing.T) {
 			logger := ilog.NewMemoryLogger()
 			visitor, setErrorLimits := newPayloadLimitsVisitor(payloadLimits{payloadSize: 10}, logger)
-			setErrorLimits(&payloadLimits{payloadSize: 10})
+			setErrorLimits(&payloadLimits{payloadSize: 10, memoSize: 10})
 			err := visitProtoPayloads(context.Background(), visitor, tc.msg, 0)
 			require.NoError(t, err)
 			require.True(t, hasWarningLine(logger))

--- a/internal/payload_limits_test.go
+++ b/internal/payload_limits_test.go
@@ -13,6 +13,8 @@ import (
 	failurepb "go.temporal.io/api/failure/v1"
 	"go.temporal.io/api/proxy"
 	querypb "go.temporal.io/api/query/v1"
+	schedulepb "go.temporal.io/api/schedule/v1"
+	workflowpb "go.temporal.io/api/workflow/v1"
 	workflowservice "go.temporal.io/api/workflowservice/v1"
 	ilog "go.temporal.io/sdk/internal/log"
 	"google.golang.org/protobuf/proto"
@@ -23,16 +25,23 @@ func TestPayloadLimitOptionsToLimits(t *testing.T) {
 		limits, err := payloadLimitOptionsToLimits(PayloadLimitOptions{})
 		require.NoError(t, err)
 		require.Equal(t, int64(512*1024), limits.payloadSize)
+		require.Equal(t, int64(2*1024), limits.memoSize)
 	})
 
 	t.Run("custom value", func(t *testing.T) {
-		limits, err := payloadLimitOptionsToLimits(PayloadLimitOptions{PayloadSizeWarning: 1024})
+		limits, err := payloadLimitOptionsToLimits(PayloadLimitOptions{PayloadSizeWarning: 1024, MemoSizeWarning: 2048})
 		require.NoError(t, err)
 		require.Equal(t, int64(1024), limits.payloadSize)
+		require.Equal(t, int64(2048), limits.memoSize)
 	})
 
 	t.Run("negative value returns error", func(t *testing.T) {
 		_, err := payloadLimitOptionsToLimits(PayloadLimitOptions{PayloadSizeWarning: -1})
+		require.Error(t, err)
+	})
+
+	t.Run("negative memo value returns error", func(t *testing.T) {
+		_, err := payloadLimitOptionsToLimits(PayloadLimitOptions{MemoSizeWarning: -1})
 		require.Error(t, err)
 	})
 }
@@ -431,4 +440,174 @@ func TestPayloadLimitsVisitorSpecializations(t *testing.T) {
 			require.True(t, hasWarningLine(logger))
 		})
 	}
+}
+
+func TestCreateScheduleRequestSpecialization(t *testing.T) {
+	makeScheduleRequest := func(memoSize, inputSize int) *workflowservice.CreateScheduleRequest {
+		return &workflowservice.CreateScheduleRequest{
+			Memo: &commonpb.Memo{Fields: map[string]*commonpb.Payload{"k": makeTestPayload(memoSize)}},
+			Schedule: &schedulepb.Schedule{
+				Action: &schedulepb.ScheduleAction{
+					Action: &schedulepb.ScheduleAction_StartWorkflow{
+						StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
+							Input: &commonpb.Payloads{Payloads: []*commonpb.Payload{makeTestPayload(inputSize)}},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	t.Run("error when combined memo+input exceeds payload error limit", func(t *testing.T) {
+		visitor, setErrorLimits := newPayloadLimitsVisitor(payloadLimits{payloadSize: 10000, memoSize: 10000}, nil)
+		setErrorLimits(&payloadLimits{payloadSize: 100})
+		msg := makeScheduleRequest(60, 60)
+		err := visitProtoPayloads(context.Background(), visitor, msg, 0)
+		require.Error(t, err)
+		var pse payloadSizeError
+		require.ErrorAs(t, err, &pse)
+	})
+
+	t.Run("warning when combined memo+input exceeds payload warning limit", func(t *testing.T) {
+		logger := ilog.NewMemoryLogger()
+		visitor, _ := newPayloadLimitsVisitor(payloadLimits{payloadSize: 10, memoSize: 10000}, logger)
+		msg := makeScheduleRequest(60, 60)
+		err := visitProtoPayloads(context.Background(), visitor, msg, 0)
+		require.NoError(t, err)
+		require.True(t, hasWarningLine(logger))
+	})
+
+	t.Run("no memo size check fires", func(t *testing.T) {
+		logger := ilog.NewMemoryLogger()
+		visitor, setErrorLimits := newPayloadLimitsVisitor(payloadLimits{payloadSize: 10000, memoSize: 10}, logger)
+		setErrorLimits(&payloadLimits{payloadSize: 10000, memoSize: 10})
+		msg := makeScheduleRequest(200, 1)
+		err := visitProtoPayloads(context.Background(), visitor, msg, 0)
+		require.NoError(t, err)
+		require.False(t, hasMemoWarningLine(logger))
+	})
+
+	t.Run("non-StartWorkflow action skips combined check", func(t *testing.T) {
+		visitor, setErrorLimits := newPayloadLimitsVisitor(payloadLimits{payloadSize: 10000, memoSize: 10000}, nil)
+		setErrorLimits(&payloadLimits{payloadSize: 1})
+		msg := &workflowservice.CreateScheduleRequest{
+			Memo: &commonpb.Memo{Fields: map[string]*commonpb.Payload{"k": makeTestPayload(200)}},
+			Schedule: &schedulepb.Schedule{
+				Action: &schedulepb.ScheduleAction{},
+			},
+		}
+		err := visitProtoPayloads(context.Background(), visitor, msg, 0)
+		require.NoError(t, err)
+	})
+}
+
+func hasMemoWarningLine(logger *ilog.MemoryLogger) bool {
+	return slices.ContainsFunc(logger.Lines(), func(line string) bool {
+		return strings.Contains(line, "WARN  [TMPRL1103] Attempted to upload memo with size that exceeded the warning limit.")
+	})
+}
+
+func TestMemoLimitsVisitorWarning(t *testing.T) {
+	makeMemo := func(payloadSize int) *commonpb.Memo {
+		return &commonpb.Memo{Fields: map[string]*commonpb.Payload{"k": makeTestPayload(payloadSize)}}
+	}
+
+	t.Run("warning when aggregate memo size exceeds limit", func(t *testing.T) {
+		logger := ilog.NewMemoryLogger()
+		visitor, _ := newPayloadLimitsVisitor(payloadLimits{payloadSize: 10000, memoSize: 10}, logger)
+		err := visitProtoPayloads(context.Background(), visitor, makeMemo(200), 0)
+		require.NoError(t, err)
+		require.True(t, hasMemoWarningLine(logger))
+	})
+
+	t.Run("no warning when aggregate memo size is under limit", func(t *testing.T) {
+		logger := ilog.NewMemoryLogger()
+		visitor, _ := newPayloadLimitsVisitor(payloadLimits{payloadSize: 10000, memoSize: 10000}, logger)
+		err := visitProtoPayloads(context.Background(), visitor, makeMemo(10), 0)
+		require.NoError(t, err)
+		require.Empty(t, logger.Lines())
+	})
+
+	t.Run("zero memo warning limit disables memo warning", func(t *testing.T) {
+		logger := ilog.NewMemoryLogger()
+		visitor, _ := newPayloadLimitsVisitor(payloadLimits{payloadSize: 10000, memoSize: 0}, logger)
+		err := visitProtoPayloads(context.Background(), visitor, makeMemo(10000), 0)
+		require.NoError(t, err)
+		require.Empty(t, logger.Lines())
+	})
+
+	t.Run("memo warning does not trigger payload warning", func(t *testing.T) {
+		logger := ilog.NewMemoryLogger()
+		// memo limit low, payload limit high — only memo warning should fire
+		visitor, _ := newPayloadLimitsVisitor(payloadLimits{payloadSize: 10000, memoSize: 10}, logger)
+		err := visitProtoPayloads(context.Background(), visitor, makeMemo(200), 0)
+		require.NoError(t, err)
+		require.True(t, hasMemoWarningLine(logger))
+		require.False(t, hasWarningLine(logger))
+	})
+
+	t.Run("fires for StartWorkflowExecutionRequest memo", func(t *testing.T) {
+		logger := ilog.NewMemoryLogger()
+		visitor, _ := newPayloadLimitsVisitor(payloadLimits{payloadSize: 10000, memoSize: 10}, logger)
+		msg := &workflowservice.StartWorkflowExecutionRequest{
+			Memo: &commonpb.Memo{Fields: map[string]*commonpb.Payload{"k": makeTestPayload(200)}},
+		}
+		err := visitProtoPayloads(context.Background(), visitor, msg, 0)
+		require.NoError(t, err)
+		require.True(t, hasMemoWarningLine(logger))
+	})
+
+	t.Run("UpdateScheduleRequest memo skips error but not warning", func(t *testing.T) {
+		logger := ilog.NewMemoryLogger()
+		visitor, setErrorLimits := newPayloadLimitsVisitor(payloadLimits{payloadSize: 10000, memoSize: 10}, logger)
+		setErrorLimits(&payloadLimits{memoSize: 10})
+		msg := &workflowservice.UpdateScheduleRequest{
+			Memo: &commonpb.Memo{Fields: map[string]*commonpb.Payload{"k": makeTestPayload(200)}},
+		}
+		err := visitProtoPayloads(context.Background(), visitor, msg, 0)
+		require.NoError(t, err)
+		require.True(t, hasMemoWarningLine(logger))
+	})
+}
+
+func TestMemoLimitsVisitorError(t *testing.T) {
+	makeMemo := func(payloadSize int) *commonpb.Memo {
+		return &commonpb.Memo{Fields: map[string]*commonpb.Payload{"k": makeTestPayload(payloadSize)}}
+	}
+
+	t.Run("error when aggregate memo size exceeds error limit", func(t *testing.T) {
+		visitor, setErrorLimits := newPayloadLimitsVisitor(payloadLimits{payloadSize: 10000, memoSize: 10000}, nil)
+		setErrorLimits(&payloadLimits{memoSize: 10})
+		err := visitProtoPayloads(context.Background(), visitor, makeMemo(200), 0)
+		require.Error(t, err)
+		var pse payloadSizeError
+		require.ErrorAs(t, err, &pse)
+		require.Contains(t, pse.Error(), "memo")
+		require.Equal(t, int64(10), pse.limit)
+	})
+
+	t.Run("no error when memo size is under error limit", func(t *testing.T) {
+		visitor, setErrorLimits := newPayloadLimitsVisitor(payloadLimits{payloadSize: 10000, memoSize: 10000}, nil)
+		setErrorLimits(&payloadLimits{memoSize: 10000})
+		err := visitProtoPayloads(context.Background(), visitor, makeMemo(10), 0)
+		require.NoError(t, err)
+	})
+
+	t.Run("zero memo error limit means no error check", func(t *testing.T) {
+		visitor, setErrorLimits := newPayloadLimitsVisitor(payloadLimits{payloadSize: 10000, memoSize: 10000}, nil)
+		setErrorLimits(&payloadLimits{memoSize: 0})
+		err := visitProtoPayloads(context.Background(), visitor, makeMemo(100000), 0)
+		require.NoError(t, err)
+	})
+
+	t.Run("memo error does not trigger payload error", func(t *testing.T) {
+		visitor, setErrorLimits := newPayloadLimitsVisitor(payloadLimits{payloadSize: 10000, memoSize: 10000}, nil)
+		// memo error limit low, payload error limit high
+		setErrorLimits(&payloadLimits{payloadSize: 100000, memoSize: 10})
+		err := visitProtoPayloads(context.Background(), visitor, makeMemo(200), 0)
+		require.Error(t, err)
+		var pse payloadSizeError
+		require.ErrorAs(t, err, &pse)
+		require.Contains(t, pse.Error(), "memo")
+	})
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

- 💥 Update worker to get memo error limits from Temporal server and enforce those limits by default. The SDK will now eagerly fail a task that has too large memos instead of uploading them to the server and having the server fail the workflow. If the server doesn't report error limits, error limits are not enforced in the worker.
- Add client memo limits options for setting memo size warning thresholds. Warnings are emitted in client and worker for memos that are above these thresholds.

### 💥 Behavioral change details
Within workers, if a memo exceeds the server limits, the worker will eagerly fail the current task instead of uploading the object with the too large memo. This allows the task to be retried instead of entirely failing the workflow from within the server.

Customers who use gRPC proxies that alter memos before they are passed to the server (encryption in the proxy, offloading to external storage within proxy) should disable this new behavior on the worker using the new DisablePayloadErrorLimit option introduced in https://github.com/temporalio/sdk-go/pull/2255. For example:

```go
c, err := client.Dial(...)

w := worker.New(c, "queue-name", worker.Options{
    DisablePayloadErrorLimit: true,
})
```

## Why?

Users need to know when memo sizes are approaching or have exceeded size limits. This will help prevent workflow outages and inform users to adjust their workflows to make use of alternate storage methods or to store small memo information.

## Checklist
<!--- add/delete as needed --->

1. How was this tested: Unit tests
1. Any docs updates needed? Yes
