### PR TITLE
Refactor poller autoscaling

### DIFF
--- a/internal/internal_nexus_worker.go
+++ b/internal/internal_nexus_worker.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"github.com/nexus-rpc/sdk-go/nexus"
+	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/sdk/internal/common/metrics"
 )
@@ -66,7 +67,8 @@ func newNexusWorker(opts nexusWorkerOptions) (*nexusWorker, error) {
 		metricsHandler:               params.MetricsHandler,
 		workerPollCompleteOnShutdown: params.workerPollCompleteOnShutdown,
 		slotReservationData: slotReservationData{
-			taskQueue: params.TaskQueue,
+			taskQueue:     params.TaskQueue,
+			taskQueueKind: enumspb.TASK_QUEUE_KIND_NORMAL,
 		},
 		isInternalWorker: params.isInternalWorker(),
 	}

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -391,7 +391,8 @@ func newWorkflowTaskWorkerInternal(
 		metricsHandler:               params.MetricsHandler,
 		workerPollCompleteOnShutdown: params.workerPollCompleteOnShutdown,
 		slotReservationData: slotReservationData{
-			taskQueue: params.TaskQueue,
+			taskQueue:     params.TaskQueue,
+			taskQueueKind: enumspb.TASK_QUEUE_KIND_UNSPECIFIED,
 		},
 	}
 
@@ -439,7 +440,8 @@ func newWorkflowTaskWorkerInternal(
 		fatalErrCb:     laParams.WorkerFatalErrorCallback,
 		metricsHandler: laParams.MetricsHandler,
 		slotReservationData: slotReservationData{
-			taskQueue: params.TaskQueue,
+			taskQueue:     params.TaskQueue,
+			taskQueueKind: enumspb.TASK_QUEUE_KIND_NORMAL,
 		},
 	},
 	)
@@ -601,7 +603,8 @@ func newActivityWorker(
 		sessionTokenBucket:           sessionTokenBucket,
 		workerPollCompleteOnShutdown: params.workerPollCompleteOnShutdown,
 		slotReservationData: slotReservationData{
-			taskQueue: params.TaskQueue,
+			taskQueue:     params.TaskQueue,
+			taskQueueKind: enumspb.TASK_QUEUE_KIND_NORMAL,
 		},
 	}
 

--- a/internal/internal_worker_base.go
+++ b/internal/internal_worker_base.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
 	"golang.org/x/time/rate"
 	"google.golang.org/grpc/codes"
@@ -187,10 +188,10 @@ type (
 		taskPollerType string
 		// pollerCount is the number of pollers tasks to start. There may be less than this
 		// due to limited slots, rate limiting, or poller autoscaling.
-		pollerCount      int
-		taskPoller       taskPoller
-		pollerAutoscaler *pollerAutoscaler
-		dynamicRunner    *dynamicScalableTaskPollerRunner
+		pollerCount       int
+		taskPoller        taskPoller
+		pollerAutoscaler  *pollerAutoscaler
+		autoscalingRunner *autoscalingTaskPollerRunner
 	}
 
 	// baseWorkerOptions options to configure base worker.
