### PR TITLE
Add tracing for standalone activity client calls

### DIFF
--- a/interceptor/tracing_interceptor.go
+++ b/interceptor/tracing_interceptor.go
@@ -267,6 +267,28 @@ func (t *tracingClientOutboundInterceptor) ExecuteWorkflow(
 	return run, err
 }
 
+func (t *tracingClientOutboundInterceptor) ExecuteActivity(
+	ctx context.Context,
+	in *ClientExecuteActivityInput,
+) (client.ActivityHandle, error) {
+	// Start span and write to header
+	span, ctx, err := t.root.startSpanFromContext(ctx, &TracerStartSpanOptions{
+		Operation: "StartActivity",
+		Name:      in.ActivityType,
+		ToHeader:  true,
+		Time:      time.Now(),
+	}, t.root.headerReader(ctx), t.root.headerWriter(ctx))
+	if err != nil {
+		return nil, err
+	}
+	var finishOpts TracerFinishSpanOptions
+	defer span.Finish(&finishOpts)
+
+	handle, err := t.Next.ExecuteActivity(ctx, in)
+	finishOpts.Error = err
+	return handle, err
+}
+
 func (t *tracingClientOutboundInterceptor) SignalWorkflow(ctx context.Context, in *ClientSignalWorkflowInput) error {
 	// Only add tracing if enabled
 	if t.root.options.DisableSignalTracing {


### PR DESCRIPTION
## What was changed
Implemented ExecuteActivity on tracingClientOutboundInterceptor so standalone activity client calls create a StartActivity span and write tracing context to the header.

## Why?
Standalone activity client calls currently bypass the tracing client outbound interceptor because the tracing interceptor does not implement the standalone activity method. This means client-side tracing spans are not created for standalone activity execution.

## Checklist

1. Closes #2286

2. How was this tested:

- go test ./interceptor/... -count=1
- go test ./internal -run TestExecuteActivityHeaderAvailableToInterceptors -count=1
- go test ./... -count=1

3. Any docs updates needed?
No docs updates needed.
