### PR TITLE
Generic Temporal Nexus Operation Handler

### DIFF
--- a/temporalnexus/temporal_operation.go
+++ b/temporalnexus/temporal_operation.go
@@ -91,8 +91,6 @@ func (r TemporalOperationResult[R]) toHandlerResult() (nexus.HandlerStartOperati
 // NOTE: Experimental
 type NexusClient struct {
 	client                client.Client
-	namespace             string
-	taskQueue             string
 	startOperationOptions nexus.StartOperationOptions
 	asyncStarted          *atomic.Bool
 }
@@ -250,15 +248,12 @@ func (o *temporalOperation[I, O]) Start(
 	// Prevent the test env client from panicking.
 	ctx = context.WithValue(ctx, internal.IsWorkflowRunOpContextKey, true)
 
-	nctx, ok := internal.NexusOperationContextFromGoContext(ctx)
-	if !ok {
+	if _, ok := internal.NexusOperationContextFromGoContext(ctx); !ok {
 		return nil, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeInternal, "internal error")
 	}
 
 	nc := NexusClient{
 		client:                GetClient(ctx),
-		namespace:             nctx.Namespace,
-		taskQueue:             nctx.TaskQueue,
 		startOperationOptions: options,
 		asyncStarted:          &atomic.Bool{},
 	}

--- a/temporalnexus/temporal_operation.go
+++ b/temporalnexus/temporal_operation.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"sync/atomic"
 
 	"github.com/nexus-rpc/sdk-go/nexus"
 	"go.temporal.io/sdk/client"
@@ -54,7 +55,7 @@ type NexusClient struct {
 	namespace             string
 	taskQueue             string
 	startOperationOptions nexus.StartOperationOptions
-	asyncStarted          *bool
+	asyncStarted          *atomic.Bool
 }
 
 // GetWorkflowClient returns the underlying Temporal client for advanced or fallback use cases.
@@ -93,7 +94,7 @@ func StartUntypedWorkflow[R any](
 	workflow any,
 	args ...any,
 ) (TemporalOperationResult[R], error) {
-	if nc.asyncStarted != nil && *nc.asyncStarted {
+	if nc.asyncStarted != nil && nc.asyncStarted.Load() {
 		return TemporalOperationResult[R]{}, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "only one async operation can be started per operation invocation")
 	}
 
@@ -106,7 +107,7 @@ func StartUntypedWorkflow[R any](
 	}
 
 	if nc.asyncStarted != nil {
-		*nc.asyncStarted = true
+		nc.asyncStarted.Store(true)
 	}
 	nexus.AddHandlerLinks(ctx, handle.link())
 	return NewAsyncResult[R](handle.token()), nil
@@ -204,13 +205,12 @@ func (o *temporalOperation[I, O]) Start(
 		return nil, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeInternal, "internal error")
 	}
 
-	started := false
 	nc := NexusClient{
 		client:                GetClient(ctx),
 		namespace:             nctx.Namespace,
 		taskQueue:             nctx.TaskQueue,
 		startOperationOptions: options,
-		asyncStarted:          &started,
+		asyncStarted:          &atomic.Bool{},
 	}
 
 	result, err := o.options.Start(ctx, nc, input, options)

--- a/temporalnexus/temporal_operation.go
+++ b/temporalnexus/temporal_operation.go
@@ -54,10 +54,11 @@ type NexusClient struct {
 	namespace             string
 	taskQueue             string
 	startOperationOptions nexus.StartOperationOptions
+	asyncStarted          *bool
 }
 
 // GetWorkflowClient returns the underlying Temporal client for advanced or fallback use cases.
-func (nc *NexusClient) GetWorkflowClient() client.Client {
+func (nc NexusClient) GetWorkflowClient() client.Client {
 	return nc.client
 }
 
@@ -92,6 +93,10 @@ func StartUntypedWorkflow[R any](
 	workflow any,
 	args ...any,
 ) (TemporalOperationResult[R], error) {
+	if nc.asyncStarted != nil && *nc.asyncStarted {
+		return TemporalOperationResult[R]{}, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "only one async operation can be started per operation invocation")
+	}
+
 	// Prevent the test env client from panicking when we try to use it from an operation.
 	ctx = context.WithValue(ctx, internal.IsWorkflowRunOpContextKey, true)
 
@@ -100,6 +105,10 @@ func StartUntypedWorkflow[R any](
 		return TemporalOperationResult[R]{}, err
 	}
 
+	if nc.asyncStarted != nil {
+		*nc.asyncStarted = true
+	}
+	nexus.AddHandlerLinks(ctx, handle.link())
 	return NewAsyncResult[R](handle.token()), nil
 }
 
@@ -195,11 +204,13 @@ func (o *temporalOperation[I, O]) Start(
 		return nil, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeInternal, "internal error")
 	}
 
+	started := false
 	nc := NexusClient{
 		client:                GetClient(ctx),
 		namespace:             nctx.Namespace,
 		taskQueue:             nctx.TaskQueue,
 		startOperationOptions: options,
+		asyncStarted:          &started,
 	}
 
 	result, err := o.options.Start(ctx, nc, input, options)

--- a/temporalnexus/temporal_operation.go
+++ b/temporalnexus/temporal_operation.go
@@ -94,7 +94,7 @@ func StartUntypedWorkflow[R any](
 	workflow any,
 	args ...any,
 ) (TemporalOperationResult[R], error) {
-	if nc.asyncStarted != nil && nc.asyncStarted.Load() {
+	if nc.asyncStarted != nil && !nc.asyncStarted.CompareAndSwap(false, true) {
 		return TemporalOperationResult[R]{}, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "only one async operation can be started per operation invocation")
 	}
 
@@ -103,11 +103,10 @@ func StartUntypedWorkflow[R any](
 
 	handle, err := ExecuteUntypedWorkflow[R](ctx, nc.startOperationOptions, workflowOpts, workflow, args...)
 	if err != nil {
+		if nc.asyncStarted != nil {
+			nc.asyncStarted.Store(false)
+		}
 		return TemporalOperationResult[R]{}, err
-	}
-
-	if nc.asyncStarted != nil {
-		nc.asyncStarted.Store(true)
 	}
 	nexus.AddHandlerLinks(ctx, handle.link())
 	return NewAsyncResult[R](handle.token()), nil
@@ -142,9 +141,9 @@ type TemporalOperationOptions[I, O any] struct {
 	// Required.
 	Start func(ctx context.Context, nc NexusClient, input I, options nexus.StartOperationOptions) (TemporalOperationResult[O], error)
 	// CancelWorkflowRun handles cancel for workflow-run operation tokens.
-	// It receives a NexusClient and the workflow ID extracted from the token.
+	// It receives the Temporal client and the workflow ID extracted from the token.
 	// If nil, defaults to cancelling the workflow via the Temporal client.
-	CancelWorkflowRun func(ctx context.Context, nc NexusClient, workflowID string, options nexus.CancelOperationOptions) error
+	CancelWorkflowRun func(ctx context.Context, c client.Client, workflowID string, options nexus.CancelOperationOptions) error
 }
 
 // NewTemporalOperation creates a generic Nexus operation backed by Temporal.
@@ -176,8 +175,8 @@ func MustNewTemporalOperation[I, O any](opts TemporalOperationOptions[I, O]) nex
 }
 
 // defaultCancelWorkflowRun is the default cancel handler for workflow-run operation tokens.
-func defaultCancelWorkflowRun(ctx context.Context, nc NexusClient, workflowID string, _ nexus.CancelOperationOptions) error {
-	return nc.client.CancelWorkflow(ctx, workflowID, "")
+func defaultCancelWorkflowRun(ctx context.Context, c client.Client, workflowID string, _ nexus.CancelOperationOptions) error {
+	return c.CancelWorkflow(ctx, workflowID, "")
 }
 
 // temporalOperation implements nexus.Operation[I, O] for a generic Temporal-backed operation.
@@ -235,17 +234,6 @@ func (o *temporalOperation[I, O]) Cancel(ctx context.Context, token string, opti
 		}
 	}
 
-	nctx, ok := internal.NexusOperationContextFromGoContext(ctx)
-	if !ok {
-		return nexus.NewHandlerErrorf(nexus.HandlerErrorTypeInternal, "internal error")
-	}
-
-	nc := NexusClient{
-		client:    GetClient(ctx),
-		namespace: nctx.Namespace,
-		taskQueue: nctx.TaskQueue,
-	}
-
 	switch tokenType {
 	case operationTokenTypeWorkflowRun:
 		wfToken, err := loadWorkflowRunOperationToken(token)
@@ -256,7 +244,7 @@ func (o *temporalOperation[I, O]) Cancel(ctx context.Context, token string, opti
 				Cause:   err,
 			}
 		}
-		return o.options.CancelWorkflowRun(ctx, nc, wfToken.WorkflowID, options)
+		return o.options.CancelWorkflowRun(ctx, GetClient(ctx), wfToken.WorkflowID, options)
 	default:
 		return nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "unknown operation token type: %d", tokenType)
 	}