@@ -289,7 +290,7 @@ type (
 
 	barrier chan struct{}
 
-	dynamicScalableTaskPollerRunner struct {
+	autoscalingTaskPollerRunner struct {
 		autoscaler *pollerAutoscaler
 		wakeCh     chan struct{}
 		activeMu   sync.Mutex
@@ -422,7 +423,7 @@ func (bw *baseWorker) Start() {
 			bw.pollerBalancer.registerPollerType(taskWorker.taskPollerType)
 		}
 
-		if taskWorker.dynamicRunner != nil {
+		if taskWorker.autoscalingRunner != nil {
 			bw.stopWG.Add(1)
 			bw.pollerWG.Add(1)
 			go bw.runAutoscalingPoller(taskWorker)
@@ -499,7 +500,7 @@ func (bw *baseWorker) runPoller(taskWorker scalableTaskPoller) {
 			}
 		}
 
-		bw.reserveSlotAsync(ctx, reserveChan)
+		bw.reserveSlotAsync(ctx, reserveChan, taskWorker)
 
 		select {
 		case <-bw.stopCh:
@@ -554,12 +555,12 @@ func (bw *baseWorker) runAutoscalingPoller(taskWorker scalableTaskPoller) {
 			}
 		}
 
-		releaseActive, err := taskWorker.dynamicRunner.acquire(bw.limiterContext)
+		releaseActive, err := taskWorker.autoscalingRunner.acquire(bw.limiterContext)
 		if err != nil {
 			return
 		}
 
-		bw.reserveSlotAsync(ctx, reserveChan)
+		bw.reserveSlotAsync(ctx, reserveChan, taskWorker)
 
 		var permit *SlotPermit
 		select {
@@ -598,11 +599,16 @@ func (bw *baseWorker) runAutoscalingPoller(taskWorker scalableTaskPoller) {
 	}
 }
 
-func (bw *baseWorker) reserveSlotAsync(ctx context.Context, reserveChan chan<- *SlotPermit) {
+func (bw *baseWorker) reserveSlotAsync(
+	ctx context.Context,
+	reserveChan chan<- *SlotPermit,
+	taskWorker scalableTaskPoller,
+) {
 	bw.stopWG.Add(1)
 	go func() {
 		defer bw.stopWG.Done()
-		s, err := bw.slotSupplier.ReserveSlot(ctx, &bw.options.slotReservationData)
+		reservationData := bw.slotReservationData(taskWorker)
+		s, err := bw.slotSupplier.ReserveSlot(ctx, &reservationData)
 		if err != nil {
 			if !errors.Is(err, context.Canceled) {
 				bw.logger.Error("Error while trying to reserve slot", "error", err)
@@ -620,6 +626,30 @@ func (bw *baseWorker) reserveSlotAsync(ctx context.Context, reserveChan chan<- *
 			bw.releaseSlot(s, SlotReleaseReasonUnused)
 		}
 	}()
+}
+
+func (bw *baseWorker) slotReservationData(taskWorker scalableTaskPoller) slotReservationData {
+	data := bw.options.slotReservationData
+	if kind, ok := taskQueueKindForPoller(taskWorker); ok {
+		data.taskQueueKind = kind
+	}
+	return data
+}
+
+func taskQueueKindForPoller(taskWorker scalableTaskPoller) (enumspb.TaskQueueKind, bool) {
+	switch taskWorker.taskPollerType {
+	case metrics.PollerTypeWorkflowStickyTask:
+		return enumspb.TASK_QUEUE_KIND_STICKY, true
+	case metrics.PollerTypeWorkflowTask:
+		// Autoscaling workflow pollers are split by queue kind. SimpleMaximum
+		// workflow pollers are mixed, so their kind is not known at reservation time.
+		if taskWorker.autoscalingRunner != nil {
+			return enumspb.TASK_QUEUE_KIND_NORMAL, true
+		}
+	case metrics.PollerTypeActivityTask, metrics.PollerTypeNexusTask:
+		return enumspb.TASK_QUEUE_KIND_NORMAL, true
+	}
+	return enumspb.TASK_QUEUE_KIND_UNSPECIFIED, false
 }
 
 func (bw *baseWorker) tryReserveSlot() *SlotPermit {
@@ -996,14 +1026,14 @@ func (prh *pollerAutoscaler) newPeriod() {
 	prh.scaleUpAllowed.Store(float64(ingestedThisPeriod) >= float64(ingestedLastPeriod)*1.1)
 }
 
-func newDynamicScalableTaskPollerRunner(autoscaler *pollerAutoscaler) *dynamicScalableTaskPollerRunner {
-	return &dynamicScalableTaskPollerRunner{
+func newAutoscalingTaskPollerRunner(autoscaler *pollerAutoscaler) *autoscalingTaskPollerRunner {
+	return &autoscalingTaskPollerRunner{
 		autoscaler: autoscaler,
 		wakeCh:     make(chan struct{}, 1),
 	}
 }
 
-func (r *dynamicScalableTaskPollerRunner) acquire(ctx context.Context) (func(), error) {
+func (r *autoscalingTaskPollerRunner) acquire(ctx context.Context) (func(), error) {
 	for {
 		r.activeMu.Lock()
 		target := int(r.autoscaler.target.Load())
@@ -1022,21 +1052,21 @@ func (r *dynamicScalableTaskPollerRunner) acquire(ctx context.Context) (func(), 
 	}
 }
 
-func (r *dynamicScalableTaskPollerRunner) release() {
+func (r *autoscalingTaskPollerRunner) release() {
 	r.activeMu.Lock()
 	r.active--
 	r.activeMu.Unlock()
 	r.signal()
 }
 
-func (r *dynamicScalableTaskPollerRunner) signal() {
+func (r *autoscalingTaskPollerRunner) signal() {
 	select {
 	case r.wakeCh <- struct{}{}:
 	default:
 	}
 }
 
-func (r *dynamicScalableTaskPollerRunner) activePolls() int {
+func (r *autoscalingTaskPollerRunner) activePolls() int {
 	r.activeMu.Lock()
 	defer r.activeMu.Unlock()
 	return r.active
@@ -1062,9 +1092,9 @@ func newScalableTaskPoller(
 			logger:                    logger,
 			serverSupportsAutoscaling: serverSupportsAutoscaling,
 		})
-		tw.dynamicRunner = newDynamicScalableTaskPollerRunner(tw.pollerAutoscaler)
+		tw.autoscalingRunner = newAutoscalingTaskPollerRunner(tw.pollerAutoscaler)
 		tw.pollerAutoscaler.targetChangedCallback = func() {
-			tw.dynamicRunner.signal()
+			tw.autoscalingRunner.signal()
 		}
 	case *pollerBehaviorSimpleMaximum:
 		tw.pollerCount = p.maximumNumberOfPollers

--- a/internal/internal_worker_base.go
+++ b/internal/internal_worker_base.go
@@ -187,10 +187,10 @@ type (
 		taskPollerType string
 		// pollerCount is the number of pollers tasks to start. There may be less than this
 		// due to limited slots, rate limiting, or poller autoscaling.
-		pollerCount                  int
-		taskPoller                   taskPoller
-		pollerAutoscalerReportHandle *pollScalerReportHandle
-		pollerSemaphore              *pollerSemaphore
+		pollerCount      int
+		taskPoller       taskPoller
+		pollerAutoscaler *pollerAutoscaler
+		dynamicRunner    *dynamicScalableTaskPollerRunner
 	}
 
 	// baseWorkerOptions options to configure base worker.
@@ -265,21 +265,21 @@ type (
 		permit *SlotPermit
 	}
 
-	pollScalerReportHandleOptions struct {
+	pollerAutoscalerOptions struct {
 		initialPollerCount        int
 		maxPollerCount            int
 		minPollerCount            int
 		logger                    log.Logger
-		scaleCallback             func(int)
+		targetChangedCallback     func()
 		serverSupportsAutoscaling *atomic.Bool
 	}
 
-	pollScalerReportHandle struct {
+	pollerAutoscaler struct {
 		minPollerCount            int
 		maxPollerCount            int
 		logger                    log.Logger
 		target                    atomic.Int64
-		scaleCallback             func(int)
+		targetChangedCallback     func()
 		everSawScalingDecision    atomic.Bool
 		serverSupportsAutoscaling *atomic.Bool
 		ingestedThisPeriod        atomic.Int64
@@ -289,12 +289,11 @@ type (
 
 	barrier chan struct{}
 
-	// pollerSemaphore is a semaphore that limits the number of concurrent pollers.
-	// it is effectively a resizable semaphore.
-	pollerSemaphore struct {
-		maxPermits int
-		permits    int
-		bs         chan barrier
+	dynamicScalableTaskPollerRunner struct {
+		autoscaler *pollerAutoscaler
+		wakeCh     chan struct{}
+		activeMu   sync.Mutex
+		active     int
 	}
 
 	// pollerBalancer is used to balance the number of poll requests from different poller types
@@ -423,17 +422,23 @@ func (bw *baseWorker) Start() {
 			bw.pollerBalancer.registerPollerType(taskWorker.taskPollerType)
 		}
 
-		for i := 0; i < taskWorker.pollerCount; i++ {
+		if taskWorker.dynamicRunner != nil {
 			bw.stopWG.Add(1)
 			bw.pollerWG.Add(1)
-			go bw.runPoller(taskWorker)
+			go bw.runAutoscalingPoller(taskWorker)
+		} else {
+			for i := 0; i < taskWorker.pollerCount; i++ {
+				bw.stopWG.Add(1)
+				bw.pollerWG.Add(1)
+				go bw.runPoller(taskWorker)
+			}
 		}
 
-		if taskWorker.pollerAutoscalerReportHandle != nil {
+		if taskWorker.pollerAutoscaler != nil {
 			bw.stopWG.Add(1)
 			go func() {
 				defer bw.stopWG.Done()
-				taskWorker.pollerAutoscalerReportHandle.run(bw.stopCh)
+				taskWorker.pollerAutoscaler.run(bw.stopCh)
 			}()
 		}
 	}
@@ -477,7 +482,6 @@ func (bw *baseWorker) shouldDrainOnShutdown() bool {
 func (bw *baseWorker) runPoller(taskWorker scalableTaskPoller) {
 	defer bw.stopWG.Done()
 	defer bw.pollerWG.Done()
-	// Note: With poller autoscaling, this metric doesn't make a lot of sense since the number of pollers can go up and down.
 	bw.metricsHandler.Counter(metrics.PollerStartCounter).Inc(1)
 
 	ctx, cancelfn := context.WithCancel(context.Background())
@@ -485,72 +489,137 @@ func (bw *baseWorker) runPoller(taskWorker scalableTaskPoller) {
 	reserveChan := make(chan *SlotPermit)
 
 	for {
-		if func() bool {
-			if bw.noRepoll.Load() {
-				return true
-			}
-			if taskWorker.pollerSemaphore != nil {
-				if taskWorker.pollerSemaphore.acquire(bw.limiterContext) != nil {
-					return true
-				}
-				defer taskWorker.pollerSemaphore.release()
-			}
-			// Call the balancer to make sure one poller type doesn't starve the others of slots.
-			if bw.pollerBalancer != nil {
-				if bw.pollerBalancer.balance(bw.limiterContext, taskWorker.taskPollerType) != nil {
-					return true
-				}
-			}
-
-			bw.stopWG.Add(1)
-			go func() {
-				defer bw.stopWG.Done()
-				s, err := bw.slotSupplier.ReserveSlot(ctx, &bw.options.slotReservationData)
-				if err != nil {
-					if !errors.Is(err, context.Canceled) {
-						bw.logger.Error("Error while trying to reserve slot", "error", err)
-						select {
-						case reserveChan <- nil:
-						case <-ctx.Done():
-							return
-						}
-					}
-					return
-				}
-				select {
-				case reserveChan <- s:
-				case <-ctx.Done():
-					bw.releaseSlot(s, SlotReleaseReasonUnused)
-				}
-			}()
-
-			select {
-			case <-bw.stopCh:
-				return true
-			case permit := <-reserveChan:
-				if permit == nil { // There was an error reserving a slot
-					// Avoid spamming reserve hard in the event it's constantly failing
-					if ctx.Err() == nil {
-						time.Sleep(time.Second)
-					}
-					return false
-				}
-				if bw.sessionTokenBucket != nil {
-					bw.sessionTokenBucket.waitForAvailableToken()
-				}
-				if bw.pollerBalancer != nil {
-					bw.pollerBalancer.incrementPoller(taskWorker.taskPollerType)
-				}
-				bw.pollTask(taskWorker, permit)
-				if bw.pollerBalancer != nil {
-					bw.pollerBalancer.decrementPoller(taskWorker.taskPollerType)
-				}
-			}
-			return false
-		}() {
+		if bw.noRepoll.Load() {
 			return
 		}
+		// Call the balancer to make sure one poller type doesn't starve the others of slots.
+		if bw.pollerBalancer != nil {
+			if bw.pollerBalancer.balance(bw.limiterContext, taskWorker.taskPollerType) != nil {
+				return
+			}
+		}
+
+		bw.reserveSlotAsync(ctx, reserveChan)
+
+		select {
+		case <-bw.stopCh:
+			return
+		case permit := <-reserveChan:
+			if permit == nil { // There was an error reserving a slot
+				// Avoid spamming reserve hard in the event it's constantly failing
+				if ctx.Err() == nil {
+					time.Sleep(time.Second)
+				}
+				continue
+			}
+			if bw.sessionTokenBucket != nil {
+				bw.sessionTokenBucket.waitForAvailableToken()
+			}
+			if bw.pollerBalancer != nil {
+				bw.pollerBalancer.incrementPoller(taskWorker.taskPollerType)
+			}
+			bw.pollTask(taskWorker, permit)
+			if bw.pollerBalancer != nil {
+				bw.pollerBalancer.decrementPoller(taskWorker.taskPollerType)
+			}
+		}
 	}
+}
+
+// runAutoscalingPoller is the autoscaling counterpart to runPoller. runPoller is
+// itself the long-lived poller: it reserves a slot, opens one poll RPC
+// synchronously, and loops. The autoscaling path instead uses this goroutine as
+// a manager: it reserves a slot, waits for active polls to be below the current
+// autoscaler target, then spawns a short-lived goroutine for that poll RPC.
+func (bw *baseWorker) runAutoscalingPoller(taskWorker scalableTaskPoller) {
+	defer bw.stopWG.Done()
+	defer bw.pollerWG.Done()
+
+	ctx, cancelfn := context.WithCancel(context.Background())
+	reserveChan := make(chan *SlotPermit)
+	var pollWG sync.WaitGroup
+
+	defer pollWG.Wait()
+	defer cancelfn()
+
+	for {
+		if bw.noRepoll.Load() {
+			return
+		}
+		// Call the balancer before reserving a slot so one poller type cannot
+		// hold slots while waiting for another type to start polling.
+		if bw.pollerBalancer != nil {
+			if bw.pollerBalancer.balance(bw.limiterContext, taskWorker.taskPollerType) != nil {
+				return
+			}
+		}
+
+		releaseActive, err := taskWorker.dynamicRunner.acquire(bw.limiterContext)
+		if err != nil {
+			return
+		}
+
+		bw.reserveSlotAsync(ctx, reserveChan)
+
+		var permit *SlotPermit
+		select {
+		case <-bw.stopCh:
+			releaseActive()
+			return
+		case permit = <-reserveChan:
+		}
+		if permit == nil { // There was an error reserving a slot
+			releaseActive()
+			// Avoid spamming reserve hard in the event it's constantly failing
+			if ctx.Err() == nil {
+				time.Sleep(time.Second)
+			}
+			continue
+		}
+
+		if bw.sessionTokenBucket != nil {
+			bw.sessionTokenBucket.waitForAvailableToken()
+		}
+		if bw.pollerBalancer != nil {
+			bw.pollerBalancer.incrementPoller(taskWorker.taskPollerType)
+		}
+
+		pollWG.Add(1)
+		bw.stopWG.Add(1)
+		go func(slotPermit *SlotPermit) {
+			defer bw.stopWG.Done()
+			defer pollWG.Done()
+			defer releaseActive()
+			if bw.pollerBalancer != nil {
+				defer bw.pollerBalancer.decrementPoller(taskWorker.taskPollerType)
+			}
+			bw.pollTask(taskWorker, slotPermit)
+		}(permit)
+	}
+}
+
+func (bw *baseWorker) reserveSlotAsync(ctx context.Context, reserveChan chan<- *SlotPermit) {
+	bw.stopWG.Add(1)
+	go func() {
+		defer bw.stopWG.Done()
+		s, err := bw.slotSupplier.ReserveSlot(ctx, &bw.options.slotReservationData)
+		if err != nil {
+			if !errors.Is(err, context.Canceled) {
+				bw.logger.Error("Error while trying to reserve slot", "error", err)
+				select {
+				case reserveChan <- nil:
+				case <-ctx.Done():
+					return
+				}
+			}
+			return
+		}
+		select {
+		case reserveChan <- s:
+		case <-ctx.Done():
+			bw.releaseSlot(s, SlotReleaseReasonUnused)
+		}
+	}()
 }
 
 func (bw *baseWorker) tryReserveSlot() *SlotPermit {
@@ -700,8 +769,8 @@ func (bw *baseWorker) pollTask(taskWorker scalableTaskPoller, slotPermit *SlotPe
 				}
 				return
 			}
-			if taskWorker.pollerAutoscalerReportHandle != nil {
-				taskWorker.pollerAutoscalerReportHandle.handleError(err)
+			if taskWorker.pollerAutoscaler != nil {
+				taskWorker.pollerAutoscaler.handleError(err)
 			}
 			// We use the secondary retrier on resource exhausted
 			_, resourceExhausted := err.(*serviceerror.ResourceExhausted)
@@ -712,8 +781,8 @@ func (bw *baseWorker) pollTask(taskWorker scalableTaskPoller, slotPermit *SlotPe
 	}
 
 	if task != nil {
-		if taskWorker.pollerAutoscalerReportHandle != nil {
-			taskWorker.pollerAutoscalerReportHandle.handleTask(task)
+		if taskWorker.pollerAutoscaler != nil {
+			taskWorker.pollerAutoscaler.handleTask(task)
 		}
 
 		if bw.shouldDrainOnShutdown() {
@@ -810,7 +879,7 @@ func (bw *baseWorker) stopPolling() {
 	bw.noRepoll.Store(true)
 }
 
-func newPollScalerReportHandle(options pollScalerReportHandleOptions) *pollScalerReportHandle {
+func newPollerAutoscaler(options pollerAutoscalerOptions) *pollerAutoscaler {
 	logger := options.logger
 	if logger == nil {
 		logger = internallog.NewNopLogger()
@@ -819,18 +888,18 @@ func newPollScalerReportHandle(options pollScalerReportHandleOptions) *pollScale
 	if serverSupportsAutoscaling == nil {
 		serverSupportsAutoscaling = &atomic.Bool{}
 	}
-	psr := &pollScalerReportHandle{
+	psr := &pollerAutoscaler{
 		maxPollerCount:            options.maxPollerCount,
 		minPollerCount:            options.minPollerCount,
 		logger:                    logger,
-		scaleCallback:             options.scaleCallback,
+		targetChangedCallback:     options.targetChangedCallback,
 		serverSupportsAutoscaling: serverSupportsAutoscaling,
 	}
 	psr.target.Store(int64(options.initialPollerCount))
 	return psr
 }
 
-func (prh *pollScalerReportHandle) handleTask(task taskForWorker) {
+func (prh *pollerAutoscaler) handleTask(task taskForWorker) {
 	if !task.isEmpty() {
 		prh.ingestedThisPeriod.Add(1)
 	}
@@ -860,7 +929,7 @@ func (prh *pollScalerReportHandle) handleTask(task taskForWorker) {
 	}
 }
 
-func (prh *pollScalerReportHandle) updateTarget(f func(int64) int64) {
+func (prh *pollerAutoscaler) updateTarget(f func(int64) int64) {
 	target := prh.target.Load()
 	newTarget := f(target)
 	if newTarget < int64(prh.minPollerCount) {
@@ -877,16 +946,15 @@ func (prh *pollScalerReportHandle) updateTarget(f func(int64) int64) {
 			newTarget = int64(prh.maxPollerCount)
 		}
 	}
-	permits := int(newTarget)
-	if prh.scaleCallback != nil {
+	if prh.targetChangedCallback != nil {
 		traceLog(func() {
-			prh.logger.Debug("Updating number of permits", "permits", permits)
+			prh.logger.Debug("Updating poller autoscaler target", "target", int(newTarget))
 		})
-		prh.scaleCallback(permits)
+		prh.targetChangedCallback()
 	}
 }
 
-func (prh *pollScalerReportHandle) handleError(err error) {
+func (prh *pollerAutoscaler) handleError(err error) {
 	// If we have never seen a scaling decision and the server doesn't support
 	// poller autoscaling, we don't want to scale down on errors, because we
 	// might never scale up again.
@@ -904,7 +972,7 @@ func (prh *pollScalerReportHandle) handleError(err error) {
 	}
 }
 
-func (prh *pollScalerReportHandle) run(stopCh <-chan struct{}) {
+func (prh *pollerAutoscaler) run(stopCh <-chan struct{}) {
 	ticker := time.NewTicker(pollerAutoscalingReportInterval)
 	// Here we periodically check if we should permit increasing the
 	// poller count further. We do this by comparing the number of ingested items in the
@@ -922,63 +990,56 @@ func (prh *pollScalerReportHandle) run(stopCh <-chan struct{}) {
 	}
 }
 
-func (prh *pollScalerReportHandle) newPeriod() {
+func (prh *pollerAutoscaler) newPeriod() {
 	ingestedThisPeriod := prh.ingestedThisPeriod.Swap(0)
 	ingestedLastPeriod := prh.ingestedLastPeriod.Swap(ingestedThisPeriod)
 	prh.scaleUpAllowed.Store(float64(ingestedThisPeriod) >= float64(ingestedLastPeriod)*1.1)
 }
 
-func newPollerSemaphore(maxPermits int) *pollerSemaphore {
-	ps := &pollerSemaphore{
-		maxPermits: maxPermits,
-		permits:    0,
-		bs:         make(chan barrier, 1),
+func newDynamicScalableTaskPollerRunner(autoscaler *pollerAutoscaler) *dynamicScalableTaskPollerRunner {
+	return &dynamicScalableTaskPollerRunner{
+		autoscaler: autoscaler,
+		wakeCh:     make(chan struct{}, 1),
 	}
-	ps.bs <- make(barrier)
-	return ps
 }
 
-func (ps *pollerSemaphore) acquire(ctx context.Context) error {
+func (r *dynamicScalableTaskPollerRunner) acquire(ctx context.Context) (func(), error) {
 	for {
-		// Acquire barrier.
-		b := <-ps.bs
-		if ps.permits < ps.maxPermits {
-			ps.permits++
-			// Release barrier.
-			ps.bs <- b
-			return nil
+		r.activeMu.Lock()
+		target := int(r.autoscaler.target.Load())
+		if r.active < target {
+			r.active++
+			r.activeMu.Unlock()
+			return r.release, nil
 		}
-		// Release barrier.
-		ps.bs <- b
+		r.activeMu.Unlock()
 
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
-		case <-b:
-			continue
+			return nil, ctx.Err()
+		case <-r.wakeCh:
 		}
 	}
 }
 
-func (ps *pollerSemaphore) release() {
-	// Acquire barrier.
-	b := <-ps.bs
-	ps.permits--
-	// Release one waiter if there are any waiting.
-	select {
-	case b <- struct{}{}:
-	default:
-	}
-	// Release barrier.
-	ps.bs <- b
+func (r *dynamicScalableTaskPollerRunner) release() {
+	r.activeMu.Lock()
+	r.active--
+	r.activeMu.Unlock()
+	r.signal()
 }
 
-func (ps *pollerSemaphore) updatePermits(maxPermits int) {
-	// Acquire barrier.
-	b := <-ps.bs
-	ps.maxPermits = maxPermits
-	// Release barrier.
-	ps.bs <- b
+func (r *dynamicScalableTaskPollerRunner) signal() {
+	select {
+	case r.wakeCh <- struct{}{}:
+	default:
+	}
+}
+
+func (r *dynamicScalableTaskPollerRunner) activePolls() int {
+	r.activeMu.Lock()
+	defer r.activeMu.Unlock()
+	return r.active
 }
 
 func newScalableTaskPoller(
@@ -994,18 +1055,17 @@ func newScalableTaskPoller(
 	}
 	switch p := pollerBehavior.(type) {
 	case *pollerBehaviorAutoscaling:
-		tw.pollerCount = p.maximumNumberOfPollers
-		tw.pollerSemaphore = newPollerSemaphore(p.initialNumberOfPollers)
-		tw.pollerAutoscalerReportHandle = newPollScalerReportHandle(pollScalerReportHandleOptions{
+		tw.pollerAutoscaler = newPollerAutoscaler(pollerAutoscalerOptions{
 			initialPollerCount:        p.initialNumberOfPollers,
 			maxPollerCount:            p.maximumNumberOfPollers,
 			minPollerCount:            p.minimumNumberOfPollers,
 			logger:                    logger,
 			serverSupportsAutoscaling: serverSupportsAutoscaling,
-			scaleCallback: func(newTarget int) {
-				tw.pollerSemaphore.updatePermits(newTarget)
-			},
 		})
+		tw.dynamicRunner = newDynamicScalableTaskPollerRunner(tw.pollerAutoscaler)
+		tw.pollerAutoscaler.targetChangedCallback = func() {
+			tw.dynamicRunner.signal()
+		}
 	case *pollerBehaviorSimpleMaximum:
 		tw.pollerCount = p.maximumNumberOfPollers
 	}

--- a/internal/internal_worker_base_test.go
+++ b/internal/internal_worker_base_test.go
@@ -17,13 +17,13 @@ import (
 )
 
 type (
-	PollScalerReportHandleSuite struct {
+	PollerAutoscalerSuite struct {
 		suite.Suite
 	}
 )
 
-func TestPollScalerReportHandleSuite(t *testing.T) {
-	suite.Run(t, new(PollScalerReportHandleSuite))
+func TestPollerAutoscalerSuite(t *testing.T) {
+	suite.Run(t, new(PollerAutoscalerSuite))
 }
 
 type (
@@ -39,7 +39,7 @@ func (s *ScalableTaskPollerSuite) TestNewScalableTaskPollerSetsTaskPollerType() 
 		},
 	)
 
-	blockingPoller := newSemaphoreProbeTaskPoller()
+	blockingPoller := newBlockingProbeTaskPoller()
 	poller := newScalableTaskPoller(
 		blockingPoller,
 		ilog.NewNopLogger(),
@@ -49,6 +49,32 @@ func (s *ScalableTaskPollerSuite) TestNewScalableTaskPollerSetsTaskPollerType() 
 	)
 
 	s.Equal(metrics.PollerTypeWorkflowStickyTask, poller.taskPollerType)
+}
+
+func (s *ScalableTaskPollerSuite) TestNewScalableTaskPollerUsesDynamicRunnerOnlyForAutoscaling() {
+	autoscalingPoller := newScalableTaskPoller(
+		newBlockingProbeTaskPoller(),
+		ilog.NewNopLogger(),
+		&pollerBehaviorAutoscaling{
+			initialNumberOfPollers: 1,
+			maximumNumberOfPollers: 2,
+			minimumNumberOfPollers: 1,
+		},
+		metrics.PollerTypeWorkflowTask,
+		&atomic.Bool{},
+	)
+	s.NotNil(autoscalingPoller.dynamicRunner)
+	s.Equal(0, autoscalingPoller.pollerCount)
+
+	simpleMaximumPoller := newScalableTaskPoller(
+		newBlockingProbeTaskPoller(),
+		ilog.NewNopLogger(),
+		&pollerBehaviorSimpleMaximum{maximumNumberOfPollers: 2},
+		metrics.PollerTypeWorkflowTask,
+		&atomic.Bool{},
+	)
+	s.Nil(simpleMaximumPoller.dynamicRunner)
+	s.Equal(2, simpleMaximumPoller.pollerCount)
 }
 func TestScalableTaskPollerSuite(t *testing.T) {
 	suite.Run(t, new(ScalableTaskPollerSuite))
@@ -92,62 +118,50 @@ func (t *emptyTask) scaleDecision() (pollerScaleDecision, bool) {
 	return pollerScaleDecision{}, false
 }
 
-func (s *PollScalerReportHandleSuite) TestErrorScaleDown() {
-	targetSuggestion := 0
-	ps := newPollScalerReportHandle(pollScalerReportHandleOptions{
+func (s *PollerAutoscalerSuite) TestErrorScaleDown() {
+	ps := newPollerAutoscaler(pollerAutoscalerOptions{
 		initialPollerCount: 8,
 		maxPollerCount:     10,
 		minPollerCount:     2,
-		scaleCallback: func(suggestion int) {
-			targetSuggestion = suggestion
-		},
 	})
 	ps.handleTask(newTestTask(0))
 	ps.handleError(serviceerror.NewResourceExhausted(enumspb.RESOURCE_EXHAUSTED_CAUSE_CONCURRENT_LIMIT, ""))
-	assert.Equal(s.T(), 4, targetSuggestion, "should suggest scaling down on resource exhausted error")
+	assert.Equal(s.T(), int64(4), ps.target.Load(), "should suggest scaling down on resource exhausted error")
 	// Non resource exhausted errors should scale down by 1
 	ps.handleError(serviceerror.NewInternal("test error"))
-	assert.Equal(s.T(), 3, targetSuggestion)
+	assert.Equal(s.T(), int64(3), ps.target.Load())
 	ps.handleError(serviceerror.NewInternal("test error"))
-	assert.Equal(s.T(), 2, targetSuggestion)
+	assert.Equal(s.T(), int64(2), ps.target.Load())
 	// We should not scale down below minPollerCount
 	ps.handleError(serviceerror.NewInternal("test error"))
-	assert.Equal(s.T(), 2, targetSuggestion)
+	assert.Equal(s.T(), int64(2), ps.target.Load())
 	ps.handleError(serviceerror.NewResourceExhausted(enumspb.RESOURCE_EXHAUSTED_CAUSE_CONCURRENT_LIMIT, ""))
-	assert.Equal(s.T(), 2, targetSuggestion)
+	assert.Equal(s.T(), int64(2), ps.target.Load())
 }
 
-func (s *PollScalerReportHandleSuite) TestScaleDownOnEmptyTask() {
-	targetSuggestion := 0
-	ps := newPollScalerReportHandle(pollScalerReportHandleOptions{
+func (s *PollerAutoscalerSuite) TestScaleDownOnEmptyTask() {
+	ps := newPollerAutoscaler(pollerAutoscalerOptions{
 		initialPollerCount: 8,
 		maxPollerCount:     10,
 		minPollerCount:     2,
-		scaleCallback: func(suggestion int) {
-			targetSuggestion = suggestion
-		},
 	})
 	ps.handleTask(newTestTask(0))
 	ps.handleTask(newEmptyTask())
-	assert.Equal(s.T(), 7, targetSuggestion)
+	assert.Equal(s.T(), int64(7), ps.target.Load())
 }
 
-func (s *PollScalerReportHandleSuite) TestScaleUpOnDelay() {
-	targetSuggestion := 0
-	ps := newPollScalerReportHandle(pollScalerReportHandleOptions{
+func (s *PollerAutoscalerSuite) TestScaleUpOnDelay() {
+	ps := newPollerAutoscaler(pollerAutoscalerOptions{
 		initialPollerCount: 8,
 		maxPollerCount:     10,
 		minPollerCount:     2,
-		scaleCallback: func(suggestion int) {
-			targetSuggestion = suggestion
-		},
 	})
 	ps.handleTask(newTestTask(10))
-	assert.Equal(s.T(), 0, targetSuggestion)
+	assert.Equal(s.T(), int64(8), ps.target.Load())
 	ps.newPeriod()
 	ps.handleTask(newTestTask(100))
 	// We should scale up to but not past the max poller count
-	assert.Equal(s.T(), 10, targetSuggestion)
+	assert.Equal(s.T(), int64(10), ps.target.Load())
 
 }
 
@@ -158,7 +172,7 @@ func (s *ScalableTaskPollerSuite) TestAutoscalingConcurrencyScalesUpToMaximum() 
 		minimumNumberOfPollers: 1,
 	}
 
-	blockingPoller := newSemaphoreProbeTaskPoller()
+	blockingPoller := newBlockingProbeTaskPoller()
 	poller := newScalableTaskPoller(blockingPoller, ilog.NewNopLogger(), behavior, "", nil)
 	bw := newBaseWorker(baseWorkerOptions{
 		slotSupplier:     &testSlotSupplier{},
@@ -173,27 +187,25 @@ func (s *ScalableTaskPollerSuite) TestAutoscalingConcurrencyScalesUpToMaximum() 
 
 	bw.Start()
 	defer func() {
-		allowBlockedPollers(blockingPoller, poller.pollerSemaphore)
+		blockingPoller.Allow(readDynamicPollerState(poller.dynamicRunner))
 		blockingPoller.Close()
 		bw.Stop()
 	}()
 
-	eventuallySemaphoreState(s.T(), blockingPoller, poller.pollerSemaphore, 2, 2, "expected initial poller to start")
+	eventuallyDynamicPollerState(s.T(), poller.dynamicRunner, 2, "expected initial pollers to start")
 
 	require.Never(s.T(), func() bool {
-		allowBlockedPollers(blockingPoller, poller.pollerSemaphore)
-		permits, _ := readSemaphoreState(poller.pollerSemaphore)
-		return permits > 2
+		blockingPoller.Allow(readDynamicPollerState(poller.dynamicRunner))
+		return readDynamicPollerState(poller.dynamicRunner) > 2
 	}, 200*time.Millisecond, 10*time.Millisecond, "should not exceed initial concurrency")
 
-	poller.pollerAutoscalerReportHandle.updateTarget(func(int64) int64 { return 3 })
+	poller.pollerAutoscaler.updateTarget(func(int64) int64 { return 3 })
 
-	eventuallySemaphoreState(s.T(), blockingPoller, poller.pollerSemaphore, 3, 3, "expected concurrency to scale up to maximum")
+	eventuallyDynamicPollerState(s.T(), poller.dynamicRunner, 3, "expected concurrency to scale up to maximum")
 
 	require.Never(s.T(), func() bool {
-		allowBlockedPollers(blockingPoller, poller.pollerSemaphore)
-		permits, _ := readSemaphoreState(poller.pollerSemaphore)
-		return permits > 3
+		blockingPoller.Allow(readDynamicPollerState(poller.dynamicRunner))
+		return readDynamicPollerState(poller.dynamicRunner) > 3
 	}, 200*time.Millisecond, 10*time.Millisecond, "should not exceed maximum concurrency")
 }
 
@@ -204,7 +216,7 @@ func (s *ScalableTaskPollerSuite) TestAutoscalingScalesDownToMinimum() {
 		minimumNumberOfPollers: 1,
 	}
 
-	blockingPoller := newSemaphoreProbeTaskPoller()
+	blockingPoller := newBlockingProbeTaskPoller()
 	poller := newScalableTaskPoller(blockingPoller, ilog.NewNopLogger(), behavior, "", nil)
 
 	bw := newBaseWorker(baseWorkerOptions{
@@ -220,39 +232,120 @@ func (s *ScalableTaskPollerSuite) TestAutoscalingScalesDownToMinimum() {
 
 	bw.Start()
 	defer func() {
-		allowBlockedPollers(blockingPoller, poller.pollerSemaphore)
+		blockingPoller.Allow(readDynamicPollerState(poller.dynamicRunner))
 		blockingPoller.Close()
 		bw.Stop()
 	}()
 
-	eventuallySemaphoreState(s.T(), blockingPoller, poller.pollerSemaphore, 2, 2, "expected initial concurrency")
+	eventuallyDynamicPollerState(s.T(), poller.dynamicRunner, 2, "expected initial concurrency")
 
-	poller.pollerAutoscalerReportHandle.updateTarget(func(target int64) int64 { return 1 })
+	poller.pollerAutoscaler.updateTarget(func(target int64) int64 { return 1 })
+	blockingPoller.Allow(2)
 
-	eventuallySemaphoreState(s.T(), blockingPoller, poller.pollerSemaphore, 1, 1, "expected concurrency to reduce to minimum")
+	eventuallyDynamicPollerState(s.T(), poller.dynamicRunner, 1, "expected concurrency to reduce to minimum")
 
 	require.Never(s.T(), func() bool {
-		allowBlockedPollers(blockingPoller, poller.pollerSemaphore)
-		permits, _ := readSemaphoreState(poller.pollerSemaphore)
-		return permits == 0
+		blockingPoller.Allow(readDynamicPollerState(poller.dynamicRunner))
+		return readDynamicPollerState(poller.dynamicRunner) == 0
 	}, 200*time.Millisecond, 10*time.Millisecond, "should not scale below minimum")
 }
 
-type semaphoreProbeTaskPoller struct {
+func (s *ScalableTaskPollerSuite) TestAutoscalingDoesNotHoldSlotWhileWaitingForPollCapacity() {
+	behavior := &pollerBehaviorAutoscaling{
+		initialNumberOfPollers: 1,
+		maximumNumberOfPollers: 2,
+		minimumNumberOfPollers: 1,
+	}
+
+	blockingPoller := newBlockingProbeTaskPoller()
+	poller := newScalableTaskPoller(blockingPoller, ilog.NewNopLogger(), behavior, "", nil)
+	slotSupplier := newLimitedSlotSupplier(2)
+
+	bw := newBaseWorker(baseWorkerOptions{
+		slotSupplier:     slotSupplier,
+		maxTaskPerSecond: 1000,
+		taskPollers:      []scalableTaskPoller{poller},
+		taskProcessor:    noopTaskProcessor{},
+		workerType:       "AutoscalingSlotCapacityTest",
+		logger:           ilog.NewNopLogger(),
+		stopTimeout:      time.Second,
+		metricsHandler:   metrics.NopHandler,
+	})
+
+	bw.Start()
+	defer func() {
+		blockingPoller.Allow(readDynamicPollerState(poller.dynamicRunner))
+		blockingPoller.Close()
+		bw.Stop()
+	}()
+
+	eventuallyDynamicPollerState(s.T(), poller.dynamicRunner, 1, "expected initial poller to start")
+
+	require.Never(s.T(), func() bool {
+		return slotSupplier.reserves.Load() > 1
+	}, 200*time.Millisecond, 10*time.Millisecond,
+		"autoscaling poller should not reserve another slot while blocked by its target")
+
+	permit := slotSupplier.TryReserveSlot(nil)
+	require.NotNil(s.T(), permit, "unused slot should remain available while autoscaling target is full")
+	slotSupplier.ReleaseSlot(nil)
+}
+
+func (s *ScalableTaskPollerSuite) TestAutoscalingBalancerDoesNotHoldSlotsWhileBlocked() {
+	behavior := &pollerBehaviorAutoscaling{
+		initialNumberOfPollers: 2,
+		maximumNumberOfPollers: 2,
+		minimumNumberOfPollers: 1,
+	}
+
+	blockingPoller := newBlockingProbeTaskPoller()
+	poller := newScalableTaskPoller(blockingPoller, ilog.NewNopLogger(), behavior, "a", nil)
+	slotSupplier := newLimitedSlotSupplier(2)
+
+	bw := newBaseWorker(baseWorkerOptions{
+		slotSupplier:     slotSupplier,
+		maxTaskPerSecond: 1000,
+		taskPollers: []scalableTaskPoller{
+			poller,
+			{taskPollerType: "b"},
+		},
+		taskProcessor:  noopTaskProcessor{},
+		workerType:     "AutoscalingBalancerTest",
+		logger:         ilog.NewNopLogger(),
+		stopTimeout:    time.Second,
+		metricsHandler: metrics.NopHandler,
+	})
+
+	bw.Start()
+	defer func() {
+		blockingPoller.Allow(readDynamicPollerState(poller.dynamicRunner))
+		blockingPoller.Close()
+		bw.Stop()
+	}()
+
+	eventuallyDynamicPollerState(s.T(), poller.dynamicRunner, 1, "expected first poller to start")
+
+	require.Never(s.T(), func() bool {
+		return slotSupplier.reserves.Load() > 1
+	}, 200*time.Millisecond, 10*time.Millisecond,
+		"autoscaling poller should not reserve another slot while blocked by poller balancer")
+}
+
+type blockingProbeTaskPoller struct {
 	signals chan struct{}
 	done    chan struct{}
 	closed  atomic.Bool
 }
 
-func newSemaphoreProbeTaskPoller() *semaphoreProbeTaskPoller {
-	return &semaphoreProbeTaskPoller{
+func newBlockingProbeTaskPoller() *blockingProbeTaskPoller {
+	return &blockingProbeTaskPoller{
 		signals: make(chan struct{}, 32),
 		done:    make(chan struct{}),
 	}
 }
 
-// PollTask implements taskPoller and blocks until a signal is provided so the semaphore permits stay acquired.
-func (p *semaphoreProbeTaskPoller) PollTask() (taskForWorker, error) {
+// PollTask implements taskPoller and blocks until a signal is provided so active polls stay acquired.
+func (p *blockingProbeTaskPoller) PollTask() (taskForWorker, error) {
 	select {
 	case <-p.signals:
 		return nil, nil
@@ -261,7 +354,7 @@ func (p *semaphoreProbeTaskPoller) PollTask() (taskForWorker, error) {
 	}
 }
 
-func (p *semaphoreProbeTaskPoller) Allow(n int) {
+func (p *blockingProbeTaskPoller) Allow(n int) {
 	for range n {
 		select {
 		case p.signals <- struct{}{}:
@@ -271,39 +364,23 @@ func (p *semaphoreProbeTaskPoller) Allow(n int) {
 	}
 }
 
-func (p *semaphoreProbeTaskPoller) Close() {
+func (p *blockingProbeTaskPoller) Close() {
 	if p.closed.CompareAndSwap(false, true) {
 		close(p.done)
 	}
 }
 
-func allowBlockedPollers(p *semaphoreProbeTaskPoller, sem *pollerSemaphore) {
-	if p == nil || sem == nil {
-		return
-	}
-	permits, _ := readSemaphoreState(sem)
-	if permits > 0 {
-		p.Allow(permits)
-	}
-}
-
-func eventuallySemaphoreState(t *testing.T, blockingPoller *semaphoreProbeTaskPoller, sem *pollerSemaphore, expectedPermits, expectedMax int, msg string) {
+func eventuallyDynamicPollerState(t *testing.T, runner *dynamicScalableTaskPollerRunner, expectedActive int, msg string) {
 	require.Eventually(t, func() bool {
-		allowBlockedPollers(blockingPoller, sem)
-		permits, max := readSemaphoreState(sem)
-		return permits == expectedPermits && max == expectedMax
+		return readDynamicPollerState(runner) == expectedActive
 	}, time.Second, 10*time.Millisecond, msg)
 }
 
-func readSemaphoreState(ps *pollerSemaphore) (permits int, max int) {
-	if ps == nil {
-		return 0, 0
+func readDynamicPollerState(runner *dynamicScalableTaskPollerRunner) int {
+	if runner == nil {
+		return 0
 	}
-	barrier := <-ps.bs
-	permits = ps.permits
-	max = ps.maxPermits
-	ps.bs <- barrier
-	return
+	return runner.activePolls()
 }
 
 type testSlotSupplier struct{}
@@ -326,6 +403,49 @@ func (s *testSlotSupplier) MarkSlotUsed(SlotMarkUsedInfo) {}
 func (s *testSlotSupplier) ReleaseSlot(SlotReleaseInfo) {}
 
 func (s *testSlotSupplier) MaxSlots() int { return 0 }
+
+type limitedSlotSupplier struct {
+	slots    chan struct{}
+	reserves atomic.Int32
+	releases atomic.Int32
+}
+
+func newLimitedSlotSupplier(slots int) *limitedSlotSupplier {
+	s := &limitedSlotSupplier{slots: make(chan struct{}, slots)}
+	for i := 0; i < slots; i++ {
+		s.slots <- struct{}{}
+	}
+	return s
+}
+
+func (s *limitedSlotSupplier) ReserveSlot(ctx context.Context, info SlotReservationInfo) (*SlotPermit, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-s.slots:
+		s.reserves.Add(1)
+		return &SlotPermit{}, nil
+	}
+}
+
+func (s *limitedSlotSupplier) TryReserveSlot(SlotReservationInfo) *SlotPermit {
+	select {
+	case <-s.slots:
+		s.reserves.Add(1)
+		return &SlotPermit{}
+	default:
+		return nil
+	}
+}
+
+func (s *limitedSlotSupplier) MarkSlotUsed(SlotMarkUsedInfo) {}
+
+func (s *limitedSlotSupplier) ReleaseSlot(SlotReleaseInfo) {
+	s.releases.Add(1)
+	s.slots <- struct{}{}
+}
+
+func (s *limitedSlotSupplier) MaxSlots() int { return cap(s.slots) }
 
 type noopTaskProcessor struct{}
 
@@ -399,6 +519,69 @@ func TestTaskNotDroppedDuringShutdown(t *testing.T) {
 	select {
 	case <-stopDone:
 		// Stop completed cleanly
+	case <-time.After(5 * time.Second):
+		t.Fatal("Stop() did not return in time")
+	}
+}
+
+func TestAutoscalingTaskNotDroppedDuringShutdown(t *testing.T) {
+	taskProcessed := make(chan struct{}, 1)
+	pollStarted := make(chan struct{})
+	tp := &shutdownTaskPoller{
+		pollStarted: pollStarted,
+		returnTask:  make(chan struct{}),
+		task:        &testTask{},
+	}
+	processor := &recordingTaskProcessor{
+		processed: taskProcessed,
+	}
+	workerPollCompleteOnShutdown := &atomic.Bool{}
+	workerPollCompleteOnShutdown.Store(true)
+	poller := newScalableTaskPoller(
+		tp,
+		ilog.NewNopLogger(),
+		&pollerBehaviorAutoscaling{
+			initialNumberOfPollers: 1,
+			maximumNumberOfPollers: 2,
+			minimumNumberOfPollers: 1,
+		},
+		"test",
+		&atomic.Bool{},
+	)
+
+	bw := newBaseWorker(baseWorkerOptions{
+		slotSupplier:                 &testSlotSupplier{},
+		maxTaskPerSecond:             1000,
+		taskPollers:                  []scalableTaskPoller{poller},
+		taskProcessor:                processor,
+		workerType:                   "AutoscalingShutdownTest",
+		logger:                       ilog.NewNopLogger(),
+		stopTimeout:                  5 * time.Second,
+		metricsHandler:               metrics.NopHandler,
+		workerPollCompleteOnShutdown: workerPollCompleteOnShutdown,
+	})
+
+	bw.Start()
+	<-pollStarted
+	bw.noRepoll.Store(true)
+
+	stopDone := make(chan struct{})
+	go func() {
+		bw.Stop()
+		close(stopDone)
+	}()
+
+	<-bw.stopCh
+	close(tp.returnTask)
+
+	select {
+	case <-taskProcessed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("task polled during autoscaling shutdown was not processed")
+	}
+
+	select {
+	case <-stopDone:
 	case <-time.After(5 * time.Second):
 		t.Fatal("Stop() did not return in time")
 	}
@@ -750,16 +933,12 @@ func (p *stopAwareShutdownPoller) PollTask() (taskForWorker, error) {
 	return nil, errStop
 }
 
-func (s *PollScalerReportHandleSuite) TestAutoscaleDownOnTimeoutWithCapability() {
-	targetSuggestion := 0
-	ps := newPollScalerReportHandle(pollScalerReportHandleOptions{
+func (s *PollerAutoscalerSuite) TestAutoscaleDownOnTimeoutWithCapability() {
+	ps := newPollerAutoscaler(pollerAutoscalerOptions{
 		initialPollerCount:        10,
 		maxPollerCount:            10,
 		minPollerCount:            1,
 		serverSupportsAutoscaling: &atomic.Bool{},
-		scaleCallback: func(suggestion int) {
-			targetSuggestion = suggestion
-		},
 	})
 	ps.serverSupportsAutoscaling.Store(true)
 
@@ -767,19 +946,15 @@ func (s *PollScalerReportHandleSuite) TestAutoscaleDownOnTimeoutWithCapability()
 	for i := 0; i < 20; i++ {
 		ps.handleTask(newEmptyTask())
 	}
-	assert.Equal(s.T(), 1, targetSuggestion)
+	assert.Equal(s.T(), int64(1), ps.target.Load())
 	assert.False(s.T(), ps.everSawScalingDecision.Load())
 }
 
-func (s *PollScalerReportHandleSuite) TestAutoscaleDownOnTimeoutWithoutCapability() {
-	targetSuggestion := 0
-	ps := newPollScalerReportHandle(pollScalerReportHandleOptions{
+func (s *PollerAutoscalerSuite) TestAutoscaleDownOnTimeoutWithoutCapability() {
+	ps := newPollerAutoscaler(pollerAutoscalerOptions{
 		initialPollerCount: 10,
 		maxPollerCount:     10,
 		minPollerCount:     1,
-		scaleCallback: func(suggestion int) {
-			targetSuggestion = suggestion
-		},
 	})
 
 	// Send 20 empty polls - should NOT scale down because we haven't seen a
@@ -787,21 +962,16 @@ func (s *PollScalerReportHandleSuite) TestAutoscaleDownOnTimeoutWithoutCapabilit
 	for i := 0; i < 20; i++ {
 		ps.handleTask(newEmptyTask())
 	}
-	// target never changed from initial, callback was never called
-	assert.Equal(s.T(), 0, targetSuggestion)
+	// target never changed from initial
 	assert.Equal(s.T(), int64(10), ps.target.Load())
 }
 
-func (s *PollScalerReportHandleSuite) TestAutoscaleDownOnTimeoutClampsToMin() {
-	targetSuggestion := 0
-	ps := newPollScalerReportHandle(pollScalerReportHandleOptions{
+func (s *PollerAutoscalerSuite) TestAutoscaleDownOnTimeoutClampsToMin() {
+	ps := newPollerAutoscaler(pollerAutoscalerOptions{
 		initialPollerCount:        10,
 		maxPollerCount:            10,
 		minPollerCount:            3,
 		serverSupportsAutoscaling: &atomic.Bool{},
-		scaleCallback: func(suggestion int) {
-			targetSuggestion = suggestion
-		},
 	})
 	ps.serverSupportsAutoscaling.Store(true)
 
@@ -809,28 +979,24 @@ func (s *PollScalerReportHandleSuite) TestAutoscaleDownOnTimeoutClampsToMin() {
 	for i := 0; i < 20; i++ {
 		ps.handleTask(newEmptyTask())
 	}
-	assert.Equal(s.T(), 3, targetSuggestion)
+	assert.Equal(s.T(), int64(3), ps.target.Load())
 	assert.False(s.T(), ps.everSawScalingDecision.Load())
 }
 
-func (s *PollScalerReportHandleSuite) TestErrorScaleDownWithCapability() {
-	targetSuggestion := 0
-	ps := newPollScalerReportHandle(pollScalerReportHandleOptions{
+func (s *PollerAutoscalerSuite) TestErrorScaleDownWithCapability() {
+	ps := newPollerAutoscaler(pollerAutoscalerOptions{
 		initialPollerCount:        8,
 		maxPollerCount:            10,
 		minPollerCount:            2,
 		serverSupportsAutoscaling: &atomic.Bool{},
-		scaleCallback: func(suggestion int) {
-			targetSuggestion = suggestion
-		},
 	})
 	ps.serverSupportsAutoscaling.Store(true)
 
 	// Should scale down on errors even without having seen a scaling decision
 	ps.handleError(serviceerror.NewResourceExhausted(enumspb.RESOURCE_EXHAUSTED_CAUSE_CONCURRENT_LIMIT, ""))
-	assert.Equal(s.T(), 4, targetSuggestion)
+	assert.Equal(s.T(), int64(4), ps.target.Load())
 	ps.handleError(serviceerror.NewInternal("test error"))
-	assert.Equal(s.T(), 3, targetSuggestion)
+	assert.Equal(s.T(), int64(3), ps.target.Load())
 }
 
 // TestPollerBalancerReturnsNilWhenOwnCountZero is a regression test for
@@ -925,7 +1091,7 @@ func (s *ScalableTaskPollerSuite) TestNewScalableTaskPollerAllTypes() {
 	for _, tc := range cases {
 		s.Run(tc.name, func() {
 			poller := newScalableTaskPoller(
-				newSemaphoreProbeTaskPoller(),
+				newBlockingProbeTaskPoller(),
 				ilog.NewNopLogger(),
 				behavior,
 				tc.ptype,

--- a/internal/internal_worker_base_test.go
+++ b/internal/internal_worker_base_test.go
@@ -63,7 +63,7 @@ func (s *ScalableTaskPollerSuite) TestNewScalableTaskPollerUsesDynamicRunnerOnly
 		metrics.PollerTypeWorkflowTask,
 		&atomic.Bool{},
 	)
-	s.NotNil(autoscalingPoller.dynamicRunner)
+	s.NotNil(autoscalingPoller.autoscalingRunner)
 	s.Equal(0, autoscalingPoller.pollerCount)
 
 	simpleMaximumPoller := newScalableTaskPoller(
@@ -73,9 +73,71 @@ func (s *ScalableTaskPollerSuite) TestNewScalableTaskPollerUsesDynamicRunnerOnly
 		metrics.PollerTypeWorkflowTask,
 		&atomic.Bool{},
 	)
-	s.Nil(simpleMaximumPoller.dynamicRunner)
+	s.Nil(simpleMaximumPoller.autoscalingRunner)
 	s.Equal(2, simpleMaximumPoller.pollerCount)
 }
+
+func (s *ScalableTaskPollerSuite) TestSlotReservationDataUsesKnownTaskQueueKind() {
+	autoscalingBehavior := &pollerBehaviorAutoscaling{
+		initialNumberOfPollers: 1,
+		maximumNumberOfPollers: 2,
+		minimumNumberOfPollers: 1,
+	}
+	bw := &baseWorker{
+		options: baseWorkerOptions{
+			slotReservationData: slotReservationData{
+				taskQueue:     "test-task-queue",
+				taskQueueKind: enumspb.TASK_QUEUE_KIND_UNSPECIFIED,
+			},
+		},
+	}
+
+	nonStickyPoller := newScalableTaskPoller(
+		newBlockingProbeTaskPoller(),
+		ilog.NewNopLogger(),
+		autoscalingBehavior,
+		metrics.PollerTypeWorkflowTask,
+		&atomic.Bool{},
+	)
+	s.Equal(enumspb.TASK_QUEUE_KIND_NORMAL, bw.slotReservationData(nonStickyPoller).taskQueueKind)
+
+	stickyPoller := newScalableTaskPoller(
+		newBlockingProbeTaskPoller(),
+		ilog.NewNopLogger(),
+		autoscalingBehavior,
+		metrics.PollerTypeWorkflowStickyTask,
+		&atomic.Bool{},
+	)
+	s.Equal(enumspb.TASK_QUEUE_KIND_STICKY, bw.slotReservationData(stickyPoller).taskQueueKind)
+
+	mixedPoller := newScalableTaskPoller(
+		newBlockingProbeTaskPoller(),
+		ilog.NewNopLogger(),
+		&pollerBehaviorSimpleMaximum{maximumNumberOfPollers: 1},
+		metrics.PollerTypeWorkflowTask,
+		&atomic.Bool{},
+	)
+	s.Equal(enumspb.TASK_QUEUE_KIND_UNSPECIFIED, bw.slotReservationData(mixedPoller).taskQueueKind)
+}
+
+func (s *ScalableTaskPollerSuite) TestTrackingSlotSupplierPassesTaskQueueKind() {
+	supplier := &captureReservationInfoSlotSupplier{}
+	trackingSupplier := newTrackingSlotSupplier(supplier, trackingSlotSupplierOptions{
+		logger:         ilog.NewNopLogger(),
+		metricsHandler: metrics.NopHandler,
+	})
+
+	permit, err := trackingSupplier.ReserveSlot(context.Background(), &slotReservationData{
+		taskQueue:     "test-task-queue",
+		taskQueueKind: enumspb.TASK_QUEUE_KIND_STICKY,
+	})
+
+	s.NoError(err)
+	s.NotNil(permit)
+	s.Equal("test-task-queue", supplier.taskQueue)
+	s.Equal(enumspb.TASK_QUEUE_KIND_STICKY, supplier.taskQueueKind)
+}
+
 func TestScalableTaskPollerSuite(t *testing.T) {
 	suite.Run(t, new(ScalableTaskPollerSuite))
 }
@@ -187,25 +249,25 @@ func (s *ScalableTaskPollerSuite) TestAutoscalingConcurrencyScalesUpToMaximum() 
 
 	bw.Start()
 	defer func() {
-		blockingPoller.Allow(readDynamicPollerState(poller.dynamicRunner))
+		blockingPoller.Allow(readAutoscalingPollerState(poller.autoscalingRunner))
 		blockingPoller.Close()
 		bw.Stop()
 	}()
 
-	eventuallyDynamicPollerState(s.T(), poller.dynamicRunner, 2, "expected initial pollers to start")
+	eventuallyAutoscalingPollerState(s.T(), poller.autoscalingRunner, 2, "expected initial pollers to start")
 
 	require.Never(s.T(), func() bool {
-		blockingPoller.Allow(readDynamicPollerState(poller.dynamicRunner))
-		return readDynamicPollerState(poller.dynamicRunner) > 2
+		blockingPoller.Allow(readAutoscalingPollerState(poller.autoscalingRunner))
+		return readAutoscalingPollerState(poller.autoscalingRunner) > 2
 	}, 200*time.Millisecond, 10*time.Millisecond, "should not exceed initial concurrency")
 
 	poller.pollerAutoscaler.updateTarget(func(int64) int64 { return 3 })
 
-	eventuallyDynamicPollerState(s.T(), poller.dynamicRunner, 3, "expected concurrency to scale up to maximum")
+	eventuallyAutoscalingPollerState(s.T(), poller.autoscalingRunner, 3, "expected concurrency to scale up to maximum")
 
 	require.Never(s.T(), func() bool {
-		blockingPoller.Allow(readDynamicPollerState(poller.dynamicRunner))
-		return readDynamicPollerState(poller.dynamicRunner) > 3
+		blockingPoller.Allow(readAutoscalingPollerState(poller.autoscalingRunner))
+		return readAutoscalingPollerState(poller.autoscalingRunner) > 3
 	}, 200*time.Millisecond, 10*time.Millisecond, "should not exceed maximum concurrency")
 }
 
@@ -232,21 +294,21 @@ func (s *ScalableTaskPollerSuite) TestAutoscalingScalesDownToMinimum() {
 
 	bw.Start()
 	defer func() {
-		blockingPoller.Allow(readDynamicPollerState(poller.dynamicRunner))
+		blockingPoller.Allow(readAutoscalingPollerState(poller.autoscalingRunner))
 		blockingPoller.Close()
 		bw.Stop()
 	}()
 
-	eventuallyDynamicPollerState(s.T(), poller.dynamicRunner, 2, "expected initial concurrency")
+	eventuallyAutoscalingPollerState(s.T(), poller.autoscalingRunner, 2, "expected initial concurrency")
 
 	poller.pollerAutoscaler.updateTarget(func(target int64) int64 { return 1 })
 	blockingPoller.Allow(2)
 
-	eventuallyDynamicPollerState(s.T(), poller.dynamicRunner, 1, "expected concurrency to reduce to minimum")
+	eventuallyAutoscalingPollerState(s.T(), poller.autoscalingRunner, 1, "expected concurrency to reduce to minimum")
 
 	require.Never(s.T(), func() bool {
-		blockingPoller.Allow(readDynamicPollerState(poller.dynamicRunner))
-		return readDynamicPollerState(poller.dynamicRunner) == 0
+		blockingPoller.Allow(readAutoscalingPollerState(poller.autoscalingRunner))
+		return readAutoscalingPollerState(poller.autoscalingRunner) == 0
 	}, 200*time.Millisecond, 10*time.Millisecond, "should not scale below minimum")
 }
 
@@ -274,12 +336,12 @@ func (s *ScalableTaskPollerSuite) TestAutoscalingDoesNotHoldSlotWhileWaitingForP
 
 	bw.Start()
 	defer func() {
-		blockingPoller.Allow(readDynamicPollerState(poller.dynamicRunner))
+		blockingPoller.Allow(readAutoscalingPollerState(poller.autoscalingRunner))
 		blockingPoller.Close()
 		bw.Stop()
 	}()
 
-	eventuallyDynamicPollerState(s.T(), poller.dynamicRunner, 1, "expected initial poller to start")
+	eventuallyAutoscalingPollerState(s.T(), poller.autoscalingRunner, 1, "expected initial poller to start")
 
 	require.Never(s.T(), func() bool {
 		return slotSupplier.reserves.Load() > 1
@@ -318,12 +380,12 @@ func (s *ScalableTaskPollerSuite) TestAutoscalingBalancerDoesNotHoldSlotsWhileBl
 
 	bw.Start()
 	defer func() {
-		blockingPoller.Allow(readDynamicPollerState(poller.dynamicRunner))
+		blockingPoller.Allow(readAutoscalingPollerState(poller.autoscalingRunner))
 		blockingPoller.Close()
 		bw.Stop()
 	}()
 
-	eventuallyDynamicPollerState(s.T(), poller.dynamicRunner, 1, "expected first poller to start")
+	eventuallyAutoscalingPollerState(s.T(), poller.autoscalingRunner, 1, "expected first poller to start")
 
 	require.Never(s.T(), func() bool {
 		return slotSupplier.reserves.Load() > 1
@@ -370,13 +432,13 @@ func (p *blockingProbeTaskPoller) Close() {
 	}
 }
 
-func eventuallyDynamicPollerState(t *testing.T, runner *dynamicScalableTaskPollerRunner, expectedActive int, msg string) {
+func eventuallyAutoscalingPollerState(t *testing.T, runner *autoscalingTaskPollerRunner, expectedActive int, msg string) {
 	require.Eventually(t, func() bool {
-		return readDynamicPollerState(runner) == expectedActive
+		return readAutoscalingPollerState(runner) == expectedActive
 	}, time.Second, 10*time.Millisecond, msg)
 }
 
-func readDynamicPollerState(runner *dynamicScalableTaskPollerRunner) int {
+func readAutoscalingPollerState(runner *autoscalingTaskPollerRunner) int {
 	if runner == nil {
 		return 0
 	}
@@ -403,6 +465,37 @@ func (s *testSlotSupplier) MarkSlotUsed(SlotMarkUsedInfo) {}
 func (s *testSlotSupplier) ReleaseSlot(SlotReleaseInfo) {}
 
 func (s *testSlotSupplier) MaxSlots() int { return 0 }
+
+type captureReservationInfoSlotSupplier struct {
+	taskQueue     string
+	taskQueueKind enumspb.TaskQueueKind
+}
+
+func (s *captureReservationInfoSlotSupplier) ReserveSlot(
+	ctx context.Context,
+	info SlotReservationInfo,
+) (*SlotPermit, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+	s.taskQueue = info.TaskQueue()
+	s.taskQueueKind = info.TaskQueueKind()
+	return &SlotPermit{}, nil
+}
+
+func (s *captureReservationInfoSlotSupplier) TryReserveSlot(info SlotReservationInfo) *SlotPermit {
+	s.taskQueue = info.TaskQueue()
+	s.taskQueueKind = info.TaskQueueKind()
+	return &SlotPermit{}
+}
+
+func (s *captureReservationInfoSlotSupplier) MarkSlotUsed(SlotMarkUsedInfo) {}
+
+func (s *captureReservationInfoSlotSupplier) ReleaseSlot(SlotReleaseInfo) {}
+
+func (s *captureReservationInfoSlotSupplier) MaxSlots() int { return 0 }
 
 type limitedSlotSupplier struct {
 	slots    chan struct{}

--- a/internal/tuning.go
+++ b/internal/tuning.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	enumspb "go.temporal.io/api/enums/v1"
 	"golang.org/x/sync/semaphore"
 
 	"go.temporal.io/sdk/internal/common/metrics"
@@ -46,6 +47,10 @@ type SlotReservationInfo interface {
 	// TaskQueue returns the task queue for which a slot is being reserved. In the case of local
 	// activities, this is the same as the workflow's task queue.
 	TaskQueue() string
+	// TaskQueueKind returns the kind of task queue for which a slot is being reserved.
+	// Workflow task reservations return unspecified for SimpleMaximum pollers because
+	// they may choose between normal and sticky queues after slot reservation.
+	TaskQueueKind() enumspb.TaskQueueKind
 	// WorkerBuildId returns the build ID of the worker that is reserving the slot.
 	WorkerBuildId() string
 	// WorkerBuildId returns the build ID of the worker that is reserving the slot.
@@ -297,11 +302,13 @@ func (f *FixedSizeSlotSupplier) MaxSlots() int {
 }
 
 type slotReservationData struct {
-	taskQueue string
+	taskQueue     string
+	taskQueueKind enumspb.TaskQueueKind
 }
 
 type slotReserveInfoImpl struct {
 	taskQueue      string
+	taskQueueKind  enumspb.TaskQueueKind
 	workerBuildId  string
 	workerIdentity string
 	issuedSlots    *atomic.Int32
@@ -311,6 +318,10 @@ type slotReserveInfoImpl struct {
 
 func (s slotReserveInfoImpl) TaskQueue() string {
 	return s.taskQueue
+}
+
+func (s slotReserveInfoImpl) TaskQueueKind() enumspb.TaskQueueKind {
+	return s.taskQueueKind
 }
 
 func (s slotReserveInfoImpl) WorkerBuildId() string {
@@ -416,6 +427,7 @@ func (t *trackingSlotSupplier) ReserveSlot(
 ) (*SlotPermit, error) {
 	permit, err := t.inner.ReserveSlot(ctx, slotReserveInfoImpl{
 		taskQueue:      data.taskQueue,
+		taskQueueKind:  data.taskQueueKind,
 		workerBuildId:  t.workerBuildId,
 		workerIdentity: t.workerIdentity,
 		issuedSlots:    &t.issuedSlotsAtomic,
@@ -439,6 +451,7 @@ func (t *trackingSlotSupplier) ReserveSlot(
 func (t *trackingSlotSupplier) TryReserveSlot(data *slotReservationData) *SlotPermit {
 	permit := t.inner.TryReserveSlot(slotReserveInfoImpl{
 		taskQueue:      data.taskQueue,
+		taskQueueKind:  data.taskQueueKind,
 		workerBuildId:  t.workerBuildId,
 		workerIdentity: t.workerIdentity,
 		issuedSlots:    &t.issuedSlotsAtomic,


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->
Dynamic polling behavior was moved out into its own logic. Fundamentally, we no longer create a set number of goroutines (the `maximum` for autoscaling) on worker start. We instead create a `pollerAutoscaler` manager than spins up goroutines after reserving a worker slot for each poll RPC.

With this refactor, `pollerSemaphore` is no longer needed, autoscaling is now controlled by `dynamicScalableTaskPollerRunner.active` vs `pollerAutoscaler.target`.

Was also able to now specify task queue type slot reservation with autoscaling, although simplemax is still unspecified because they are mixed at reservation time.

NOTE: The `PollerStartCounter` metric was removed for autoscaling, it's not really a metric that makes sense for autoscaling, and there wasn't a good way to maintain its pre-refactor behavior.

## Why?
Poller autoscaling was originally designed to mirror the existing polling structure of creating a set number of goroutines (the `maximum` for autoscaling) on worker start.

We're now aligning with Rust on creating new goroutines on each poll RPC

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->
Partially addresses https://github.com/temporalio/sdk-go/issues/2191 for the autoscaling case, SimpleMax still doesn't specify TQ type

2. How was this tested:
  - Updates autoscaling tests to assert active dynamic poll count instead of semaphore permits.
  - Adds coverage that autoscaling uses the dynamic runner while SimpleMaximum does not.
  - Adds shutdown regression coverage to ensure tasks returned during shutdown are still processed.
  - Adds balancer regression coverage to ensure autoscaling does not hold worker slots while blocked waiting for another
    poller type.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core worker polling concurrency and shutdown/drain paths; mistakes could starve tasks or leak slots, though coverage targets balancer blocking and shutdown processing.
> 
> **Overview**
> Refactors **poller autoscaling** so workers no longer start a fixed pool of goroutines up to the autoscaling maximum. A single manager loop (`runAutoscalingPoller`) waits on an `autoscalingTaskPollerRunner` target, reserves a worker slot, then spawns short-lived goroutines per poll RPC—replacing `pollerSemaphore` and the old `pollScalerReportHandle` / `scaleCallback` permit model (`pollerAutoscaler` + `targetChangedCallback`).
> 
> **Slot reservation** now carries `taskQueueKind` on `SlotReservationInfo` and per-poller overrides (`taskQueueKindForPoller`): autoscaling workflow pollers split normal vs sticky; activity/nexus/local activity use normal; SimpleMaximum workflow pollers stay **unspecified** because queue choice happens after reserve. Workers set default kinds in `slotReservationData` where applicable.
> 
> **Behavior fixes:** balancer runs before slot reserve on the autoscaling path so pollers do not hold slots while blocked on capacity or other poller types; shared `reserveSlotAsync` extracts slot reservation. **PollerStartCounter** is no longer incremented for autoscaling pollers. Tests were renamed/expanded around active poll counts, task queue kind propagation, shutdown drain, and slot-holding regressions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c06ea6f793bf62c07b364a0082ea245c92a19ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->