### PR TITLE
test: stabilize integration tests against dev-server slowness

### DIFF
--- a/internal/cliversion/cliversion.go
+++ b/internal/cliversion/cliversion.go
@@ -1,5 +1,0 @@
-// Package cliversion holds the Temporal CLI version pinned for integration tests.
-package cliversion
-
-// CLIVersion is the Temporal CLI release used by integration test dev servers.
-const CLIVersion = "v1.7.1-standalone-nexus-operations"

--- a/internal/cliversion/cliversion.go
+++ b/internal/cliversion/cliversion.go
@@ -1,0 +1,5 @@
+// Package cliversion holds the Temporal CLI version pinned for integration tests.
+package cliversion
+
+// CLIVersion is the Temporal CLI release used by integration test dev servers.
+const CLIVersion = "v1.7.1-standalone-nexus-operations"

--- a/internal/cmd/build/main.go
+++ b/internal/cmd/build/main.go
@@ -23,7 +23,7 @@ import (
 	_ "honnef.co/go/tools/staticcheck"
 
 	"go.temporal.io/sdk/client"
-	"go.temporal.io/sdk/internal/cliversion"
+	"go.temporal.io/sdk/internal/devserverdefaults"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/testsuite"
 )
@@ -128,7 +128,7 @@ func (b *builder) integrationTest() error {
 	if *devServerFlag {
 		devServer, err := testsuite.StartDevServer(context.Background(), testsuite.DevServerOptions{
 			CachedDownload: testsuite.CachedDownload{
-				Version: cliversion.CLIVersion,
+				Version: devserverdefaults.CLIVersion,
 			},
 			ClientOptions: &client.Options{
 				HostPort:  "127.0.0.1:7233",
@@ -137,9 +137,7 @@ func (b *builder) integrationTest() error {
 			DBFilename:       "temporal.sqlite",
 			LogLevel:         "warn",
 			SearchAttributes: searchAttributes,
-			ExtraArgs: []string{
-				"--sqlite-pragma", "journal_mode=WAL",
-				"--sqlite-pragma", "synchronous=OFF",
+			ExtraArgs: append(devserverdefaults.SQLitePragmas(),
 				"--dynamic-config-value", "frontend.enableExecuteMultiOperation=true",
 				"--dynamic-config-value", "frontend.enableUpdateWorkflowExecution=true",
 				"--dynamic-config-value", "frontend.enableUpdateWorkflowExecutionAsyncAccepted=true",
@@ -171,7 +169,7 @@ func (b *builder) integrationTest() error {
 				"--dynamic-config-value", "nexusoperation.enableStandalone=true",
 				"--dynamic-config-value", "history.enableChasmCallbacks=true",
 				"--dynamic-config-value", "frontend.ListWorkersEnabled=true",
-			},
+			),
 		})
 		if err != nil {
 			return fmt.Errorf("failed starting dev server: %w", err)

--- a/internal/cmd/build/main.go
+++ b/internal/cmd/build/main.go
@@ -23,6 +23,7 @@ import (
 	_ "honnef.co/go/tools/staticcheck"
 
 	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/internal/cliversion"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/testsuite"
 )
@@ -127,7 +128,7 @@ func (b *builder) integrationTest() error {
 	if *devServerFlag {
 		devServer, err := testsuite.StartDevServer(context.Background(), testsuite.DevServerOptions{
 			CachedDownload: testsuite.CachedDownload{
-				Version: "v1.7.1-standalone-nexus-operations",
+				Version: cliversion.CLIVersion,
 			},
 			ClientOptions: &client.Options{
 				HostPort:  "127.0.0.1:7233",

--- a/internal/devserverdefaults/devserverdefaults.go
+++ b/internal/devserverdefaults/devserverdefaults.go
@@ -1,0 +1,14 @@
+// Package devserverdefaults holds settings shared between dev-server callsites.
+package devserverdefaults
+
+// CLIVersion is the Temporal CLI release used by integration test dev servers.
+const CLIVersion = "v1.7.1-standalone-nexus-operations"
+
+// SQLitePragmas returns the SQLite tuning flags to splice into a dev server's
+// ExtraArgs.
+func SQLitePragmas() []string {
+	return []string{
+		"--sqlite-pragma", "journal_mode=WAL",
+		"--sqlite-pragma", "synchronous=OFF",
+	}
+}

--- a/test/external_storage_test.go
+++ b/test/external_storage_test.go
@@ -18,7 +18,6 @@ import (
 	"go.temporal.io/sdk/activity"
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/converter"
-	ilog "go.temporal.io/sdk/internal/log"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/worker"
 	"go.temporal.io/sdk/workflow"
@@ -148,7 +147,6 @@ type ExternalStorageTestSuite struct {
 	suite.Suite
 	ConfigAndClientSuiteBase
 	driver *memStorageDriver
-	client client.Client
 	worker worker.Worker
 }
 
@@ -164,27 +162,26 @@ func (s *ExternalStorageTestSuite) SetupSuite() {
 func (s *ExternalStorageTestSuite) SetupTest() {
 	s.taskQueueName = taskQueuePrefix + "-ext-" + s.T().Name()
 	s.driver = newMemDriver("test")
-	var err error
-	s.client, err = client.Dial(client.Options{
-		HostPort:  s.config.ServiceAddr,
-		Namespace: s.config.Namespace,
-		Logger:    ilog.NewDefaultLogger(),
-		ExternalStorage: converter.ExternalStorage{
+	s.NoError(s.InitClient(func(opts *client.Options) {
+		opts.ExternalStorage = converter.ExternalStorage{
 			Drivers:              []converter.StorageDriver{s.driver},
 			PayloadSizeThreshold: extStoreThreshold,
-		},
-		ConnectionOptions:       client.ConnectionOptions{TLS: s.config.TLS},
-		WorkerHeartbeatInterval: -1,
-	})
-	s.NoError(err)
+		}
+	}))
 	s.worker = worker.New(s.client, s.taskQueueName, worker.Options{
 		WorkflowPanicPolicy: worker.FailWorkflow,
 	})
 }
 
 func (s *ExternalStorageTestSuite) TearDownTest() {
-	s.worker.Stop()
-	s.client.Close()
+	if s.worker != nil {
+		s.worker.Stop()
+		s.worker = nil
+	}
+	if s.client != nil {
+		s.client.Close()
+		s.client = nil
+	}
 }
 
 // oversized returns a string that exceeds extStoreThreshold by extra bytes.
@@ -403,19 +400,14 @@ func (s *ExternalStorageTestSuite) TestDriverSelector() {
 	var selectMu sync.Mutex
 	selector := &roundRobinSelector{drivers: []converter.StorageDriver{d1, d2}, mu: &selectMu, idx: &selectIdx}
 
-	var err error
 	s.client.Close()
-	s.client, err = client.Dial(client.Options{
-		HostPort:  s.config.ServiceAddr,
-		Namespace: s.config.Namespace,
-		Logger:    ilog.NewDefaultLogger(),
-		ExternalStorage: converter.ExternalStorage{
+	var err error
+	s.client, err = s.newClient(func(opts *client.Options) {
+		opts.ExternalStorage = converter.ExternalStorage{
 			Drivers:              []converter.StorageDriver{d1, d2},
 			DriverSelector:       selector,
 			PayloadSizeThreshold: extStoreThreshold,
-		},
-		ConnectionOptions:       client.ConnectionOptions{TLS: s.config.TLS},
-		WorkerHeartbeatInterval: -1,
+		}
 	})
 	s.NoError(err)
 	// Re-create worker bound to the new client.
@@ -496,13 +488,7 @@ func (s *ExternalStorageTestSuite) TestRetrieveFailure() {
 func (s *ExternalStorageTestSuite) TestWorkerWithoutExternalStorageFails() {
 	// Build a client and worker with no ExternalStorage. s.client still has the
 	// driver, so it can store the oversized input; the worker below cannot retrieve it.
-	noStorageClient, err := client.Dial(client.Options{
-		HostPort:                s.config.ServiceAddr,
-		Namespace:               s.config.Namespace,
-		Logger:                  ilog.NewDefaultLogger(),
-		ConnectionOptions:       client.ConnectionOptions{TLS: s.config.TLS},
-		WorkerHeartbeatInterval: -1,
-	})
+	noStorageClient, err := s.newClient()
 	s.NoError(err)
 	defer noStorageClient.Close()
 
@@ -582,16 +568,11 @@ func (s *ExternalStorageTestSuite) TestNoStorageWhenBelowThreshold() {
 func (s *ExternalStorageTestSuite) TestDriverPanicOnRetrieve() {
 	pd := &panicMemDriver{memStorageDriver: newMemDriver("test"), panicOnRetrieve: true}
 
-	c, err := client.Dial(client.Options{
-		HostPort:  s.config.ServiceAddr,
-		Namespace: s.config.Namespace,
-		Logger:    ilog.NewDefaultLogger(),
-		ExternalStorage: converter.ExternalStorage{
+	c, err := s.newClient(func(opts *client.Options) {
+		opts.ExternalStorage = converter.ExternalStorage{
 			Drivers:              []converter.StorageDriver{pd},
 			PayloadSizeThreshold: extStoreThreshold,
-		},
-		ConnectionOptions:       client.ConnectionOptions{TLS: s.config.TLS},
-		WorkerHeartbeatInterval: -1,
+		}
 	})
 	s.NoError(err)
 	defer c.Close()
@@ -631,16 +612,11 @@ func extStorePanicOnStoreWorkflow(_ workflow.Context) (string, error) {
 func (s *ExternalStorageTestSuite) TestDriverPanicOnStore() {
 	pd := &panicMemDriver{memStorageDriver: newMemDriver("test"), panicOnStore: true}
 
-	c, err := client.Dial(client.Options{
-		HostPort:  s.config.ServiceAddr,
-		Namespace: s.config.Namespace,
-		Logger:    ilog.NewDefaultLogger(),
-		ExternalStorage: converter.ExternalStorage{
+	c, err := s.newClient(func(opts *client.Options) {
+		opts.ExternalStorage = converter.ExternalStorage{
 			Drivers:              []converter.StorageDriver{pd},
 			PayloadSizeThreshold: extStoreThreshold,
-		},
-		ConnectionOptions:       client.ConnectionOptions{TLS: s.config.TLS},
-		WorkerHeartbeatInterval: -1,
+		}
 	})
 	s.NoError(err)
 	defer c.Close()

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -171,26 +171,19 @@ func (ts *IntegrationTestSuite) SetupTest() {
 		clientInterceptors = append(clientInterceptors, interceptor)
 	}
 
-	var err error
 	trafficController := test.NewSimpleTrafficController()
-	ts.client, err = client.Dial(client.Options{
-		HostPort:  ts.config.ServiceAddr,
-		Namespace: ts.config.Namespace,
-		Logger:    ilog.NewDefaultLogger(),
-		ContextPropagators: []workflow.ContextPropagator{
+	ts.NoError(ts.InitClient(func(opts *client.Options) {
+		opts.ContextPropagators = []workflow.ContextPropagator{
 			NewKeysPropagator([]string{testContextKey1}),
 			NewKeysPropagator([]string{testContextKey2}),
-		},
-		MetricsHandler:          metricsHandler,
-		TrafficController:       trafficController,
-		Interceptors:            clientInterceptors,
-		ConnectionOptions:       client.ConnectionOptions{TLS: ts.config.TLS},
-		WorkerHeartbeatInterval: -1,
-		PayloadLimits: client.PayloadLimitOptions{
+		}
+		opts.MetricsHandler = metricsHandler
+		opts.TrafficController = trafficController
+		opts.Interceptors = clientInterceptors
+		opts.PayloadLimits = client.PayloadLimitOptions{
 			PayloadSizeWarning: 128,
-		},
-	})
-	ts.NoError(err)
+		}
+	}))
 
 	ts.trafficController = trafficController
 	ts.activities.clearInvoked()
@@ -288,6 +281,9 @@ func (ts *IntegrationTestSuite) TearDownTest() {
 	}
 	if ts.client != nil {
 		ts.client.Close()
+		// Nil out so the next SetupTest's InitClient creates a fresh client
+		// instead of skipping via its non-nil idempotency check.
+		ts.client = nil
 	}
 }
 

--- a/test/nexus_test.go
+++ b/test/nexus_test.go
@@ -79,13 +79,10 @@ func newTestContext(t *testing.T, ctx context.Context, optionFuncs ...testContex
 
 	metricsHandler := metrics.NewCapturingHandler()
 	logger := ilog.NewMemoryLogger()
-	c, err := client.DialContext(ctx, client.Options{
-		HostPort:          config.ServiceAddr,
-		Namespace:         config.Namespace,
-		Logger:            logger,
-		ConnectionOptions: client.ConnectionOptions{TLS: config.TLS},
-		MetricsHandler:    metricsHandler,
-		Interceptors:      options.clientInterceptors,
+	c, err := newClientFromConfig(ctx, config, func(opts *client.Options) {
+		opts.Logger = logger
+		opts.MetricsHandler = metricsHandler
+		opts.Interceptors = options.clientInterceptors
 	})
 	require.NoError(t, err)
 

--- a/test/payload_limits_test.go
+++ b/test/payload_limits_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
@@ -54,7 +55,11 @@ func (ts *PayloadLimitsTestSuite) SetupSuite() {
 	_, httpPort, err := net.SplitHostPort(ts.config.ServiceHTTPAddr)
 	ts.NoError(err)
 
-	// Start dev server with low payload limits
+	// File-backed SQLite so database/sql uses a real connection pool. Default
+	// in-memory mode is pool-of-one, where one sqlite3_interrupt() (e.g. from a
+	// context cancellation during worker shutdown) can wedge every later query.
+	dbPath := filepath.Join(ts.T().TempDir(), "payload-limits.sqlite")
+
 	ts.server, err = testsuite.StartDevServer(context.Background(), testsuite.DevServerOptions{
 		CachedDownload: testsuite.CachedDownload{
 			Version: "v1.6.0",
@@ -63,7 +68,8 @@ func (ts *PayloadLimitsTestSuite) SetupSuite() {
 			HostPort:  ts.config.ServiceAddr,
 			Namespace: ts.config.Namespace,
 		},
-		LogLevel: "warn",
+		DBFilename: dbPath,
+		LogLevel:   "warn",
 		ExtraArgs: []string{
 			"--http-port", httpPort,
 			"--dynamic-config-value", fmt.Sprintf("limit.blobSize.error=%d", payloadSizeErrorLimit),
@@ -71,13 +77,19 @@ func (ts *PayloadLimitsTestSuite) SetupSuite() {
 		},
 	})
 	ts.NoError(err)
-
-	ts.NoError(WaitForTCP(time.Minute, ts.config.ServiceAddr))
 }
 
 func (ts *PayloadLimitsTestSuite) SetupTest() {
 	ts.Assertions = require.New(ts.T())
 	ts.taskQueueName = taskQueuePrefix + "-" + ts.T().Name()
+	// Fail fast if the dev server is wedged.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_, err := ts.server.Client().WorkflowService().DescribeNamespace(ctx,
+		&workflowservice.DescribeNamespaceRequest{Namespace: ts.config.Namespace})
+	if err != nil {
+		ts.T().Fatalf("dev server health probe failed (namespace=%q): %v", ts.config.Namespace, err)
+	}
 	// Only initialize if not already set (tests can call ResetClientAndWorker themselves)
 	if ts.client == nil {
 		ts.NoError(ts.InitClient())
@@ -556,7 +568,6 @@ func (ts *PayloadLimitsTestSuite) TestPayloadSizeErrorActivityHeartbeat() {
 	ts.assertActivityTaskFailed(ctx, run)
 	ts.assertLogContains(logger, payloadErrorMessage)
 }
-
 
 func (ts *PayloadLimitsTestSuite) TestPayloadSizeWarningClientCustom() {
 	ctx, cancel := context.WithCancel(context.Background())

--- a/test/payload_limits_test.go
+++ b/test/payload_limits_test.go
@@ -18,6 +18,7 @@ import (
 	workflowservice "go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/sdk/activity"
 	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/internal/cliversion"
 	ilog "go.temporal.io/sdk/internal/log"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/testsuite"
@@ -62,7 +63,7 @@ func (ts *PayloadLimitsTestSuite) SetupSuite() {
 
 	ts.server, err = testsuite.StartDevServer(context.Background(), testsuite.DevServerOptions{
 		CachedDownload: testsuite.CachedDownload{
-			Version: "v1.6.0",
+			Version: cliversion.CLIVersion,
 		},
 		ClientOptions: &client.Options{
 			HostPort:  ts.config.ServiceAddr,

--- a/test/payload_limits_test.go
+++ b/test/payload_limits_test.go
@@ -18,7 +18,7 @@ import (
 	workflowservice "go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/sdk/activity"
 	"go.temporal.io/sdk/client"
-	"go.temporal.io/sdk/internal/cliversion"
+	"go.temporal.io/sdk/internal/devserverdefaults"
 	ilog "go.temporal.io/sdk/internal/log"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/testsuite"
@@ -63,7 +63,7 @@ func (ts *PayloadLimitsTestSuite) SetupSuite() {
 
 	ts.server, err = testsuite.StartDevServer(context.Background(), testsuite.DevServerOptions{
 		CachedDownload: testsuite.CachedDownload{
-			Version: cliversion.CLIVersion,
+			Version: devserverdefaults.CLIVersion,
 		},
 		ClientOptions: &client.Options{
 			HostPort:  ts.config.ServiceAddr,
@@ -71,11 +71,11 @@ func (ts *PayloadLimitsTestSuite) SetupSuite() {
 		},
 		DBFilename: dbPath,
 		LogLevel:   "warn",
-		ExtraArgs: []string{
+		ExtraArgs: append(devserverdefaults.SQLitePragmas(),
 			"--http-port", httpPort,
 			"--dynamic-config-value", fmt.Sprintf("limit.blobSize.error=%d", payloadSizeErrorLimit),
 			"--dynamic-config-value", fmt.Sprintf("limit.blobSize.warn=%d", payloadSizeWarningLimit),
-		},
+		),
 	})
 	ts.NoError(err)
 }

--- a/test/test_utils_test.go
+++ b/test/test_utils_test.go
@@ -59,9 +59,6 @@ func NewConfig(configCallbacks ...ConfigureConfigCallback) Config {
 		Namespace:               "integration-test-namespace",
 		ShouldRegisterNamespace: true,
 	}
-	for _, configure := range configCallbacks {
-		configure(&cfg)
-	}
 	if addr := getEnvServiceAddr(); addr != "" {
 		cfg.ServiceAddr = addr
 	}
@@ -90,6 +87,9 @@ func NewConfig(configCallbacks ...ConfigureConfigCallback) Config {
 			panic(fmt.Sprintf("Failed loading client cert: %v", err))
 		}
 		cfg.TLS = &tls.Config{Certificates: []tls.Certificate{cert}}
+	}
+	for _, configure := range configCallbacks {
+		configure(&cfg)
 	}
 	return cfg
 }

--- a/test/test_utils_test.go
+++ b/test/test_utils_test.go
@@ -248,11 +248,16 @@ func (ts *ConfigAndClientSuiteBase) InitClient(clientOpts ...ConfigureClientOpti
 }
 
 func (ts *ConfigAndClientSuiteBase) newClient(clientOpts ...ConfigureClientOptions) (client.Client, error) {
+	return newClientFromConfig(context.Background(), ts.config, clientOpts...)
+}
+
+// newClientFromConfig builds a Client from a Config and optional callback-based overrides.
+func newClientFromConfig(ctx context.Context, config Config, clientOpts ...ConfigureClientOptions) (client.Client, error) {
 	options := client.Options{
-		HostPort:  ts.config.ServiceAddr,
-		Namespace: ts.config.Namespace,
+		HostPort:  config.ServiceAddr,
+		Namespace: config.Namespace,
 		ConnectionOptions: client.ConnectionOptions{
-			TLS:                  ts.config.TLS,
+			TLS:                  config.TLS,
 			GetSystemInfoTimeout: ctxTimeout,
 		},
 		WorkerHeartbeatInterval: -1,
@@ -263,7 +268,7 @@ func (ts *ConfigAndClientSuiteBase) newClient(clientOpts ...ConfigureClientOptio
 	if options.Logger == nil {
 		options.Logger = ilog.NewDefaultLogger()
 	}
-	return client.Dial(options)
+	return client.DialContext(ctx, options)
 }
 
 func SimplestWorkflow(_ workflow.Context) error {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

- Consolidate integration test CLI version
- Consolidate client creation
- Reorder config callbacks to be applied last
- Use database file for payload limits tests

## Why?

Various connection issues have appeared lately in tests. Some indications show that:
- The client GetSystemInfoTimeout was too short (fixed by consolidating client creation)
- Payload limits tests were not using the correct namespace (fixed by reordering config callbacks)
- Resetting client and worker in payload limits tests is causing contention in database connections (fixed by using database file so connection pooling is enabled, just like main integration test suite).
