### PR TITLE
Add Standalone Activity support to Temporal Nexus Operation Handler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,6 +169,7 @@ jobs:
           DISABLE_PRIORITY_TESTS: "1"
           DISABLE_STANDALONE_ACTIVITY_TESTS: "1"
           DISABLE_STANDALONE_NEXUS_TESTS: "1"
+          DISABLE_ACTIVITY_BACKED_NEXUS_TESTS: "1"
           DISABLE_NEXUS_CALLER_TIMEOUT_TESTS: "1"
           DISABLE_NEW_NEXUS_ERROR_FORMAT_TESTS: "1"
         working-directory: ./internal/cmd/build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,9 @@ to docs, or any other relevant information.
 - Resource-based tuner: `TryReserveSlot` (used for eager task dispatch) no longer blocks for up to
   `RampThrottle` while a concurrent `ReserveSlot` waits out the ramp throttle. The throttle behavior
   is unchanged; only the unnecessary lock contention on the eager path is removed.
+- Stand-alone activity-backed Nexus operations. `temporalnexus.MustNewTemporalOperation` can now
+  back an async Nexus operation with a stand-alone activity execution via `StartActivity` /
+  `StartUntypedActivity`. Activity-backed Nexus operations are also supported in `TestWorkflowEnvironment`.
 
 ## [1.46.0] - 2026-07-07
 

--- a/internal/cmd/build/main.go
+++ b/internal/cmd/build/main.go
@@ -169,6 +169,7 @@ func (b *builder) integrationTest() error {
 				"--dynamic-config-value", "frontend.ListWorkersEnabled=true",
 				"--dynamic-config-value", "activity.startDelayEnabled=true",
 				"--dynamic-config-value", "history.enableUpdateCallbacks=true",
+				"--dynamic-config-value", "activity.enableCallbacks=true",
 			},
 		})
 		if err != nil {

--- a/internal/error_test.go
+++ b/internal/error_test.go
@@ -1461,11 +1461,14 @@ func TestHandlerError_EncodeCommonAttributes_MultipleRoundTrips(t *testing.T) {
 	// This test verifies that common attributes (message, stack trace) are preserved
 	// even when passing through a converter that doesn't doesn't have the right codec
 
-	// Create a converter that encodes common attributes
+	// Create a converter that encodes common attributes. AlwaysEncode ensures the zlib codec
+	// actually replaces the payload — for very small inputs zlib falls back to the original
+	// payload, which would let the codec-less middle converter decode the attributes and
+	// defeat the round-trip preservation being tested here.
 	encodingConverter := NewDefaultFailureConverter(DefaultFailureConverterOptions{
 		DataConverter: converter.NewCodecDataConverter(
 			converter.GetDefaultDataConverter(),
-			converter.NewZlibCodec(converter.ZlibCodecOptions{}),
+			converter.NewZlibCodec(converter.ZlibCodecOptions{AlwaysEncode: true}),
 		),
 		EncodeCommonAttributes: true,
 	})

--- a/internal/internal_activity_client.go
+++ b/internal/internal_activity_client.go
@@ -112,6 +112,28 @@ type (
 		Priority Priority
 		// StartDelay - Time to wait before dispatching the activity. This delay is not applied to retry attempts.
 		StartDelay time.Duration
+
+		// responseInfo holds the response Link populated by the server when the activity is started.
+		// Only settable by the SDK - e.g. [temporalnexus.temporalOperation].
+		responseInfo *startActivityResponseInfo
+		// requestID is the request ID used to dedup retried starts.
+		// Only settable by the SDK - e.g. [temporalnexus.temporalOperation].
+		requestID string
+		// callbacks is the set of completion callbacks the server should invoke when the activity
+		// reaches a terminal state. Only settable by the SDK - e.g. [temporalnexus.temporalOperation].
+		callbacks []*commonpb.Callback
+		// links to be associated with the activity. Only settable by the SDK - e.g. [temporalnexus.temporalOperation].
+		links []*commonpb.Link
+		// onConflictOptions configures behavior when ActivityIdConflictPolicy is USE_EXISTING and an
+		// activity with the same ID is already running. Only settable by the SDK - e.g. [temporalnexus.temporalOperation].
+		onConflictOptions *OnConflictOptions
+	}
+
+	// startActivityResponseInfo can be populated by the SDK to receive additional fields from the
+	// StartActivityExecution response. Only settable by the SDK.
+	startActivityResponseInfo struct {
+		// Link to the started activity event.
+		Link *commonpb.Link
 	}
 
 	// ClientGetActivityHandleOptions contains input for GetActivityHandle call.
@@ -610,6 +632,9 @@ func (w *workflowClientInterceptor) ExecuteActivity(
 	} else {
 		runID = resp.RunId
 	}
+	if in.Options.responseInfo != nil {
+		in.Options.responseInfo.Link = resp.Link
+	}
 
 	return &clientActivityHandleImpl{
 		client: w.client,
@@ -656,7 +681,68 @@ func (options *ClientStartActivityOptions) validateAndSetInRequest(request *work
 	request.UserMetadata = userMetadata
 	request.Priority = convertToPBPriority(options.Priority)
 	request.StartDelay = durationpb.New(options.StartDelay)
+	if options.requestID != "" {
+		request.RequestId = options.requestID
+	}
+	request.CompletionCallbacks = options.callbacks
+	request.Links = options.links
+	if options.onConflictOptions != nil {
+		request.OnConflictOptions = &commonpb.OnConflictOptions{
+			AttachRequestId:           options.onConflictOptions.AttachRequestID,
+			AttachCompletionCallbacks: options.onConflictOptions.AttachCompletionCallbacks,
+			AttachLinks:               options.onConflictOptions.AttachLinks,
+		}
+	}
 	return nil
+}
+
+// SetRequestIDOnStartActivityOptions is an internal-only method for setting the request ID on
+// ClientStartActivityOptions. Used by [temporalnexus.temporalOperation] for retry idempotency.
+func SetRequestIDOnStartActivityOptions(opts *ClientStartActivityOptions, requestID string) {
+	opts.requestID = requestID
+}
+
+// SetCallbacksOnStartActivityOptions is an internal-only method for setting completion callbacks on
+// ClientStartActivityOptions. Callbacks are purposefully not exposed to users for the time being.
+func SetCallbacksOnStartActivityOptions(opts *ClientStartActivityOptions, callbacks []*commonpb.Callback) {
+	opts.callbacks = callbacks
+}
+
+// SetLinksOnStartActivityOptions is an internal-only method for setting links on
+// ClientStartActivityOptions. Links are purposefully not exposed to users for the time being.
+func SetLinksOnStartActivityOptions(opts *ClientStartActivityOptions, links []*commonpb.Link) {
+	opts.links = links
+}
+
+// SetOnConflictOptionsOnStartActivityOptions is an internal-only method for setting on-conflict
+// options on ClientStartActivityOptions. Used to ensure that when an activity with the same ID is
+// already running and the conflict policy is USE_EXISTING, the caller's request ID, callback, and
+// links are attached to the existing activity.
+func SetOnConflictOptionsOnStartActivityOptions(opts *ClientStartActivityOptions) {
+	opts.onConflictOptions = &OnConflictOptions{
+		AttachRequestID:           true,
+		AttachCompletionCallbacks: true,
+		AttachLinks:               true,
+	}
+}
+
+// SetResponseInfoOnStartActivityOptions is an internal-only method for setting a response info
+// pointer on ClientStartActivityOptions. The returned pointer is populated by ExecuteActivity with
+// the start response's Link.
+func SetResponseInfoOnStartActivityOptions(opts *ClientStartActivityOptions) *startActivityResponseInfo {
+	if opts.responseInfo == nil {
+		opts.responseInfo = &startActivityResponseInfo{}
+	}
+	return opts.responseInfo
+}
+
+// GetResponseLinkFromStartActivityResponseInfo returns the activity start Link captured from the
+// server response, or nil if none was captured.
+func GetResponseLinkFromStartActivityResponseInfo(info *startActivityResponseInfo) *commonpb.Link {
+	if info == nil {
+		return nil
+	}
+	return info.Link
 }
 
 func (w *workflowClientInterceptor) GetActivityHandle(

--- a/internal/link_converter.go
+++ b/internal/link_converter.go
@@ -22,9 +22,11 @@ const (
 	urlPathNamespaceKey           = "namespace"
 	urlPathWorkflowIDKey          = "workflowID"
 	urlPathOperationIDKey         = "operationID"
+	urlPathActivityIDKey          = "activityID"
 	urlPathRunIDKey               = "runID"
 	urlPathWorkflowEventTemplate  = "/namespaces/%s/workflows/%s/%s/history"
 	urlPathNexusOperationTemplate = "/namespaces/%s/nexus-operations/%s/%s/details"
+	urlPathActivityTemplate       = "/namespaces/%s/activities/%s/%s/details"
 
 	linkWorkflowEventReferenceTypeKey = "referenceType"
 	linkEventIDKey                    = "eventID"
@@ -47,6 +49,13 @@ var (
 		`^/namespaces/%s/nexus-operations/%s/%s/details$`,
 		rePatternNamespace,
 		rePatternOperationID,
+		rePatternRunID,
+	))
+	rePatternActivityID = fmt.Sprintf(`(?P<%s>[^/]+)`, urlPathActivityIDKey)
+	urlPathActivityRE   = regexp.MustCompile(fmt.Sprintf(
+		`^/namespaces/%s/activities/%s/%s/details$`,
+		rePatternNamespace,
+		rePatternActivityID,
 		rePatternRunID,
 	))
 	eventReferenceType     = string((&commonpb.Link_WorkflowEvent_EventReference{}).ProtoReflect().Descriptor().Name())
@@ -237,6 +246,64 @@ func ConvertNexusLinkToLinkNexusOperation(link nexus.Link) (*commonpb.Link_Nexus
 	}
 
 	return no, nil
+}
+
+// ConvertLinkActivityToNexusLink converts a Link_Activity type to a Nexus Link.
+//
+// NOTE: Experimental
+func ConvertLinkActivityToNexusLink(a *commonpb.Link_Activity) nexus.Link {
+	u := &url.URL{
+		Scheme: urlSchemeTemporalKey,
+		Path:   fmt.Sprintf(urlPathActivityTemplate, a.GetNamespace(), a.GetActivityId(), a.GetRunId()),
+		RawPath: fmt.Sprintf(
+			urlPathActivityTemplate,
+			url.PathEscape(a.GetNamespace()),
+			url.PathEscape(a.GetActivityId()),
+			url.PathEscape(a.GetRunId()),
+		),
+	}
+	return nexus.Link{
+		URL:  u,
+		Type: string(a.ProtoReflect().Descriptor().FullName()),
+	}
+}
+
+// ConvertNexusLinkToLinkActivity converts a Nexus Link back to a Link_Activity.
+//
+// NOTE: Experimental
+func ConvertNexusLinkToLinkActivity(link nexus.Link) (*commonpb.Link_Activity, error) {
+	a := &commonpb.Link_Activity{}
+	if link.Type != string(a.ProtoReflect().Descriptor().FullName()) {
+		return nil, fmt.Errorf(
+			"cannot parse link type %q to %q",
+			link.Type,
+			a.ProtoReflect().Descriptor().FullName(),
+		)
+	}
+	if link.URL == nil {
+		return nil, fmt.Errorf("failed to parse link to Link_Activity: empty URL")
+	}
+	if link.URL.Scheme != urlSchemeTemporalKey {
+		return nil, fmt.Errorf("failed to parse link to Link_Activity: invalid scheme: %s", link.URL.Scheme)
+	}
+	matches := urlPathActivityRE.FindStringSubmatch(link.URL.EscapedPath())
+	if len(matches) != 4 {
+		return nil, fmt.Errorf("failed to parse link to Link_Activity: malformed URL path")
+	}
+	var err error
+	a.Namespace, err = url.PathUnescape(matches[urlPathActivityRE.SubexpIndex(urlPathNamespaceKey)])
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse link to Link_Activity: %w", err)
+	}
+	a.ActivityId, err = url.PathUnescape(matches[urlPathActivityRE.SubexpIndex(urlPathActivityIDKey)])
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse link to Link_Activity: %w", err)
+	}
+	a.RunId, err = url.PathUnescape(matches[urlPathActivityRE.SubexpIndex(urlPathRunIDKey)])
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse link to Link_Activity: %w", err)
+	}
+	return a, nil
 }
 
 func convertLinkWorkflowEventEventReferenceToURLQuery(eventRef *commonpb.Link_WorkflowEvent_EventReference) string {

--- a/internal/nexus_operations.go
+++ b/internal/nexus_operations.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"sync"
 
+	"github.com/google/uuid"
 	"github.com/nexus-rpc/sdk-go/nexus"
 	commonpb "go.temporal.io/api/common/v1"
 	"go.temporal.io/api/enums/v1"
@@ -80,6 +81,18 @@ func (nc *NexusOperationContext) ResponseLinks() []*commonpb.Link {
 
 func (nc *NexusOperationContext) ResolveWorkflowName(wf any) (string, error) {
 	return getWorkflowFunctionName(nc.registry, wf)
+}
+
+// ResolveActivityName returns the registered name of the given activity function reference (or
+// string name) by consulting the worker's registry, so that activities registered under a custom
+// name via [RegisterActivityOptions.Name] are resolved to that name rather than the raw Go
+// function name.
+func (nc *NexusOperationContext) ResolveActivityName(activity any, args []any) (string, error) {
+	at, err := getValidatedActivityFunction(activity, args, nc.registry)
+	if err != nil {
+		return "", err
+	}
+	return at.Name, nil
 }
 
 type nexusOperationEnvironment struct {
@@ -804,11 +817,126 @@ func (t *testSuiteClientForNexusOperations) UpdateWorkerVersioningRules(ctx cont
 }
 
 func (t *testSuiteClientForNexusOperations) ExecuteActivity(ctx context.Context, options ClientStartActivityOptions, activity any, args ...any) (ClientActivityHandle, error) {
-	panic("unimplemented in the test environment")
+	if set, ok := ctx.Value(IsWorkflowRunOpContextKey).(bool); !ok || !set {
+		panic("not implemented in the test environment")
+	}
+	if options.ID == "" {
+		return nil, fmt.Errorf("activity ID is required")
+	}
+	activityType, err := getValidatedActivityFunction(activity, args, t.env.GetRegistry())
+	if err != nil {
+		return nil, fmt.Errorf("cannot validate activity function: %w", err)
+	}
+	input, err := encodeArgs(t.env.dataConverter, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot encode activity args: %w", err)
+	}
+
+	var callback *commonpb.Callback
+	if len(options.callbacks) > 0 {
+		callback = options.callbacks[0]
+	}
+
+	taskQueue := options.TaskQueue
+	if taskQueue == "" {
+		taskQueue = t.env.workflowInfo.TaskQueueName
+	}
+
+	activityID := options.ID
+	runID := uuid.NewString()
+
+	if options.responseInfo != nil {
+		options.responseInfo.Link = &commonpb.Link{
+			Variant: &commonpb.Link_Activity_{
+				Activity: &commonpb.Link_Activity{
+					Namespace:  t.env.workflowInfo.Namespace,
+					ActivityId: activityID,
+					RunId:      runID,
+				},
+			},
+		}
+	}
+
+	params := ExecuteActivityParams{
+		ExecuteActivityOptions: ExecuteActivityOptions{
+			ActivityID:             activityID,
+			TaskQueueName:          taskQueue,
+			ScheduleToCloseTimeout: options.ScheduleToCloseTimeout,
+			ScheduleToStartTimeout: options.ScheduleToStartTimeout,
+			StartToCloseTimeout:    options.StartToCloseTimeout,
+			HeartbeatTimeout:       options.HeartbeatTimeout,
+			RetryPolicy:            convertToPBRetryPolicy(options.RetryPolicy),
+		},
+		ActivityType:  *activityType,
+		Input:         input,
+		DataConverter: t.env.dataConverter,
+	}
+
+	t.env.postCallback(func() {
+		t.env.ExecuteActivity(params, func(result *commonpb.Payloads, actErr error) {
+			if callback == nil {
+				return
+			}
+			ncb := callback.GetNexus()
+			if ncb == nil {
+				return
+			}
+			seqStr := ncb.GetHeader()["operation-sequence"]
+			if seqStr == "" {
+				return
+			}
+			seq, err := strconv.ParseInt(seqStr, 10, 64)
+			if err != nil {
+				panic(fmt.Errorf("unexpected operation sequence in callback header: %s: %w", seqStr, err))
+			}
+			operationToken := ncb.GetHeader()[nexus.HeaderOperationToken]
+			var payload *commonpb.Payload
+			if len(result.GetPayloads()) > 0 {
+				payload = result.Payloads[0]
+			}
+			t.env.resolveNexusOperation(seq, operationToken, payload, actErr)
+		})
+	}, false)
+
+	return &testEnvActivityHandleForNexusOperations{
+		env:   t.env,
+		id:    activityID,
+		runID: runID,
+	}, nil
 }
 
 func (t *testSuiteClientForNexusOperations) GetActivityHandle(options ClientGetActivityHandleOptions) ClientActivityHandle {
-	panic("unimplemented in the test environment")
+	return &testEnvActivityHandleForNexusOperations{
+		env:   t.env,
+		id:    options.ActivityID,
+		runID: options.RunID,
+	}
+}
+
+type testEnvActivityHandleForNexusOperations struct {
+	env   *testWorkflowEnvironmentImpl
+	id    string
+	runID string
+}
+
+func (h *testEnvActivityHandleForNexusOperations) GetID() string    { return h.id }
+func (h *testEnvActivityHandleForNexusOperations) GetRunID() string { return h.runID }
+
+func (h *testEnvActivityHandleForNexusOperations) Cancel(ctx context.Context, options ClientCancelActivityOptions) error {
+	h.env.RequestCancelActivity(ActivityID{id: h.id})
+	return nil
+}
+
+func (h *testEnvActivityHandleForNexusOperations) Get(ctx context.Context, valuePtr any) error {
+	panic("not implemented in the test environment")
+}
+
+func (h *testEnvActivityHandleForNexusOperations) Describe(ctx context.Context, options ClientDescribeActivityOptions) (*ClientActivityExecutionDescription, error) {
+	panic("not implemented in the test environment")
+}
+
+func (h *testEnvActivityHandleForNexusOperations) Terminate(ctx context.Context, options ClientTerminateActivityOptions) error {
+	panic("not implemented in the test environment")
 }
 
 func (t *testSuiteClientForNexusOperations) ListActivities(ctx context.Context, options ClientListActivitiesOptions) (ClientListActivitiesResult, error) {

--- a/temporalnexus/link_converter.go
+++ b/temporalnexus/link_converter.go
@@ -59,3 +59,17 @@ func ConvertCommonLinkToNexusLink(commonLink *commonpb.Link) nexus.Link {
 		return nexus.Link{}
 	}
 }
+
+// ConvertLinkActivityToNexusLink converts a Link_Activity type to a Nexus Link.
+//
+// NOTE: Experimental
+func ConvertLinkActivityToNexusLink(a *commonpb.Link_Activity) nexus.Link {
+	return internal.ConvertLinkActivityToNexusLink(a)
+}
+
+// ConvertNexusLinkToLinkActivity converts a Nexus Link back to a Link_Activity.
+//
+// NOTE: Experimental
+func ConvertNexusLinkToLinkActivity(link nexus.Link) (*commonpb.Link_Activity, error) {
+	return internal.ConvertNexusLinkToLinkActivity(link)
+}

--- a/temporalnexus/operation.go
+++ b/temporalnexus/operation.go
@@ -383,6 +383,16 @@ func convertNexusLinks(nexusLinks []nexus.Link, log log.Logger) ([]*common.Link,
 					WorkflowEvent: link,
 				},
 			})
+		case string((&common.Link_Activity{}).ProtoReflect().Descriptor().FullName()):
+			link, err := ConvertNexusLinkToLinkActivity(nexusLink)
+			if err != nil {
+				return nil, err
+			}
+			links = append(links, &common.Link{
+				Variant: &common.Link_Activity_{
+					Activity: link,
+				},
+			})
 		case string((&common.Link_NexusOperation{}).ProtoReflect().Descriptor().FullName()):
 			link, err := ConvertNexusLinkToLinkNexusOperation(nexusLink)
 			if err != nil {

--- a/temporalnexus/temporal_operation.go
+++ b/temporalnexus/temporal_operation.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/nexus-rpc/sdk-go/nexus"
-	"go.temporal.io/api/common/v1"
+	commonpb "go.temporal.io/api/common/v1"
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/internal"
 	"go.temporal.io/sdk/workflow"
@@ -20,6 +20,8 @@ var (
 		Cause: errors.New("cannot cancel an UpdateWorkflow operation"),
 	}
 )
+
+const errMultipleAsyncOperationsMsg = "only one async operation can be started per operation invocation"
 
 // StartTemporalOperationOptions are options provided to the Start callback of a Temporal Nexus operation.
 // Mirrors [nexus.StartOperationOptions].
@@ -62,6 +64,18 @@ type CancelTemporalUpdateWorkflowOptions struct {
 	// UpdateID to be cancelled.
 	UpdateID string
 	// RunID of the workflow
+	RunID string
+}
+
+// CancelTemporalActivityExecutionOptions are options provided to the CancelActivityExecution
+// callback of a Temporal Nexus operation.
+//
+// NOTE: Experimental
+type CancelTemporalActivityExecutionOptions struct {
+	// ActivityID extracted from the operation token.
+	ActivityID string
+	// RunID extracted from the operation token. May be empty for tokens generated before the
+	// activity was started (e.g. callback tokens).
 	RunID string
 }
 
@@ -160,7 +174,7 @@ func StartUntypedWorkflow[R any](
 	args ...any,
 ) (TemporalOperationResult[R], error) {
 	if nc.asyncStarted != nil && !nc.asyncStarted.CompareAndSwap(false, true) {
-		return TemporalOperationResult[R]{}, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "only one async operation can be started per operation invocation")
+		return TemporalOperationResult[R]{}, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, errMultipleAsyncOperationsMsg)
 	}
 
 	// Prevent the test env client from panicking when we try to use it from an operation.
