### PR TITLE
Enable SDKFlagMemoUserDCEncode flag by default

### DIFF
--- a/internal/internal_flags.go
+++ b/internal/internal_flags.go
@@ -53,7 +53,7 @@ var sdkFlagsAllowed = map[sdkFlag]bool{
 	SDKPriorityUpdateHandling:             true,
 	SDKFlagBlockedSelectorSignalReceive:   false,
 	SDKFlagCancelAwaitTimerOnCondition:    false,
-	SDKFlagMemoUserDCEncode:               false,
+	SDKFlagMemoUserDCEncode:               true,
 	SDKFlagWorkflowNewChannelLostMessages: false,
 }
 

--- a/internal/internal_schedule_client_test.go
+++ b/internal/internal_schedule_client_test.go
@@ -266,10 +266,8 @@ func (s *scheduleClientTestSuite) TestCreateScheduleWorkflowMemoDataConverter() 
 		defer func() { sdkFlagsAllowed[SDKFlagMemoUserDCEncode] = orig }()
 		testFn()
 	})
-	s.T().Run("new behavior", func(t *testing.T) {
-		orig := sdkFlagsAllowed[SDKFlagMemoUserDCEncode]
-		sdkFlagsAllowed[SDKFlagMemoUserDCEncode] = true
-		defer func() { sdkFlagsAllowed[SDKFlagMemoUserDCEncode] = orig }()
+	s.T().Run("default behavior", func(t *testing.T) {
+		s.True(sdkFlagsAllowed[SDKFlagMemoUserDCEncode])
 		testFn()
 	})
 }
@@ -318,10 +316,8 @@ func (s *scheduleClientTestSuite) TestCreateScheduleWorkflowMemoUserAndDefaultCo
 		defer func() { sdkFlagsAllowed[SDKFlagMemoUserDCEncode] = orig }()
 		testFn()
 	})
-	s.T().Run("new behavior", func(t *testing.T) {
-		orig := sdkFlagsAllowed[SDKFlagMemoUserDCEncode]
-		sdkFlagsAllowed[SDKFlagMemoUserDCEncode] = true
-		defer func() { sdkFlagsAllowed[SDKFlagMemoUserDCEncode] = orig }()
+	s.T().Run("default behavior", func(t *testing.T) {
+		s.True(sdkFlagsAllowed[SDKFlagMemoUserDCEncode])
 		testFn()
 	})
 }

--- a/internal/internal_workflow_client_test.go
+++ b/internal/internal_workflow_client_test.go
@@ -1966,10 +1966,8 @@ func (s *workflowClientTestSuite) TestStartWorkflowWithMemoDataConverter() {
 		defer func() { sdkFlagsAllowed[SDKFlagMemoUserDCEncode] = orig }()
 		testFn()
 	})
-	s.T().Run("new behavior", func(t *testing.T) {
-		orig := sdkFlagsAllowed[SDKFlagMemoUserDCEncode]
-		sdkFlagsAllowed[SDKFlagMemoUserDCEncode] = true
-		defer func() { sdkFlagsAllowed[SDKFlagMemoUserDCEncode] = orig }()
+	s.T().Run("default behavior", func(t *testing.T) {
+		s.True(sdkFlagsAllowed[SDKFlagMemoUserDCEncode])
 		testFn()
 	})
 }
@@ -2038,10 +2036,8 @@ func (s *workflowClientTestSuite) TestStartWorkflowWithMemoUserAndDefaultConvert
 		defer func() { sdkFlagsAllowed[SDKFlagMemoUserDCEncode] = orig }()
 		testFn()
 	})
-	s.T().Run("new behavior", func(t *testing.T) {
-		orig := sdkFlagsAllowed[SDKFlagMemoUserDCEncode]
-		sdkFlagsAllowed[SDKFlagMemoUserDCEncode] = true
-		defer func() { sdkFlagsAllowed[SDKFlagMemoUserDCEncode] = orig }()
+	s.T().Run("default behavior", func(t *testing.T) {
+		s.True(sdkFlagsAllowed[SDKFlagMemoUserDCEncode])
 		testFn()
 	})
 }


### PR DESCRIPTION
## What was changed
Enabled `SDKFlagMemoUserDCEncode` by default

## Why?
Behavior was previously fixed but gated behind SDK flags. Now that a few releases have been out, we can enable these flag by default.

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-go/issues/1045

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Updated existing tests for default behavior. We have existing replay tests from the last PR to verify replay of old behavior on new default https://github.com/temporalio/sdk-go/pull/2121

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the default memo encoding path to prefer the user `DataConverter` (with fallback), which can alter memo payload encodings and surfaced error messages for some clients. Risk is moderate due to potential compatibility/behavior differences across deployments and tests relying on prior defaults.
> 
> **Overview**
> Enables `SDKFlagMemoUserDCEncode` by default in `sdkFlagsAllowed`, making memo serialization use the user `DataConverter` (with fallback) without requiring an explicit flag flip.
> 
> Updates schedule and workflow client tests to treat the enabled flag as the **default behavior** (asserting it is `true`) while retaining coverage for the legacy `false` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a24099a31368c527e626bfb0360df0faa3d4205. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->