### PR TITLE
Add missing Describe() method to external storage s3driver docs

### DIFF
--- a/contrib/aws/s3driver/README.md
+++ b/contrib/aws/s3driver/README.md
@@ -113,6 +113,7 @@ type Client interface {
     PutObject(ctx context.Context, bucket, key string, data []byte) error
     ObjectExists(ctx context.Context, bucket, key string) (bool, error)
     GetObject(ctx context.Context, bucket, key string) ([]byte, error)
+    Describe() map[string]string
 }
 ```
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Just added `Describe()` to the docs which was missing. I was reading through the driver code and spotted this. Describe is [a newer addition](https://github.com/temporalio/sdk-go/pull/2316) to the original interface.

## Why?
Keep the `Client` interface in the documentation in sync with the actual definition.