### PR TITLE
Fix Worker Deployment test flakes

### DIFF
--- a/test/payload_limits_test.go
+++ b/test/payload_limits_test.go
@@ -76,6 +76,7 @@ func (ts *PayloadLimitsTestSuite) SetupSuite() {
 }
 
 func (ts *PayloadLimitsTestSuite) SetupTest() {
+	ts.Assertions = require.New(ts.T())
 	ts.taskQueueName = taskQueuePrefix + "-" + ts.T().Name()
 	// Only initialize if not already set (tests can call ResetClientAndWorker themselves)
 	if ts.client == nil {

--- a/test/worker_deployment_test.go
+++ b/test/worker_deployment_test.go
@@ -618,7 +618,7 @@ func (ts *WorkerDeploymentTestSuite) TestUpdateWorkflowExecutionOptions() {
 	if os.Getenv("DISABLE_SERVER_1_27_TESTS") != "" {
 		ts.T().Skip("temporal server 1.27+ required")
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
 	defer cancel()
 
 	deploymentName := "deploy-test-" + uuid.NewString()
@@ -1015,7 +1015,7 @@ func (ts *WorkerDeploymentTestSuite) TestRampVersions() {
 	if os.Getenv("DISABLE_SERVER_1_27_TESTS") != "" {
 		ts.T().Skip("temporal server 1.27+ required")
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
 	defer cancel()
 
 	deploymentName := "deploy-test-" + uuid.NewString()
@@ -1365,7 +1365,7 @@ func (ts *WorkerDeploymentTestSuite) TestContinueAsNewWithVersionUpgrade() {
 	if os.Getenv("DISABLE_SERVER_1_27_TESTS") != "" {
 		ts.T().Skip("temporal server 1.27+ required")
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
 	defer cancel()
 
 	deploymentName := "deploy-test-" + uuid.NewString()
@@ -1468,7 +1468,7 @@ func (ts *WorkerDeploymentTestSuite) TestContinueAsNewWithRampingVersion() {
 	if os.Getenv("DISABLE_SERVER_1_27_TESTS") != "" {
 		ts.T().Skip("temporal server 1.27+ required")
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
 	defer cancel()
 
 	deploymentName := "deploy-test-" + uuid.NewString()

--- a/test/worker_deployment_test.go
+++ b/test/worker_deployment_test.go
@@ -344,7 +344,7 @@ func (ts *WorkerDeploymentTestSuite) TestPinnedBehaviorThreeWorkers() {
 	if os.Getenv("DISABLE_SERVER_1_27_TESTS") != "" {
 		ts.T().Skip("temporal server 1.27+ required")
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
 	defer cancel()
 
 	deploymentName := "deploy-test-" + uuid.NewString()

--- a/test/worker_deployment_test.go
+++ b/test/worker_deployment_test.go
@@ -57,6 +57,7 @@ func (ts *WorkerDeploymentTestSuite) TearDownSuite() {
 }
 
 func (ts *WorkerDeploymentTestSuite) SetupTest() {
+	ts.Assertions = require.New(ts.T())
 	ts.taskQueueName = taskQueuePrefix + "-" + ts.T().Name()
 }
 
@@ -429,6 +430,7 @@ func (ts *WorkerDeploymentTestSuite) TestPinnedBehaviorThreeWorkers() {
 		ConflictToken: response1.ConflictToken,
 	})
 	ts.NoError(err)
+	ts.waitForWorkerDeploymentRoutingConfigPropagation(ctx, deploymentName, v1.BuildID, "")
 
 	// start workflow1 with 1.0, WaitSignalToStartVersionedOne, auto-upgrade
 	handle1, err := ts.client.ExecuteWorkflow(ctx, ts.startWorkflowOptions("1"), "WaitSignalToStartVersioned")
@@ -443,6 +445,7 @@ func (ts *WorkerDeploymentTestSuite) TestPinnedBehaviorThreeWorkers() {
 		ConflictToken: response2.ConflictToken,
 	})
 	ts.NoError(err)
+	ts.waitForWorkerDeploymentRoutingConfigPropagation(ctx, deploymentName, v2.BuildID, "")
 
 	// start workflow2 with 2.0, WaitSignalToStartVersionedOne, pinned
 	handle2, err := ts.client.ExecuteWorkflow(ctx, ts.startWorkflowOptions("2"), "WaitSignalToStartVersioned")
@@ -452,15 +455,13 @@ func (ts *WorkerDeploymentTestSuite) TestPinnedBehaviorThreeWorkers() {
 
 	ts.waitForWorkerDeploymentVersion(ctx, dHandle, v3)
 
-	// Needed if server constant maxFastUserDataFetches is not >= 20
-	//time.Sleep(10 * time.Second)
-
 	_, err = dHandle.SetCurrentVersion(ctx, client.WorkerDeploymentSetCurrentVersionOptions{
 		BuildID:       v3.BuildID,
 		ConflictToken: response3.ConflictToken,
 		Identity:      "client1",
 	})
 	ts.NoError(err)
+	ts.waitForWorkerDeploymentRoutingConfigPropagation(ctx, deploymentName, v3.BuildID, "")
 
 	desc, err := dHandle.Describe(ctx, client.WorkerDeploymentDescribeOptions{})
 
@@ -896,13 +897,12 @@ func (ts *WorkerDeploymentTestSuite) TestDeploymentDrainage() {
 			Version:       v1,
 		},
 	})
-	ts.NoError(worker1.Start())
-	defer worker1.Stop()
-
 	worker1.RegisterWorkflowWithOptions(ts.workflows.WaitSignalToStartVersionedOne, workflow.RegisterOptions{
 		Name:               "WaitSignalToStartVersioned",
 		VersioningBehavior: workflow.VersioningBehaviorPinned,
 	})
+	ts.NoError(worker1.Start())
+	defer worker1.Stop()
 
 	worker2 := worker.New(ts.client, ts.taskQueueName, worker.Options{
 		DeploymentOptions: worker.DeploymentOptions{
@@ -910,14 +910,10 @@ func (ts *WorkerDeploymentTestSuite) TestDeploymentDrainage() {
 			Version:       v2,
 		},
 	})
-	ts.NoError(worker2.Start())
-	defer worker2.Stop()
-
 	worker2.RegisterWorkflowWithOptions(ts.workflows.WaitSignalToStartVersionedTwo, workflow.RegisterOptions{
 		Name:               "WaitSignalToStartVersioned",
 		VersioningBehavior: workflow.VersioningBehaviorAutoUpgrade,
 	})
-
 	ts.NoError(worker2.Start())
 	defer worker2.Stop()
 
@@ -937,6 +933,7 @@ func (ts *WorkerDeploymentTestSuite) TestDeploymentDrainage() {
 		ConflictToken: response1.ConflictToken,
 	})
 	ts.NoError(err)
+	ts.waitForWorkerDeploymentRoutingConfigPropagation(ctx, deploymentName, v1.BuildID, "")
 
 	// Show no drainage
 
@@ -968,6 +965,7 @@ func (ts *WorkerDeploymentTestSuite) TestDeploymentDrainage() {
 		ConflictToken: response2.ConflictToken,
 	})
 	ts.NoError(err)
+	ts.waitForWorkerDeploymentRoutingConfigPropagation(ctx, deploymentName, v2.BuildID, "")
 
 	// Show 1.0) Draining and 2.0) not
 

--- a/test/worker_deployment_test.go
+++ b/test/worker_deployment_test.go
@@ -116,7 +116,7 @@ func (ts *WorkerDeploymentTestSuite) waitForWorkerDeploymentRoutingConfigPropaga
 			return false
 		}
 		return false
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 10*time.Second, 100*time.Millisecond)
 }
 
 func (ts *WorkerDeploymentTestSuite) waitForWorkflowRunning(ctx context.Context, handle client.WorkflowRun) {

--- a/test/worker_deployment_test.go
+++ b/test/worker_deployment_test.go
@@ -332,6 +332,7 @@ func (ts *WorkerDeploymentTestSuite) TestBuildIDWithSession() {
 		ConflictToken: response1.ConflictToken,
 	})
 	ts.NoError(err)
+	ts.waitForWorkerDeploymentRoutingConfigPropagation(ctx, deploymentName, v1.BuildID, "")
 
 	// start workflow1 with 1.0, BasicSession, auto-upgrade
 	wfHandle, err := ts.client.ExecuteWorkflow(ctx, ts.startWorkflowOptions("evolving-wf-1"), "SessionBuildIDWorkflow")
@@ -681,6 +682,7 @@ func (ts *WorkerDeploymentTestSuite) TestUpdateWorkflowExecutionOptions() {
 		ConflictToken: response1.ConflictToken,
 	})
 	ts.NoError(err)
+	ts.waitForWorkerDeploymentRoutingConfigPropagation(ctx, deploymentName, v1.BuildID, "")
 
 	handle1, err := ts.client.ExecuteWorkflow(ctx, ts.startWorkflowOptions("1"), "WaitSignalToStartVersioned")
 	ts.NoError(err)
@@ -761,6 +763,7 @@ func (ts *WorkerDeploymentTestSuite) TestUpdateWorkflowExecutionOptions() {
 		ConflictToken: response2.ConflictToken,
 	})
 	ts.NoError(err)
+	ts.waitForWorkerDeploymentRoutingConfigPropagation(ctx, deploymentName, v2.BuildID, "")
 
 	ts.NoError(ts.client.SignalWorkflow(ctx, handle1.GetID(), handle1.GetRunID(), "start-signal", "prefix"))
 	ts.NoError(ts.client.SignalWorkflow(ctx, handle2.GetID(), handle2.GetRunID(), "start-signal", "prefix"))
@@ -1091,6 +1094,7 @@ func (ts *WorkerDeploymentTestSuite) TestRampVersions() {
 		Percentage:    float32(100.0),
 	})
 	ts.NoError(err)
+	ts.waitForWorkerDeploymentRoutingConfigPropagation(ctx, deploymentName, v1.BuildID, v2.BuildID)
 
 	ts.True(!ts.runWorkflowAndCheckV1(ctx, "1"))
 	ts.True(!ts.runWorkflowAndCheckV1(ctx, "2"))
@@ -1102,17 +1106,19 @@ func (ts *WorkerDeploymentTestSuite) TestRampVersions() {
 		Percentage:    float32(0.0),
 	})
 	ts.NoError(err)
+	ts.waitForWorkerDeploymentRoutingConfigPropagation(ctx, deploymentName, v1.BuildID, v2.BuildID)
 
 	ts.True(ts.runWorkflowAndCheckV1(ctx, "1"))
 	ts.True(ts.runWorkflowAndCheckV1(ctx, "2"))
 
-	// Ramp 0% to 2.0
+	// Ramp 50% to 2.0
 	_, err = dHandle.SetRampingVersion(ctx, client.WorkerDeploymentSetRampingVersionOptions{
 		BuildID:       v2.BuildID,
 		ConflictToken: response4.ConflictToken,
 		Percentage:    float32(50.0),
 	})
 	ts.NoError(err)
+	ts.waitForWorkerDeploymentRoutingConfigPropagation(ctx, deploymentName, v1.BuildID, v2.BuildID)
 
 	// very likely probability (1-2^33) of success
 	ts.Eventually(func() bool {

--- a/test/worker_deployment_test.go
+++ b/test/worker_deployment_test.go
@@ -897,12 +897,13 @@ func (ts *WorkerDeploymentTestSuite) TestDeploymentDrainage() {
 			Version:       v1,
 		},
 	})
+	ts.NoError(worker1.Start())
+	defer worker1.Stop()
+
 	worker1.RegisterWorkflowWithOptions(ts.workflows.WaitSignalToStartVersionedOne, workflow.RegisterOptions{
 		Name:               "WaitSignalToStartVersioned",
 		VersioningBehavior: workflow.VersioningBehaviorPinned,
 	})
-	ts.NoError(worker1.Start())
-	defer worker1.Stop()
 
 	worker2 := worker.New(ts.client, ts.taskQueueName, worker.Options{
 		DeploymentOptions: worker.DeploymentOptions{
@@ -910,10 +911,14 @@ func (ts *WorkerDeploymentTestSuite) TestDeploymentDrainage() {
 			Version:       v2,
 		},
 	})
+	ts.NoError(worker2.Start())
+	defer worker2.Stop()
+
 	worker2.RegisterWorkflowWithOptions(ts.workflows.WaitSignalToStartVersionedTwo, workflow.RegisterOptions{
 		Name:               "WaitSignalToStartVersioned",
 		VersioningBehavior: workflow.VersioningBehaviorAutoUpgrade,
 	})
+
 	ts.NoError(worker2.Start())
 	defer worker2.Stop()
 


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->
  1. SetupTest rebinds ts.Assertions — Each subtest now gets its own require.Assertions bound to the subtest's T(), so a FailNow() in a subtest no longer kills the parent suite.
  2. Added waitForWorkerDeploymentRoutingConfigPropagation calls — 5 total:
    - TestPinnedBehaviorThreeWorkers: after each of the 3 SetCurrentVersion calls
    - TestDeploymentDrainage: after both SetCurrentVersion calls

## Why?
For 2), this fix is needed due to a bump from dev server bumping from v1.6.2-server-1.31.0-151.6 → v1.7.0. The old server (v1.6.2) returned UNSPECIFIED for RoutingConfigUpdateState — the feature wasn't implemented yet, so SetCurrentVersion was fast enough that routing was immediate. 

The new server (v1.7.0) made a conscious decision to make this API eventually consistent, for scalability. 

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to test code, mainly adding waits/timeouts to handle eventual consistency and rebinding `require.Assertions` to each subtest.
> 
> **Overview**
> Improves test-suite stability by rebinding `ts.Assertions` in `SetupTest` so `FailNow` in subtests doesn’t terminate the parent suite.
> 
> Worker deployment integration tests now explicitly wait for routing config updates to propagate (via `waitForWorkerDeploymentRoutingConfigPropagation`) after `SetCurrentVersion`/`SetRampingVersion`, and several contexts/timeouts were increased to reduce flakes against eventually-consistent server behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a3a82d26bc51522e370e1a287ebc22719a749fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->