### PR TITLE
Disable gomod version-bump PRs, keep security alerts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    open-pull-requests-limit: 0
     cooldown:
       default-days: 14
   - package-ecosystem: github-actions


### PR DESCRIPTION
## What was changed

Set `open-pull-requests-limit: 0` for `gomod` in Dependabot config.

## Why?

After discussion with @yuandrew, we agreed to suppress automatic version update PRs while still allowing Dependabot security PRs through. Go dependencies are upgraded on-demand, not automatically.