### PR TITLE
Fix unsupported link log

### DIFF
--- a/temporalnexus/operation.go
+++ b/temporalnexus/operation.go
@@ -383,8 +383,10 @@ func convertNexusLinks(nexusLinks []nexus.Link, log log.Logger) ([]*common.Link,
 					WorkflowEvent: link,
 				},
 			})
+		case string((&common.Link_NexusOperation{}).ProtoReflect().Descriptor().FullName()):
+			// TODO: forward Link_NexusOperation variants once frontend validateLinks accepts them.
 		default:
-			log.Warn("ignoring unsupported link data type: %q", nexusLink.Type)
+			log.Warn("ignoring unsupported link data type", "LinkType", nexusLink.Type)
 		}
 	}
 	return links, nil


### PR DESCRIPTION
Fix unsupported link log. Log was trying to do a format string with a key/value logger.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts logging and adds a no-op branch for `Link_NexusOperation`, with no behavior changes to link conversion beyond clearer warnings.
> 
> **Overview**
> Fixes `convertNexusLinks` to log unsupported Nexus link types using structured key/value logging (instead of a printf-style format string).
> 
> Adds an explicit `Link_NexusOperation` switch case that is currently *intentionally ignored* (with a TODO to forward once frontend validation supports it), reducing noise from falling into the generic unsupported-type warning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b77e681f8c82122d84ebf242a716ce9481af88f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->