### PR TITLE
SEC-1653: remediate missing-govulncheck-workflow

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,0 +1,16 @@
+name: Govulncheck
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  govulncheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: go.mod
+      - uses: temporalio/public-actions/golang/govulncheck@main


### PR DESCRIPTION
> 🏕️ This pull request was created by [camper](https://github.com/temporalio/camper), an automated security campaign tool.

## Finding

<table>
  <tr><td><strong>Rule</strong></td><td><code>missing-govulncheck-workflow</code></td></tr>
  <tr><td><strong>Severity</strong></td><td>MEDIUM</td></tr>
  <tr><td><strong>Repository</strong></td><td><code>temporalio/sdk-go</code></td></tr>
  <tr><td><strong>Ticket</strong></td><td><a href="https://temporalio.atlassian.net/browse/SEC-1653">SEC-1653</a></td></tr>
</table>

## Summary

- `.github/workflows/govulncheck.yml`: Added a pull_request-only Govulncheck workflow with `contents: read` permissions, canonical `ubuntu-latest` runner, pinned `actions/checkout` and `actions/setup-go` SHAs (matching `ci.yml` comments), `go-version-file: go.mod`, and `temporalio/public-actions/golang/govulncheck@main` for differential vulnerability scanning.

## Instructions

- **Approve** to merge this fix
- **Request changes** to trigger a new remediation attempt
- `/camper rebase` — rebase onto the base branch
- `/camper close` — close this PR without merging
- `/camper retry` — close and retry with a new fix