--- a/temporalnexus/temporal_operation.go
+++ b/temporalnexus/temporal_operation.go
@@ -1,0 +1,252 @@
+package temporalnexus
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/nexus-rpc/sdk-go/nexus"
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/internal"
+	"go.temporal.io/sdk/workflow"
+)
+
+// TemporalOperationResult encapsulates either a synchronous result or an asynchronous operation token.
+// Exactly one of sync or token must be set.
+type TemporalOperationResult[R any] struct {
+	sync  *R
+	token string
+}
+
+// NewSyncResult creates a TemporalOperationResult with a synchronous value.
+func NewSyncResult[R any](value R) TemporalOperationResult[R] {
+	return TemporalOperationResult[R]{sync: &value}
+}
+
+// NewAsyncResult creates a TemporalOperationResult with an asynchronous operation token.
+func NewAsyncResult[R any](token string) TemporalOperationResult[R] {
+	return TemporalOperationResult[R]{token: token}
+}
+
+// toHandlerResult converts this result to a nexus.HandlerStartOperationResult.
+// Returns an error if both sync and token are set, or neither is set.
+func (r TemporalOperationResult[R]) toHandlerResult() (nexus.HandlerStartOperationResult[R], error) {
+	hasSync := r.sync != nil
+	hasToken := r.token != ""
+
+	if hasSync && hasToken {
+		return nil, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeInternal, "invalid TemporalOperationResult: both sync and token are set")
+	}
+	if !hasSync && !hasToken {
+		return nil, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeInternal, "invalid TemporalOperationResult: neither sync nor token is set")
+	}
+
+	if hasSync {
+		return &nexus.HandlerStartOperationResultSync[R]{Value: *r.sync}, nil
+	}
+	return &nexus.HandlerStartOperationResultAsync{OperationToken: r.token}, nil
+}
+
+// NexusClient wraps the Temporal client.Client with Nexus-aware context.
+// It is scoped to a single operation invocation and should not be stored beyond the Start callback.
+type NexusClient struct {
+	client                client.Client
+	namespace             string
+	taskQueue             string
+	startOperationOptions nexus.StartOperationOptions
+}
+
+// GetWorkflowClient returns the underlying Temporal client for advanced or fallback use cases.
+func (nc *NexusClient) GetWorkflowClient() client.Client {
+	return nc.client
+}
+
+// StartWorkflow starts a type-safe workflow run for a Nexus operation, linking the execution
+// chain to the Nexus operation (callbacks, links, request ID). It always returns an async
+// result with a workflow-run operation token.
+//
+// The workflow parameter must have the signature func(workflow.Context, I) (O, error).
+// For workflows that don't follow this signature, use [StartUntypedWorkflow].
+//
+// These are free functions because Go does not allow generic methods on non-generic structs.
+func StartWorkflow[I, O any, WF func(workflow.Context, I) (O, error)](
+	ctx context.Context,
+	nc NexusClient,
+	workflowOpts client.StartWorkflowOptions,
+	workflow WF,
+	arg I,
+) (TemporalOperationResult[O], error) {
+	return StartUntypedWorkflow[O](ctx, nc, workflowOpts, workflow, arg)
+}
+
+// StartUntypedWorkflow starts a workflow run for a Nexus operation by function reference or
+// string name, linking the execution chain to the Nexus operation (callbacks, links, request ID).
+// It always returns an async result with a workflow-run operation token.
+//
+// Useful for invoking workflows that don't follow the single argument / single return type signature.
+// See [StartWorkflow] for the type-safe variant.
+func StartUntypedWorkflow[R any](
+	ctx context.Context,
+	nc NexusClient,
+	workflowOpts client.StartWorkflowOptions,
+	workflow any,
+	args ...any,
+) (TemporalOperationResult[R], error) {
+	// Prevent the test env client from panicking when we try to use it from an operation.
+	ctx = context.WithValue(ctx, internal.IsWorkflowRunOpContextKey, true)
+
+	handle, err := ExecuteUntypedWorkflow[R](ctx, nc.startOperationOptions, workflowOpts, workflow, args...)
+	if err != nil {
+		return TemporalOperationResult[R]{}, err
+	}
+
+	return NewAsyncResult[R](handle.token()), nil
+}
+
+// TemporalOperationOptions configures a generic Temporal Nexus operation.
+//
+// Asynchronous workflow-backed operation:
+//
+//	op, err := NewTemporalOperation(TemporalOperationOptions[MyInput, MyOutput]{
+//		Name: "my-async-op",
+//		Start: func(ctx context.Context, nc NexusClient, input MyInput, opts nexus.StartOperationOptions) (TemporalOperationResult[MyOutput], error) {
+//			return StartWorkflow[MyOutput](ctx, nc,
+//				client.StartWorkflowOptions{ID: "wf-" + input.ID},
+//				MyWorkflow, input)
+//		},
+//	})
+//
+// Synchronous operation:
+//
+//	op, err := NewTemporalOperation(TemporalOperationOptions[string, string]{
+//		Name: "my-sync-op",
+//		Start: func(ctx context.Context, nc NexusClient, input string, opts nexus.StartOperationOptions) (TemporalOperationResult[string], error) {
+//			return NewSyncResult("result: " + input), nil
+//		},
+//	})
+type TemporalOperationOptions[I, O any] struct {
+	// Name of the operation. Required.
+	Name string
+	// Start handles the operation start. It receives the operation context, a [NexusClient] scoped
+	// to this invocation, the operation input, and the Nexus start operation options.
+	// Required.
+	Start func(ctx context.Context, nc NexusClient, input I, options nexus.StartOperationOptions) (TemporalOperationResult[O], error)
+	// CancelWorkflowRun handles cancel for workflow-run operation tokens.
+	// It receives a NexusClient and the workflow ID extracted from the token.
+	// If nil, defaults to cancelling the workflow via the Temporal client.
+	CancelWorkflowRun func(ctx context.Context, nc NexusClient, workflowID string, options nexus.CancelOperationOptions) error
+}
+
+// NewTemporalOperation creates a generic Nexus operation backed by Temporal.
+// The returned operation satisfies nexus.Operation[I, O] for service registration.
+func NewTemporalOperation[I, O any](opts TemporalOperationOptions[I, O]) (nexus.Operation[I, O], error) {
+	if opts.Name == "" {
+		return nil, errors.New("invalid options: Name is required")
+	}
+	if strings.HasPrefix(opts.Name, "__temporal_") {
+		return nil, errors.New("invalid options: __temporal_ is a reserved prefix")
+	}
+	if opts.Start == nil {
+		return nil, errors.New("invalid options: Start is required")
+	}
+	if opts.CancelWorkflowRun == nil {
+		opts.CancelWorkflowRun = defaultCancelWorkflowRun
+	}
+	return &temporalOperation[I, O]{options: opts}, nil
+}
+
+// MustNewTemporalOperation creates a generic Nexus operation backed by Temporal.
+// Panics if invalid options are provided.
+func MustNewTemporalOperation[I, O any](opts TemporalOperationOptions[I, O]) nexus.Operation[I, O] {
+	op, err := NewTemporalOperation(opts)
+	if err != nil {
+		panic(err)
+	}
+	return op
+}
+
+// defaultCancelWorkflowRun is the default cancel handler for workflow-run operation tokens.
+func defaultCancelWorkflowRun(ctx context.Context, nc NexusClient, workflowID string, _ nexus.CancelOperationOptions) error {
+	return nc.client.CancelWorkflow(ctx, workflowID, "")
+}
+
+// temporalOperation implements nexus.Operation[I, O] for a generic Temporal-backed operation.
+type temporalOperation[I, O any] struct {
+	nexus.UnimplementedOperation[I, O]
+
+	options TemporalOperationOptions[I, O]
+}
+
+func (o *temporalOperation[I, O]) Name() string {
+	return o.options.Name
+}
+
+// Start begins a Nexus operation by constructing a NexusClient and delegating to the user's Start function.
+func (o *temporalOperation[I, O]) Start(
+	ctx context.Context,
+	input I,
+	options nexus.StartOperationOptions,
+) (nexus.HandlerStartOperationResult[O], error) {
+	// Prevent the test env client from panicking.
+	ctx = context.WithValue(ctx, internal.IsWorkflowRunOpContextKey, true)
+
+	nctx, ok := internal.NexusOperationContextFromGoContext(ctx)
+	if !ok {
+		return nil, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeInternal, "internal error")
+	}
+
+	nc := NexusClient{
+		client:                GetClient(ctx),
+		namespace:             nctx.Namespace,
+		taskQueue:             nctx.TaskQueue,
+		startOperationOptions: options,
+	}
+
+	result, err := o.options.Start(ctx, nc, input, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return result.toHandlerResult()
+}
+
+// Cancel parses the operation token, dispatches to the appropriate per-token-type cancel handler.
+func (o *temporalOperation[I, O]) Cancel(ctx context.Context, token string, options nexus.CancelOperationOptions) error {
+	// Prevent the test env client from panicking.
+	ctx = context.WithValue(ctx, internal.IsWorkflowRunOpContextKey, true)
+
+	tokenType, err := loadTokenType(token)
+	if err != nil {
+		return &nexus.HandlerError{
+			Type:    nexus.HandlerErrorTypeBadRequest,
+			Message: "invalid operation token",
+			Cause:   err,
+		}
+	}
+
+	nctx, ok := internal.NexusOperationContextFromGoContext(ctx)
+	if !ok {
+		return nexus.NewHandlerErrorf(nexus.HandlerErrorTypeInternal, "internal error")
+	}
+
+	nc := NexusClient{
+		client:    GetClient(ctx),
+		namespace: nctx.Namespace,
+		taskQueue: nctx.TaskQueue,
+	}
+
+	switch tokenType {
+	case operationTokenTypeWorkflowRun:
+		wfToken, err := loadWorkflowRunOperationToken(token)
+		if err != nil {
+			return &nexus.HandlerError{
+				Type:    nexus.HandlerErrorTypeBadRequest,
+				Message: "invalid operation token",
+				Cause:   err,
+			}
+		}
+		return o.options.CancelWorkflowRun(ctx, nc, wfToken.WorkflowID, options)
+	default:
+		return nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "unknown operation token type: %d", tokenType)
+	}
+}

--- a/temporalnexus/temporal_operation.go
+++ b/temporalnexus/temporal_operation.go
@@ -12,19 +12,56 @@ import (
 	"go.temporal.io/sdk/workflow"
 )
 
