### PR TITLE
Fix upload/download stats to use wall-clock duration

### DIFF
--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -459,6 +459,7 @@ func (wtp *workflowTaskProcessor) processWorkflowTask(task *workflowTask) (retEr
 	defer close(doneCh)
 
 	downloadPayloadMetrics := &workflowTaskStorageMetrics{}
+	downloadPayloadMetrics.Start() // start wall-clock before visits begin
 	ctx := extstore.WithStorageOperationCallback(context.Background(), downloadPayloadMetrics)
 
 	var taskErr error
@@ -466,6 +467,7 @@ func (wtp *workflowTaskProcessor) processWorkflowTask(task *workflowTask) (retEr
 		wtp.handleInboundVisitorError(task.task, taskErr)
 		return nil
 	}
+	downloadPayloadMetrics.Stop() // capture end time before any other work
 
 	wfctx, err := wtp.contextManager.GetOrCreateWorkflowContext(task.task, task.historyIterator)
 	if err != nil {
@@ -589,6 +591,7 @@ func (wtp *workflowTaskProcessor) RespondTaskCompletedWithMetrics(
 	}
 
 	uploadPayloadMetrics := &workflowTaskStorageMetrics{}
+	uploadPayloadMetrics.Start() // start wall-clock before visits begin
 	ctx := extstore.WithStorageOperationCallback(context.Background(), uploadPayloadMetrics)
 	ctx = extstore.WithStorageTarget(ctx, extstore.StorageDriverWorkflowInfo{
 		Namespace:    wtp.namespace,
@@ -624,6 +627,7 @@ func (wtp *workflowTaskProcessor) RespondTaskCompletedWithMetrics(
 		}
 		taskCompletion = &workflowTaskCompletion{rawRequest: wtp.errorToFailWorkflowTask(task.TaskToken, taskErr)}
 	}
+	uploadPayloadMetrics.Stop() // capture end time before network call
 
 	taskDuration := time.Since(startTime)
 	metricsHandler.Timer(metrics.WorkflowTaskExecutionLatency).Record(taskDuration)
@@ -643,7 +647,7 @@ func (wtp *workflowTaskProcessor) RespondTaskCompletedWithMetrics(
 		loggerDurationKeyVals = append(loggerDurationKeyVals,
 			tagPayloadDownloadCount, downloadPayloadMetrics.payloadCount,
 			tagPayloadDownloadSize, downloadPayloadMetrics.totalSize,
-			tagPayloadDownloadDuration, downloadPayloadMetrics.totalDuration,
+			tagPayloadDownloadDuration, downloadPayloadMetrics.WallClockDuration(),
 			tagPayloadDownloadDrivers, downloadPayloadMetrics.GetDriverNames(),
 		)
 	}
@@ -651,7 +655,7 @@ func (wtp *workflowTaskProcessor) RespondTaskCompletedWithMetrics(
 		loggerDurationKeyVals = append(loggerDurationKeyVals,
 			tagPayloadUploadCount, uploadPayloadMetrics.payloadCount,
 			tagPayloadUploadSize, uploadPayloadMetrics.totalSize,
-			tagPayloadUploadDuration, uploadPayloadMetrics.totalDuration,
+			tagPayloadUploadDuration, uploadPayloadMetrics.WallClockDuration(),
 			tagPayloadUploadDrivers, uploadPayloadMetrics.GetDriverNames(),
 		)
 	}
@@ -868,11 +872,26 @@ func (wtp *workflowTaskProcessor) errorToFailWorkflowTaskWithCause(taskToken []b
 }
 
 type workflowTaskStorageMetrics struct {
-	mu            sync.Mutex
-	payloadCount  int
-	totalSize     int64
-	totalDuration time.Duration
-	driverNames   map[string]struct{}
+	mu           sync.Mutex
+	payloadCount int
+	totalSize    int64
+	startTime   time.Time
+	endTime     time.Time
+	driverNames map[string]struct{}
+}
+
+// Start records the wall-clock start time for this metrics collector.
+// Call immediately before visitProtoPayloads.
+func (callback *workflowTaskStorageMetrics) Start() {
+	callback.mu.Lock()
+	defer callback.mu.Unlock()
+	callback.startTime = time.Now()
+}
+
+func (callback *workflowTaskStorageMetrics) Stop() {
+	callback.mu.Lock()
+	defer callback.mu.Unlock()
+	callback.endTime = time.Now()
 }
 
 func (callback *workflowTaskStorageMetrics) PayloadBatchCompleted(count int, size int64, duration time.Duration, driverNames []string) {
@@ -880,13 +899,25 @@ func (callback *workflowTaskStorageMetrics) PayloadBatchCompleted(count int, siz
 	defer callback.mu.Unlock()
 	callback.payloadCount += count
 	callback.totalSize += size
-	callback.totalDuration += duration
 	for _, name := range driverNames {
 		if callback.driverNames == nil {
 			callback.driverNames = make(map[string]struct{})
 		}
 		callback.driverNames[name] = struct{}{}
 	}
+}
+
+// WallClockDuration returns the elapsed time between Start() and Stop().
+// This reflects true wall-clock latency for only the storage phase —
+// unaffected by workflow execution or network calls that follow.
+// Returns 0 if Start() or Stop() was never called.
+func (callback *workflowTaskStorageMetrics) WallClockDuration() time.Duration {
+	callback.mu.Lock()
+	defer callback.mu.Unlock()
+	if callback.startTime.IsZero() || callback.endTime.IsZero() {
+		return 0
+	}
+	return callback.endTime.Sub(callback.startTime)
 }
 
 func (callback *workflowTaskStorageMetrics) GetDriverNames() []string {

--- a/internal/internal_task_pollers_test.go
+++ b/internal/internal_task_pollers_test.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"encoding/binary"
 	"errors"
-	"github.com/google/uuid"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
@@ -659,4 +662,62 @@ func TestDoPollGracefulShutdown(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestWorkflowTaskStorageMetrics_WallClockDuration(t *testing.T) {
+	// Before Start() — should return 0
+	m := &workflowTaskStorageMetrics{}
+	assert.Zero(t, m.WallClockDuration(), "should return 0 before Start()")
+
+	// After Start() but before Stop() — still 0 (no end time yet)
+	m.Start()
+	assert.Zero(t, m.WallClockDuration(), "should return 0 before Stop()")
+
+	// After Stop() — should return a positive duration
+	time.Sleep(5 * time.Millisecond)
+	m.Stop()
+	d := m.WallClockDuration()
+	assert.Greater(t, d, time.Duration(0), "should return positive duration after Stop()")
+
+	// Second Stop() should not reset — duration only grows
+	time.Sleep(5 * time.Millisecond)
+	m.Stop()
+	d2 := m.WallClockDuration()
+	assert.GreaterOrEqual(t, d2, d, "duration should not shrink on second Stop()")
+}
+
+func TestWorkflowTaskStorageMetrics_PayloadBatchCompleted(t *testing.T) {
+	m := &workflowTaskStorageMetrics{}
+	m.Start()
+
+	// Simulate two concurrent batch callbacks
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		m.PayloadBatchCompleted(3, 100, 80*time.Millisecond, []string{"s3"})
+	}()
+	go func() {
+		defer wg.Done()
+		time.Sleep(10 * time.Millisecond)
+		m.PayloadBatchCompleted(2, 50, 60*time.Millisecond, []string{"gcs"})
+	}()
+
+	wg.Wait()
+	m.Stop()
+
+	// payloadCount and totalSize accumulate correctly
+	assert.Equal(t, 5, m.payloadCount)
+	assert.Equal(t, int64(150), m.totalSize)
+
+	// driver names collected from both callbacks
+	assert.Equal(t, []string{"gcs", "s3"}, m.GetDriverNames())
+
+	// Wall-clock duration is NOT the sum of individual durations (80+60=140ms)
+	// It is the time between Start() and Stop() — much less than 140ms
+	d := m.WallClockDuration()
+	assert.Less(t, d, 140*time.Millisecond,
+		"wall-clock should be less than sum of individual durations (edge detection, not summation)")
+	assert.Greater(t, d, time.Duration(0))
 }


### PR DESCRIPTION
Use edge detection (Start/Stop) to bracket visitProtoPayloads rather than
summing individual PayloadBatchCompleted durations

Fixes #2378

## What was changed

**`internal/internal_task_pollers.go`**

- Replaced `totalDuration time.Duration` field on `workflowTaskStorageMetrics`
  with `startTime` and `endTime time.Time` fields.
- Added `Start()` — records wall-clock start immediately before
  `visitProtoPayloads` is called (rising edge).
- Added `Stop()` — records wall-clock end immediately after
  `visitProtoPayloads` returns (falling edge), before any subsequent
  workflow execution or network calls.
- Added `WallClockDuration()` — returns `endTime.Sub(startTime)`, a fixed
  interval between two captured timestamps. Replaces `totalDuration` at
  both log sites (`tagPayloadDownloadDuration`, `tagPayloadUploadDuration`).
- `PayloadBatchCompleted` no longer accumulates `duration` — it only tracks
  `payloadCount`, `totalSize`, and `driverNames`.

**`internal/internal_task_pollers_test.go`**

- `TestWorkflowTaskStorageMetrics_WallClockDuration` — verifies the
  Start/Stop/WallClockDuration lifecycle: returns 0 before `Start()`,
  returns 0 before `Stop()`, returns a positive duration after `Stop()`,
  does not shrink on a second `Stop()` call.
- `TestWorkflowTaskStorageMetrics_PayloadBatchCompleted` — simulates two
  concurrent callbacks and asserts that `payloadCount` and `totalSize`
  accumulate correctly, driver names are collected from both callbacks,
  and wall-clock duration is less than the sum of individual durations
  (proving edge detection rather than summation).

## Why?

`PayloadBatchCompleted` was called once per `Visit` invocation with a
`duration` argument representing the wall-clock time for that Visit.
When `payloadVisitorConcurrency > 1`, multiple Visit calls run
concurrently. Summing their individual durations overcounts proportionally
to the number of concurrent visits:

```
Visit 1: t=0ms  → t=100ms   duration=100ms
Visit 2: t=10ms → t=120ms   duration=110ms   (runs concurrently with Visit 1)

Old: totalDuration = 100 + 110 = 210ms  ← wrong, they overlapped
New: Stop() − Start() = 120ms − 0ms = 120ms  ← correct wall-clock
```



## Checklist

1. Closes #2378
2. How was this tested:
   - `TestWorkflowTaskStorageMetrics_WallClockDuration` — unit test for
     the Start/Stop/WallClockDuration lifecycle.
   - `TestWorkflowTaskStorageMetrics_PayloadBatchCompleted` — concurrent
     callbacks assert wall-clock < sum of individual durations.
   - Run: `go test ./internal/ -run "TestWorkflowTaskStorageMetrics" -v`
3. Any docs updates needed? No — internal observability change only, no
   public API or user-visible behavior change.