### PR TITLE
Converter: add optional retry policy for PayloadCodec calls

### DIFF
--- a/converter/codec.go
+++ b/converter/codec.go
@@ -3,11 +3,14 @@ package converter
 import (
 	"bytes"
 	"compress/zlib"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"strings"
+	"time"
 
 	commonpb "go.temporal.io/api/common/v1"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -130,12 +133,69 @@ func encodePayloads(payloads []*commonpb.Payload, codecs []PayloadCodec) ([]*com
 	return payloads, nil
 }
 
+// Defaults applied by (*CodecDataConverter).callWithRetry when a
+// CodecRetryPolicy field is zero. Values mirror the conventions in
+// internal/common/retry.Default* so codec retry behavior is consistent with
+// the rest of the SDK's retry surface.
+const (
+	defaultCodecRetryInitialInterval       = 100 * time.Millisecond
+	defaultCodecRetryBackoffCoefficient    = 2.0
+	defaultCodecRetryMaximumIntervalFactor = 100
+)
+
+// CodecRetryPolicy controls retry and backoff for individual PayloadCodec
+// Encode/Decode calls made by a CodecDataConverter. Zero values for each
+// field fall back to the documented defaults so the zero value is usable.
+type CodecRetryPolicy struct {
+	// InitialInterval is the wait before the first retry. Defaults to 100ms.
+	InitialInterval time.Duration
+	// BackoffCoefficient is the multiplier applied to InitialInterval after
+	// each failed attempt. Defaults to 2.0.
+	BackoffCoefficient float64
+	// MaximumInterval caps the per-attempt wait. Defaults to 100 *
+	// InitialInterval.
+	MaximumInterval time.Duration
+	// MaximumAttempts is the total attempt count including the first call.
+	// 0 means unlimited (bounded only by ExpirationInterval and the
+	// retry-loop context).
+	MaximumAttempts int
+	// ExpirationInterval is the absolute wall-clock budget across all
+	// attempts. 0 means no time bound.
+	ExpirationInterval time.Duration
+}
+
+// CodecDataConverterOptions configures a CodecDataConverter built with
+// NewCodecDataConverterWithOptions. The zero value preserves the behavior of
+// NewCodecDataConverter exactly: each codec is invoked once and the first
+// error aborts the chain.
+type CodecDataConverterOptions struct {
+	// RetryPolicy, if non-nil, is applied to each individual PayloadCodec
+	// Encode and Decode call. Each codec in the chain is retried
+	// independently, so a transient failure in one codec does not re-run
+	// codecs that already succeeded — this matters for non-idempotent codecs
+	// such as authenticated encryption.
+	RetryPolicy *CodecRetryPolicy
+
+	// IsRetryable, if non-nil, is consulted on every codec error to decide
+	// whether to retry. Return true to keep retrying (subject to RetryPolicy
+	// limits), false to fail fast. If nil, all errors are treated as
+	// retryable.
+	IsRetryable func(error) bool
+
+	// Context, if non-nil, governs cancellation of waits between retry
+	// attempts. Defaults to context.Background(). The context is only used
+	// to short-circuit retry sleeps; it is not propagated into PayloadCodec
+	// calls, which do not take a context today.
+	Context context.Context
+}
+
 // CodecDataConverter is a DataConverter that wraps an underlying data
 // converter and supports chained encoding of just the payload without regard
 // for serialization to/from actual types.
 type CodecDataConverter struct {
-	parent DataConverter
-	codecs []PayloadCodec
+	parent  DataConverter
+	codecs  []PayloadCodec
+	options CodecDataConverterOptions
 }
 
 // NewCodecDataConverter wraps the given parent DataConverter and performs
@@ -143,16 +203,130 @@ type CodecDataConverter struct {
 // ToPayload(s), the codecs are applied last to first meaning the earlier
 // encoders wrap the later ones. When decoding for FromPayload(s) and
 // ToString(s), the decoders are applied first to last to reverse the effect.
+//
+// Each codec call is invoked exactly once. To opt in to retries on transient
+// codec failures (e.g. for codecs that call external KMS/HTTP services), use
+// NewCodecDataConverterWithOptions.
 func NewCodecDataConverter(parent DataConverter, codecs ...PayloadCodec) DataConverter {
-	return &CodecDataConverter{parent, codecs}
+	return &CodecDataConverter{parent, codecs, CodecDataConverterOptions{}}
+}
+
+// NewCodecDataConverterWithOptions wraps the given parent DataConverter with
+// the given chain of PayloadCodecs, configurable via CodecDataConverterOptions.
+// The codec chain semantics are identical to NewCodecDataConverter; options
+// only add retry behavior around each individual codec call. A zero options
+// value is equivalent to calling NewCodecDataConverter.
+func NewCodecDataConverterWithOptions(
+	parent DataConverter,
+	codecs []PayloadCodec,
+	options CodecDataConverterOptions,
+) DataConverter {
+	return &CodecDataConverter{parent, codecs, options}
 }
 
 func (e *CodecDataConverter) encode(payloads []*commonpb.Payload) ([]*commonpb.Payload, error) {
-	return encodePayloads(payloads, e.codecs)
+	if e.options.RetryPolicy == nil {
+		return encodePayloads(payloads, e.codecs)
+	}
+	var err error
+	for i := len(e.codecs) - 1; i >= 0; i-- {
+		codec := e.codecs[i]
+		if payloads, err = e.callWithRetry(func() ([]*commonpb.Payload, error) {
+			return codec.Encode(payloads)
+		}); err != nil {
+			return payloads, err
+		}
+	}
+	return payloads, nil
 }
 
 func (e *CodecDataConverter) decode(payloads []*commonpb.Payload) ([]*commonpb.Payload, error) {
-	return decodePayloads(payloads, e.codecs)
+	if e.options.RetryPolicy == nil {
+		return decodePayloads(payloads, e.codecs)
+	}
+	var err error
+	for _, codec := range e.codecs {
+		if payloads, err = e.callWithRetry(func() ([]*commonpb.Payload, error) {
+			return codec.Decode(payloads)
+		}); err != nil {
+			return payloads, err
+		}
+	}
+	return payloads, nil
+}
+
+// callWithRetry runs op according to e.options.RetryPolicy and IsRetryable.
+// When RetryPolicy is nil, op is called exactly once. Otherwise op is retried
+// using exponential backoff bounded by MaximumAttempts, ExpirationInterval,
+// and the options' Context (defaulting to context.Background()).
+func (e *CodecDataConverter) callWithRetry(op func() ([]*commonpb.Payload, error)) ([]*commonpb.Payload, error) {
+	policy := e.options.RetryPolicy
+	if policy == nil {
+		return op()
+	}
+
+	ctx := e.options.Context
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	initialInterval := policy.InitialInterval
+	if initialInterval <= 0 {
+		initialInterval = defaultCodecRetryInitialInterval
+	}
+	backoffCoeff := policy.BackoffCoefficient
+	if backoffCoeff <= 0 {
+		backoffCoeff = defaultCodecRetryBackoffCoefficient
+	}
+	maxInterval := policy.MaximumInterval
+	if maxInterval <= 0 {
+		maxInterval = defaultCodecRetryMaximumIntervalFactor * initialInterval
+	}
+
+	startTime := time.Now()
+	var (
+		payloads []*commonpb.Payload
+		err      error
+	)
+
+	for attempt := 1; ; attempt++ {
+		payloads, err = op()
+		if err == nil {
+			return payloads, nil
+		}
+
+		if e.options.IsRetryable != nil && !e.options.IsRetryable(err) {
+			return payloads, err
+		}
+
+		if policy.MaximumAttempts > 0 && attempt >= policy.MaximumAttempts {
+			return payloads, err
+		}
+
+		elapsed := time.Since(startTime)
+		if policy.ExpirationInterval > 0 && elapsed >= policy.ExpirationInterval {
+			return payloads, err
+		}
+
+		interval := math.Min(
+			float64(initialInterval)*math.Pow(backoffCoeff, float64(attempt-1)),
+			float64(maxInterval),
+		)
+		if policy.ExpirationInterval > 0 {
+			interval = math.Min(interval, float64(policy.ExpirationInterval-elapsed))
+		}
+		if interval <= 0 {
+			return payloads, err
+		}
+
+		timer := time.NewTimer(time.Duration(interval))
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return payloads, err
+		case <-timer.C:
+		}
+	}
 }
 
 // ToPayload implements DataConverter.ToPayload performing encoding on the
@@ -257,7 +431,7 @@ func (e *CodecDataConverter) WithSerializationContext(ctx SerializationContext) 
 	if !changed {
 		return e
 	}
-	return &CodecDataConverter{parent, codecs}
+	return &CodecDataConverter{parent, codecs, e.options}
 }
 
 const remotePayloadCodecEncodePath = "/encode"