@@ -219,7 +233,7 @@ func StartUpdateWorkflow[R any](
 	}
 	if !nc.asyncStarted.CompareAndSwap(false, true) {
 		return TemporalOperationResult[R]{}, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest,
-			"only one async operation can be started per operation invocation")
+			errMultipleAsyncOperationsMsg)
 	}
 	defer func() {
 		if opFailed {
@@ -249,10 +263,10 @@ func StartUpdateWorkflow[R any](
 		header = make(nexus.Header)
 	}
 	header.Set(nexus.HeaderOperationToken, token)
-	internal.SetCallbacksOnNexusOperation(&updateWorkflowOptions, []*common.Callback{
+	internal.SetCallbacksOnNexusOperation(&updateWorkflowOptions, []*commonpb.Callback{
 		{
-			Variant: &common.Callback_Nexus_{
-				Nexus: &common.Callback_Nexus{
+			Variant: &commonpb.Callback_Nexus_{
+				Nexus: &commonpb.Callback_Nexus{
 					Url:    nc.startOperationOptions.CallbackURL,
 					Header: header,
 				},
@@ -324,6 +338,149 @@ func validateUpdateWorkflowNexusOperation(u client.UpdateWorkflowOptions) error 
 	}
 }
 
+// StartActivity schedules a stand-alone activity execution for a Nexus operation and returns an
+// async result with an activity-execution operation token.
+//
+// The activity parameter must have the signature func(context.Context, I) (O, error). For
+// activities that don't follow this signature, use [StartUntypedActivity].
+//
+// activityOpts must specify an ID and at least one of StartToCloseTimeout
+// or ScheduleToCloseTimeout. TaskQueue defaults to the current worker's task queue when empty.
+//
+// These are free functions because Go does not allow generic methods on non-generic structs.
+func StartActivity[I, O any, AF func(context.Context, I) (O, error)](
+	ctx context.Context,
+	nc NexusClient,
+	activityOpts client.StartActivityOptions,
+	activity AF,
+	arg I,
+) (TemporalOperationResult[O], error) {
+	return StartUntypedActivity[O](ctx, nc, activityOpts, activity, arg)
+}
+
+// StartUntypedActivity schedules a stand-alone activity execution for a Nexus operation by
+// activity function reference or string name. It always returns an async result with an
+// activity-execution operation token.
+//
+// Automatically propagates the callback, links, and request ID from the Nexus operation options
+// to the activity start request.
+//
+// See [StartActivity] for the type-safe variant.
+func StartUntypedActivity[R any](
+	ctx context.Context,
+	nc NexusClient,
+	activityOpts client.StartActivityOptions,
+	activity any,
+	args ...any,
+) (TemporalOperationResult[R], error) {
+	if nc.asyncStarted != nil && !nc.asyncStarted.CompareAndSwap(false, true) {
+		return TemporalOperationResult[R]{}, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, errMultipleAsyncOperationsMsg)
+	}
+	ctx = context.WithValue(ctx, internal.IsWorkflowRunOpContextKey, true)
+
+	result, err := startActivity[R](ctx, nc.client, nc.startOperationOptions, activityOpts, activity, args...)
+	if err != nil {
+		if nc.asyncStarted != nil {
+			nc.asyncStarted.Store(false)
+		}
+		return TemporalOperationResult[R]{}, err
+	}
+	return result, nil
+}
+
+func startActivity[R any](
+	ctx context.Context,
+	c client.Client,
+	nexusOptions nexus.StartOperationOptions,
+	activityOpts client.StartActivityOptions,
+	activity any,
+	args ...any,
+) (TemporalOperationResult[R], error) {
+	nctx, ok := internal.NexusOperationContextFromGoContext(ctx)
+	if !ok {
+		return TemporalOperationResult[R]{}, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeInternal, "internal error")
+	}
+
+	// Resolve the activity name against the worker's registry so that activities registered under
+	// a custom name are dispatched with that name. The underlying client registry does not have
+	// the worker's activity registrations, so resolving here is required for aliasing to work.
+	activityType, err := nctx.ResolveActivityName(activity, args)
+	if err != nil {
+		return TemporalOperationResult[R]{}, err
+	}
+
+	if activityOpts.TaskQueue == "" {
+		activityOpts.TaskQueue = nctx.TaskQueue
+	}
+	if activityOpts.ScheduleToCloseTimeout == 0 && activityOpts.StartToCloseTimeout == 0 {
+		return TemporalOperationResult[R]{}, &nexus.HandlerError{
+			Type:    nexus.HandlerErrorTypeBadRequest,
+			Message: "at least one of StartToCloseTimeout or ScheduleToCloseTimeout is required",
+		}
+	}
+
+	if nexusOptions.RequestID != "" {
+		internal.SetRequestIDOnStartActivityOptions(&activityOpts, nexusOptions.RequestID)
+	}
+
+	links, err := convertNexusLinks(nexusOptions.Links, GetLogger(ctx))
+	if err != nil {
+		return TemporalOperationResult[R]{}, &nexus.HandlerError{
+			Type:    nexus.HandlerErrorTypeBadRequest,
+			Message: "could not convert links for activity start",
+			Cause:   err,
+		}
+	}
+
+	if nexusOptions.CallbackURL != "" {
+		// Callback token is generated without a run ID since the activity hasn't started yet.
+		callbackToken, err := generateActivityExecutionOperationToken(nctx.Namespace, activityOpts.ID, "")
+		if err != nil {
+			return TemporalOperationResult[R]{}, err
+		}
+		if nexusOptions.CallbackHeader == nil {
+			nexusOptions.CallbackHeader = make(nexus.Header)
+		}
+		nexusOptions.CallbackHeader.Set(nexus.HeaderOperationToken, callbackToken)
+		internal.SetCallbacksOnStartActivityOptions(&activityOpts, []*commonpb.Callback{
+			{
+				Variant: &commonpb.Callback_Nexus_{
+					Nexus: &commonpb.Callback_Nexus{
+						Url:    nexusOptions.CallbackURL,
+						Header: nexusOptions.CallbackHeader,
+					},
+				},
+				Links: links,
+			},
+		})
+	}
+
+	// Duplicated in links to be compatible with older servers that don't read links from callbacks.
+	internal.SetLinksOnStartActivityOptions(&activityOpts, links)
+	internal.SetOnConflictOptionsOnStartActivityOptions(&activityOpts)
+	responseInfo := internal.SetResponseInfoOnStartActivityOptions(&activityOpts)
+
+	handle, err := c.ExecuteActivity(ctx, activityOpts, activityType, args...)
+	if err != nil {
+		return TemporalOperationResult[R]{}, err
+	}
+	encodedToken, err := generateActivityExecutionOperationToken(nctx.Namespace, handle.GetID(), handle.GetRunID())
+	if err != nil {
+		return TemporalOperationResult[R]{}, err
+	}
+
+	activityLink := internal.GetResponseLinkFromStartActivityResponseInfo(responseInfo).GetActivity()
+	if activityLink == nil {
+		activityLink = &commonpb.Link_Activity{
+			Namespace:  nctx.Namespace,
+			ActivityId: handle.GetID(),
+			RunId:      handle.GetRunID(),
+		}
+	}
+	nexus.AddHandlerLinks(ctx, ConvertLinkActivityToNexusLink(activityLink))
+	return NewAsyncResult[R](encodedToken), nil
+}
+
 // TemporalOperationOptions configures a generic Temporal Nexus operation.
 //
 // Asynchronous workflow-backed operation:
@@ -362,6 +519,10 @@ type TemporalOperationOptions[I, O any] struct {
 	// It receives the Temporal client, the update-workflow options extracted from the token, and the
 	// Nexus cancel options. If nil, will error out with [ErrCannotCancelWorkflowUpdate] as there is no default behavior for cancelling an UpdateWorkflow.
 	CancelWorkflowUpdate func(ctx context.Context, c client.Client, options CancelTemporalUpdateWorkflowOptions, cancelOptions nexus.CancelOperationOptions) error
+	// CancelActivityExecution handles cancel for activity-execution operation tokens.
+	// It receives the Temporal client, the activity-execution options extracted from the token, and
+	// the Nexus cancel options. If nil, defaults to cancelling the activity via the Temporal client.
+	CancelActivityExecution func(ctx context.Context, c client.Client, options CancelTemporalActivityExecutionOptions, cancelOptions nexus.CancelOperationOptions) error
 }
 
 // NewTemporalOperation creates a generic Nexus operation backed by Temporal.
@@ -383,6 +544,9 @@ func NewTemporalOperation[I, O any](opts TemporalOperationOptions[I, O]) (nexus.
 	}
 	if opts.CancelWorkflowUpdate == nil {
 		opts.CancelWorkflowUpdate = defaultCancelWorkflowUpdate
+	}
+	if opts.CancelActivityExecution == nil {
+		opts.CancelActivityExecution = defaultCancelActivityExecution
 	}
 	return &temporalOperation[I, O]{options: opts}, nil
 }
@@ -407,6 +571,15 @@ func defaultCancelWorkflowRun(ctx context.Context, c client.Client, options Canc
 // default cancel function for UpdateWorkflow returns an error
 func defaultCancelWorkflowUpdate(ctx context.Context, c client.Client, options CancelTemporalUpdateWorkflowOptions, _ nexus.CancelOperationOptions) error {
 	return ErrCannotCancelWorkflowUpdate
+}
+
+// defaultCancelActivityExecution is the default cancel handler for activity-execution operation tokens.
+func defaultCancelActivityExecution(ctx context.Context, c client.Client, options CancelTemporalActivityExecutionOptions, _ nexus.CancelOperationOptions) error {
+	handle := c.GetActivityHandle(client.GetActivityHandleOptions{
+		ActivityID: options.ActivityID,
+		RunID:      options.RunID,
+	})
+	return handle.Cancel(ctx, client.CancelActivityOptions{})
 }
 
 // temporalOperation implements nexus.Operation[I, O] for a generic Temporal-backed operation.
@@ -497,6 +670,19 @@ func (o *temporalOperation[I, O]) Cancel(ctx context.Context, token string, opti
 			WorkflowID: uwfToken.WorkflowID,
 			RunID:      uwfToken.RunID,
 			UpdateID:   uwfToken.UpdateID,
+		}, options)
+	case operationTokenTypeActivityExecution:
+		actToken, err := loadActivityExecutionOperationToken(token)
+		if err != nil {
+			return &nexus.HandlerError{
+				Type:    nexus.HandlerErrorTypeBadRequest,
+				Message: "invalid operation token",
+				Cause:   err,
+			}
+		}
+		return o.options.CancelActivityExecution(ctx, GetClient(ctx), CancelTemporalActivityExecutionOptions{
+			ActivityID: actToken.ActivityID,
+			RunID:      actToken.RunID,
 		}, options)
 	default:
 		return nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "unknown operation token type: %d", tokenType)

--- a/temporalnexus/temporal_operation_test.go
+++ b/temporalnexus/temporal_operation_test.go
@@ -115,6 +115,12 @@ func TestLoadTokenType(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, operationTokenTypeWorkflowRun, tokenType)
 
+	// Valid type=2 (activity execution)
+	activityToken := base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString([]byte(`{"t":2,"ns":"ns","aid":"a"}`))
+	tokenType, err = loadTokenType(activityToken)
+	require.NoError(t, err)
+	require.Equal(t, operationTokenTypeActivityExecution, tokenType)
+
 	// Unknown type=99
 	unknownToken := base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString([]byte(`{"t":99}`))
 	_, err = loadTokenType(unknownToken)
@@ -137,6 +143,18 @@ func TestLoadTokenType(t *testing.T) {
 	missingType := base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString([]byte(`{"ns":"ns"}`))
 	_, err = loadTokenType(missingType)
 	require.ErrorContains(t, err, "invalid operation token: 0")
+}
+
+func TestNewTemporalOperationDefaultsCancelActivityExecution(t *testing.T) {
+	opAny, err := NewTemporalOperation(TemporalOperationOptions[string, string]{
+		Name: "test",
+		Start: func(ctx context.Context, nc NexusClient, input string, opts StartTemporalOperationOptions) (TemporalOperationResult[string], error) {
+			return NewSyncResult("ok"), nil
+		},
+	})
+	require.NoError(t, err)
+	op := opAny.(*temporalOperation[string, string])
+	require.NotNil(t, op.options.CancelActivityExecution)
 }
 
 func TestDoubleStartGuard(t *testing.T) {

--- a/temporalnexus/token.go
+++ b/temporalnexus/token.go
@@ -12,16 +12,13 @@ type operationTokenType int
 const (
 	operationTokenTypeReserved operationTokenType = iota
 	operationTokenTypeWorkflowRun
-	operationTokenTypeActivity
+	operationTokenTypeActivityExecution
 	operationTokenTypeUpdateWorkflow
 	// also Update With Start, Get Workflow Result, Stand Alone Activities
 	operationTokenTypeMaxVal
 )
 
 func (o operationTokenType) IsValid() bool {
-	if o == operationTokenTypeActivity { // temporary until activity is added
-		return false
-	}
 	return 0 < o && o < operationTokenTypeMaxVal
 }
 
@@ -66,6 +63,19 @@ func generateOperationToken(opType operationTokenType, namespace string) operati
 		Type:          opType,
 		NamespaceName: namespace,
 	}
+}
+
+// activityExecutionOperationToken is the decoded form of the activity-execution operation token.
+type activityExecutionOperationToken struct {
+	// Version of the token. Not emitted; only used to reject newer token versions on load.
+	Version int `json:"v,omitempty"`
+	// Type of the operation. Must be operationTokenTypeActivityExecution.
+	Type          operationTokenType `json:"t"`
+	NamespaceName string             `json:"ns"`
+	ActivityID    string             `json:"aid"`
+	// RunID of the activity execution. Omitted on the token used for the callback's
+	// HeaderOperationToken, since the run ID is only known after the activity has been started.
+	RunID string `json:"rid,omitempty"`
 }
 
 func generateWorkflowRunOperationToken(namespace, workflowID string) (string, error) {
@@ -122,6 +132,44 @@ func loadTokenType(data string) (operationTokenType, error) {
 		return 0, fmt.Errorf("invalid operation token: %d", partial.Type)
 	}
 	return partial.Type, nil
+}
+
+func generateActivityExecutionOperationToken(namespace, activityID, runID string) (string, error) {
+	token := activityExecutionOperationToken{
+		Type:          operationTokenTypeActivityExecution,
+		NamespaceName: namespace,
+		ActivityID:    activityID,
+		RunID:         runID,
+	}
+	data, err := json.Marshal(token)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal activity execution operation token: %w", err)
+	}
+	return base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString(data), nil
+}
+
+func loadActivityExecutionOperationToken(data string) (activityExecutionOperationToken, error) {
+	var token activityExecutionOperationToken
+	if len(data) == 0 {
+		return token, errors.New("invalid activity execution token: token is empty")
+	}
+	b, err := base64.URLEncoding.WithPadding(base64.NoPadding).DecodeString(data)
+	if err != nil {
+		return token, fmt.Errorf("failed to decode token: %w", err)
+	}
+	if err := json.Unmarshal(b, &token); err != nil {
+		return token, fmt.Errorf("failed to unmarshal activity execution operation token: %w", err)
+	}
+	if token.Type != operationTokenTypeActivityExecution {
+		return token, fmt.Errorf("invalid activity execution token type: %v, expected: %v", token.Type, operationTokenTypeActivityExecution)
+	}
+	if token.Version != 0 {
+		return token, fmt.Errorf(`invalid activity execution token: "v" field should not be present`)
+	}
+	if token.ActivityID == "" {
+		return token, errors.New("invalid activity execution token: missing activity ID (aid)")
+	}
+	return token, nil
 }
 
 func loadWorkflowRunOperationToken(data string) (workflowRunOperationToken, error) {

--- a/temporalnexus/token_test.go
+++ b/temporalnexus/token_test.go
@@ -56,6 +56,76 @@ func TestEncodeDecodeUpdateWorkflowOperationToken(t *testing.T) {
 	require.Equal(t, uwt, decoded)
 }
 
+func TestEncodeDecodeActivityExecutionOperationToken(t *testing.T) {
+	want := activityExecutionOperationToken{
+		Type:          operationTokenTypeActivityExecution,
+		NamespaceName: "ns",
+		ActivityID:    "a-1",
+		RunID:         "r-1",
+	}
+	token, err := generateActivityExecutionOperationToken("ns", "a-1", "r-1")
+	require.NoError(t, err)
+	got, err := loadActivityExecutionOperationToken(token)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}
+
+func TestEncodeActivityExecutionOperationTokenDoesNotIncludeVersion(t *testing.T) {
+	data, err := generateActivityExecutionOperationToken("ns", "a-1", "r-1")
+	require.NoError(t, err)
+
+	b, err := base64.URLEncoding.WithPadding(base64.NoPadding).DecodeString(data)
+	require.NoError(t, err)
+
+	var token map[string]interface{}
+	err = json.Unmarshal(b, &token)
+	require.NoError(t, err)
+	require.NotContains(t, token, "v", "version field should not be present in the token")
+	require.Equal(t, 2.0, token["t"], "token type should be activity execution")
+	require.Equal(t, "ns", token["ns"], "namespace name should match")
+	require.Equal(t, "a-1", token["aid"], "activity ID should match")
+	require.Equal(t, "r-1", token["rid"], "run ID should match")
+}
+
+func TestEncodeActivityExecutionOperationTokenOmitsRunIDWhenEmpty(t *testing.T) {
+	data, err := generateActivityExecutionOperationToken("ns", "a-1", "")
+	require.NoError(t, err)
+
+	b, err := base64.URLEncoding.WithPadding(base64.NoPadding).DecodeString(data)
+	require.NoError(t, err)
+
+	var token map[string]interface{}
+	err = json.Unmarshal(b, &token)
+	require.NoError(t, err)
+	require.NotContains(t, token, "rid", "run ID field should be omitted when empty")
+}
+
+func TestDecodeActivityExecutionOperationTokenErrors(t *testing.T) {
+	var err error
+
+	_, err = loadActivityExecutionOperationToken("")
+	require.ErrorContains(t, err, "invalid activity execution token: token is empty")
+
+	_, err = loadActivityExecutionOperationToken("not-base64!@#$")
+	require.ErrorContains(t, err, "failed to decode token: illegal base64 data")
+
+	invalidJSONToken := base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString([]byte("invalid json"))
+	_, err = loadActivityExecutionOperationToken(invalidJSONToken)
+	require.ErrorContains(t, err, "failed to unmarshal activity execution operation token")
+
+	wrongTypeToken := base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString([]byte(`{"t":1,"aid":"a-1"}`))
+	_, err = loadActivityExecutionOperationToken(wrongTypeToken)
+	require.ErrorContains(t, err, "invalid activity execution token type: 1, expected: 2")
+
+	missingAIDToken := base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString([]byte(`{"t":2}`))
+	_, err = loadActivityExecutionOperationToken(missingAIDToken)
+	require.ErrorContains(t, err, "missing activity ID (aid)")
+
+	versionedToken := base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString([]byte(`{"v":1,"t":2,"aid":"a-1"}`))
+	_, err = loadActivityExecutionOperationToken(versionedToken)
+	require.ErrorContains(t, err, `invalid activity execution token: "v" field should not be present`)
+}
+
 func TestDecodeWorkflowRunOperationTokenErrors(t *testing.T) {
 	var err error
 

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -10017,18 +10017,65 @@ func (ts *IntegrationTestSuite) TestTemporalOperationSuite() {
 	typedInput := "typed-wf-" + uuid.NewString()
 	untypedInput := "untyped-wf-" + uuid.NewString()
 	signalInput := "signal-wf-" + uuid.NewString()
+	callerNexusStartedLinks := func(run client.WorkflowRun) []*commonpb.Link {
+		iter := ts.client.GetWorkflowHistory(ctx, run.GetID(), run.GetRunID(), false, enumspb.HISTORY_EVENT_FILTER_TYPE_ALL_EVENT)
+		for iter.HasNext() {
+			e, err := iter.Next()
+			ts.NoError(err)
+			if e.GetEventType() == enumspb.EVENT_TYPE_NEXUS_OPERATION_STARTED {
+				return e.GetLinks()
+			}
+		}
+		return nil
+	}
+
+	verifyWorkflowLinks := func(startedWorkflowID string) func(run client.WorkflowRun) {
+		return func(run client.WorkflowRun) {
+			// Forward: caller's NexusOperationStarted → started workflow event.
+			var fwd *commonpb.Link_WorkflowEvent
+			for _, link := range callerNexusStartedLinks(run) {
+				if w := link.GetWorkflowEvent(); w != nil {
+					fwd = w
+				}
+			}
+			ts.NotNil(fwd, "caller's NexusOperationStarted should have a Link_WorkflowEvent to started workflow")
+			if fwd != nil {
+				ts.Equal(startedWorkflowID, fwd.GetWorkflowId())
+			}
+
+			// Backward: started workflow's WorkflowExecutionStarted completion callback links back to caller.
+			siter := ts.client.GetWorkflowHistory(ctx, startedWorkflowID, "", false, enumspb.HISTORY_EVENT_FILTER_TYPE_ALL_EVENT)
+			ts.True(siter.HasNext())
+			startedEvent, err := siter.Next()
+			ts.NoError(err)
+			var back *commonpb.Link_WorkflowEvent
+			for _, cb := range startedEvent.GetWorkflowExecutionStartedEventAttributes().GetCompletionCallbacks() {
+				for _, link := range cb.GetLinks() {
+					if w := link.GetWorkflowEvent(); w != nil {
+						back = w
+					}
+				}
+			}
+			ts.NotNil(back, "started workflow's completion callback should link back to caller's NexusOperationScheduled")
+			if back != nil {
+				ts.Equal(run.GetID(), back.GetWorkflowId())
+			}
+		}
+	}
+
 	for _, tc := range []struct {
 		name     string
 		wf       func(workflow.Context, string) (string, error)
 		input    string
 		expected string
+		verify   func(run client.WorkflowRun)
 	}{
-		{"Sync result", ts.workflows.TemporalOpSyncCaller, "hello", "sync-hello"},
-		{"Async with StartWorkflow", ts.workflows.TemporalOpAsyncTypedCaller, typedInput, typedInput},
-		{"Async with StartUntypedWorkflow", ts.workflows.TemporalOpAsyncUntypedCaller, untypedInput, untypedInput},
-		{"Cancel", ts.workflows.TemporalOpCancelCaller, "cancel-wf-" + uuid.NewString(), ""},
-		{"Custom cancel with GetWorkflowClient", ts.workflows.TemporalOpCustomCancelCaller, "custom-cancel-wf-" + uuid.NewString(), ""},
-		{"GetWorkflowClient in Start", ts.workflows.TemporalOpClientInStartCaller, signalInput, "signaled-" + signalInput},
+		{"Sync result", ts.workflows.TemporalOpSyncCaller, "hello", "sync-hello", nil},
+		{"Async with StartWorkflow", ts.workflows.TemporalOpAsyncTypedCaller, typedInput, typedInput, verifyWorkflowLinks(typedInput)},
+		{"Async with StartUntypedWorkflow", ts.workflows.TemporalOpAsyncUntypedCaller, untypedInput, untypedInput, verifyWorkflowLinks(untypedInput)},
+		{"Cancel", ts.workflows.TemporalOpCancelCaller, "cancel-wf-" + uuid.NewString(), "", nil},
+		{"Custom cancel with GetWorkflowClient", ts.workflows.TemporalOpCustomCancelCaller, "custom-cancel-wf-" + uuid.NewString(), "", nil},
+		{"GetWorkflowClient in Start", ts.workflows.TemporalOpClientInStartCaller, signalInput, "signaled-" + signalInput, nil},
 	} {
 		ts.Run(tc.name, func() {
 			run, err := ts.client.ExecuteWorkflow(ctx, startOpts, tc.wf, tc.input)
@@ -10036,6 +10083,461 @@ func (ts *IntegrationTestSuite) TestTemporalOperationSuite() {
 			var result string
 			ts.NoError(run.Get(ctx, &result))
 			ts.Equal(tc.expected, result)
+			if tc.verify != nil {
+				tc.verify(run)
+			}
 		})
 	}
+}
+
+// TestStandaloneActivityHeartbeatDetailsRegression demonstrates that the
+// missing-LastHeartbeatDetails bug on stand-alone activity heartbeat timeouts is NOT Nexus
+// specific. The activity is scheduled directly via client.ExecuteActivity (no Nexus
+// involvement), heartbeats once with deterministic details, then stalls until the server
+// fires a HEARTBEAT-typed timeout. The caller polls via ClientActivityHandle.Get and asserts
+// that TimeoutError exposes LastHeartbeatDetails — the same invariant the legacy
+// workflow-backed activity timeout path upholds at
+// service/history/timer_queue_active_task_executor.go:346.
+//
+// **Currently expected to FAIL on NEXUS-400**: chasm/lib/activity/statemachine.go's
+// TIMEOUT_TYPE_HEARTBEAT branch builds the terminal failure via createHeartbeatTimeoutFailure()
+// without copying a.LastHeartbeat.Details into TimeoutFailureInfo.LastHeartbeatDetails.
+func (ts *IntegrationTestSuite) TestStandaloneActivityHeartbeatDetailsRegression() {
+	ts.T().Skip("NEXUS-400: server does not surface LastHeartbeatDetails on stand-alone activity heartbeat timeouts (chasm/lib/activity/statemachine.go TIMEOUT_TYPE_HEARTBEAT branch)")
+
+	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
+	defer cancel()
+
+	handle, err := ts.client.ExecuteActivity(ctx, client.StartActivityOptions{
+		ID:                  "sa-hb-details-" + uuid.NewString(),
+		TaskQueue:           ts.taskQueueName,
+		StartToCloseTimeout: 30 * time.Second,
+		HeartbeatTimeout:    1 * time.Second,
+		RetryPolicy:         &temporal.RetryPolicy{MaximumAttempts: 1},
+	}, heartbeatThenStallNexusActivity, "ignored")
+	ts.NoError(err)
+
+	var result string
+	err = handle.Get(ctx, &result)
+	ts.Error(err, "expected heartbeat timeout")
+
+	var timeoutErr *temporal.TimeoutError
+	if !errors.As(err, &timeoutErr) {
+		ts.Failf("expected *temporal.TimeoutError", "got %T: %v", err, err)
+		return
+	}
+	ts.Equal(enumspb.TIMEOUT_TYPE_HEARTBEAT, timeoutErr.TimeoutType(),
+		"timeout must be reported as Heartbeat-typed")
+
+	ts.True(timeoutErr.HasLastHeartbeatDetails(),
+		"stand-alone activity heartbeat-timeout must surface LastHeartbeatDetails (regression vs. workflow-backed activities; see chasm/lib/activity/statemachine.go TIMEOUT_TYPE_HEARTBEAT branch)")
+	if timeoutErr.HasLastHeartbeatDetails() {
+		var details string
+		ts.NoError(timeoutErr.LastHeartbeatDetails(&details))
+		ts.Equal(heartbeatTimeoutTestDetails, details,
+			"recovered LastHeartbeatDetails must match the value recorded by RecordHeartbeat")
+	}
+}
+
+// TestActivityBackedNexusOperationSuite covers the SDK + server behavior for Nexus
+// operations whose backing execution is a stand-alone activity (see temporalnexus.StartActivity).
+// It is intentionally separated from TestTemporalOperationSuite (which covers workflow-backed
+// and sync operations) so the failure/timeout/retry surface for activity-backed operations
+// can grow without bloating the workflow-backed table.
+func (ts *IntegrationTestSuite) TestActivityBackedNexusOperationSuite() {
+	if os.Getenv("DISABLE_ACTIVITY_BACKED_NEXUS_TESTS") != "" {
+		ts.T().SkipNow()
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
+	defer cancel()
+
+	endpoint := "activity-backed-nexus-ep-" + uuid.NewString()
+	_, err := ts.client.OperatorService().CreateNexusEndpoint(ctx, &operatorservice.CreateNexusEndpointRequest{
+		Spec: &nexuspb.EndpointSpec{
+			Name: endpoint,
+			Target: &nexuspb.EndpointTarget{
+				Variant: &nexuspb.EndpointTarget_Worker_{
+					Worker: &nexuspb.EndpointTarget_Worker{
+						Namespace: ts.config.Namespace,
+						TaskQueue: ts.taskQueueName,
+					},
+				},
+			},
+		},
+	})
+	ts.NoError(err)
+	temporalOpEndpoint = endpoint
+
+	startOpts := client.StartWorkflowOptions{
+		TaskQueue: ts.taskQueueName, WorkflowTaskTimeout: time.Second,
+	}
+
+	typedActivityInput := "typed-act-" + uuid.NewString()
+	untypedActivityInput := "untyped-act-" + uuid.NewString()
+	renamedActivityInput := "renamed-act-" + uuid.NewString()
+	failureActivityInput := "failure-act-" + uuid.NewString()
+	timeoutActivityInput := "timeout-act-" + uuid.NewString()
+	cancelActivityInput := "cancel-act-" + uuid.NewString()
+	stcTimeoutActivityInput := "stc-act-" + uuid.NewString()
+	heartbeatTimeoutActivityInput := "heartbeat-act-" + uuid.NewString()
+	retrySucceedActivityInput := "retry-succeed-act-" + uuid.NewString()
+	retryExhaustActivityInput := "retry-exhaust-act-" + uuid.NewString()
+
+	callerNexusStartedLinks := func(run client.WorkflowRun) []*commonpb.Link {
+		iter := ts.client.GetWorkflowHistory(ctx, run.GetID(), run.GetRunID(), false, enumspb.HISTORY_EVENT_FILTER_TYPE_ALL_EVENT)
+		for iter.HasNext() {
+			e, err := iter.Next()
+			ts.NoError(err)
+			if e.GetEventType() == enumspb.EVENT_TYPE_NEXUS_OPERATION_STARTED {
+				return e.GetLinks()
+			}
+		}
+		return nil
+	}
+
+	// verifyActivityLinks asserts forward (caller NexusOperationStarted -> activity) and
+	// backward (activity execution info -> caller workflow event) link plumbing.
+	//
+	// NEXUS-400: server does not currently emit Link_Activity on NexusOperationStarted nor
+	// Link_WorkflowEvent on the backing activity's execution info for activity-backed Nexus
+	// operations. Body commented out until the server fix lands; the helper stays in place
+	// so callers compile and the test table is unchanged.
+	verifyActivityLinks := func(activityID string) func(run client.WorkflowRun) {
+		_ = callerNexusStartedLinks
+		_ = activityID
+		return func(run client.WorkflowRun) {
+			// var fwd *commonpb.Link_Activity
+			// for _, link := range callerNexusStartedLinks(run) {
+			// 	if a := link.GetActivity(); a != nil {
+			// 		fwd = a
+			// 	}
+			// }
+			// ts.NotNil(fwd, "caller's NexusOperationStarted should have a Link_Activity")
+			// if fwd != nil {
+			// 	ts.Equal(activityID, fwd.GetActivityId())
+			// }
+			//
+			// handle := ts.client.GetActivityHandle(client.GetActivityHandleOptions{ActivityID: activityID})
+			// desc, err := handle.Describe(ctx, client.DescribeActivityOptions{})
+			// ts.NoError(err)
+			// var back *commonpb.Link_WorkflowEvent
+			// for _, link := range desc.RawExecutionInfo.GetLinks() {
+			// 	if w := link.GetWorkflowEvent(); w != nil {
+			// 		back = w
+			// 	}
+			// }
+			// ts.NotNil(back, "activity should have a Link_WorkflowEvent back to caller")
+			// if back != nil {
+			// 	ts.Equal(run.GetID(), back.GetWorkflowId())
+			// }
+			_ = run
+		}
+	}
+
+	// verifyActivityFinalStatus polls the activity's Describe until it reports the expected
+	// terminal status, asserting that server-side propagation of the Nexus operation outcome
+	// (cancellation, failure, timeout) actually reaches the backing activity.
+	verifyActivityFinalStatus := func(activityID string, expected enumspb.ActivityExecutionStatus) func(client.WorkflowRun) {
+		return func(_ client.WorkflowRun) {
+			handle := ts.client.GetActivityHandle(client.GetActivityHandleOptions{ActivityID: activityID})
+			require.Eventually(ts.T(), func() bool {
+				desc, err := handle.Describe(ctx, client.DescribeActivityOptions{})
+				if err != nil {
+					return false
+				}
+				return desc.Status == expected
+			}, 10*time.Second, 200*time.Millisecond,
+				"activity %s never reached status %s", activityID, expected)
+		}
+	}
+
+	// verifyActivityAttemptAtLeast polls Describe until the activity's recorded Attempt is
+	// at least minAttempt. Used to assert that server-driven retries actually fired before
+	// the activity-backed Nexus operation completed (success or failure).
+	verifyActivityAttemptAtLeast := func(activityID string, minAttempt int32) func(client.WorkflowRun) {
+		return func(_ client.WorkflowRun) {
+			handle := ts.client.GetActivityHandle(client.GetActivityHandleOptions{ActivityID: activityID})
+			require.Eventually(ts.T(), func() bool {
+				desc, err := handle.Describe(ctx, client.DescribeActivityOptions{})
+				if err != nil {
+					return false
+				}
+				return desc.Attempt >= minAttempt
+			}, 10*time.Second, 200*time.Millisecond,
+				"activity %s never reported Attempt >= %d", activityID, minAttempt)
+		}
+	}
+
+	composeVerify := func(fns ...func(client.WorkflowRun)) func(client.WorkflowRun) {
+		return func(run client.WorkflowRun) {
+			for _, fn := range fns {
+				if fn != nil {
+					fn(run)
+				}
+			}
+		}
+	}
+
+	for _, tc := range []struct {
+		name     string
+		wf       func(workflow.Context, string) (string, error)
+		input    string
+		expected string
+		verify   func(run client.WorkflowRun)
+	}{
+		{"Async with StartActivity", ts.workflows.TemporalOpAsyncActivityCaller, typedActivityInput, typedActivityInput, verifyActivityLinks("act-" + typedActivityInput)},
+		{"Async with StartUntypedActivity", ts.workflows.TemporalOpAsyncUntypedActivityCaller, untypedActivityInput, untypedActivityInput, verifyActivityLinks("act-untyped-" + untypedActivityInput)},
+		// Regression: activities registered with a custom name via activity.RegisterOptions.Name
+		// must be resolved through the worker's registry when scheduled via
+		// temporalnexus.StartActivity — otherwise the raw Go function name is sent and the
+		// activity fails as unregistered.
+		{"Async with StartActivity resolves worker-registered activity alias", ts.workflows.TemporalOpRenamedActivityCaller, renamedActivityInput, "renamed:" + renamedActivityInput, verifyActivityLinks("renamed-act-" + renamedActivityInput)},
+		{
+			"Cancel activity execution",
+			ts.workflows.TemporalOpCancelActivityCaller,
+			cancelActivityInput, "",
+			composeVerify(
+				verifyActivityLinks("cancel-act-"+cancelActivityInput),
+				verifyActivityFinalStatus("cancel-act-"+cancelActivityInput, enumspb.ACTIVITY_EXECUTION_STATUS_CANCELED),
+			),
+		},
+		{
+			"Failure ApplicationError propagated",
+			ts.workflows.TemporalOpFailingActivityCaller,
+			failureActivityInput,
+			"application:NexusActivityTestFailureType:activity failed: " + failureActivityInput,
+			composeVerify(
+				verifyActivityLinks("failing-act-"+failureActivityInput),
+				verifyActivityFinalStatus("failing-act-"+failureActivityInput, enumspb.ACTIVITY_EXECUTION_STATUS_FAILED),
+			),
+		},
+		{
+			"StartToClose timeout propagated",
+			ts.workflows.TemporalOpTimeoutActivityCaller,
+			timeoutActivityInput,
+			"timeout:StartToClose",
+			composeVerify(
+				verifyActivityLinks("timeout-act-"+timeoutActivityInput),
+				verifyActivityFinalStatus("timeout-act-"+timeoutActivityInput, enumspb.ACTIVITY_EXECUTION_STATUS_TIMED_OUT),
+			),
+		},
+		{
+			"ScheduleToClose timeout propagated",
+			ts.workflows.TemporalOpScheduleToCloseTimeoutCaller,
+			stcTimeoutActivityInput,
+			"timeout:ScheduleToClose",
+			composeVerify(
+				verifyActivityLinks("schedule-to-close-act-"+stcTimeoutActivityInput),
+				verifyActivityFinalStatus("schedule-to-close-act-"+stcTimeoutActivityInput, enumspb.ACTIVITY_EXECUTION_STATUS_TIMED_OUT),
+			),
+		},
+		{
+			"Heartbeat timeout propagated",
+			ts.workflows.TemporalOpHeartbeatTimeoutCaller,
+			heartbeatTimeoutActivityInput,
+			"timeout:Heartbeat",
+			composeVerify(
+				verifyActivityLinks("heartbeat-act-"+heartbeatTimeoutActivityInput),
+				verifyActivityFinalStatus("heartbeat-act-"+heartbeatTimeoutActivityInput, enumspb.ACTIVITY_EXECUTION_STATUS_TIMED_OUT),
+			),
+		},
+		{
+			"Retry then succeed",
+			ts.workflows.TemporalOpRetryThenSucceedCaller,
+			retrySucceedActivityInput,
+			retrySucceedActivityInput,
+			composeVerify(
+				verifyActivityLinks("retry-succeed-act-"+retrySucceedActivityInput),
+				verifyActivityFinalStatus("retry-succeed-act-"+retrySucceedActivityInput, enumspb.ACTIVITY_EXECUTION_STATUS_COMPLETED),
+				verifyActivityAttemptAtLeast("retry-succeed-act-"+retrySucceedActivityInput, 3),
+			),
+		},
+		{
+			"Retry exhaustion propagates last failure",
+			ts.workflows.TemporalOpRetryExhaustCaller,
+			retryExhaustActivityInput,
+			"application:NexusActivityRetryTestFailureType:attempt 2 failed; will succeed on 999",
+			composeVerify(
+				verifyActivityLinks("retry-exhaust-act-"+retryExhaustActivityInput),
+				verifyActivityFinalStatus("retry-exhaust-act-"+retryExhaustActivityInput, enumspb.ACTIVITY_EXECUTION_STATUS_FAILED),
+				verifyActivityAttemptAtLeast("retry-exhaust-act-"+retryExhaustActivityInput, 2),
+			),
+		},
+	} {
+		ts.Run(tc.name, func() {
+			run, err := ts.client.ExecuteWorkflow(ctx, startOpts, tc.wf, tc.input)
+			ts.NoError(err)
+			var result string
+			ts.NoError(run.Get(ctx, &result))
+			ts.Equal(tc.expected, result)
+			if tc.verify != nil {
+				tc.verify(run)
+			}
+		})
+	}
+
+	// Heartbeat timeout should carry LastHeartbeatDetails to the caller workflow. The
+	// backing activity records exactly one heartbeat with a deterministic payload before
+	// stalling; the server fires a HEARTBEAT-typed timeout while the activity is still
+	// running. The caller's TimeoutError must expose the previously-recorded heartbeat
+	// details, mirroring workflow-backed activity heartbeat-timeout semantics.
+	//
+	// **Currently expected to FAIL on NEXUS-400**: chasm/lib/activity/statemachine.go's
+	// TIMEOUT_TYPE_HEARTBEAT branch builds the failure via createHeartbeatTimeoutFailure(),
+	// which only populates TimeoutFailureInfo.TimeoutType — LastHeartbeatDetails is never
+	// copied from a.LastHeartbeat. Server bug. See review memo for details.
+	ts.Run("Heartbeat timeout delivers LastHeartbeatDetails", func() {
+		ts.T().Skip("NEXUS-400: server does not populate LastHeartbeatDetails on stand-alone activity heartbeat timeouts (chasm/lib/activity/statemachine.go TIMEOUT_TYPE_HEARTBEAT branch)")
+
+		input := "hb-details-" + uuid.NewString()
+		run, err := ts.client.ExecuteWorkflow(ctx, startOpts, ts.workflows.TemporalOpHeartbeatDetailsTimeoutCaller, input)
+		ts.NoError(err)
+		var result string
+		ts.NoError(run.Get(ctx, &result))
+		ts.Equal("timeout:Heartbeat:details=intermediate-progress-50pct", result,
+			"stand-alone activity heartbeat-timeout must populate LastHeartbeatDetails on the TimeoutFailureInfo delivered to the Nexus caller")
+	})
+
+	// Two callers attaching callbacks to the same backing activity (via USE_EXISTING +
+	// AttachCompletionCallbacks). Both invocations of the Nexus operation with the same input
+	// resolve to a single activity. The activity intentionally sleeps long enough for the
+	// second caller's StartActivityExecution to land before completion. When the activity
+	// completes, both callbacks must fire, both caller workflows must receive the same
+	// result, and the activity must have only one actual execution.
+	ts.Run("Two callers share one backing activity (both callbacks fire)", func() {
+		sharedInput := "shared-" + uuid.NewString()
+		activityID := "shared-act-" + sharedInput
+
+		var (
+			runA, runB client.WorkflowRun
+			errA, errB error
+			wg         sync.WaitGroup
+		)
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			opts := startOpts
+			opts.ID = "shared-caller-A-" + sharedInput
+			runA, errA = ts.client.ExecuteWorkflow(ctx, opts, ts.workflows.TemporalOpSharedActivityCaller, sharedInput)
+		}()
+		go func() {
+			defer wg.Done()
+			// Small delay so caller A's StartActivityExecution lands first and creates the
+			// activity; caller B then resolves to it via USE_EXISTING.
+			time.Sleep(500 * time.Millisecond)
+			opts := startOpts
+			opts.ID = "shared-caller-B-" + sharedInput
+			runB, errB = ts.client.ExecuteWorkflow(ctx, opts, ts.workflows.TemporalOpSharedActivityCaller, sharedInput)
+		}()
+		wg.Wait()
+		ts.NoError(errA)
+		ts.NoError(errB)
+
+		var resA, resB string
+		ts.NoError(runA.Get(ctx, &resA))
+		ts.NoError(runB.Get(ctx, &resB))
+		ts.Equal(sharedInput, resA, "caller A must receive the shared activity's result")
+		ts.Equal(sharedInput, resB, "caller B must receive the shared activity's result")
+
+		// SDK's typed Describe doesn't expose Callbacks; reach for the raw frontend RPC.
+		descResp, err := ts.client.WorkflowService().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  ts.config.Namespace,
+			ActivityId: activityID,
+		})
+		ts.NoError(err)
+		ts.Equal(enumspb.ACTIVITY_EXECUTION_STATUS_COMPLETED, descResp.GetInfo().GetStatus(),
+			"shared activity must reach COMPLETED")
+		ts.Equal(int32(1), descResp.GetInfo().GetAttempt(),
+			"activity must only have run once (both callers shared the same execution)")
+		ts.Len(descResp.GetCallbacks(), 2,
+			"both callers must have attached callbacks to the same activity")
+
+		// Both callers' NexusOperationStarted events must carry a Link_Activity pointing at the
+		// shared activity (forward link from caller -> activity).
+		//
+		// NEXUS-400: server does not currently emit Link_Activity on NexusOperationStarted for
+		// activity-backed Nexus operations. Commented out until the server fix lands.
+		_ = activityID
+		// for _, run := range []client.WorkflowRun{runA, runB} {
+		// 	iter := ts.client.GetWorkflowHistory(ctx, run.GetID(), run.GetRunID(), false, enumspb.HISTORY_EVENT_FILTER_TYPE_ALL_EVENT)
+		// 	var fwd *commonpb.Link_Activity
+		// 	for iter.HasNext() {
+		// 		e, err := iter.Next()
+		// 		ts.NoError(err)
+		// 		if e.GetEventType() == enumspb.EVENT_TYPE_NEXUS_OPERATION_STARTED {
+		// 			for _, link := range e.GetLinks() {
+		// 				if a := link.GetActivity(); a != nil {
+		// 					fwd = a
+		// 				}
+		// 			}
+		// 		}
+		// 	}
+		// 	ts.NotNil(fwd, "caller %s should have a Link_Activity on NexusOperationStarted", run.GetID())
+		// 	if fwd != nil {
+		// 		ts.Equal(activityID, fwd.GetActivityId())
+		// 	}
+		// }
+	})
+
+	// Caller workflow terminated mid-operation: the backing activity terminates its own
+	// caller before returning, so by the time the activity-completion callback is delivered
+	// to the server, the caller's Nexus operation state machine lives inside an already-
+	// closed workflow. Asserts that (a) the workflow ends up Terminated, (b) the activity
+	// still records COMPLETED server-side, and (c) the server handles the orphaned
+	// callback without panicking and without rewriting the closed workflow's history with
+	// a post-termination Nexus completion event.
+	ts.Run("Caller workflow terminated mid-operation", func() {
+		run, err := ts.client.ExecuteWorkflow(ctx, startOpts, ts.workflows.TemporalOpTerminateCallerCaller, "")
+		ts.NoError(err)
+		callerWorkflowID := run.GetID()
+
+		var result string
+		err = run.Get(ctx, &result)
+		ts.Error(err, "expected caller workflow to be terminated")
+		var terminatedErr *temporal.TerminatedError
+		ts.True(errors.As(err, &terminatedErr), "expected *temporal.TerminatedError, got %T: %v", err, err)
+
+		// Activity must still reach COMPLETED — terminating the caller workflow does not
+		// abort the backing activity; the activity is its own CHASM execution.
+		activityID := "terminate-caller-act-" + callerWorkflowID
+		handle := ts.client.GetActivityHandle(client.GetActivityHandleOptions{ActivityID: activityID})
+		require.Eventually(ts.T(), func() bool {
+			desc, err := handle.Describe(ctx, client.DescribeActivityOptions{})
+			if err != nil {
+				return false
+			}
+			return desc.Status == enumspb.ACTIVITY_EXECUTION_STATUS_COMPLETED
+		}, 10*time.Second, 200*time.Millisecond,
+			"backing activity %s never reached COMPLETED", activityID)
+
+		// Caller workflow is Terminated, and there must be no Nexus completion event after
+		// the termination event — an orphaned callback must not mutate a terminal workflow.
+		desc, err := ts.client.DescribeWorkflowExecution(ctx, callerWorkflowID, run.GetRunID())
+		ts.NoError(err)
+		ts.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_TERMINATED, desc.GetWorkflowExecutionInfo().GetStatus())
+
+		hist := ts.client.GetWorkflowHistory(ctx, callerWorkflowID, run.GetRunID(), false, enumspb.HISTORY_EVENT_FILTER_TYPE_ALL_EVENT)
+		var lastEventType enumspb.EventType
+		nexusCompletionAfterTermination := false
+		sawTerminated := false
+		for hist.HasNext() {
+			e, err := hist.Next()
+			ts.NoError(err)
+			lastEventType = e.GetEventType()
+			if e.GetEventType() == enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_TERMINATED {
+				sawTerminated = true
+				continue
+			}
+			if sawTerminated &&
+				(e.GetEventType() == enumspb.EVENT_TYPE_NEXUS_OPERATION_COMPLETED ||
+					e.GetEventType() == enumspb.EVENT_TYPE_NEXUS_OPERATION_FAILED ||
+					e.GetEventType() == enumspb.EVENT_TYPE_NEXUS_OPERATION_CANCELED) {
+				nexusCompletionAfterTermination = true
+			}
+		}
+		ts.True(sawTerminated, "expected WorkflowExecutionTerminated event in caller history")
+		ts.False(nexusCompletionAfterTermination,
+			"orphaned callback must not write a Nexus completion event after WorkflowExecutionTerminated (last event was %v)", lastEventType)
+	})
 }

--- a/test/nexus_test.go
+++ b/test/nexus_test.go
@@ -2330,6 +2330,54 @@ func TestWorkflowTestSuite_WorkflowRunOperation(t *testing.T) {
 	})
 }
 