+// StartTemporalOperationOptions are options provided to the Start callback of a Temporal Nexus operation.
+// Mirrors [nexus.StartOperationOptions].
+//
+// NOTE: Experimental
+type StartTemporalOperationOptions struct {
+	// Header contains the request header fields received by the server.
+	//
+	// Header keys with the "content-" prefix are reserved for [nexus.Serializer] headers and are not
+	// available here.
+	Header nexus.Header
+	// CallbackURL is used to deliver completion of async operations.
+	CallbackURL string
+	// CallbackHeader contains header fields set by the client that are required to be attached to the
+	// callback request when an asynchronous operation completes.
+	CallbackHeader nexus.Header
+	// RequestID may be used by the server handler to dedupe a start request.
+	RequestID string
+	// Links contain arbitrary caller information. Handlers may use these links as metadata on
+	// resources associated with an operation.
+	Links []nexus.Link
+}
+
+// CancelTemporalWorkflowRunOptions are options provided to the CancelWorkflowRun callback of a
+// Temporal Nexus operation.
+//
+// NOTE: Experimental
+type CancelTemporalWorkflowRunOptions struct {
+	// WorkflowID extracted from the operation token.
+	WorkflowID string
+}
+
 // TemporalOperationResult encapsulates either a synchronous result or an asynchronous operation token.
 // Exactly one of sync or token must be set.
+//
+// NOTE: Experimental
 type TemporalOperationResult[R any] struct {
 	sync  *R
 	token string
 }
 
 // NewSyncResult creates a TemporalOperationResult with a synchronous value.
+//
+// NOTE: Experimental
 func NewSyncResult[R any](value R) TemporalOperationResult[R] {
 	return TemporalOperationResult[R]{sync: &value}
 }
 
 // NewAsyncResult creates a TemporalOperationResult with an asynchronous operation token.
+//
+// NOTE: Experimental
 func NewAsyncResult[R any](token string) TemporalOperationResult[R] {
 	return TemporalOperationResult[R]{token: token}
 }