--- a/converter/codec_test.go
+++ b/converter/codec_test.go
@@ -2,13 +2,17 @@ package converter
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	commonpb "go.temporal.io/api/common/v1"
@@ -354,4 +358,334 @@ func TestCodecDataConverter_ToPayload_EncodeError(t *testing.T) {
 	require.EqualError(err, "some encode error")
 	// Also assert that the original payload is returned on error.
 	require.True(proto.Equal(originalPayload, payload))
+}
+
+// flakyCodec is a test PayloadCodec that fails the first failuresBeforeSuccess
+// Encode and Decode calls and then begins succeeding. Call counts are tracked
+// atomically so tests can assert exact attempt counts.
+type flakyCodec struct {
+	encodeFailures      int32
+	decodeFailures      int32
+	encodeAttempts      int32
+	decodeAttempts      int32
+	err                 error
+	innerEncoding       string
+	passThroughOnEncode bool
+}
+
+func (c *flakyCodec) Encode(payloads []*commonpb.Payload) ([]*commonpb.Payload, error) {
+	attempt := atomic.AddInt32(&c.encodeAttempts, 1)
+	if attempt <= c.encodeFailures {
+		return payloads, c.err
+	}
+	if c.passThroughOnEncode {
+		return payloads, nil
+	}
+	result := make([]*commonpb.Payload, len(payloads))
+	for i, p := range payloads {
+		b, err := proto.Marshal(p)
+		if err != nil {
+			return payloads, err
+		}
+		result[i] = &commonpb.Payload{
+			Metadata: map[string][]byte{MetadataEncoding: []byte(c.innerEncoding)},
+			Data:     b,
+		}
+	}
+	return result, nil
+}
+
+func (c *flakyCodec) Decode(payloads []*commonpb.Payload) ([]*commonpb.Payload, error) {
+	attempt := atomic.AddInt32(&c.decodeAttempts, 1)
+	if attempt <= c.decodeFailures {
+		return payloads, c.err
+	}
+	result := make([]*commonpb.Payload, len(payloads))
+	for i, p := range payloads {
+		if string(p.Metadata[MetadataEncoding]) != c.innerEncoding {
+			result[i] = p
+			continue
+		}
+		result[i] = &commonpb.Payload{}
+		if err := proto.Unmarshal(p.Data, result[i]); err != nil {
+			return payloads, err
+		}
+	}
+	return result, nil
+}
+
+// countingCodec is a pass-through PayloadCodec that records Encode/Decode
+// invocation counts. Useful for asserting per-codec retry boundaries.
+type countingCodec struct {
+	encodeAttempts int32
+	decodeAttempts int32
+}
+
+func (c *countingCodec) Encode(payloads []*commonpb.Payload) ([]*commonpb.Payload, error) {
+	atomic.AddInt32(&c.encodeAttempts, 1)
+	return payloads, nil
+}
+
+func (c *countingCodec) Decode(payloads []*commonpb.Payload) ([]*commonpb.Payload, error) {
+	atomic.AddInt32(&c.decodeAttempts, 1)
+	return payloads, nil
+}
+
+// fastRetry returns a CodecRetryPolicy with sub-millisecond intervals so that
+// retry tests complete quickly.
+func fastRetry(maxAttempts int) *CodecRetryPolicy {
+	return &CodecRetryPolicy{
+		InitialInterval:    time.Millisecond,
+		BackoffCoefficient: 1.0,
+		MaximumInterval:    time.Millisecond,
+		MaximumAttempts:    maxAttempts,
+	}
+}
+
+func TestCodecDataConverter_Retry_EncodeSucceedsAfterTransientFailures(t *testing.T) {
+	require := require.New(t)
+
+	codec := &flakyCodec{
+		encodeFailures: 2,
+		err:            errors.New("transient"),
+		innerEncoding:  "test/flaky",
+	}
+	conv := NewCodecDataConverterWithOptions(
+		GetDefaultDataConverter(),
+		[]PayloadCodec{codec},
+		CodecDataConverterOptions{RetryPolicy: fastRetry(4)},
+	)
+
+	payload, err := conv.ToPayload("foo")
+	require.NoError(err)
+	require.NotNil(payload)
+	require.Equal(int32(3), atomic.LoadInt32(&codec.encodeAttempts))
+}
+
+func TestCodecDataConverter_Retry_EncodeExhaustsAttempts(t *testing.T) {
+	require := require.New(t)
+
+	codec := &flakyCodec{
+		encodeFailures: 100,
+		err:            errors.New("permanent"),
+		innerEncoding:  "test/flaky",
+	}
+	conv := NewCodecDataConverterWithOptions(
+		GetDefaultDataConverter(),
+		[]PayloadCodec{codec},
+		CodecDataConverterOptions{RetryPolicy: fastRetry(3)},
+	)
+
+	_, err := conv.ToPayload("foo")
+	require.Error(err)
+	require.EqualError(err, "permanent")
+	require.Equal(int32(3), atomic.LoadInt32(&codec.encodeAttempts))
+}
+
+func TestCodecDataConverter_Retry_DecodeRetried(t *testing.T) {
+	require := require.New(t)
+
+	codec := &flakyCodec{
+		decodeFailures: 2,
+		err:            errors.New("transient"),
+		innerEncoding:  "test/flaky",
+	}
+	conv := NewCodecDataConverterWithOptions(
+		GetDefaultDataConverter(),
+		[]PayloadCodec{codec},
+		CodecDataConverterOptions{RetryPolicy: fastRetry(4)},
+	)
+
+	// Build an encoded payload by hand so Decode has something to chew on.
+	defaultConv := GetDefaultDataConverter()
+	innerPayload, err := defaultConv.ToPayload("foo")
+	require.NoError(err)
+	innerBytes, err := proto.Marshal(innerPayload)
+	require.NoError(err)
+	encoded := &commonpb.Payload{
+		Metadata: map[string][]byte{MetadataEncoding: []byte("test/flaky")},
+		Data:     innerBytes,
+	}
+
+	var out string
+	require.NoError(conv.FromPayload(encoded, &out))
+	require.Equal("foo", out)
+	require.Equal(int32(3), atomic.LoadInt32(&codec.decodeAttempts))
+}
+
+func TestCodecDataConverter_Retry_NonRetryableErrorFailsImmediately(t *testing.T) {
+	require := require.New(t)
+
+	sentinel := errors.New("do not retry")
+	codec := &flakyCodec{
+		encodeFailures: 100,
+		err:            sentinel,
+		innerEncoding:  "test/flaky",
+	}
+	conv := NewCodecDataConverterWithOptions(
+		GetDefaultDataConverter(),
+		[]PayloadCodec{codec},
+		CodecDataConverterOptions{
+			RetryPolicy: fastRetry(10),
+			IsRetryable: func(err error) bool { return !errors.Is(err, sentinel) },
+		},
+	)
+
+	_, err := conv.ToPayload("foo")
+	require.ErrorIs(err, sentinel)
+	require.Equal(int32(1), atomic.LoadInt32(&codec.encodeAttempts))
+}
+
+func TestCodecDataConverter_Retry_DefaultPolicyPreservesOldBehavior(t *testing.T) {
+	require := require.New(t)
+
+	errCodec := &errorCodecOnEncode{err: fmt.Errorf("some encode error")}
+	conv := NewCodecDataConverterWithOptions(
+		GetDefaultDataConverter(),
+		[]PayloadCodec{errCodec},
+		CodecDataConverterOptions{},
+	)
+
+	originalPayload, err := GetDefaultDataConverter().ToPayload("foo")
+	require.NoError(err)
+
+	payload, err := conv.ToPayload("foo")
+	require.Error(err)
+	require.EqualError(err, "some encode error")
+	require.True(proto.Equal(originalPayload, payload))
+}
+
+func TestCodecDataConverter_Retry_PerCodecBoundary(t *testing.T) {
+	require := require.New(t)
+
+	flaky := &flakyCodec{
+		encodeFailures:      2,
+		err:                 errors.New("transient"),
+		passThroughOnEncode: true,
+	}
+	counter := &countingCodec{}
+
+	// Encode iterates backwards, so the codec slice [counter, flaky] runs
+	// flaky first then counter. flaky fails twice and succeeds on the third
+	// attempt; counter must be invoked exactly once.
+	conv := NewCodecDataConverterWithOptions(
+		GetDefaultDataConverter(),
+		[]PayloadCodec{counter, flaky},
+		CodecDataConverterOptions{RetryPolicy: fastRetry(5)},
+	)
+
+	_, err := conv.ToPayload("foo")
+	require.NoError(err)
+	require.Equal(int32(3), atomic.LoadInt32(&flaky.encodeAttempts))
+	require.Equal(int32(1), atomic.LoadInt32(&counter.encodeAttempts))
+}
+
+func TestCodecDataConverter_Retry_ContextCancellationStopsRetries(t *testing.T) {
+	require := require.New(t)
+
+	codec := &flakyCodec{
+		encodeFailures: 1000,
+		err:            errors.New("transient"),
+		innerEncoding:  "test/flaky",
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	conv := NewCodecDataConverterWithOptions(
+		GetDefaultDataConverter(),
+		[]PayloadCodec{codec},
+		CodecDataConverterOptions{
+			RetryPolicy: &CodecRetryPolicy{
+				InitialInterval:    50 * time.Millisecond,
+				BackoffCoefficient: 1.0,
+				MaximumInterval:    50 * time.Millisecond,
+				// MaximumAttempts: 0 = unlimited; context must stop the loop.
+			},
+			Context: ctx,
+		},
+	)
+
+	cancel() // cancel before the call so the first sleep returns immediately
+	start := time.Now()
+	_, err := conv.ToPayload("foo")
+	elapsed := time.Since(start)
+
+	require.Error(err)
+	require.EqualError(err, "transient")
+	require.Less(elapsed, 100*time.Millisecond, "retry loop should exit promptly on cancel")
+	// At least one attempt happened; far fewer than would occur in 100ms of
+	// unbounded retries at 50ms intervals.
+	require.GreaterOrEqual(atomic.LoadInt32(&codec.encodeAttempts), int32(1))
+	require.Less(atomic.LoadInt32(&codec.encodeAttempts), int32(5))
+}
+
+func TestCodecDataConverter_Retry_NewCodecDataConverterIsZeroOptions(t *testing.T) {
+	require := require.New(t)
+
+	codec := NewZlibCodec(ZlibCodecOptions{AlwaysEncode: true})
+	defaultConv := GetDefaultDataConverter()
+
+	convA := NewCodecDataConverter(defaultConv, codec)
+	convB := NewCodecDataConverterWithOptions(
+		defaultConv,
+		[]PayloadCodec{codec},
+		CodecDataConverterOptions{},
+	)
+
+	payloadA, err := convA.ToPayload("hello")
+	require.NoError(err)
+	payloadB, err := convB.ToPayload("hello")
+	require.NoError(err)
+	require.True(proto.Equal(payloadA, payloadB))
+}
+
+// retryTestSerializationContext is a no-op SerializationContext used only to
+// exercise the WithSerializationContext path in the retry tests.
+type retryTestSerializationContext struct{}
+
+func (retryTestSerializationContext) isSerializationContext() {}
+
+func TestCodecDataConverter_Retry_OptionsPreservedThroughSerializationContext(t *testing.T) {
+	require := require.New(t)
+
+	codec := &flakyCodec{
+		encodeFailures: 2,
+		err:            errors.New("transient"),
+		innerEncoding:  "test/flaky",
+	}
+	conv := NewCodecDataConverterWithOptions(
+		GetDefaultDataConverter(),
+		[]PayloadCodec{codec},
+		CodecDataConverterOptions{RetryPolicy: fastRetry(4)},
+	)
+
+	ctxAware, ok := conv.(DataConverterWithSerializationContext)
+	require.True(ok, "CodecDataConverter should implement DataConverterWithSerializationContext")
+
+	rederived := ctxAware.WithSerializationContext(retryTestSerializationContext{})
+	require.NotNil(rederived)
+
+	_, err := rederived.ToPayload("foo")
+	require.NoError(err, "retry options must survive WithSerializationContext")
+	require.Equal(int32(3), atomic.LoadInt32(&codec.encodeAttempts))
+}
+
+func TestCodecDataConverter_Retry_NilContextDefaultsToBackground(t *testing.T) {
+	require := require.New(t)
+
+	codec := &flakyCodec{
+		encodeFailures: 1,
+		err:            errors.New("transient"),
+		innerEncoding:  "test/flaky",
+	}
+	conv := NewCodecDataConverterWithOptions(
+		GetDefaultDataConverter(),
+		[]PayloadCodec{codec},
+		CodecDataConverterOptions{
+			RetryPolicy: fastRetry(3),
+			Context:     nil,
+		},
+	)
+
+	_, err := conv.ToPayload("foo")
+	require.NoError(err)
+	require.Equal(int32(2), atomic.LoadInt32(&codec.encodeAttempts))
 }


### PR DESCRIPTION
Adds NewCodecDataConverterWithOptions and a CodecDataConverterOptions struct exposing an opt-in retry policy applied per individual codec call. Motivated by codecs that call external services (the in-tree RemotePayloadCodec, KMS-backed codecs, schema-registry codecs) where transient failures today abort the whole conversion with no recovery path.

NewCodecDataConverter signature is unchanged; the zero-value options struct preserves current behavior.

Fixes #2370

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

New public surface, all in `converter/codec.go`:

```go
func NewCodecDataConverterWithOptions(
    parent DataConverter,
    codecs []PayloadCodec,
    options CodecDataConverterOptions,
) DataConverter

type CodecDataConverterOptions struct {
    RetryPolicy *CodecRetryPolicy
    IsRetryable func(error) bool
    Context     context.Context
}

type CodecRetryPolicy struct {
    InitialInterval    time.Duration
    BackoffCoefficient float64
    MaximumInterval    time.Duration
    MaximumAttempts    int
    ExpirationInterval time.Duration
}
```

Behavior:

- Default (no `RetryPolicy` set): each codec is invoked exactly once and the first error aborts the chain. Byte-for-byte identical to current behavior. A `TestCodecDataConverter_Retry_NewCodecDataConverterIsZeroOptions` test asserts equivalence.
- With `RetryPolicy` set: each codec in the chain is wrapped in a retry loop independently. `IsRetryable` (if non-nil) classifies each error; nil means retry all, matching the convention in `internal/common/backoff.Retry` and `temporal.RetryPolicy` (empty `NonRetryableErrorTypes` retries everything). `Context` (defaulting to `context.Background()`) governs cancellation of sleeps between attempts.
- `CodecRetryPolicy` zero-value field defaults: 100ms initial interval, backoff coefficient 2.0, max interval equal to 100 times initial. These mirror the conventions used by `internal/common/retry.Default*` via three unexported package constants declared at the top of `converter/codec.go`.

Retry boundary is per-codec, not per-chain. A chain of `[compress, encrypt]` only retries the failing codec. Re-running a successful predecessor would invalidate its output for non-idempotent codecs such as authenticated encryption and KMS data-key wrapping.

Files modified:

- `converter/codec.go` (+186, -6): new exported types and constructor, three unexported default constants, private `callWithRetry` helper (no `internal/` import), `options` field on `CodecDataConverter`, updated `WithSerializationContext` to propagate options through derived converters. Existing `NewCodecDataConverter` doc comment updated to mention the new sibling.
- `converter/codec_test.go` (+334): `flakyCodec`, `countingCodec`, `retryTestSerializationContext`, and `fastRetry` helpers, plus ten new retry tests.

Zero changes outside `converter/`. No new module dependencies (`go.mod` and `go.sum` are untouched; verified by `go mod tidy` producing no diff). No changes under `internal/`. No changes to the `PayloadCodec` interface. No changes to `NewPayloadCodecHTTPHandler`.

Out of scope, deliberately:

- Retry behavior on `PayloadConverter` and `FailureConverter`. Those have programmer-error failure modes rather than transient I/O.
- Adding `context.Context` to the `PayloadCodec` interface itself. The options-struct `Context` only governs sleeps between retries.
- Retry inside `NewPayloadCodecHTTPHandler`. Server-side retry is the operator's responsibility.
- Promotion of `internal/common/backoff` to a public package.

## Why?

A `PayloadCodec` may call an external service during Encode and Decode. The in-tree `RemotePayloadCodec` is the canonical example (HTTP to a sidecar), and KMS-backed encryption codecs plus schema-registry codecs are common community variants. Any of these can fail transiently from network blips, throttling, or 5xx responses. Today the SDK has no way to retry a codec call: the first error from any codec immediately aborts the encode/decode and surfaces to user code. Each downstream user has to either fork the codec or wrap retry logic inside their own codec implementation, which duplicates effort across the ecosystem and does not help the stdlib `RemotePayloadCodec`, which has no retries today (`pc.options.Client.Do(req)` followed by `return payloads, err`).

This proposal complements PR #2228, which made codec-failure side effects non-catastrophic for session workflows. That fix prevents permanent bricking when a codec failure cascades through a session activity cancellation, but a transient `DeadlineExceeded` from a remote codec still kills the in-flight workflow task and forces the server to retry the entire task. This PR is the root-cause complement: codecs that opt in can absorb the transient blip in place without ever losing the workflow task.

Determinism: codecs run at the SDK serialization boundary, never inside the workflow goroutine's user code. Retrying does not introduce new history events, new commands, or new branches in workflow code. History replay re-invokes the codec the same way it would on the original execution. Replay-aware retries are safe by construction.

Design choices the maintainers may want to weigh in on (carried from issue #2370):

1. Local `CodecRetryPolicy` struct as proposed, or thread something else (`temporal.RetryPolicy` would require breaking an import cycle from `converter/` back into `temporal/`).
2. Per-codec retry boundary as proposed, or would a `RetryWholeChain bool` opt-in be preferred.
3. `IsRetryable nil = retry all` matches `backoff.Retry` and `temporal.RetryPolicy` conventions. Would the safer `IsRetryable nil = retry none` default be preferred instead.

## Checklist

1. Closes #2370

2. How was this tested:

Local verification, all from `internal/cmd/build`:

```bash
go run . check                                   # vet, errcheck, staticcheck, doclink: clean
go run . unit-test -run "TestCodecDataConverter" # 11 tests pass (10 new plus 1 pre-existing)
go run . unit-test                               # full suite passes, zero FAIL lines
go run . integration-test -dev-server            # passes; one pre-existing Nexus flake unrelated to converter
```

Ten new tests in `converter/codec_test.go`:

- `TestCodecDataConverter_Retry_EncodeSucceedsAfterTransientFailures`: flaky codec fails twice and succeeds on the third attempt.
- `TestCodecDataConverter_Retry_EncodeExhaustsAttempts`: always-failing codec exhausts `MaximumAttempts` and returns the last error.
- `TestCodecDataConverter_Retry_DecodeRetried`: symmetric coverage on the Decode path.
- `TestCodecDataConverter_Retry_NonRetryableErrorFailsImmediately`: `IsRetryable` returns false; single attempt.
- `TestCodecDataConverter_Retry_DefaultPolicyPreservesOldBehavior`: backward compatibility confirmed against the pre-existing `errorCodecOnEncode` fake.
- `TestCodecDataConverter_Retry_PerCodecBoundary`: verifies a successful predecessor codec is not re-run when a later codec retries.
- `TestCodecDataConverter_Retry_ContextCancellationStopsRetries`: context cancellation aborts the retry loop and surfaces the codec error, not `context.Canceled`.
- `TestCodecDataConverter_Retry_NewCodecDataConverterIsZeroOptions`: `NewCodecDataConverter` produces output behaviorally identical to `NewCodecDataConverterWithOptions` with a zero-value options struct.
- `TestCodecDataConverter_Retry_OptionsPreservedThroughSerializationContext`: `WithSerializationContext` derivation does not silently drop retry config.
- `TestCodecDataConverter_Retry_NilContextDefaultsToBackground`: `Context: nil` does not panic and falls back to `context.Background()`.

The pre-existing `TestCodecDataConverter_ToPayload_EncodeError` was not modified and continues to pass without changes. The six other pre-existing `TestCodecDataConverter_*` tests (propagation, signing-mismatch, etc.) also pass unchanged.

In addition to in-repo tests, an out-of-tree consumer program that calls `NewCodecDataConverterWithOptions` against a flaky codec returning `kms 503` for the first two attempts succeeds on the third attempt and prints `err=<nil> payload=true`. This confirms the public API shape is usable from outside the SDK module.

All retry tests use sub-millisecond intervals so the new suite runs in well under one second.

3. Any docs updates needed?

No external docs updates are required. The public API additions carry doc comments on every exported symbol matching the density set by `serialization_context.go`. The existing `NewCodecDataConverter` doc comment was updated to point readers at the new sibling constructor for the retry-aware path. No README updates needed; no docs.temporal.io updates needed since this is a Go SDK addition with self-documenting types.
