### PR TITLE
Upgrade SDK to v1.44.1

### DIFF
--- a/internal/version.go
+++ b/internal/version.go
@@ -8,7 +8,7 @@ const (
 	// Server validates if SDKVersion fits its supported range and rejects request if it doesn't.
 	//
 	// Exposed as: [go.temporal.io/sdk/temporal.SDKVersion]
-	SDKVersion = "1.44.0"
+	SDKVersion = "1.44.1"
 
 	// SDKName represents the name of the SDK.
 	SDKName = clientNameHeaderValue


### PR DESCRIPTION
New release

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single constant version string change with no logic, API, or security behavior changes.
> 
> **Overview**
> Bumps the embedded **Temporal Go SDK** semver from `1.44.0` to `1.44.1` in `internal/version.go`. That value is sent on RPC headers so the server can validate client compatibility; no other metadata or supported-server range changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81a4a08a8df6209296967061f7b808c4d1812884. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->