@@ -50,6 +87,8 @@ func (r TemporalOperationResult[R]) toHandlerResult() (nexus.HandlerStartOperati
 
 // NexusClient wraps the Temporal client.Client with Nexus-aware context.
 // It is scoped to a single operation invocation and should not be stored beyond the Start callback.
+//
+// NOTE: Experimental
 type NexusClient struct {
 	client                client.Client
 	namespace             string
@@ -59,6 +98,8 @@ type NexusClient struct {
 }
 
 // GetWorkflowClient returns the underlying Temporal client for advanced or fallback use cases.
+//
+// NOTE: Experimental
 func (nc NexusClient) GetWorkflowClient() client.Client {
 	return nc.client
 }
@@ -71,6 +112,8 @@ func (nc NexusClient) GetWorkflowClient() client.Client {
 // For workflows that don't follow this signature, use [StartUntypedWorkflow].
 //
 // These are free functions because Go does not allow generic methods on non-generic structs.
+//
+// NOTE: Experimental
 func StartWorkflow[I, O any, WF func(workflow.Context, I) (O, error)](
 	ctx context.Context,
 	nc NexusClient,
@@ -87,6 +130,8 @@ func StartWorkflow[I, O any, WF func(workflow.Context, I) (O, error)](
 //
 // Useful for invoking workflows that don't follow the single argument / single return type signature.
 // See [StartWorkflow] for the type-safe variant.
+//
+// NOTE: Experimental
 func StartUntypedWorkflow[R any](
 	ctx context.Context,
 	nc NexusClient,
@@ -118,7 +163,7 @@ func StartUntypedWorkflow[R any](
 //
 //	op, err := NewTemporalOperation(TemporalOperationOptions[MyInput, MyOutput]{
 //		Name: "my-async-op",
-//		Start: func(ctx context.Context, nc NexusClient, input MyInput, opts nexus.StartOperationOptions) (TemporalOperationResult[MyOutput], error) {
+//		Start: func(ctx context.Context, nc NexusClient, input MyInput, opts StartTemporalOperationOptions) (TemporalOperationResult[MyOutput], error) {
 //			return StartWorkflow[MyOutput](ctx, nc,
 //				client.StartWorkflowOptions{ID: "wf-" + input.ID},
 //				MyWorkflow, input)
@@ -129,25 +174,29 @@ func StartUntypedWorkflow[R any](
 //
 //	op, err := NewTemporalOperation(TemporalOperationOptions[string, string]{
 //		Name: "my-sync-op",
-//		Start: func(ctx context.Context, nc NexusClient, input string, opts nexus.StartOperationOptions) (TemporalOperationResult[string], error) {
+//		Start: func(ctx context.Context, nc NexusClient, input string, opts StartTemporalOperationOptions) (TemporalOperationResult[string], error) {
 //			return NewSyncResult("result: " + input), nil
 //		},
 //	})
+//
+// NOTE: Experimental
 type TemporalOperationOptions[I, O any] struct {
 	// Name of the operation. Required.
 	Name string
 	// Start handles the operation start. It receives the operation context, a [NexusClient] scoped
-	// to this invocation, the operation input, and the Nexus start operation options.
+	// to this invocation, the operation input, and the start operation options.
 	// Required.
-	Start func(ctx context.Context, nc NexusClient, input I, options nexus.StartOperationOptions) (TemporalOperationResult[O], error)
+	Start func(ctx context.Context, nc NexusClient, input I, options StartTemporalOperationOptions) (TemporalOperationResult[O], error)
 	// CancelWorkflowRun handles cancel for workflow-run operation tokens.
-	// It receives the Temporal client and the workflow ID extracted from the token.
-	// If nil, defaults to cancelling the workflow via the Temporal client.
-	CancelWorkflowRun func(ctx context.Context, c client.Client, workflowID string, options nexus.CancelOperationOptions) error
+	// It receives the Temporal client, the workflow-run options extracted from the token, and the
+	// Nexus cancel options. If nil, defaults to cancelling the workflow via the Temporal client.
+	CancelWorkflowRun func(ctx context.Context, c client.Client, options CancelTemporalWorkflowRunOptions, cancelOptions nexus.CancelOperationOptions) error
 }
 
 // NewTemporalOperation creates a generic Nexus operation backed by Temporal.
 // The returned operation satisfies nexus.Operation[I, O] for service registration.
+//
+// NOTE: Experimental
 func NewTemporalOperation[I, O any](opts TemporalOperationOptions[I, O]) (nexus.Operation[I, O], error) {
 	if opts.Name == "" {
 		return nil, errors.New("invalid options: Name is required")
@@ -166,6 +215,8 @@ func NewTemporalOperation[I, O any](opts TemporalOperationOptions[I, O]) (nexus.
 
 // MustNewTemporalOperation creates a generic Nexus operation backed by Temporal.
 // Panics if invalid options are provided.
+//
+// NOTE: Experimental
 func MustNewTemporalOperation[I, O any](opts TemporalOperationOptions[I, O]) nexus.Operation[I, O] {
 	op, err := NewTemporalOperation(opts)
 	if err != nil {
@@ -175,8 +226,8 @@ func MustNewTemporalOperation[I, O any](opts TemporalOperationOptions[I, O]) nex
 }
 
 // defaultCancelWorkflowRun is the default cancel handler for workflow-run operation tokens.
-func defaultCancelWorkflowRun(ctx context.Context, c client.Client, workflowID string, _ nexus.CancelOperationOptions) error {
-	return c.CancelWorkflow(ctx, workflowID, "")
+func defaultCancelWorkflowRun(ctx context.Context, c client.Client, options CancelTemporalWorkflowRunOptions, _ nexus.CancelOperationOptions) error {
+	return c.CancelWorkflow(ctx, options.WorkflowID, "")
 }
 
 // temporalOperation implements nexus.Operation[I, O] for a generic Temporal-backed operation.
@@ -212,7 +263,13 @@ func (o *temporalOperation[I, O]) Start(
 		asyncStarted:          &atomic.Bool{},
 	}
 
-	result, err := o.options.Start(ctx, nc, input, options)
+	result, err := o.options.Start(ctx, nc, input, StartTemporalOperationOptions{
+		Header:         options.Header,
+		CallbackURL:    options.CallbackURL,
+		CallbackHeader: options.CallbackHeader,
+		RequestID:      options.RequestID,
+		Links:          options.Links,
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -244,7 +301,9 @@ func (o *temporalOperation[I, O]) Cancel(ctx context.Context, token string, opti
 				Cause:   err,
 			}
 		}
-		return o.options.CancelWorkflowRun(ctx, GetClient(ctx), wfToken.WorkflowID, options)
+		return o.options.CancelWorkflowRun(ctx, GetClient(ctx), CancelTemporalWorkflowRunOptions{
+			WorkflowID: wfToken.WorkflowID,
+		}, options)
 	default:
 		return nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "unknown operation token type: %d", tokenType)
 	}

--- a/temporalnexus/temporal_operation_test.go
+++ b/temporalnexus/temporal_operation_test.go
@@ -1,0 +1,141 @@
+package temporalnexus
+
+import (
+	"context"
+	"encoding/base64"
+	"testing"
+
+	"github.com/nexus-rpc/sdk-go/nexus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewSyncResult(t *testing.T) {
+	result := NewSyncResult("hello")
+	require.NotNil(t, result.sync)
+	require.Equal(t, "hello", *result.sync)
+	require.Empty(t, result.token)
+}
+
+func TestNewAsyncResult(t *testing.T) {
+	result := NewAsyncResult[string]("tok123")
+	require.Nil(t, result.sync)
+	require.Equal(t, "tok123", result.token)
+}
+
+func TestToHandlerResultSync(t *testing.T) {
+	result := NewSyncResult("value")
+	handlerResult, err := result.toHandlerResult()
+	require.NoError(t, err)
+	syncResult, ok := handlerResult.(*nexus.HandlerStartOperationResultSync[string])
+	require.True(t, ok, "expected sync result type")
+	require.Equal(t, "value", syncResult.Value)
+}
+
+func TestToHandlerResultAsync(t *testing.T) {
+	result := NewAsyncResult[string]("tok123")
+	handlerResult, err := result.toHandlerResult()
+	require.NoError(t, err)
+	asyncResult, ok := handlerResult.(*nexus.HandlerStartOperationResultAsync)
+	require.True(t, ok, "expected async result type")
+	require.Equal(t, "tok123", asyncResult.OperationToken)
+}
+
+func TestToHandlerResultBothSet(t *testing.T) {
+	result := TemporalOperationResult[string]{
+		sync:  strPtr("value"),
+		token: "tok123",
+	}
+	_, err := result.toHandlerResult()
+	require.Error(t, err)
+	var handlerErr *nexus.HandlerError
+	require.ErrorAs(t, err, &handlerErr)
+	require.Equal(t, nexus.HandlerErrorTypeInternal, handlerErr.Type)
+	require.Contains(t, handlerErr.Message, "both sync and token are set")
+}
+
+func TestToHandlerResultNeitherSet(t *testing.T) {
+	result := TemporalOperationResult[string]{}
+	_, err := result.toHandlerResult()
+	require.Error(t, err)
+	var handlerErr *nexus.HandlerError
+	require.ErrorAs(t, err, &handlerErr)
+	require.Equal(t, nexus.HandlerErrorTypeInternal, handlerErr.Type)
+	require.Contains(t, handlerErr.Message, "neither sync nor token is set")
+}
+
+func TestNewTemporalOperationValidation(t *testing.T) {
+	_, err := NewTemporalOperation(TemporalOperationOptions[string, string]{})
+	require.ErrorContains(t, err, "Name is required")
+
+	_, err = NewTemporalOperation(TemporalOperationOptions[string, string]{
+		Name: "__temporal_test",
+	})
+	require.ErrorContains(t, err, "__temporal_ is a reserved prefix")
+
+	_, err = NewTemporalOperation(TemporalOperationOptions[string, string]{
+		Name: "test",
+	})
+	require.ErrorContains(t, err, "Start is required")
+
+	// Valid options
+	_, err = NewTemporalOperation(TemporalOperationOptions[string, string]{
+		Name: "test",
+		Start: func(ctx context.Context, nc NexusClient, input string, opts nexus.StartOperationOptions) (TemporalOperationResult[string], error) {
+			return NewSyncResult("ok"), nil
+		},
+	})
+	require.NoError(t, err)
+}
+
+func TestMustNewTemporalOperationPanics(t *testing.T) {
+	require.Panics(t, func() {
+		MustNewTemporalOperation(TemporalOperationOptions[string, string]{})
+	})
+}
+
+func TestMustNewTemporalOperationValid(t *testing.T) {
+	require.NotPanics(t, func() {
+		MustNewTemporalOperation(TemporalOperationOptions[string, string]{
+			Name: "test",
+			Start: func(ctx context.Context, nc NexusClient, input string, opts nexus.StartOperationOptions) (TemporalOperationResult[string], error) {
+				return NewSyncResult("ok"), nil
+			},
+		})
+	})
+}
+
+func TestLoadTokenType(t *testing.T) {
+	// Valid type=1
+	validToken := base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString([]byte(`{"t":1,"ns":"ns","wid":"w"}`))
+	tokenType, err := loadTokenType(validToken)
+	require.NoError(t, err)
+	require.Equal(t, operationTokenTypeWorkflowRun, tokenType)
+
+	// Unknown type=99
+	unknownToken := base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString([]byte(`{"t":99}`))
+	tokenType, err = loadTokenType(unknownToken)
+	require.NoError(t, err)
+	require.Equal(t, operationTokenType(99), tokenType)
+
+	// Empty token
+	_, err = loadTokenType("")
+	require.ErrorContains(t, err, "token is empty")
+
+	// Malformed base64
+	_, err = loadTokenType("not-base64!@#$")
+	require.ErrorContains(t, err, "failed to decode token")
+
+	// Invalid JSON
+	invalidJSON := base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString([]byte("invalid json"))
+	_, err = loadTokenType(invalidJSON)
+	require.ErrorContains(t, err, "failed to unmarshal operation token")
+
+	// Missing type field (t=0)
+	missingType := base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString([]byte(`{"ns":"ns"}`))
+	_, err = loadTokenType(missingType)
+	require.ErrorContains(t, err, "missing or zero token type")
+}
+
+func strPtr(s string) *string {
+	return &s
+}

--- a/temporalnexus/temporal_operation_test.go
+++ b/temporalnexus/temporal_operation_test.go
@@ -3,6 +3,7 @@ package temporalnexus
 import (
 	"context"
 	"encoding/base64"
+	"sync/atomic"
 	"testing"
 
 	"github.com/nexus-rpc/sdk-go/nexus"
@@ -139,7 +140,8 @@ func TestLoadTokenType(t *testing.T) {
 }
 
 func TestDoubleStartGuard(t *testing.T) {
-	started := true
+	var started atomic.Bool
+	started.Store(true)
 	nc := NexusClient{asyncStarted: &started}
 
 	_, err := StartUntypedWorkflow[string](context.Background(), nc, client.StartWorkflowOptions{}, "ignored")

--- a/temporalnexus/temporal_operation_test.go
+++ b/temporalnexus/temporal_operation_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/nexus-rpc/sdk-go/nexus"
 	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/workflow"
 )
 
 func TestNewSyncResult(t *testing.T) {
@@ -134,6 +136,21 @@ func TestLoadTokenType(t *testing.T) {
 	missingType := base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString([]byte(`{"ns":"ns"}`))
 	_, err = loadTokenType(missingType)
 	require.ErrorContains(t, err, "missing or zero token type")
+}
+
+func TestDoubleStartGuard(t *testing.T) {
+	started := true
+	nc := NexusClient{asyncStarted: &started}
+
+	_, err := StartUntypedWorkflow[string](context.Background(), nc, client.StartWorkflowOptions{}, "ignored")
+	var handlerErr *nexus.HandlerError
+	require.ErrorAs(t, err, &handlerErr)
+	require.Equal(t, nexus.HandlerErrorTypeBadRequest, handlerErr.Type)
+	require.Contains(t, handlerErr.Message, "only one async operation")
+
+	_, err = StartWorkflow(context.Background(), nc, client.StartWorkflowOptions{}, func(_ workflow.Context, _ string) (string, error) { return "", nil }, "ignored")
+	require.ErrorAs(t, err, &handlerErr)
+	require.Equal(t, nexus.HandlerErrorTypeBadRequest, handlerErr.Type)
 }
 
 func strPtr(s string) *string {

--- a/temporalnexus/temporal_operation_test.go
+++ b/temporalnexus/temporal_operation_test.go
@@ -83,7 +83,7 @@ func TestNewTemporalOperationValidation(t *testing.T) {
 	// Valid options
 	_, err = NewTemporalOperation(TemporalOperationOptions[string, string]{
 		Name: "test",
-		Start: func(ctx context.Context, nc NexusClient, input string, opts nexus.StartOperationOptions) (TemporalOperationResult[string], error) {
+		Start: func(ctx context.Context, nc NexusClient, input string, opts StartTemporalOperationOptions) (TemporalOperationResult[string], error) {
 			return NewSyncResult("ok"), nil
 		},
 	})
@@ -100,7 +100,7 @@ func TestMustNewTemporalOperationValid(t *testing.T) {
 	require.NotPanics(t, func() {
 		MustNewTemporalOperation(TemporalOperationOptions[string, string]{
 			Name: "test",
-			Start: func(ctx context.Context, nc NexusClient, input string, opts nexus.StartOperationOptions) (TemporalOperationResult[string], error) {
+			Start: func(ctx context.Context, nc NexusClient, input string, opts StartTemporalOperationOptions) (TemporalOperationResult[string], error) {
 				return NewSyncResult("ok"), nil
 			},
 		})

--- a/temporalnexus/token.go
+++ b/temporalnexus/token.go
@@ -37,6 +37,28 @@ func generateWorkflowRunOperationToken(namespace, workflowID string) (string, er
 	return base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString(data), nil
 }
 
+// loadTokenType decodes just the type field from an operation token without full validation.
+// This allows cancel dispatch to route by token type before deserializing the full token.
+func loadTokenType(data string) (operationTokenType, error) {
+	if len(data) == 0 {
+		return 0, errors.New("invalid operation token: token is empty")
+	}
+	b, err := base64.URLEncoding.WithPadding(base64.NoPadding).DecodeString(data)
+	if err != nil {
+		return 0, fmt.Errorf("failed to decode token: %w", err)
+	}
+	var partial struct {
+		Type operationTokenType `json:"t"`
+	}
+	if err := json.Unmarshal(b, &partial); err != nil {
+		return 0, fmt.Errorf("failed to unmarshal operation token: %w", err)
+	}
+	if partial.Type == 0 {
+		return 0, errors.New("invalid operation token: missing or zero token type")
+	}
+	return partial.Type, nil
+}
+
 func loadWorkflowRunOperationToken(data string) (workflowRunOperationToken, error) {
 	var token workflowRunOperationToken
 	if len(data) == 0 {

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -9576,3 +9576,183 @@ func (ts *IntegrationTestSuite) TestExecuteNexusOperationSuite() {
 		ts.Contains(err.Error(), "service is required")
 	})
 }
+
+func (ts *IntegrationTestSuite) TestTemporalOperationSuite() {
+	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
+	defer cancel()
+
+	endpoint := "temporal-op-test-ep-" + uuid.NewString()
+	_, err := ts.client.OperatorService().CreateNexusEndpoint(ctx, &operatorservice.CreateNexusEndpointRequest{
+		Spec: &nexuspb.EndpointSpec{
+			Name: endpoint,
+			Target: &nexuspb.EndpointTarget{
+				Variant: &nexuspb.EndpointTarget_Worker_{
+					Worker: &nexuspb.EndpointTarget_Worker{
+						Namespace: ts.config.Namespace,
+						TaskQueue: ts.taskQueueName,
+					},
+				},
+			},
+		},
+	})
+	ts.NoError(err)
+
+	echoWF := func(ctx workflow.Context, input string) (string, error) {
+		return input, nil
+	}
+	waitForCancelWF := func(ctx workflow.Context, _ string) (string, error) {
+		return "", workflow.Await(ctx, func() bool { return false })
+	}
+	// Workflow that waits for a signal and returns the signaled value.
+	waitForSignalWF := func(ctx workflow.Context, _ string) (string, error) {
+		var result string
+		ch := workflow.GetSignalChannel(ctx, "my-signal")
+		ch.Receive(ctx, &result)
+		return result, nil
+	}
+
+	syncOp := temporalnexus.MustNewTemporalOperation(temporalnexus.TemporalOperationOptions[string, string]{
+		Name: "sync-op",
+		Start: func(ctx context.Context, nc temporalnexus.NexusClient, input string, opts nexus.StartOperationOptions) (temporalnexus.TemporalOperationResult[string], error) {
+			return temporalnexus.NewSyncResult("sync-" + input), nil
+		},
+	})
+	asyncTypedOp := temporalnexus.MustNewTemporalOperation(temporalnexus.TemporalOperationOptions[string, string]{
+		Name: "async-typed-op",
+		Start: func(ctx context.Context, nc temporalnexus.NexusClient, input string, opts nexus.StartOperationOptions) (temporalnexus.TemporalOperationResult[string], error) {
+			return temporalnexus.StartWorkflow(ctx, nc, client.StartWorkflowOptions{ID: input}, echoWF, input)
+		},
+	})
+	asyncUntypedOp := temporalnexus.MustNewTemporalOperation(temporalnexus.TemporalOperationOptions[string, string]{
+		Name: "async-untyped-op",
+		Start: func(ctx context.Context, nc temporalnexus.NexusClient, input string, opts nexus.StartOperationOptions) (temporalnexus.TemporalOperationResult[string], error) {
+			return temporalnexus.StartUntypedWorkflow[string](ctx, nc, client.StartWorkflowOptions{ID: input}, echoWF, input)
+		},
+	})
+	cancelOp := temporalnexus.MustNewTemporalOperation(temporalnexus.TemporalOperationOptions[string, string]{
+		Name: "cancel-op",
+		Start: func(ctx context.Context, nc temporalnexus.NexusClient, input string, opts nexus.StartOperationOptions) (temporalnexus.TemporalOperationResult[string], error) {
+			return temporalnexus.StartWorkflow(ctx, nc, client.StartWorkflowOptions{ID: input}, waitForCancelWF, input)
+		},
+	})
+	// Op that uses nc.GetWorkflowClient() in Start to signal the workflow after starting it.
+	clientInStartOp := temporalnexus.MustNewTemporalOperation(temporalnexus.TemporalOperationOptions[string, string]{
+		Name: "client-in-start-op",
+		Start: func(ctx context.Context, nc temporalnexus.NexusClient, input string, opts nexus.StartOperationOptions) (temporalnexus.TemporalOperationResult[string], error) {
+			result, err := temporalnexus.StartWorkflow(ctx, nc, client.StartWorkflowOptions{ID: input}, waitForSignalWF, input)
+			if err != nil {
+				return result, err
+			}
+			// Use the Temporal client to signal the workflow we just started.
+			err = nc.GetWorkflowClient().SignalWorkflow(ctx, input, "", "my-signal", "signaled-"+input)
+			if err != nil {
+				return result, err
+			}
+			return result, nil
+		},
+	})
+	customCancelOp := temporalnexus.MustNewTemporalOperation(temporalnexus.TemporalOperationOptions[string, string]{
+		Name: "custom-cancel-op",
+		Start: func(ctx context.Context, nc temporalnexus.NexusClient, input string, opts nexus.StartOperationOptions) (temporalnexus.TemporalOperationResult[string], error) {
+			return temporalnexus.StartWorkflow(ctx, nc, client.StartWorkflowOptions{ID: input}, waitForCancelWF, input)
+		},
+		CancelWorkflowRun: func(ctx context.Context, nc temporalnexus.NexusClient, workflowID string, opts nexus.CancelOperationOptions) error {
+			return nc.GetWorkflowClient().TerminateWorkflow(ctx, workflowID, "", "terminated via nexus cancel")
+		},
+	})
+
+	service := nexus.NewService("temporal-op-test")
+	ts.NoError(service.Register(syncOp, asyncTypedOp, asyncUntypedOp, cancelOp, customCancelOp, clientInStartOp))
+	ts.worker.RegisterNexusService(service)
+	ts.worker.RegisterWorkflow(echoWF)
+	ts.worker.RegisterWorkflow(waitForCancelWF)
+	ts.worker.RegisterWorkflow(waitForSignalWF)
+
+	callerWF := func(ctx workflow.Context, input string) (string, error) {
+		c := workflow.NewNexusClient(endpoint, service.Name)
+		fut := c.ExecuteOperation(ctx, syncOp, input, workflow.NexusOperationOptions{})
+		var result string
+		return result, fut.Get(ctx, &result)
+	}
+	typedCallerWF := func(ctx workflow.Context, input string) (string, error) {
+		c := workflow.NewNexusClient(endpoint, service.Name)
+		fut := c.ExecuteOperation(ctx, asyncTypedOp, input, workflow.NexusOperationOptions{})
+		var result string
+		return result, fut.Get(ctx, &result)
+	}
+	untypedCallerWF := func(ctx workflow.Context, input string) (string, error) {
+		c := workflow.NewNexusClient(endpoint, service.Name)
+		fut := c.ExecuteOperation(ctx, asyncUntypedOp, input, workflow.NexusOperationOptions{})
+		var result string
+		return result, fut.Get(ctx, &result)
+	}
+	cancelCallerWF := func(ctx workflow.Context, input string) (string, error) {
+		c := workflow.NewNexusClient(endpoint, service.Name)
+		opCtx, opCancel := workflow.WithCancel(ctx)
+		fut := c.ExecuteOperation(opCtx, cancelOp, input, workflow.NexusOperationOptions{})
+		var exec workflow.NexusOperationExecution
+		if err := fut.GetNexusOperationExecution().Get(ctx, &exec); err != nil {
+			return "", fmt.Errorf("expected start to succeed: %w", err)
+		}
+		opCancel()
+		if err := fut.Get(ctx, nil); err == nil {
+			return "", fmt.Errorf("expected cancel error")
+		}
+		return "", nil
+	}
+	customCancelCallerWF := func(ctx workflow.Context, input string) (string, error) {
+		c := workflow.NewNexusClient(endpoint, service.Name)
+		opCtx, opCancel := workflow.WithCancel(ctx)
+		fut := c.ExecuteOperation(opCtx, customCancelOp, input, workflow.NexusOperationOptions{})
+		var exec workflow.NexusOperationExecution
+		if err := fut.GetNexusOperationExecution().Get(ctx, &exec); err != nil {
+			return "", fmt.Errorf("expected start to succeed: %w", err)
+		}
+		opCancel()
+		if err := fut.Get(ctx, nil); err == nil {
+			return "", fmt.Errorf("expected cancel error")
+		}
+		return "", nil
+	}
+	clientInStartCallerWF := func(ctx workflow.Context, input string) (string, error) {
+		c := workflow.NewNexusClient(endpoint, service.Name)
+		fut := c.ExecuteOperation(ctx, clientInStartOp, input, workflow.NexusOperationOptions{})
+		var result string
+		return result, fut.Get(ctx, &result)
+	}
+	ts.worker.RegisterWorkflow(callerWF)
+	ts.worker.RegisterWorkflow(typedCallerWF)
+	ts.worker.RegisterWorkflow(untypedCallerWF)
+	ts.worker.RegisterWorkflow(cancelCallerWF)
+	ts.worker.RegisterWorkflow(customCancelCallerWF)
+	ts.worker.RegisterWorkflow(clientInStartCallerWF)
+
+	startOpts := client.StartWorkflowOptions{
+		TaskQueue: ts.taskQueueName, WorkflowTaskTimeout: time.Second,
+	}
+
+	typedInput := "typed-wf-" + uuid.NewString()
+	untypedInput := "untyped-wf-" + uuid.NewString()
+	signalInput := "signal-wf-" + uuid.NewString()
+	for _, tc := range []struct {
+		name     string
+		wf       func(workflow.Context, string) (string, error)
+		input    string
+		expected string
+	}{
+		{"Sync result", callerWF, "hello", "sync-hello"},
+		{"Async with StartWorkflow", typedCallerWF, typedInput, typedInput},
+		{"Async with StartUntypedWorkflow", untypedCallerWF, untypedInput, untypedInput},
+		{"Cancel", cancelCallerWF, "cancel-wf-" + uuid.NewString(), ""},
+		{"Custom cancel with GetWorkflowClient", customCancelCallerWF, "custom-cancel-wf-" + uuid.NewString(), ""},
+		{"GetWorkflowClient in Start", clientInStartCallerWF, signalInput, "signaled-" + signalInput},
+	} {
+		ts.Run(tc.name, func() {
+			run, err := ts.client.ExecuteWorkflow(ctx, startOpts, tc.wf, tc.input)
+			ts.NoError(err)
+			var result string
+			ts.NoError(run.Get(ctx, &result))
+			ts.Equal(tc.expected, result)
+		})
+	}
+}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -7200,6 +7200,7 @@ func (ts *IntegrationTestSuite) startWorkflowOptions(wfID string) client.StartWo
 func (ts *IntegrationTestSuite) registerWorkflowsAndActivities(w worker.Worker) {
 	ts.workflows.register(w)
 	ts.activities.register(w)
+	w.RegisterNexusService(temporalOpService)
 }
 
 func (ts *IntegrationTestSuite) registerStandaloneNexusOperations(w worker.Worker) {

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -17,7 +17,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/nexus-rpc/sdk-go/nexus"
 	"github.com/opentracing/opentracing-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -56,7 +55,6 @@ import (
 	"go.temporal.io/sdk/internal/interceptortest"
 	ilog "go.temporal.io/sdk/internal/log"
 	"go.temporal.io/sdk/temporal"
-	"go.temporal.io/sdk/temporalnexus"
 	"go.temporal.io/sdk/worker"
 	"go.temporal.io/sdk/workflow"
 )
@@ -9596,136 +9594,7 @@ func (ts *IntegrationTestSuite) TestTemporalOperationSuite() {
 		},
 	})
 	ts.NoError(err)
-
-	echoWF := func(ctx workflow.Context, input string) (string, error) {
-		return input, nil
-	}
-	waitForCancelWF := func(ctx workflow.Context, _ string) (string, error) {
-		return "", workflow.Await(ctx, func() bool { return false })
-	}
-	// Workflow that waits for a signal and returns the signaled value.
-	waitForSignalWF := func(ctx workflow.Context, _ string) (string, error) {
-		var result string
-		ch := workflow.GetSignalChannel(ctx, "my-signal")
-		ch.Receive(ctx, &result)
-		return result, nil
-	}
-
-	syncOp := temporalnexus.MustNewTemporalOperation(temporalnexus.TemporalOperationOptions[string, string]{
-		Name: "sync-op",
-		Start: func(ctx context.Context, nc temporalnexus.NexusClient, input string, opts nexus.StartOperationOptions) (temporalnexus.TemporalOperationResult[string], error) {
-			return temporalnexus.NewSyncResult("sync-" + input), nil
-		},
-	})
-	asyncTypedOp := temporalnexus.MustNewTemporalOperation(temporalnexus.TemporalOperationOptions[string, string]{
-		Name: "async-typed-op",
-		Start: func(ctx context.Context, nc temporalnexus.NexusClient, input string, opts nexus.StartOperationOptions) (temporalnexus.TemporalOperationResult[string], error) {
-			return temporalnexus.StartWorkflow(ctx, nc, client.StartWorkflowOptions{ID: input}, echoWF, input)
-		},
-	})
-	asyncUntypedOp := temporalnexus.MustNewTemporalOperation(temporalnexus.TemporalOperationOptions[string, string]{
-		Name: "async-untyped-op",
-		Start: func(ctx context.Context, nc temporalnexus.NexusClient, input string, opts nexus.StartOperationOptions) (temporalnexus.TemporalOperationResult[string], error) {
-			return temporalnexus.StartUntypedWorkflow[string](ctx, nc, client.StartWorkflowOptions{ID: input}, echoWF, input)
-		},
-	})
-	cancelOp := temporalnexus.MustNewTemporalOperation(temporalnexus.TemporalOperationOptions[string, string]{
-		Name: "cancel-op",
-		Start: func(ctx context.Context, nc temporalnexus.NexusClient, input string, opts nexus.StartOperationOptions) (temporalnexus.TemporalOperationResult[string], error) {
-			return temporalnexus.StartWorkflow(ctx, nc, client.StartWorkflowOptions{ID: input}, waitForCancelWF, input)
-		},
-	})
-	// Op that uses nc.GetWorkflowClient() in Start to signal the workflow after starting it.
-	clientInStartOp := temporalnexus.MustNewTemporalOperation(temporalnexus.TemporalOperationOptions[string, string]{
-		Name: "client-in-start-op",
-		Start: func(ctx context.Context, nc temporalnexus.NexusClient, input string, opts nexus.StartOperationOptions) (temporalnexus.TemporalOperationResult[string], error) {
-			result, err := temporalnexus.StartWorkflow(ctx, nc, client.StartWorkflowOptions{ID: input}, waitForSignalWF, input)
-			if err != nil {
-				return result, err
-			}
-			// Use the Temporal client to signal the workflow we just started.
-			err = nc.GetWorkflowClient().SignalWorkflow(ctx, input, "", "my-signal", "signaled-"+input)
-			if err != nil {
-				return result, err
-			}
-			return result, nil
-		},
-	})
-	customCancelOp := temporalnexus.MustNewTemporalOperation(temporalnexus.TemporalOperationOptions[string, string]{
-		Name: "custom-cancel-op",
-		Start: func(ctx context.Context, nc temporalnexus.NexusClient, input string, opts nexus.StartOperationOptions) (temporalnexus.TemporalOperationResult[string], error) {
-			return temporalnexus.StartWorkflow(ctx, nc, client.StartWorkflowOptions{ID: input}, waitForCancelWF, input)
-		},
-		CancelWorkflowRun: func(ctx context.Context, nc temporalnexus.NexusClient, workflowID string, opts nexus.CancelOperationOptions) error {
-			return nc.GetWorkflowClient().TerminateWorkflow(ctx, workflowID, "", "terminated via nexus cancel")
-		},
-	})
-
-	service := nexus.NewService("temporal-op-test")
-	ts.NoError(service.Register(syncOp, asyncTypedOp, asyncUntypedOp, cancelOp, customCancelOp, clientInStartOp))
-	ts.worker.RegisterNexusService(service)
-	ts.worker.RegisterWorkflow(echoWF)
-	ts.worker.RegisterWorkflow(waitForCancelWF)
-	ts.worker.RegisterWorkflow(waitForSignalWF)
-
-	callerWF := func(ctx workflow.Context, input string) (string, error) {
-		c := workflow.NewNexusClient(endpoint, service.Name)
-		fut := c.ExecuteOperation(ctx, syncOp, input, workflow.NexusOperationOptions{})
-		var result string
-		return result, fut.Get(ctx, &result)
-	}
-	typedCallerWF := func(ctx workflow.Context, input string) (string, error) {
-		c := workflow.NewNexusClient(endpoint, service.Name)
-		fut := c.ExecuteOperation(ctx, asyncTypedOp, input, workflow.NexusOperationOptions{})
-		var result string
-		return result, fut.Get(ctx, &result)
-	}
-	untypedCallerWF := func(ctx workflow.Context, input string) (string, error) {
-		c := workflow.NewNexusClient(endpoint, service.Name)
-		fut := c.ExecuteOperation(ctx, asyncUntypedOp, input, workflow.NexusOperationOptions{})
-		var result string
-		return result, fut.Get(ctx, &result)
-	}
-	cancelCallerWF := func(ctx workflow.Context, input string) (string, error) {
-		c := workflow.NewNexusClient(endpoint, service.Name)
-		opCtx, opCancel := workflow.WithCancel(ctx)
-		fut := c.ExecuteOperation(opCtx, cancelOp, input, workflow.NexusOperationOptions{})
-		var exec workflow.NexusOperationExecution
-		if err := fut.GetNexusOperationExecution().Get(ctx, &exec); err != nil {
-			return "", fmt.Errorf("expected start to succeed: %w", err)
-		}
-		opCancel()
-		if err := fut.Get(ctx, nil); err == nil {
-			return "", fmt.Errorf("expected cancel error")
-		}
-		return "", nil
-	}
-	customCancelCallerWF := func(ctx workflow.Context, input string) (string, error) {
-		c := workflow.NewNexusClient(endpoint, service.Name)
-		opCtx, opCancel := workflow.WithCancel(ctx)
-		fut := c.ExecuteOperation(opCtx, customCancelOp, input, workflow.NexusOperationOptions{})
-		var exec workflow.NexusOperationExecution
-		if err := fut.GetNexusOperationExecution().Get(ctx, &exec); err != nil {
-			return "", fmt.Errorf("expected start to succeed: %w", err)
-		}
-		opCancel()
-		if err := fut.Get(ctx, nil); err == nil {
-			return "", fmt.Errorf("expected cancel error")
-		}
-		return "", nil
-	}
-	clientInStartCallerWF := func(ctx workflow.Context, input string) (string, error) {
-		c := workflow.NewNexusClient(endpoint, service.Name)
-		fut := c.ExecuteOperation(ctx, clientInStartOp, input, workflow.NexusOperationOptions{})
-		var result string
-		return result, fut.Get(ctx, &result)
-	}
-	ts.worker.RegisterWorkflow(callerWF)
-	ts.worker.RegisterWorkflow(typedCallerWF)
-	ts.worker.RegisterWorkflow(untypedCallerWF)
-	ts.worker.RegisterWorkflow(cancelCallerWF)
-	ts.worker.RegisterWorkflow(customCancelCallerWF)
-	ts.worker.RegisterWorkflow(clientInStartCallerWF)
+	temporalOpEndpoint = endpoint
 
 	startOpts := client.StartWorkflowOptions{
 		TaskQueue: ts.taskQueueName, WorkflowTaskTimeout: time.Second,
@@ -9740,12 +9609,12 @@ func (ts *IntegrationTestSuite) TestTemporalOperationSuite() {
 		input    string
 		expected string
 	}{
-		{"Sync result", callerWF, "hello", "sync-hello"},
-		{"Async with StartWorkflow", typedCallerWF, typedInput, typedInput},
-		{"Async with StartUntypedWorkflow", untypedCallerWF, untypedInput, untypedInput},
-		{"Cancel", cancelCallerWF, "cancel-wf-" + uuid.NewString(), ""},
-		{"Custom cancel with GetWorkflowClient", customCancelCallerWF, "custom-cancel-wf-" + uuid.NewString(), ""},
-		{"GetWorkflowClient in Start", clientInStartCallerWF, signalInput, "signaled-" + signalInput},
+		{"Sync result", ts.workflows.TemporalOpSyncCaller, "hello", "sync-hello"},
+		{"Async with StartWorkflow", ts.workflows.TemporalOpAsyncTypedCaller, typedInput, typedInput},
+		{"Async with StartUntypedWorkflow", ts.workflows.TemporalOpAsyncUntypedCaller, untypedInput, untypedInput},
+		{"Cancel", ts.workflows.TemporalOpCancelCaller, "cancel-wf-" + uuid.NewString(), ""},
+		{"Custom cancel with GetWorkflowClient", ts.workflows.TemporalOpCustomCancelCaller, "custom-cancel-wf-" + uuid.NewString(), ""},
+		{"GetWorkflowClient in Start", ts.workflows.TemporalOpClientInStartCaller, signalInput, "signaled-" + signalInput},
 	} {
 		ts.Run(tc.name, func() {
 			run, err := ts.client.ExecuteWorkflow(ctx, startOpts, tc.wf, tc.input)

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/nexus-rpc/sdk-go/nexus"
 	"github.com/opentracing/opentracing-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -34,6 +35,7 @@ import (
 	workflowpb "go.temporal.io/api/workflow/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/sdk/contrib/sysinfo"
+	"go.temporal.io/sdk/temporalnexus"
 	"go.uber.org/goleak"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"

--- a/test/workflow_test.go
+++ b/test/workflow_test.go
@@ -3796,7 +3796,6 @@ func (w *Workflows) TemporalOpClientInStartCaller(ctx workflow.Context, input st
 }
 
 func (w *Workflows) register(worker worker.Worker) {
-	worker.RegisterNexusService(temporalOpService)
 	worker.RegisterWorkflow(w.TemporalOpEcho)
 	worker.RegisterWorkflow(w.TemporalOpWaitForCancel)
 	worker.RegisterWorkflow(w.TemporalOpWaitForSignal)

--- a/test/workflow_test.go
+++ b/test/workflow_test.go
@@ -3683,45 +3683,45 @@ func (w *Workflows) TemporalOpWaitForSignal(ctx workflow.Context, _ string) (str
 
 var temporalOpSyncOp = temporalnexus.MustNewTemporalOperation(temporalnexus.TemporalOperationOptions[string, string]{
 	Name: "sync-op",
-	Start: func(_ context.Context, _ temporalnexus.NexusClient, input string, _ nexus.StartOperationOptions) (temporalnexus.TemporalOperationResult[string], error) {
+	Start: func(_ context.Context, _ temporalnexus.NexusClient, input string, _ temporalnexus.StartTemporalOperationOptions) (temporalnexus.TemporalOperationResult[string], error) {
 		return temporalnexus.NewSyncResult("sync-" + input), nil
 	},
 })
 
 var temporalOpAsyncTypedOp = temporalnexus.MustNewTemporalOperation(temporalnexus.TemporalOperationOptions[string, string]{
 	Name: "async-typed-op",
-	Start: func(ctx context.Context, nc temporalnexus.NexusClient, input string, _ nexus.StartOperationOptions) (temporalnexus.TemporalOperationResult[string], error) {
+	Start: func(ctx context.Context, nc temporalnexus.NexusClient, input string, _ temporalnexus.StartTemporalOperationOptions) (temporalnexus.TemporalOperationResult[string], error) {
 		return temporalnexus.StartWorkflow(ctx, nc, client.StartWorkflowOptions{ID: input}, (*Workflows)(nil).TemporalOpEcho, input)
 	},
 })
 
 var temporalOpAsyncUntypedOp = temporalnexus.MustNewTemporalOperation(temporalnexus.TemporalOperationOptions[string, string]{
 	Name: "async-untyped-op",
-	Start: func(ctx context.Context, nc temporalnexus.NexusClient, input string, _ nexus.StartOperationOptions) (temporalnexus.TemporalOperationResult[string], error) {
+	Start: func(ctx context.Context, nc temporalnexus.NexusClient, input string, _ temporalnexus.StartTemporalOperationOptions) (temporalnexus.TemporalOperationResult[string], error) {
 		return temporalnexus.StartUntypedWorkflow[string](ctx, nc, client.StartWorkflowOptions{ID: input}, (*Workflows)(nil).TemporalOpEcho, input)
 	},
 })
 
 var temporalOpCancelOp = temporalnexus.MustNewTemporalOperation(temporalnexus.TemporalOperationOptions[string, string]{
 	Name: "cancel-op",
-	Start: func(ctx context.Context, nc temporalnexus.NexusClient, input string, _ nexus.StartOperationOptions) (temporalnexus.TemporalOperationResult[string], error) {
+	Start: func(ctx context.Context, nc temporalnexus.NexusClient, input string, _ temporalnexus.StartTemporalOperationOptions) (temporalnexus.TemporalOperationResult[string], error) {
 		return temporalnexus.StartWorkflow(ctx, nc, client.StartWorkflowOptions{ID: input}, (*Workflows)(nil).TemporalOpWaitForCancel, input)
 	},
 })
 
 var temporalOpCustomCancelOp = temporalnexus.MustNewTemporalOperation(temporalnexus.TemporalOperationOptions[string, string]{
 	Name: "custom-cancel-op",
-	Start: func(ctx context.Context, nc temporalnexus.NexusClient, input string, _ nexus.StartOperationOptions) (temporalnexus.TemporalOperationResult[string], error) {
+	Start: func(ctx context.Context, nc temporalnexus.NexusClient, input string, _ temporalnexus.StartTemporalOperationOptions) (temporalnexus.TemporalOperationResult[string], error) {
 		return temporalnexus.StartWorkflow(ctx, nc, client.StartWorkflowOptions{ID: input}, (*Workflows)(nil).TemporalOpWaitForCancel, input)
 	},
-	CancelWorkflowRun: func(ctx context.Context, c client.Client, workflowID string, _ nexus.CancelOperationOptions) error {
-		return c.TerminateWorkflow(ctx, workflowID, "", "terminated via nexus cancel")
+	CancelWorkflowRun: func(ctx context.Context, c client.Client, opts temporalnexus.CancelTemporalWorkflowRunOptions, _ nexus.CancelOperationOptions) error {
+		return c.TerminateWorkflow(ctx, opts.WorkflowID, "", "terminated via nexus cancel")
 	},
 })
 
 var temporalOpClientInStartOp = temporalnexus.MustNewTemporalOperation(temporalnexus.TemporalOperationOptions[string, string]{
 	Name: "client-in-start-op",
-	Start: func(ctx context.Context, nc temporalnexus.NexusClient, input string, _ nexus.StartOperationOptions) (temporalnexus.TemporalOperationResult[string], error) {
+	Start: func(ctx context.Context, nc temporalnexus.NexusClient, input string, _ temporalnexus.StartTemporalOperationOptions) (temporalnexus.TemporalOperationResult[string], error) {
 		result, err := temporalnexus.StartWorkflow(ctx, nc, client.StartWorkflowOptions{ID: input}, (*Workflows)(nil).TemporalOpWaitForSignal, input)
 		if err != nil {
 			return result, err

--- a/test/workflow_test.go
+++ b/test/workflow_test.go
@@ -3714,8 +3714,8 @@ var temporalOpCustomCancelOp = temporalnexus.MustNewTemporalOperation(temporalne
 	Start: func(ctx context.Context, nc temporalnexus.NexusClient, input string, _ nexus.StartOperationOptions) (temporalnexus.TemporalOperationResult[string], error) {
 		return temporalnexus.StartWorkflow(ctx, nc, client.StartWorkflowOptions{ID: input}, (*Workflows)(nil).TemporalOpWaitForCancel, input)
 	},
-	CancelWorkflowRun: func(ctx context.Context, nc temporalnexus.NexusClient, workflowID string, _ nexus.CancelOperationOptions) error {
-		return nc.GetWorkflowClient().TerminateWorkflow(ctx, workflowID, "", "terminated via nexus cancel")
+	CancelWorkflowRun: func(ctx context.Context, c client.Client, workflowID string, _ nexus.CancelOperationOptions) error {
+		return c.TerminateWorkflow(ctx, workflowID, "", "terminated via nexus cancel")
 	},
 })
 

--- a/test/workflow_test.go
+++ b/test/workflow_test.go
@@ -13,12 +13,15 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/nexus-rpc/sdk-go/nexus"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 
+	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/converter"
 	"go.temporal.io/sdk/internal"
 	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/temporalnexus"
 	"go.temporal.io/sdk/worker"
 	"go.temporal.io/sdk/workflow"
 )
@@ -3658,7 +3661,151 @@ func (w *Workflows) SessionCancelNDE(ctx workflow.Context) error {
 	return err
 }
 
+// temporalOpEndpoint is set by TestTemporalOperationSuite before executing
+// caller workflows. The package-level vars below close over it.
+var temporalOpEndpoint string
+
+const temporalOpServiceName = "temporal-op-test"
+
+func (w *Workflows) TemporalOpEcho(_ workflow.Context, input string) (string, error) {
+	return input, nil
+}
+
+func (w *Workflows) TemporalOpWaitForCancel(ctx workflow.Context, _ string) (string, error) {
+	return "", workflow.Await(ctx, func() bool { return false })
+}
+
+func (w *Workflows) TemporalOpWaitForSignal(ctx workflow.Context, _ string) (string, error) {
+	var result string
+	workflow.GetSignalChannel(ctx, "my-signal").Receive(ctx, &result)
+	return result, nil
+}
+
+var temporalOpSyncOp = temporalnexus.MustNewTemporalOperation(temporalnexus.TemporalOperationOptions[string, string]{
+	Name: "sync-op",
+	Start: func(_ context.Context, _ temporalnexus.NexusClient, input string, _ nexus.StartOperationOptions) (temporalnexus.TemporalOperationResult[string], error) {
+		return temporalnexus.NewSyncResult("sync-" + input), nil
+	},
+})
+
+var temporalOpAsyncTypedOp = temporalnexus.MustNewTemporalOperation(temporalnexus.TemporalOperationOptions[string, string]{
+	Name: "async-typed-op",
+	Start: func(ctx context.Context, nc temporalnexus.NexusClient, input string, _ nexus.StartOperationOptions) (temporalnexus.TemporalOperationResult[string], error) {
+		return temporalnexus.StartWorkflow(ctx, nc, client.StartWorkflowOptions{ID: input}, (*Workflows)(nil).TemporalOpEcho, input)
+	},
+})
+
+var temporalOpAsyncUntypedOp = temporalnexus.MustNewTemporalOperation(temporalnexus.TemporalOperationOptions[string, string]{
+	Name: "async-untyped-op",
+	Start: func(ctx context.Context, nc temporalnexus.NexusClient, input string, _ nexus.StartOperationOptions) (temporalnexus.TemporalOperationResult[string], error) {
+		return temporalnexus.StartUntypedWorkflow[string](ctx, nc, client.StartWorkflowOptions{ID: input}, (*Workflows)(nil).TemporalOpEcho, input)
+	},
+})
+
+var temporalOpCancelOp = temporalnexus.MustNewTemporalOperation(temporalnexus.TemporalOperationOptions[string, string]{
+	Name: "cancel-op",
+	Start: func(ctx context.Context, nc temporalnexus.NexusClient, input string, _ nexus.StartOperationOptions) (temporalnexus.TemporalOperationResult[string], error) {
+		return temporalnexus.StartWorkflow(ctx, nc, client.StartWorkflowOptions{ID: input}, (*Workflows)(nil).TemporalOpWaitForCancel, input)
+	},
+})
+
+var temporalOpCustomCancelOp = temporalnexus.MustNewTemporalOperation(temporalnexus.TemporalOperationOptions[string, string]{
+	Name: "custom-cancel-op",
+	Start: func(ctx context.Context, nc temporalnexus.NexusClient, input string, _ nexus.StartOperationOptions) (temporalnexus.TemporalOperationResult[string], error) {
+		return temporalnexus.StartWorkflow(ctx, nc, client.StartWorkflowOptions{ID: input}, (*Workflows)(nil).TemporalOpWaitForCancel, input)
+	},
+	CancelWorkflowRun: func(ctx context.Context, nc temporalnexus.NexusClient, workflowID string, _ nexus.CancelOperationOptions) error {
+		return nc.GetWorkflowClient().TerminateWorkflow(ctx, workflowID, "", "terminated via nexus cancel")
+	},
+})
+
+var temporalOpClientInStartOp = temporalnexus.MustNewTemporalOperation(temporalnexus.TemporalOperationOptions[string, string]{
+	Name: "client-in-start-op",
+	Start: func(ctx context.Context, nc temporalnexus.NexusClient, input string, _ nexus.StartOperationOptions) (temporalnexus.TemporalOperationResult[string], error) {
+		result, err := temporalnexus.StartWorkflow(ctx, nc, client.StartWorkflowOptions{ID: input}, (*Workflows)(nil).TemporalOpWaitForSignal, input)
+		if err != nil {
+			return result, err
+		}
+		if err := nc.GetWorkflowClient().SignalWorkflow(ctx, input, "", "my-signal", "signaled-"+input); err != nil {
+			return result, err
+		}
+		return result, nil
+	},
+})
+
+var temporalOpService = func() *nexus.Service {
+	s := nexus.NewService(temporalOpServiceName)
+	if err := s.Register(
+		temporalOpSyncOp,
+		temporalOpAsyncTypedOp,
+		temporalOpAsyncUntypedOp,
+		temporalOpCancelOp,
+		temporalOpCustomCancelOp,
+		temporalOpClientInStartOp,
+	); err != nil {
+		panic(err)
+	}
+	return s
+}()
+
+func (w *Workflows) TemporalOpSyncCaller(ctx workflow.Context, input string) (string, error) {
+	c := workflow.NewNexusClient(temporalOpEndpoint, temporalOpServiceName)
+	var result string
+	return result, c.ExecuteOperation(ctx, temporalOpSyncOp, input, workflow.NexusOperationOptions{}).Get(ctx, &result)
+}
+
+func (w *Workflows) TemporalOpAsyncTypedCaller(ctx workflow.Context, input string) (string, error) {
+	c := workflow.NewNexusClient(temporalOpEndpoint, temporalOpServiceName)
+	var result string
+	return result, c.ExecuteOperation(ctx, temporalOpAsyncTypedOp, input, workflow.NexusOperationOptions{}).Get(ctx, &result)
+}
+
+func (w *Workflows) TemporalOpAsyncUntypedCaller(ctx workflow.Context, input string) (string, error) {
+	c := workflow.NewNexusClient(temporalOpEndpoint, temporalOpServiceName)
+	var result string
+	return result, c.ExecuteOperation(ctx, temporalOpAsyncUntypedOp, input, workflow.NexusOperationOptions{}).Get(ctx, &result)
+}
+
+func (w *Workflows) TemporalOpCancelCaller(ctx workflow.Context, input string) (string, error) {
+	return w.runTemporalOpCancelCaller(ctx, temporalOpCancelOp, input)
+}
+
+func (w *Workflows) TemporalOpCustomCancelCaller(ctx workflow.Context, input string) (string, error) {
+	return w.runTemporalOpCancelCaller(ctx, temporalOpCustomCancelOp, input)
+}
+
+func (w *Workflows) runTemporalOpCancelCaller(ctx workflow.Context, op nexus.Operation[string, string], input string) (string, error) {
+	c := workflow.NewNexusClient(temporalOpEndpoint, temporalOpServiceName)
+	opCtx, opCancel := workflow.WithCancel(ctx)
+	fut := c.ExecuteOperation(opCtx, op, input, workflow.NexusOperationOptions{})
+	var exec workflow.NexusOperationExecution
+	if err := fut.GetNexusOperationExecution().Get(ctx, &exec); err != nil {
+		return "", fmt.Errorf("expected start to succeed: %w", err)
+	}
+	opCancel()
+	if err := fut.Get(ctx, nil); err == nil {
+		return "", fmt.Errorf("expected cancel error")
+	}
+	return "", nil
+}
+
+func (w *Workflows) TemporalOpClientInStartCaller(ctx workflow.Context, input string) (string, error) {
+	c := workflow.NewNexusClient(temporalOpEndpoint, temporalOpServiceName)
+	var result string
+	return result, c.ExecuteOperation(ctx, temporalOpClientInStartOp, input, workflow.NexusOperationOptions{}).Get(ctx, &result)
+}
+
 func (w *Workflows) register(worker worker.Worker) {
+	worker.RegisterNexusService(temporalOpService)
+	worker.RegisterWorkflow(w.TemporalOpEcho)
+	worker.RegisterWorkflow(w.TemporalOpWaitForCancel)
+	worker.RegisterWorkflow(w.TemporalOpWaitForSignal)
+	worker.RegisterWorkflow(w.TemporalOpSyncCaller)
+	worker.RegisterWorkflow(w.TemporalOpAsyncTypedCaller)
+	worker.RegisterWorkflow(w.TemporalOpAsyncUntypedCaller)
+	worker.RegisterWorkflow(w.TemporalOpCancelCaller)
+	worker.RegisterWorkflow(w.TemporalOpCustomCancelCaller)
+	worker.RegisterWorkflow(w.TemporalOpClientInStartCaller)
 	worker.RegisterWorkflow(w.ActivityCancelRepro)
 	worker.RegisterWorkflow(w.ActivityCompletionUsingID)
 	worker.RegisterWorkflow(w.ActivityHeartbeatWithRetry)


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

  Added a generic Nexus operation handler that consolidates the common pattern of "either return a synchronous
   result or start a workflow as an async operation." 

## Why?

  The existing `NewWorkflowRunOperation` /` NewSyncOperation` split forces users to pick the operation shape up front, which is awkward when:  
  - The start handler decides at runtime whether to respond sync or async.
  - The handler needs access to the Temporal client.                          
  - The user wants a custom cancel implementation (e.g. terminate instead of cancel).                                                    
                                                                                                                                           
  The new TemporalOperation unifies these cases behind one API and makes the common path much shorter. 

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New experimental Nexus/operation surface starts and cancels workflows from handlers; mistakes affect operation lifecycle and cancel behavior, though changes are additive with tests.
> 
> **Overview**
> Adds an **experimental** generic Nexus handler API in `temporalnexus` so one operation can return either a **sync** result or start a **workflow-backed async** run from a single `Start` callback, instead of choosing up front between `NewSyncOperation` and `NewWorkflowRunOperation`.
> 
> **`NewTemporalOperation` / `MustNewTemporalOperation`** build a `nexus.Operation` with validation (required name/start, reserved `__temporal_` prefix) and a default workflow-run cancel via `CancelWorkflow`. **`TemporalOperationResult`** plus `NewSyncResult` / `NewAsyncResult` map to Nexus sync vs async start responses. **`NexusClient`** scopes the Temporal client per invocation; **`StartWorkflow`** / **`StartUntypedWorkflow`** wire callbacks/links/request ID and enforce **one async start per invocation**.
> 
> **Cancel** decodes tokens with new **`loadTokenType`** in `token.go` before full workflow-token parsing. Unit tests cover result conversion, validation, token parsing, and the double-start guard; integration tests register a Nexus service and exercise sync, typed/untyped async, default cancel, custom terminate cancel, and `GetWorkflowClient` in `Start`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86be12d18ced4eec5b2a9feeb0d04839f2c9aa16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->