### PR TITLE
Release Go SDK v1.44.0

### DIFF
--- a/internal/version.go
+++ b/internal/version.go
@@ -8,7 +8,7 @@ const (
 	// Server validates if SDKVersion fits its supported range and rejects request if it doesn't.
 	//
 	// Exposed as: [go.temporal.io/sdk/temporal.SDKVersion]
-	SDKVersion = "1.43.0"
+	SDKVersion = "1.44.0"
 
 	// SDKName represents the name of the SDK.
 	SDKName = clientNameHeaderValue


### PR DESCRIPTION
Release Go SDK v1.44.0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Simple version constant bump only; no functional or behavioral code changes beyond the SDK version header sent to the server.
> 
> **Overview**
> Updates the embedded `SDKVersion` constant from `1.43.0` to `1.44.0` so clients report the new Go SDK release version in RPC metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2acd52e4e4d2dcb63caa58861cb91fee5c34916a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->