### PR TITLE
GHA Summary with failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,8 +179,8 @@ jobs:
       - name: Selected integration tests against cloud
         # Keep this list intentionally small. Add cloud-safe tests here when
         # they cover behavior that cannot be validated against the local dev server.
-        run: 'go test -v --count 1 -p 1 . -run "TestIntegrationSuite/(TestBasic|TestShutdownDuringActiveTimerActivityWorkflows)$"'
-        working-directory: test
+        run: 'go run . integration-test -p 1 -packages . -run "TestIntegrationSuite/(TestBasic|TestShutdownDuringActiveTimerActivityWorkflows)$"'
+        working-directory: ./internal/cmd/build
 
   features-test:
     uses: temporalio/features/.github/workflows/go.yaml@main

--- a/internal/cmd/build/main.go
+++ b/internal/cmd/build/main.go
@@ -16,6 +16,7 @@ import (
 	"runtime"
 	"sort"
 	"strings"
+	"sync"
 
 	_ "github.com/BurntSushi/toml"
 	_ "github.com/kisielk/errcheck/errcheck"
@@ -318,7 +319,7 @@ func (b *builder) runCmd(cmd *exec.Cmd) error {
 // runTestCmd runs a go test command while capturing output for the GitHub step
 // summary. Output is still streamed to stdout/stderr as the command runs.
 func (b *builder) runTestCmd(cmd *exec.Cmd) error {
-	var output bytes.Buffer
+	var output lockedBuffer
 	cmd.Stdout = io.MultiWriter(os.Stdout, &output)
 	cmd.Stderr = io.MultiWriter(os.Stderr, &output)
 	log.Printf("Running %v in %v with args %v", cmd.Path, cmd.Dir, cmd.Args[1:])
@@ -330,6 +331,23 @@ func (b *builder) runTestCmd(cmd *exec.Cmd) error {
 		}
 	}
 	return err
+}
+
+type lockedBuffer struct {
+	mu sync.Mutex
+	bytes.Buffer
+}
+
+func (b *lockedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.Buffer.Write(p)
+}
+
+func (b *lockedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.Buffer.String()
 }
 
 type testFailureSummaryRow struct {
@@ -409,19 +427,24 @@ func parseTestFailures(output string) []testFailureSummaryRow {
 }
 
 func filterParentFailureRows(rows []testFailureSummaryRow) []testFailureSummaryRow {
-	hasFailedSubtest := make(map[string]bool, len(rows))
+	hasFailedSubtest := make(map[testFailureSummaryKey]bool, len(rows))
 	for _, row := range rows {
 		if parent, _, ok := strings.Cut(row.Test, "/"); ok {
-			hasFailedSubtest[parent] = true
+			hasFailedSubtest[testFailureSummaryKey{Package: row.Package, Test: parent}] = true
 		}
 	}
 	filtered := rows[:0]
 	for _, row := range rows {
-		if !hasFailedSubtest[row.Test] {
+		if !hasFailedSubtest[testFailureSummaryKey{Package: row.Package, Test: row.Test}] {
 			filtered = append(filtered, row)
 		}
 	}
 	return filtered
+}
+
+type testFailureSummaryKey struct {
+	Package string
+	Test    string
 }
 
 func findMatchingRunLine(lines []string, before int, testName string) int {

--- a/internal/cmd/build/main.go
+++ b/internal/cmd/build/main.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"html"
+	"io"
 	"io/fs"
 	"log"
 	"os"
@@ -31,6 +33,7 @@ func main() {
 }
 
 const coverageDir = ".build/coverage"
+const githubStepSummaryMaxDetailBytes = 64 * 1024
 
 type builder struct {
 	thisDir string
@@ -92,6 +95,8 @@ func (b *builder) integrationTest() error {
 	// Supports some flags
 	flagSet := flag.NewFlagSet("integration-test", flag.ContinueOnError)
 	runFlag := flagSet.String("run", "", "Passed to go test as -run")
+	pFlag := flagSet.String("p", "", "Passed to go test as -p")
+	packagesFlag := flagSet.String("packages", "./...", "Packages passed to go test")
 	devServerFlag := flagSet.Bool("dev-server", false, "Use an embedded dev server")
 	coverageFileFlag := flagSet.String("coverage-file", "", "If set, enables coverage output to this filename")
 	if err := flagSet.Parse(os.Args[2:]); err != nil {
@@ -178,10 +183,13 @@ func (b *builder) integrationTest() error {
 	if *runFlag != "" {
 		args = append(args, "-run", *runFlag)
 	}
+	if *pFlag != "" {
+		args = append(args, "-p", *pFlag)
+	}
 	if *coverageFileFlag != "" {
 		args = append(args, "-coverprofile="+filepath.Join(b.rootDir, coverageDir, *coverageFileFlag), "-coverpkg=./...")
 	}
-	args = append(args, "./...")
+	args = append(args, strings.Fields(*packagesFlag)...)
 	if *devServerFlag {
 		args = append(args, "--", "-using-cli-dev-server")
 		env = append(env, "TEMPORAL_NAMESPACE=integration-test-namespace")
@@ -190,7 +198,7 @@ func (b *builder) integrationTest() error {
 	cmd := b.cmdFromRoot(args...)
 	cmd.Dir = filepath.Join(cmd.Dir, "test")
 	cmd.Env = env
-	if err := b.runCmd(cmd); err != nil {
+	if err := b.runTestCmd(cmd); err != nil {
 		return fmt.Errorf("integration test failed: %w", err)
 	}
 
@@ -286,7 +294,7 @@ func (b *builder) unitTest() error {
 		cmd := b.cmdFromRoot(args...)
 		// Need to run inside directory
 		cmd.Dir = filepath.Join(b.rootDir, testDir)
-		if err := b.runCmd(cmd); err != nil {
+		if err := b.runTestCmd(cmd); err != nil {
 			return fmt.Errorf("unit test failed in %v: %w", testDir, err)
 		}
 	}
@@ -305,6 +313,161 @@ func (b *builder) runCmd(cmd *exec.Cmd) error {
 	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
 	log.Printf("Running %v in %v with args %v", cmd.Path, cmd.Dir, cmd.Args[1:])
 	return cmd.Run()
+}
+
+// runTestCmd runs a go test command while capturing output for the GitHub step
+// summary. Output is still streamed to stdout/stderr as the command runs.
+func (b *builder) runTestCmd(cmd *exec.Cmd) error {
+	var output bytes.Buffer
+	cmd.Stdout = io.MultiWriter(os.Stdout, &output)
+	cmd.Stderr = io.MultiWriter(os.Stderr, &output)
+	log.Printf("Running %v in %v with args %v", cmd.Path, cmd.Dir, cmd.Args[1:])
+	err := cmd.Run()
+	if err != nil {
+		summaryErr := appendTestFailureSummary(os.Getenv("GITHUB_STEP_SUMMARY"), output.String())
+		if summaryErr != nil {
+			log.Printf("Failed writing test failure summary: %v", summaryErr)
+		}
+	}
+	return err
+}
+
+type testFailureSummaryRow struct {
+	Test    string
+	Package string
+	Details string
+}
+
+func appendTestFailureSummary(summaryPath, output string) error {
+	if summaryPath == "" {
+		return nil
+	}
+	rows := parseTestFailures(output)
+	if len(rows) == 0 {
+		return nil
+	}
+	f, err := os.OpenFile(summaryPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	_, err = f.WriteString(renderTestFailureSummary(rows))
+	return err
+}
+
+func parseTestFailures(output string) []testFailureSummaryRow {
+	lines := strings.Split(strings.ReplaceAll(output, "\r\n", "\n"), "\n")
+	rows := make([]testFailureSummaryRow, 0)
+	currentPackage := ""
+	packageStart := 0
+	for i := 0; i < len(lines); i++ {
+		line := lines[i]
+		if strings.HasPrefix(line, "FAIL\t") {
+			fields := strings.Fields(line)
+			if len(fields) >= 2 {
+				currentPackage = fields[1]
+				for rowIndex := packageStart; rowIndex < len(rows); rowIndex++ {
+					if rows[rowIndex].Package == "" {
+						rows[rowIndex].Package = currentPackage
+					}
+				}
+				packageStart = len(rows)
+			}
+			continue
+		}
+		const failPrefix = "--- FAIL: "
+		trimmedLine := strings.TrimLeft(line, " \t")
+		if !strings.HasPrefix(trimmedLine, failPrefix) {
+			continue
+		}
+		name := strings.TrimSpace(strings.TrimPrefix(trimmedLine, failPrefix))
+		if idx := strings.Index(name, " "); idx >= 0 {
+			name = name[:idx]
+		}
+		start := findMatchingRunLine(lines, i, name)
+		end := len(lines)
+		for j := start + 1; j < len(lines); j++ {
+			next := lines[j]
+			if isRunLine(next) || strings.HasPrefix(next, "FAIL\t") || strings.HasPrefix(next, "ok  \t") {
+				end = j
+				break
+			}
+		}
+		rows = append(rows, testFailureSummaryRow{
+			Test:    name,
+			Package: currentPackage,
+			Details: strings.Join(lines[start:end], "\n"),
+		})
+	}
+	sort.SliceStable(rows, func(i, j int) bool {
+		if rows[i].Package != rows[j].Package {
+			return rows[i].Package < rows[j].Package
+		}
+		return rows[i].Test < rows[j].Test
+	})
+	return filterParentFailureRows(rows)
+}
+
+func filterParentFailureRows(rows []testFailureSummaryRow) []testFailureSummaryRow {
+	hasFailedSubtest := make(map[string]bool, len(rows))
+	for _, row := range rows {
+		if parent, _, ok := strings.Cut(row.Test, "/"); ok {
+			hasFailedSubtest[parent] = true
+		}
+	}
+	filtered := rows[:0]
+	for _, row := range rows {
+		if !hasFailedSubtest[row.Test] {
+			filtered = append(filtered, row)
+		}
+	}
+	return filtered
+}
+
+func findMatchingRunLine(lines []string, before int, testName string) int {
+	for i := before - 1; i >= 0; i-- {
+		if testNameFromRunLine(lines[i]) == testName {
+			return i
+		}
+	}
+	return before
+}
+
+func testNameFromRunLine(line string) string {
+	fields := strings.Fields(strings.TrimLeft(line, " \t"))
+	if len(fields) != 3 || fields[0] != "===" || fields[1] != "RUN" {
+		return ""
+	}
+	return fields[2]
+}
+
+func isRunLine(line string) bool {
+	return strings.HasPrefix(strings.TrimLeft(line, " \t"), "=== RUN ")
+}
+
+func renderTestFailureSummary(rows []testFailureSummaryRow) string {
+	var sb strings.Builder
+	sb.WriteString("## Test failures\n\n")
+	sb.WriteString("<table>\n<tr><th>Kind</th><th>Test failure</th></tr>\n")
+	for _, row := range rows {
+		details := row.Details
+		if len(details) > githubStepSummaryMaxDetailBytes {
+			details = details[:githubStepSummaryMaxDetailBytes] + "\n... (truncated; see full job logs)"
+		}
+		title := row.Test
+		if row.Package != "" {
+			title = row.Package + " / " + title
+		}
+		fmt.Fprintf(
+			&sb,
+			"<tr><td>%s</td><td><details><summary>%s</summary><pre>%s</pre></details></td></tr>\n",
+			html.EscapeString("Failed"),
+			html.EscapeString(title),
+			html.EscapeString(details),
+		)
+	}
+	sb.WriteString("</table>\n\n")
+	return sb.String()
 }
 
 func (b *builder) getInstalledTool(modPath string) (string, error) {

--- a/internal/cmd/build/main_test.go
+++ b/internal/cmd/build/main_test.go
@@ -78,6 +78,24 @@ func TestRenderTestFailureSummaryEscapesHTML(t *testing.T) {
 	}
 }
 
+func TestFilterParentFailureRowsUsesPackage(t *testing.T) {
+	rows := filterParentFailureRows([]testFailureSummaryRow{
+		{Package: "example.com/a", Test: "TestSuite"},
+		{Package: "example.com/a", Test: "TestSuite/TestSub"},
+		{Package: "example.com/b", Test: "TestSuite"},
+	})
+
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 rows, got %d: %#v", len(rows), rows)
+	}
+	if rows[0].Package != "example.com/a" || rows[0].Test != "TestSuite/TestSub" {
+		t.Fatalf("expected package a subtest row first, got %#v", rows[0])
+	}
+	if rows[1].Package != "example.com/b" || rows[1].Test != "TestSuite" {
+		t.Fatalf("expected package b parent row to be preserved, got %#v", rows[1])
+	}
+}
+
 func TestAppendTestFailureSummary(t *testing.T) {
 	summaryPath := filepath.Join(t.TempDir(), "summary.md")
 	err := appendTestFailureSummary(summaryPath, strings.Join([]string{

--- a/internal/cmd/build/main_test.go
+++ b/internal/cmd/build/main_test.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseTestFailures(t *testing.T) {
+	output := strings.Join([]string{
+		"=== RUN   TestWorkflowSuite",
+		"=== RUN   TestWorkflowSuite/TestChildWorkflow",
+		"2026/05/28 19:18:39 INFO  Started Worker",
+		"    workflow_test.go:42: expected success",
+		"2026/05/28 19:18:50 INFO  Stopped Worker",
+		"--- FAIL: TestWorkflowSuite (0.01s)",
+		"    --- FAIL: TestWorkflowSuite/TestChildWorkflow (0.01s)",
+		"        workflow_test.go:42: expected success",
+		"=== RUN   TestWorkflowSuite/TestNextWorkflow",
+		"2026/05/28 19:19:01 INFO  Next test output",
+		"--- PASS: TestWorkflowSuite/TestNextWorkflow (0.01s)",
+		"FAIL",
+		"FAIL\tgo.temporal.io/sdk/internal\t0.123s",
+		"",
+	}, "\n")
+
+	rows := parseTestFailures(output)
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 failure row, got %d: %#v", len(rows), rows)
+	}
+	for _, row := range rows {
+		if row.Package != "go.temporal.io/sdk/internal" {
+			t.Fatalf("expected package to be filled from FAIL line, got %#v", row)
+		}
+	}
+	if rows[0].Test != "TestWorkflowSuite/TestChildWorkflow" {
+		t.Fatalf("unexpected test: %q", rows[0].Test)
+	}
+	if !strings.Contains(rows[0].Details, "expected success") {
+		t.Fatalf("expected detail block to include failure message, got %q", rows[0].Details)
+	}
+	for _, want := range []string{
+		"=== RUN   TestWorkflowSuite/TestChildWorkflow",
+		"Started Worker",
+		"Stopped Worker",
+	} {
+		if !strings.Contains(rows[0].Details, want) {
+			t.Fatalf("expected detail block to include %q, got %q", want, rows[0].Details)
+		}
+	}
+	if strings.Contains(rows[0].Details, "Next test output") {
+		t.Fatalf("expected detail block to stop before next test, got %q", rows[0].Details)
+	}
+}
+
+func TestRenderTestFailureSummaryEscapesHTML(t *testing.T) {
+	summary := renderTestFailureSummary([]testFailureSummaryRow{
+		{
+			Test:    "Test<Bad>",
+			Package: "go.temporal.io/sdk/test",
+			Details: "got <value> & failed",
+		},
+	})
+
+	for _, want := range []string{
+		"## Test failures",
+		"<table>",
+		"go.temporal.io/sdk/test / Test&lt;Bad&gt;",
+		"got &lt;value&gt; &amp; failed",
+	} {
+		if !strings.Contains(summary, want) {
+			t.Fatalf("summary missing %q:\n%s", want, summary)
+		}
+	}
+	if strings.Contains(summary, "Working directory") {
+		t.Fatalf("summary should not include working directory:\n%s", summary)
+	}
+}
+
+func TestAppendTestFailureSummary(t *testing.T) {
+	summaryPath := filepath.Join(t.TempDir(), "summary.md")
+	err := appendTestFailureSummary(summaryPath, strings.Join([]string{
+		"=== RUN   TestFailed",
+		"--- FAIL: TestFailed (0.00s)",
+		"    main_test.go:10: boom",
+		"FAIL",
+		"FAIL\texample.com/pkg\t0.001s",
+	}, "\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(summaryPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "example.com/pkg / TestFailed") {
+		t.Fatalf("summary not written correctly:\n%s", string(data))
+	}
+}


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->
Generate a summary page that gives more specific details on test failures.

Moved cloud test invocation over to use the same wrapper we use for other tests

## Why?
Hopefully saves us from clicking on each job and pressing CMD+F and searching "FAIL: " to see which test failed

Heavily took inspiration from https://github.com/temporalio/temporal/pull/9912. We don't use tools/testrunner, so our summary page is more general

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<img width="901" height="591" alt="image" src="https://github.com/user-attachments/assets/202ca755-1957-4cfe-ab07-46b13504217b" />

https://github.com/temporalio/sdk-go/actions/runs/26598600152?pr=2376

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and developer-tooling only; no SDK runtime or auth changes, with behavior covered by new parser/renderer tests.
> 
> **Overview**
> CI and the internal build wrapper now surface **failed `go test` output** on the GitHub Actions job summary, so reviewers can see which tests failed without digging through raw logs.
> 
> **`runTestCmd`** tees test stdout/stderr while streaming to the console; on failure it parses `--- FAIL:` lines (with package names from `FAIL\t` lines), drops redundant parent-suite rows when a subtest failed, caps detail size, HTML-escapes content, and appends a collapsible **Test failures** table to `GITHUB_STEP_SUMMARY`.
> 
> **`integration-test`** gains `-p` and `-packages` flags (forwarded to `go test`); unit and integration runs use `runTestCmd` instead of `runCmd`. The **cloud-test** job is switched from `go test` in `test/` to `go run . integration-test` from `internal/cmd/build` with `-p 1 -packages .` and the same `-run` filter.
> 
> New unit tests cover failure parsing, parent/subtest filtering, HTML escaping, and summary file append.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a062e3e3bd9055dda28c900bb24b4c09b39a9a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->