### PR TITLE
Set time to 10 minutes not 60 seconds

### DIFF
--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -748,8 +748,8 @@ func (env *testWorkflowEnvironmentImpl) executeActivity(
 
 	parameters := ExecuteActivityParams{
 		ExecuteActivityOptions: ExecuteActivityOptions{
-			ScheduleToCloseTimeout: 600 * time.Second,
-			StartToCloseTimeout:    600 * time.Second,
+			ScheduleToCloseTimeout: 10 * time.Minute,
+			StartToCloseTimeout:    10 * time.Minute,
 		},
 		ActivityType: *activityType,
 		Input:        input,


### PR DESCRIPTION
## What was changed
Change a line for 600 seconds to 10 minutes

## Why?
No one ever says 600 seconds, most likely people will grep for 10 minutes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a small, test-suite-only change that keeps the effective timeout the same but uses a more readable duration literal.
> 
> **Overview**
> Updates the test workflow environment’s default activity `ScheduleToCloseTimeout` and `StartToCloseTimeout` to use `10 * time.Minute` instead of `600 * time.Second`, with no behavior change (still a 10-minute timeout).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c67004c5203194874a9e92a284c79b02633afea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->