### PR TITLE
Document default for ChildWorkflowOptions.WorkflowIDReusePolicy

### DIFF
--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -461,8 +461,10 @@ type (
 		// Optional: default false
 		WaitForCancellation bool
 
-		// WorkflowIDReusePolicy - Whether server allow reuse of workflow ID, can be useful
-		// for dedup logic if set to WorkflowIdReusePolicyRejectDuplicate
+		// WorkflowIDReusePolicy - Specifies server behavior if a *completed* workflow with the same id exists.
+		// This can be useful for dedupe logic if set to WorkflowIdReusePolicyRejectDuplicate.
+		//
+		// Optional: defaults to AllowDuplicate.
 		WorkflowIDReusePolicy enumspb.WorkflowIdReusePolicy
 
 		// RetryPolicy specify how to retry child workflow if error happens.

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -461,7 +461,7 @@ type (
 		// Optional: default false
 		WaitForCancellation bool
 
-		// WorkflowIDReusePolicy - Specifies server behavior if a *completed* workflow with the same id exists.
+		// WorkflowIDReusePolicy - Controls how the server handles attempts to reuse the ID of a completed workflow.
 		// This can be useful for dedupe logic if set to WorkflowIdReusePolicyRejectDuplicate.
 		//
 		// Optional: defaults to AllowDuplicate.


### PR DESCRIPTION


## What was changed
<!-- Describe what has changed in this PR -->
 Documented default for ChildWorkflowOptions.WorkflowIDReusePolicy

## Why?
clarity

## Checklist
<!--- add/delete as needed --->

1. Closes #2098 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only change documenting the default `WorkflowIDReusePolicy` for child workflows; no runtime behavior is modified.
> 
> **Overview**
> Updates the `ChildWorkflowOptions.WorkflowIDReusePolicy` docstring in `internal/workflow.go` to clarify its semantics (ID reuse for *completed* workflows) and explicitly document the default value as `AllowDuplicate` for dedupe-related configuration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edb18e0a0aab9bd7856340553c0c6f722ec40f0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->