### PR TITLE
contrib/envconfig: add Authority field to ClientConfigProfile

### DIFF
--- a/contrib/envconfig/client_config.go
+++ b/contrib/envconfig/client_config.go
@@ -37,6 +37,9 @@ type ClientConfigProfile struct {
 	// lowercased and hyphens are replaced with underscores. This is used for deduplicating/overriding too, so manually
 	// set values that are not normalized may not get overridden with [ClientConfigProfile.ApplyEnvVars].
 	GRPCMeta map[string]string
+	// Authority specifies the value to be used as the :authority pseudo-header and virtual host name.
+	// See [client.ConnectionOptions.Authority] for more.
+	Authority string
 }
 
 // ClientConfigTLS is TLS configuration for a client.
@@ -116,6 +119,7 @@ func (c *ClientConfigProfile) ToClientOptions(options ToClientOptionsRequest) (c
 	if len(c.GRPCMeta) > 0 {
 		opts.HeadersProvider = fixedHeaders(c.GRPCMeta)
 	}
+	opts.ConnectionOptions.Authority = c.Authority
 	return opts, nil
 }
 

--- a/contrib/envconfig/client_config_load.go
+++ b/contrib/envconfig/client_config_load.go
@@ -278,6 +278,9 @@ func (c *ClientConfigProfile) ApplyEnvVars(env EnvLookup) error {
 	if s, ok := env.LookupEnv("TEMPORAL_API_KEY"); ok {
 		c.APIKey = s
 	}
+	if s, ok := env.LookupEnv("TEMPORAL_CLIENT_AUTHORITY"); ok {
+		c.Authority = s
+	}
 	if s, ok := env.LookupEnv("TEMPORAL_TLS"); ok {
 		if v, ok := envVarToBool(s); ok {
 			if c.TLS == nil {

--- a/contrib/envconfig/client_config_load_test.go
+++ b/contrib/envconfig/client_config_load_test.go
@@ -83,6 +83,7 @@ func TestClientProfileApplyEnvVars(t *testing.T) {
 address = "my-address"
 namespace = "my-namespace"
 api_key = "my-api-key"
+authority = "my-authority"
 codec = { endpoint = "my-endpoint", auth = "my-auth" }
 grpc_meta = { some-heAder1 = "some-value1", some-header2 = "some-value2", some_heaDer3 = "some-value3" }
 some_future_key = "some future value not handled"
@@ -109,6 +110,7 @@ disable_host_verification = true`
 	require.Equal(t, "my-api-key", prof.APIKey)
 	require.Equal(t, "my-endpoint", prof.Codec.Endpoint)
 	require.Equal(t, "my-auth", prof.Codec.Auth)
+	require.Equal(t, "my-authority", prof.Authority)
 	require.True(t, prof.TLS.Disabled)
 	require.Equal(t, "my-client-cert-path", prof.TLS.ClientCertPath)
 	require.Equal(t, []byte("my-client-cert-data"), prof.TLS.ClientCertData)
@@ -143,6 +145,7 @@ disable_host_verification = true`
 			"TEMPORAL_TLS_DISABLE_HOST_VERIFICATION": "false",
 			"TEMPORAL_CODEC_ENDPOINT":                "my-endpoint-new",
 			"TEMPORAL_CODEC_AUTH":                    "my-auth-new",
+			"TEMPORAL_CLIENT_AUTHORITY":              "my-authority-new",
 			// Leave first header alone, replace second header, set third as empty, add a fourth
 			"TEMPORAL_GRPC_META_SOME_HEADER2": "some-value2-new",
 			"TEMPORAL_GRPC_META_SOME_HEADER3": "",
@@ -155,6 +158,7 @@ disable_host_verification = true`
 	require.Equal(t, "my-api-key-new", prof.APIKey)
 	require.Equal(t, "my-endpoint-new", prof.Codec.Endpoint)
 	require.Equal(t, "my-auth-new", prof.Codec.Auth)
+	require.Equal(t, "my-authority-new", prof.Authority)
 	require.False(t, prof.TLS.Disabled)
 	require.Equal(t, "my-client-cert-path-new", prof.TLS.ClientCertPath)
 	require.Equal(t, []byte("my-client-cert-data-new"), prof.TLS.ClientCertData)

--- a/contrib/envconfig/client_config_toml.go
+++ b/contrib/envconfig/client_config_toml.go
@@ -18,6 +18,7 @@ var knownProfileKeys = map[string]bool{
 	"tls":       true,
 	"codec":     true,
 	"grpc_meta": true,
+	"authority": true,
 }
 
 // ClientConfigToTOMLOptions are options for [ClientConfig.ToTOML].
@@ -163,6 +164,7 @@ type tomlClientConfigProfile struct {
 	TLS       *tomlClientConfigTLS   `toml:"tls,omitempty"`
 	Codec     *tomlClientConfigCodec `toml:"codec,omitempty"`
 	GRPCMeta  map[string]string      `toml:"grpc_meta,omitempty"`
+	Authority string                 `toml:"authority,omitempty"`
 }
 
 func (c *tomlClientConfigProfile) toClientConfig() *ClientConfigProfile {
@@ -172,6 +174,7 @@ func (c *tomlClientConfigProfile) toClientConfig() *ClientConfigProfile {
 		APIKey:    c.APIKey,
 		TLS:       c.TLS.toClientConfig(),
 		Codec:     c.Codec.toClientConfig(),
+		Authority: c.Authority,
 	}
 	// gRPC meta keys have to be normalized
 	if len(c.GRPCMeta) > 0 {
@@ -187,6 +190,7 @@ func (c *tomlClientConfigProfile) fromClientConfig(conf *ClientConfigProfile) {
 	c.Address = conf.Address
 	c.Namespace = conf.Namespace
 	c.APIKey = conf.APIKey
+	c.Authority = conf.Authority
 	if conf.TLS != nil {
 		c.TLS = &tomlClientConfigTLS{}
 		c.TLS.fromClientConfig(conf.TLS)

--- a/contrib/envconfig/client_config_toml_test.go
+++ b/contrib/envconfig/client_config_toml_test.go
@@ -14,6 +14,7 @@ func TestClientConfigTOMLFull(t *testing.T) {
 address = "my-address"
 namespace = "my-namespace"
 api_key = "my-api-key"
+authority = "my-authority"
 codec = { endpoint = "my-endpoint", auth = "my-auth" }
 grpc_meta = { sOme-hEader_key = "some-value" }
 some_future_key = "some future value not handled"
@@ -46,6 +47,7 @@ disable_host_verification = true`
 	require.Equal(t, []byte("my-server-ca-cert-data"), prof.TLS.ServerCACertData)
 	require.Equal(t, "my-server-name", prof.TLS.ServerName)
 	require.True(t, prof.TLS.DisableHostVerification)
+	require.Equal(t, "my-authority", prof.Authority)
 	require.Equal(t, map[string]string{"some-header-key": "some-value"}, prof.GRPCMeta)
 
 	// Back to toml and back to structure again, then deep equality check


### PR DESCRIPTION
## Problem

`ClientConfigProfile` in `contrib/envconfig` does not expose `ConnectionOptions.Authority`, which sets the gRPC `:authority` pseudo-header. This means users of the CLI's profile-based config (`--profile`) have no way to set `client-authority`.

## Solution

Add an `Authority string` field to `ClientConfigProfile` and wire it through:

- **TOML config**: `authority` key under a profile section
- **Environment variable**: `TEMPORAL_CLIENT_AUTHORITY`
- **Client options**: maps to `client.Options.ConnectionOptions.Authority`

Follows the exact same pattern as every other field on the profile (Address, Namespace, APIKey, etc).

Fixes #2369
Related CLI issue: temporalio/cli#1013