+func TestWorkflowTestSuite_ActivityBackedNexusOperation(t *testing.T) {
+	echoActivity := func(ctx context.Context, in string) (string, error) {
+		return "echo:" + in, nil
+	}
+
+	op := temporalnexus.MustNewTemporalOperation(temporalnexus.TemporalOperationOptions[string, string]{
+		Name: "act-op",
+		Start: func(ctx context.Context, nc temporalnexus.NexusClient, input string, _ temporalnexus.StartTemporalOperationOptions) (temporalnexus.TemporalOperationResult[string], error) {
+			return temporalnexus.StartActivity(ctx, nc, client.StartActivityOptions{
+				ID:                  "act-" + input,
+				StartToCloseTimeout: 10 * time.Second,
+			}, echoActivity, input)
+		},
+	})
+
+	callerWF := func(ctx workflow.Context, input string) (string, error) {
+		nc := workflow.NewNexusClient("endpoint", "test")
+		fut := nc.ExecuteOperation(ctx, op, input, workflow.NexusOperationOptions{})
+		var exec workflow.NexusOperationExecution
+		if err := fut.GetNexusOperationExecution().Get(ctx, &exec); err != nil {
+			return "", err
+		}
+		if exec.OperationToken == "" {
+			return "", errors.New("got empty operation token")
+		}
+		var result string
+		if err := fut.Get(ctx, &result); err != nil {
+			return "", err
+		}
+		return result, nil
+	}
+
+	service := nexus.NewService("test")
+	service.Register(op)
+
+	suite := testsuite.WorkflowTestSuite{}
+	env := suite.NewTestWorkflowEnvironment()
+	env.RegisterActivity(echoActivity)
+	env.RegisterNexusService(service)
+
+	env.ExecuteWorkflow(callerWF, "hello")
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+	var got string
+	require.NoError(t, env.GetWorkflowResult(&got))
+	require.Equal(t, "echo:hello", got)
+}
+
 func TestWorkflowTestSuite_WorkflowRunOperation_ScheduleToCloseTimeout(t *testing.T) {
 	handlerSleepDuration := 500 * time.Millisecond
 	handlerWF := func(ctx workflow.Context, _ nexus.NoValue) (nexus.NoValue, error) {

--- a/test/workflow_test.go
+++ b/test/workflow_test.go
@@ -17,6 +17,7 @@ import (
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 
+	"go.temporal.io/sdk/activity"
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/converter"
 	"go.temporal.io/sdk/internal"
@@ -3786,6 +3787,313 @@ var temporalOpClientInStartOp = temporalnexus.MustNewTemporalOperation(temporaln
 	},
 })
 
+var temporalOpAsyncActivityOp = temporalnexus.MustNewTemporalOperation(temporalnexus.TemporalOperationOptions[string, string]{
+	Name: "async-activity-op",
+	Start: func(ctx context.Context, nc temporalnexus.NexusClient, input string, _ temporalnexus.StartTemporalOperationOptions) (temporalnexus.TemporalOperationResult[string], error) {
+		return temporalnexus.StartActivity(ctx, nc, client.StartActivityOptions{
+			ID:                  "act-" + input,
+			StartToCloseTimeout: 30 * time.Second,
+		}, (*Activities)(nil).EchoString, input)
+	},
+})
+
+var temporalOpAsyncUntypedActivityOp = temporalnexus.MustNewTemporalOperation(temporalnexus.TemporalOperationOptions[string, string]{
+	Name: "async-untyped-activity-op",
+	Start: func(ctx context.Context, nc temporalnexus.NexusClient, input string, _ temporalnexus.StartTemporalOperationOptions) (temporalnexus.TemporalOperationResult[string], error) {
+		return temporalnexus.StartUntypedActivity[string](ctx, nc, client.StartActivityOptions{
+			ID:                  "act-untyped-" + input,
+			StartToCloseTimeout: 30 * time.Second,
+		}, (*Activities)(nil).EchoString, input)
+	},
+})
+
+var temporalOpCancelActivityOp = temporalnexus.MustNewTemporalOperation(temporalnexus.TemporalOperationOptions[string, string]{
+	Name: "cancel-activity-op",
+	Start: func(ctx context.Context, nc temporalnexus.NexusClient, input string, _ temporalnexus.StartTemporalOperationOptions) (temporalnexus.TemporalOperationResult[string], error) {
+		return temporalnexus.StartActivity(ctx, nc, client.StartActivityOptions{
+			ID:                  "cancel-act-" + input,
+			StartToCloseTimeout: 60 * time.Second,
+			HeartbeatTimeout:    5 * time.Second,
+		}, waitForCancelNexusActivity, time.Minute)
+	},
+})
+
+// waitForCancelNexusActivity is a top-level activity (not a method) that heartbeats until
+// it sees a context cancellation, then returns the cancellation error. Used by the
+// cancel-activity-op integration test.
+func waitForCancelNexusActivity(ctx context.Context, delay time.Duration) (string, error) {
+	endTime := time.Now().Add(delay)
+	for time.Now().Before(endTime) {
+		activity.RecordHeartbeat(ctx)
+		if errors.Is(ctx.Err(), context.Canceled) {
+			return "", ctx.Err()
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return "timed out", nil
+}
+
+// failingNexusActivity always returns a non-retryable ApplicationError carrying the input as
+// part of its message. Used by the failing-activity-op integration test to assert that an
+// activity-backed Nexus operation's failure is delivered to the caller workflow with the
+// underlying ApplicationError preserved.
+func failingNexusActivity(_ context.Context, input string) (string, error) {
+	return "", temporal.NewNonRetryableApplicationError("activity failed: "+input, "NexusActivityTestFailureType", nil)
+}
+
+// sleepingNexusActivity sleeps for the given duration or until its context is canceled. Used
+// to force a StartToClose, Heartbeat, or ScheduleToClose timeout depending on the
+// timeouts configured on the activity options.
+func sleepingNexusActivity(ctx context.Context, dur time.Duration) (string, error) {
+	select {
+	case <-time.After(dur):
+		return "slept", nil
+	case <-ctx.Done():
+		return "", ctx.Err()
+	}
+}
+
+// heartbeatTimeoutTestDetails is recorded as the heartbeat payload by
+// heartbeatThenStallNexusActivity. The TemporalOpHeartbeatDetailsTimeoutCaller test asserts
+// this exact string can be recovered from the caller workflow's TimeoutError.LastHeartbeatDetails.
+const heartbeatTimeoutTestDetails = "intermediate-progress-50pct"
+
+// heartbeatThenStallNexusActivity records exactly one heartbeat with deterministic details,
+// then stalls without sending any more heartbeats. With HeartbeatTimeout set to ~1s on the
+// surrounding op, the server fires a HEARTBEAT timeout while the activity is still sleeping.
+// The caller workflow should observe a TimeoutError whose LastHeartbeatDetails decodes back
+// to heartbeatTimeoutTestDetails, mirroring workflow-backed activity heartbeat-timeout
+// semantics.
+func heartbeatThenStallNexusActivity(ctx context.Context, _ string) (string, error) {
+	activity.RecordHeartbeat(ctx, heartbeatTimeoutTestDetails)
+	// Give the SDK heartbeat flusher time to send before we stop heartbeating.
+	time.Sleep(300 * time.Millisecond)
+	select {
+	case <-time.After(10 * time.Second):
+		return "noop", nil
+	case <-ctx.Done():
+		return "", ctx.Err()
+	}
+}
+
+// terminateCallerNexusActivity uses activity.GetClient to terminate the workflow that
+// invoked the surrounding Nexus operation, then returns success. The point is to put the
+// caller into a terminal state BEFORE the activity-backed Nexus operation's completion
+// callback is delivered, so the server's completion-callback path is exercised against an
+// already-closed workflow.
+func terminateCallerNexusActivity(ctx context.Context, callerWorkflowID string) (string, error) {
+	c := activity.GetClient(ctx)
+	if err := c.TerminateWorkflow(ctx, callerWorkflowID, "", "terminated by activity to exercise orphaned-callback path"); err != nil {
+		return "", err
+	}
+	return "terminated-" + callerWorkflowID, nil
+}
+
+// failsNTimesInput is the input for failsNTimesNexusActivity. Encoded inline rather than as
+// raw strings so the activity can drive its decision off a typed input.
+type failsNTimesInput struct {
+	Input            string
+	SucceedOnAttempt int32
+}
+
+// failsNTimesNexusActivity returns a retryable ApplicationError until activity.GetInfo
+// reports that the current attempt is >= SucceedOnAttempt, at which point it returns Input.
+// Used to assert that the server's retry path is exercised end-to-end for activity-backed
+// Nexus operations (each retry is server-driven; the SDK only schedules the activity once).
+func failsNTimesNexusActivity(ctx context.Context, in failsNTimesInput) (string, error) {
+	info := activity.GetInfo(ctx)
+	if info.Attempt < in.SucceedOnAttempt {
+		return "", temporal.NewApplicationError(
+			fmt.Sprintf("attempt %d failed; will succeed on %d", info.Attempt, in.SucceedOnAttempt),
+			"NexusActivityRetryTestFailureType",
+		)
+	}
+	return in.Input, nil
+}
+
+var temporalOpFailingActivityOp = temporalnexus.MustNewTemporalOperation(temporalnexus.TemporalOperationOptions[string, string]{
+	Name: "failing-activity-op",
+	Start: func(ctx context.Context, nc temporalnexus.NexusClient, input string, _ temporalnexus.StartTemporalOperationOptions) (temporalnexus.TemporalOperationResult[string], error) {
+		return temporalnexus.StartActivity(ctx, nc, client.StartActivityOptions{
+			ID:                  "failing-act-" + input,
+			StartToCloseTimeout: 30 * time.Second,
+			RetryPolicy:         &temporal.RetryPolicy{MaximumAttempts: 1},
+		}, failingNexusActivity, input)
+	},
+})
+
+var temporalOpTimeoutActivityOp = temporalnexus.MustNewTemporalOperation(temporalnexus.TemporalOperationOptions[string, string]{
+	Name: "timeout-activity-op",
+	Start: func(ctx context.Context, nc temporalnexus.NexusClient, input string, _ temporalnexus.StartTemporalOperationOptions) (temporalnexus.TemporalOperationResult[string], error) {
+		return temporalnexus.StartActivity(ctx, nc, client.StartActivityOptions{
+			ID:                     "timeout-act-" + input,
+			StartToCloseTimeout:    1 * time.Second,
+			ScheduleToCloseTimeout: 5 * time.Second,
+			RetryPolicy:            &temporal.RetryPolicy{MaximumAttempts: 1},
+		}, sleepingNexusActivity, 10*time.Second)
+	},
+})
+
+// temporalOpHeartbeatDetailsTimeoutOp pairs heartbeatThenStallNexusActivity with a 1s
+// HeartbeatTimeout so a HEARTBEAT-typed timeout failure is recorded by the server. The
+// caller workflow asserts that the resulting TimeoutError carries the LastHeartbeatDetails
+// recorded prior to the stall.
+var temporalOpHeartbeatDetailsTimeoutOp = temporalnexus.MustNewTemporalOperation(temporalnexus.TemporalOperationOptions[string, string]{
+	Name: "heartbeat-details-timeout-op",
+	Start: func(ctx context.Context, nc temporalnexus.NexusClient, input string, _ temporalnexus.StartTemporalOperationOptions) (temporalnexus.TemporalOperationResult[string], error) {
+		return temporalnexus.StartActivity(ctx, nc, client.StartActivityOptions{
+			ID:                  "heartbeat-details-act-" + input,
+			StartToCloseTimeout: 30 * time.Second,
+			HeartbeatTimeout:    1 * time.Second,
+			RetryPolicy:         &temporal.RetryPolicy{MaximumAttempts: 1},
+		}, heartbeatThenStallNexusActivity, input)
+	},
+})
+
+// temporalOpScheduleToCloseTimeoutActivityOp forces a ScheduleToClose timeout: the activity
+// sleeps far longer than the total ScheduleToCloseTimeout, with retries disabled, so the
+// terminal failure is ScheduleToClose (recorded via recordScheduleToStartOrCloseTimeoutFailure
+// on the server).
+var temporalOpScheduleToCloseTimeoutActivityOp = temporalnexus.MustNewTemporalOperation(temporalnexus.TemporalOperationOptions[string, string]{
+	Name: "schedule-to-close-timeout-activity-op",
+	Start: func(ctx context.Context, nc temporalnexus.NexusClient, input string, _ temporalnexus.StartTemporalOperationOptions) (temporalnexus.TemporalOperationResult[string], error) {
+		return temporalnexus.StartActivity(ctx, nc, client.StartActivityOptions{
+			ID:                     "schedule-to-close-act-" + input,
+			StartToCloseTimeout:    30 * time.Second,
+			ScheduleToCloseTimeout: 2 * time.Second,
+			RetryPolicy:            &temporal.RetryPolicy{MaximumAttempts: 1},
+		}, sleepingNexusActivity, 10*time.Second)
+	},
+})
+
+// temporalOpHeartbeatTimeoutActivityOp forces a Heartbeat timeout: the activity sleeps
+// without calling RecordHeartbeat, so the server fires the heartbeat-timeout task and
+// (with MaximumAttempts=1) records a terminal Heartbeat-typed timeout failure.
+var temporalOpHeartbeatTimeoutActivityOp = temporalnexus.MustNewTemporalOperation(temporalnexus.TemporalOperationOptions[string, string]{
+	Name: "heartbeat-timeout-activity-op",
+	Start: func(ctx context.Context, nc temporalnexus.NexusClient, input string, _ temporalnexus.StartTemporalOperationOptions) (temporalnexus.TemporalOperationResult[string], error) {
+		return temporalnexus.StartActivity(ctx, nc, client.StartActivityOptions{
+			ID:                  "heartbeat-act-" + input,
+			StartToCloseTimeout: 30 * time.Second,
+			HeartbeatTimeout:    1 * time.Second,
+			RetryPolicy:         &temporal.RetryPolicy{MaximumAttempts: 1},
+		}, sleepingNexusActivity, 5*time.Second)
+	},
+})
+
+// temporalOpRetryThenSucceedActivityOp exercises the server-driven retry loop for an
+// activity-backed Nexus operation: failsNTimesNexusActivity fails twice then succeeds on
+// attempt 3, RetryPolicy allows up to 5 attempts. Caller must observe success and the
+// activity must report Attempt >= 3 in its final state.
+var temporalOpRetryThenSucceedActivityOp = temporalnexus.MustNewTemporalOperation(temporalnexus.TemporalOperationOptions[string, string]{
+	Name: "retry-then-succeed-activity-op",
+	Start: func(ctx context.Context, nc temporalnexus.NexusClient, input string, _ temporalnexus.StartTemporalOperationOptions) (temporalnexus.TemporalOperationResult[string], error) {
+		return temporalnexus.StartActivity(ctx, nc, client.StartActivityOptions{
+			ID:                  "retry-succeed-act-" + input,
+			StartToCloseTimeout: 30 * time.Second,
+			RetryPolicy: &temporal.RetryPolicy{
+				InitialInterval:    100 * time.Millisecond,
+				BackoffCoefficient: 1.0,
+				MaximumInterval:    100 * time.Millisecond,
+				MaximumAttempts:    5,
+			},
+		}, failsNTimesNexusActivity, failsNTimesInput{Input: input, SucceedOnAttempt: 3})
+	},
+})
+
+// temporalOpSharedActivityOp uses a stable activity ID derived from the operation input so
+// that two Nexus operations invoked with the same input resolve to the SAME backing
+// activity via ACTIVITY_ID_CONFLICT_POLICY_USE_EXISTING. With the SDK's default
+// OnConflictOptions{AttachCompletionCallbacks: true}, both callers' completion callbacks
+// end up on the one activity and both should fire when the activity completes.
+//
+// The backing activity sleeps briefly so the second caller has time to register its
+// callback before the first attempt would otherwise complete.
+var temporalOpSharedActivityOp = temporalnexus.MustNewTemporalOperation(temporalnexus.TemporalOperationOptions[string, string]{
+	Name: "shared-activity-op",
+	Start: func(ctx context.Context, nc temporalnexus.NexusClient, input string, _ temporalnexus.StartTemporalOperationOptions) (temporalnexus.TemporalOperationResult[string], error) {
+		return temporalnexus.StartActivity(ctx, nc, client.StartActivityOptions{
+			ID:                       "shared-act-" + input,
+			StartToCloseTimeout:      30 * time.Second,
+			ActivityIDConflictPolicy: enumspb.ACTIVITY_ID_CONFLICT_POLICY_USE_EXISTING,
+			RetryPolicy:              &temporal.RetryPolicy{MaximumAttempts: 1},
+		}, delayedEchoNexusActivity, input)
+	},
+})
+
+// delayedEchoNexusActivity sleeps long enough for a second concurrent Nexus caller to attach
+// its callback to this activity before completion, then returns the input verbatim. Used
+// only by the shared-activity test.
+func delayedEchoNexusActivity(ctx context.Context, input string) (string, error) {
+	select {
+	case <-time.After(3 * time.Second):
+		return input, nil
+	case <-ctx.Done():
+		return "", ctx.Err()
+	}
+}
+
+// renamedNexusActivityCustomName is the custom name under which renamedNexusActivity is
+// registered on the worker via activity.RegisterOptions.Name. The point of the rename is to
+// verify that temporalnexus.StartActivity resolves the activity name through the worker's
+// registry rather than the raw Go function name, so an activity registered under a custom
+// name is dispatched correctly.
+const renamedNexusActivityCustomName = "renamed-nexus-activity-custom-name"
+
+// renamedNexusActivity is registered under a non-default name (see
+// renamedNexusActivityCustomName) and invoked from temporalOpRenamedActivityOp by function
+// reference. If the Nexus StartActivity path failed to consult the worker's registry, the
+// activity would be scheduled under its Go function name and the server would reject it as
+// not registered, failing the caller workflow.
+func renamedNexusActivity(_ context.Context, input string) (string, error) {
+	return "renamed:" + input, nil
+}
+
+var temporalOpRenamedActivityOp = temporalnexus.MustNewTemporalOperation(temporalnexus.TemporalOperationOptions[string, string]{
+	Name: "renamed-activity-op",
+	Start: func(ctx context.Context, nc temporalnexus.NexusClient, input string, _ temporalnexus.StartTemporalOperationOptions) (temporalnexus.TemporalOperationResult[string], error) {
+		return temporalnexus.StartActivity(ctx, nc, client.StartActivityOptions{
+			ID:                  "renamed-act-" + input,
+			StartToCloseTimeout: 30 * time.Second,
+			RetryPolicy:         &temporal.RetryPolicy{MaximumAttempts: 1},
+		}, renamedNexusActivity, input)
+	},
+})
+
+// temporalOpTerminateCallerActivityOp schedules an activity that terminates the caller
+// workflow mid-operation. Used to assert that an activity completion delivered after the
+// caller workflow has reached a terminal state is handled gracefully by the server (no
+// panic, no infinite retries on the completion-callback dispatch path).
+var temporalOpTerminateCallerActivityOp = temporalnexus.MustNewTemporalOperation(temporalnexus.TemporalOperationOptions[string, string]{
+	Name: "terminate-caller-activity-op",
+	Start: func(ctx context.Context, nc temporalnexus.NexusClient, input string, _ temporalnexus.StartTemporalOperationOptions) (temporalnexus.TemporalOperationResult[string], error) {
+		return temporalnexus.StartActivity(ctx, nc, client.StartActivityOptions{
+			ID:                  "terminate-caller-act-" + input,
+			StartToCloseTimeout: 30 * time.Second,
+			RetryPolicy:         &temporal.RetryPolicy{MaximumAttempts: 1},
+		}, terminateCallerNexusActivity, input)
+	},
+})
+
+// temporalOpRetryExhaustActivityOp exercises retry exhaustion: the activity never succeeds
+// (SucceedOnAttempt=999) and RetryPolicy caps attempts at 2. Caller observes the last
+// ApplicationError; the activity's final state must show Attempt == 2 and Status == FAILED.
+var temporalOpRetryExhaustActivityOp = temporalnexus.MustNewTemporalOperation(temporalnexus.TemporalOperationOptions[string, string]{
+	Name: "retry-exhaust-activity-op",
+	Start: func(ctx context.Context, nc temporalnexus.NexusClient, input string, _ temporalnexus.StartTemporalOperationOptions) (temporalnexus.TemporalOperationResult[string], error) {
+		return temporalnexus.StartActivity(ctx, nc, client.StartActivityOptions{
+			ID:                  "retry-exhaust-act-" + input,
+			StartToCloseTimeout: 30 * time.Second,
+			RetryPolicy: &temporal.RetryPolicy{
+				InitialInterval:    100 * time.Millisecond,
+				BackoffCoefficient: 1.0,
+				MaximumInterval:    100 * time.Millisecond,
+				MaximumAttempts:    2,
+			},
+		}, failsNTimesNexusActivity, failsNTimesInput{Input: input, SucceedOnAttempt: 999})
+	},
+})
+
 var temporalOpService = func() *nexus.Service {
 	s := nexus.NewService(temporalOpServiceName)
 	if err := s.Register(
@@ -3795,6 +4103,19 @@ var temporalOpService = func() *nexus.Service {
 		temporalOpCancelOp,
 		temporalOpCustomCancelOp,
 		temporalOpClientInStartOp,
+		temporalOpAsyncActivityOp,
+		temporalOpAsyncUntypedActivityOp,
+		temporalOpCancelActivityOp,
+		temporalOpFailingActivityOp,
+		temporalOpTimeoutActivityOp,
+		temporalOpScheduleToCloseTimeoutActivityOp,
+		temporalOpHeartbeatTimeoutActivityOp,
+		temporalOpRetryThenSucceedActivityOp,
+		temporalOpRetryExhaustActivityOp,
+		temporalOpTerminateCallerActivityOp,
+		temporalOpSharedActivityOp,
+		temporalOpHeartbeatDetailsTimeoutOp,
+		temporalOpRenamedActivityOp,
 	); err != nil {
 		panic(err)
 	}
@@ -3848,6 +4169,141 @@ func (w *Workflows) TemporalOpClientInStartCaller(ctx workflow.Context, input st
 	return result, c.ExecuteOperation(ctx, temporalOpClientInStartOp, input, workflow.NexusOperationOptions{}).Get(ctx, &result)
 }
 
+func (w *Workflows) TemporalOpAsyncActivityCaller(ctx workflow.Context, input string) (string, error) {
+	c := workflow.NewNexusClient(temporalOpEndpoint, temporalOpServiceName)
+	var result string
+	return result, c.ExecuteOperation(ctx, temporalOpAsyncActivityOp, input, workflow.NexusOperationOptions{}).Get(ctx, &result)
+}
+
+func (w *Workflows) TemporalOpAsyncUntypedActivityCaller(ctx workflow.Context, input string) (string, error) {
+	c := workflow.NewNexusClient(temporalOpEndpoint, temporalOpServiceName)
+	var result string
+	return result, c.ExecuteOperation(ctx, temporalOpAsyncUntypedActivityOp, input, workflow.NexusOperationOptions{}).Get(ctx, &result)
+}
+
+func (w *Workflows) TemporalOpCancelActivityCaller(ctx workflow.Context, input string) (string, error) {
+	return w.runTemporalOpCancelCaller(ctx, temporalOpCancelActivityOp, input)
+}
+
+// runTemporalOpFailingCaller invokes an activity-backed Nexus operation expected to fail
+// with an ApplicationError and returns a deterministic "application:<type>:<message>"
+// string so the integration test can assert that the failure was propagated through the
+// completion callback with its type and message intact.
+func (w *Workflows) runTemporalOpFailingCaller(ctx workflow.Context, op nexus.Operation[string, string], input string) (string, error) {
+	c := workflow.NewNexusClient(temporalOpEndpoint, temporalOpServiceName)
+	var result string
+	err := c.ExecuteOperation(ctx, op, input, workflow.NexusOperationOptions{}).Get(ctx, &result)
+	if err == nil {
+		return "", fmt.Errorf("expected operation to fail, got result %q", result)
+	}
+	var appErr *temporal.ApplicationError
+	if errors.As(err, &appErr) {
+		return "application:" + appErr.Type() + ":" + appErr.Message(), nil
+	}
+	return "other:" + err.Error(), nil
+}
+
+// runTemporalOpTimeoutCaller invokes an activity-backed Nexus operation expected to fail
+// with a TimeoutError and returns "timeout:<TimeoutType>" so the integration test can
+// distinguish StartToClose / ScheduleToClose / Heartbeat timeouts.
+func (w *Workflows) runTemporalOpTimeoutCaller(ctx workflow.Context, op nexus.Operation[string, string], input string) (string, error) {
+	c := workflow.NewNexusClient(temporalOpEndpoint, temporalOpServiceName)
+	var result string
+	err := c.ExecuteOperation(ctx, op, input, workflow.NexusOperationOptions{}).Get(ctx, &result)
+	if err == nil {
+		return "", fmt.Errorf("expected operation to time out, got result %q", result)
+	}
+	var timeoutErr *temporal.TimeoutError
+	if errors.As(err, &timeoutErr) {
+		return "timeout:" + timeoutErr.TimeoutType().String(), nil
+	}
+	return "other:" + err.Error(), nil
+}
+
+func (w *Workflows) TemporalOpFailingActivityCaller(ctx workflow.Context, input string) (string, error) {
+	return w.runTemporalOpFailingCaller(ctx, temporalOpFailingActivityOp, input)
+}
+
+func (w *Workflows) TemporalOpTimeoutActivityCaller(ctx workflow.Context, input string) (string, error) {
+	return w.runTemporalOpTimeoutCaller(ctx, temporalOpTimeoutActivityOp, input)
+}
+
+func (w *Workflows) TemporalOpScheduleToCloseTimeoutCaller(ctx workflow.Context, input string) (string, error) {
+	return w.runTemporalOpTimeoutCaller(ctx, temporalOpScheduleToCloseTimeoutActivityOp, input)
+}
+
+func (w *Workflows) TemporalOpHeartbeatTimeoutCaller(ctx workflow.Context, input string) (string, error) {
+	return w.runTemporalOpTimeoutCaller(ctx, temporalOpHeartbeatTimeoutActivityOp, input)
+}
+
+// TemporalOpRetryThenSucceedCaller exercises the success path through retries.
+func (w *Workflows) TemporalOpRetryThenSucceedCaller(ctx workflow.Context, input string) (string, error) {
+	c := workflow.NewNexusClient(temporalOpEndpoint, temporalOpServiceName)
+	var result string
+	return result, c.ExecuteOperation(ctx, temporalOpRetryThenSucceedActivityOp, input, workflow.NexusOperationOptions{}).Get(ctx, &result)
+}
+
+func (w *Workflows) TemporalOpRetryExhaustCaller(ctx workflow.Context, input string) (string, error) {
+	return w.runTemporalOpFailingCaller(ctx, temporalOpRetryExhaustActivityOp, input)
+}
+
+// TemporalOpTerminateCallerCaller invokes an activity-backed Nexus operation whose backing
+// activity terminates this very workflow before returning. The Get below will not produce a
+// normal result because the workflow is killed mid-call; the test asserts on the workflow's
+// terminal state and the backing activity's status, not on this function's return value.
+// TemporalOpHeartbeatDetailsTimeoutCaller invokes an activity-backed Nexus operation
+// whose backing activity heartbeats once with deterministic details and then stalls until
+// the HeartbeatTimeout fires. Returns a single string encoding the observed TimeoutType and
+// (when present) the decoded LastHeartbeatDetails, so the test can assert both at once.
+func (w *Workflows) TemporalOpHeartbeatDetailsTimeoutCaller(ctx workflow.Context, input string) (string, error) {
+	c := workflow.NewNexusClient(temporalOpEndpoint, temporalOpServiceName)
+	var result string
+	err := c.ExecuteOperation(ctx, temporalOpHeartbeatDetailsTimeoutOp, input, workflow.NexusOperationOptions{}).Get(ctx, &result)
+	if err == nil {
+		return "", fmt.Errorf("expected heartbeat timeout, got result %q", result)
+	}
+	var timeoutErr *temporal.TimeoutError
+	if !errors.As(err, &timeoutErr) {
+		return "other:" + err.Error(), nil
+	}
+	out := "timeout:" + timeoutErr.TimeoutType().String()
+	if timeoutErr.HasLastHeartbeatDetails() {
+		var details string
+		if dErr := timeoutErr.LastHeartbeatDetails(&details); dErr == nil {
+			return out + ":details=" + details, nil
+		}
+		return out + ":details=<decode-err>", nil
+	}
+	return out + ":details=<missing>", nil
+}
+
+// TemporalOpSharedActivityCaller exercises the multi-caller-callback-attach scenario: two
+// workflows running this method in parallel with the SAME input both resolve to a single
+// backing activity (USE_EXISTING) and each registers its own completion callback. When the
+// activity completes both callers must receive the result.
+func (w *Workflows) TemporalOpSharedActivityCaller(ctx workflow.Context, input string) (string, error) {
+	c := workflow.NewNexusClient(temporalOpEndpoint, temporalOpServiceName)
+	var result string
+	return result, c.ExecuteOperation(ctx, temporalOpSharedActivityOp, input, workflow.NexusOperationOptions{}).Get(ctx, &result)
+}
+
+// TemporalOpRenamedActivityCaller invokes the Nexus operation backed by an activity that
+// was registered under a custom name. Asserts that StartActivity resolves aliases via the
+// worker's registry.
+func (w *Workflows) TemporalOpRenamedActivityCaller(ctx workflow.Context, input string) (string, error) {
+	c := workflow.NewNexusClient(temporalOpEndpoint, temporalOpServiceName)
+	var result string
+	return result, c.ExecuteOperation(ctx, temporalOpRenamedActivityOp, input, workflow.NexusOperationOptions{}).Get(ctx, &result)
+}
+
+func (w *Workflows) TemporalOpTerminateCallerCaller(ctx workflow.Context, _ string) (string, error) {
+	c := workflow.NewNexusClient(temporalOpEndpoint, temporalOpServiceName)
+	callerID := workflow.GetInfo(ctx).WorkflowExecution.ID
+	var result string
+	err := c.ExecuteOperation(ctx, temporalOpTerminateCallerActivityOp, callerID, workflow.NexusOperationOptions{}).Get(ctx, &result)
+	return result, err
+}
+
 func (w *Workflows) register(worker worker.Worker) {
 	worker.RegisterWorkflow(w.TemporalOpEcho)
 	worker.RegisterWorkflow(w.TemporalOpWaitForCancel)
@@ -3858,6 +4314,27 @@ func (w *Workflows) register(worker worker.Worker) {
 	worker.RegisterWorkflow(w.TemporalOpCancelCaller)
 	worker.RegisterWorkflow(w.TemporalOpCustomCancelCaller)
 	worker.RegisterWorkflow(w.TemporalOpClientInStartCaller)
+	worker.RegisterWorkflow(w.TemporalOpAsyncActivityCaller)
+	worker.RegisterWorkflow(w.TemporalOpAsyncUntypedActivityCaller)
+	worker.RegisterWorkflow(w.TemporalOpCancelActivityCaller)
+	worker.RegisterWorkflow(w.TemporalOpFailingActivityCaller)
+	worker.RegisterWorkflow(w.TemporalOpTimeoutActivityCaller)
+	worker.RegisterWorkflow(w.TemporalOpScheduleToCloseTimeoutCaller)
+	worker.RegisterWorkflow(w.TemporalOpHeartbeatTimeoutCaller)
+	worker.RegisterWorkflow(w.TemporalOpRetryThenSucceedCaller)
+	worker.RegisterWorkflow(w.TemporalOpRetryExhaustCaller)
+	worker.RegisterWorkflow(w.TemporalOpTerminateCallerCaller)
+	worker.RegisterWorkflow(w.TemporalOpSharedActivityCaller)
+	worker.RegisterWorkflow(w.TemporalOpHeartbeatDetailsTimeoutCaller)
+	worker.RegisterWorkflow(w.TemporalOpRenamedActivityCaller)
+	worker.RegisterActivity(waitForCancelNexusActivity)
+	worker.RegisterActivity(failingNexusActivity)
+	worker.RegisterActivity(sleepingNexusActivity)
+	worker.RegisterActivity(failsNTimesNexusActivity)
+	worker.RegisterActivity(terminateCallerNexusActivity)
+	worker.RegisterActivity(delayedEchoNexusActivity)
+	worker.RegisterActivity(heartbeatThenStallNexusActivity)
+	worker.RegisterActivityWithOptions(renamedNexusActivity, activity.RegisterOptions{Name: renamedNexusActivityCustomName})
 	worker.RegisterWorkflow(w.ActivityCancelRepro)
 	worker.RegisterWorkflow(w.ActivityCompletionUsingID)
 	worker.RegisterWorkflow(w.ActivityHeartbeatWithRetry)


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Add Standalone Activity support to Temporal Nexus Operation Handler

## Why?
<!-- Tell your future self why have you made these changes -->

Allows starting Standalone Activities from Nexus Operation Handlers

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Nexus async operation lifecycle, stand-alone activity RPC fields, and completion callbacks—important for correctness but well covered by new integration and unit tests; some behavior still depends on server fixes.
> 
> **Overview**
> **Activity-backed async Nexus operations** — `temporalnexus.StartActivity` and `StartUntypedActivity` let `MustNewTemporalOperation` handlers schedule **stand-alone** activities and return an async **activity-execution** operation token (new token type, cancel via default `CancelActivityExecution`). Nexus start options (request ID, completion callbacks, links) are propagated onto `ClientStartActivityOptions`, including **USE_EXISTING** attach behavior for shared backing activities.
> 
> **Client & linking** — Internal-only setters on start-activity options wire callbacks, links, on-conflict attach, and capture the start response **Link**. `Link_Activity` ↔ Nexus link conversion is added and wired into link parsing.
> 
> **Test workflow environment** — Nexus test client implements `ExecuteActivity` (when the workflow-run op context is set), simulates Nexus completion callbacks when the activity finishes, and supports cancel via activity handles.
> 
> **Tests & CI** — Large integration suite for success, cancel, failures, timeouts, retries, shared activity / dual callbacks, and terminated caller; workflow test suite unit test; dev server enables `activity.enableCallbacks`; docker CI sets `DISABLE_ACTIVITY_BACKED_NEXUS_TESTS`. Some link and heartbeat-details assertions are skipped pending server work (NEXUS-400).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 199861ca611468443093a40fd6da70973e871752. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->