### PR TITLE
Add gzip compression on by default

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -219,6 +219,16 @@ type (
 	// ConnectionOptions are optional parameters that can be specified in ClientOptions
 	ConnectionOptions = internal.ConnectionOptions
 
+	// GrpcCompression controls gRPC compression for connections to the Temporal server.
+	GrpcCompression = internal.GrpcCompression
+
+	// GrpcCompressionGzip compresses outbound gRPC request bodies with gzip and
+	// accepts gzip-compressed responses. This is the default.
+	GrpcCompressionGzip = internal.GrpcCompressionGzip
+
+	// GrpcCompressionNone disables gRPC request compression.
+	GrpcCompressionNone = internal.GrpcCompressionNone
+
 	// Credentials are optional credentials that can be specified in ClientOptions.
 	Credentials = internal.Credentials
 

--- a/internal/client.go
+++ b/internal/client.go
@@ -45,6 +45,31 @@ const (
 	QueryTypeWorkflowMetadata string = "__temporal_workflow_metadata"
 )
 
+// GrpcCompression controls gRPC compression for connections to the Temporal
+// server.
+//
+// Exposed as: [go.temporal.io/sdk/client.GrpcCompression]
+type GrpcCompression interface {
+	grpcCompression()
+}
+
+type (
+	// GrpcCompressionGzip compresses outbound gRPC request bodies with gzip and
+	// accepts gzip-compressed responses. This is the default.
+	//
+	// Exposed as: [go.temporal.io/sdk/client.GrpcCompressionGzip]
+	GrpcCompressionGzip struct{}
+
+	// GrpcCompressionNone disables gRPC request compression. The client will
+	// still accept compressed responses for encodings registered with grpc-go.
+	//
+	// Exposed as: [go.temporal.io/sdk/client.GrpcCompressionNone]
+	GrpcCompressionNone struct{}
+)
+
+func (GrpcCompressionGzip) grpcCompression() {}
+func (GrpcCompressionNone) grpcCompression() {}
+
 type (
 	// Client is the client for starting and getting information about a workflow executions as well as
 	// completing activities asynchronously.
@@ -1012,6 +1037,12 @@ type (
 
 		// MaxPayloadSize is a number of bytes that gRPC would allow to travel to and from server. Defaults to 128 MB.
 		MaxPayloadSize int
+
+		// GrpcCompression controls transport-level gRPC compression for requests
+		// sent to the Temporal server.
+		//
+		// default: GrpcCompressionGzip
+		GrpcCompression GrpcCompression
 
 		// Advanced dial options for gRPC connections. These are applied after the internal default dial options are
 		// applied. Therefore any dial options here may override internal ones. Dial options WithBlock, WithTimeout,

--- a/internal/client.go
+++ b/internal/client.go
@@ -67,8 +67,13 @@ type (
 	GrpcCompressionNone struct{}
 )
 
-func (GrpcCompressionGzip) grpcCompression() {}
-func (GrpcCompressionNone) grpcCompression() {}
+func (*GrpcCompressionGzip) grpcCompression() {}
+func (*GrpcCompressionNone) grpcCompression() {}
+
+var (
+	_ GrpcCompression = (*GrpcCompressionGzip)(nil)
+	_ GrpcCompression = (*GrpcCompressionNone)(nil)
+)
 
 type (
 	// Client is the client for starting and getting information about a workflow executions as well as
@@ -1041,7 +1046,7 @@ type (
 		// GrpcCompression controls transport-level gRPC compression for requests
 		// sent to the Temporal server.
 		//
-		// default: GrpcCompressionGzip
+		// default: &GrpcCompressionGzip{}
 		GrpcCompression GrpcCompression
 
 		// Advanced dial options for gRPC connections. These are applied after the internal default dial options are

--- a/internal/grpc_dialer.go
+++ b/internal/grpc_dialer.go
@@ -103,9 +103,9 @@ func dial(params dialParameters) (*grpc.ClientConn, error) {
 	opts = append(opts, grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxPayloadSize)))
 
 	switch compression := params.UserConnectionOptions.GrpcCompression.(type) {
-	case nil, GrpcCompressionGzip:
+	case nil, *GrpcCompressionGzip:
 		opts = append(opts, grpc.WithDefaultCallOptions(grpc.UseCompressor(grpcgzip.Name)))
-	case GrpcCompressionNone:
+	case *GrpcCompressionNone:
 	default:
 		return nil, fmt.Errorf("unsupported gRPC compression option %T", compression)
 	}

--- a/internal/grpc_dialer.go
+++ b/internal/grpc_dialer.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync/atomic"
 	"time"
 
@@ -14,6 +15,7 @@ import (
 	"google.golang.org/grpc/backoff"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+	grpcgzip "google.golang.org/grpc/encoding/gzip"
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
@@ -99,6 +101,14 @@ func dial(params dialParameters) (*grpc.ClientConn, error) {
 	opts = append(opts, securityOptions...)
 	opts = append(opts, grpc.WithDefaultCallOptions(grpc.MaxCallSendMsgSize(maxPayloadSize)))
 	opts = append(opts, grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxPayloadSize)))
+
+	switch compression := params.UserConnectionOptions.GrpcCompression.(type) {
+	case nil, GrpcCompressionGzip:
+		opts = append(opts, grpc.WithDefaultCallOptions(grpc.UseCompressor(grpcgzip.Name)))
+	case GrpcCompressionNone:
+	default:
+		return nil, fmt.Errorf("unsupported gRPC compression option %T", compression)
+	}
 
 	if !params.UserConnectionOptions.DisableKeepAliveCheck {
 		// gRPC utilizes keep alive mechanism to detect dead connections in case if server didn't close them

--- a/internal/grpc_dialer_test.go
+++ b/internal/grpc_dialer_test.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"net"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -31,6 +32,7 @@ import (
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/resolver/manual"
+	"google.golang.org/grpc/stats"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 )
@@ -335,6 +337,60 @@ func TestDialOptions(t *testing.T) {
 	require.Equal(t, expected, trace)
 }
 
+func TestGrpcCompression(t *testing.T) {
+	for _, tc := range []struct {
+		name              string
+		connectionOptions ConnectionOptions
+		wantCompression   string
+	}{
+		{
+			name:            "default",
+			wantCompression: "gzip",
+		},
+		{
+			name: "explicit gzip",
+			connectionOptions: ConnectionOptions{
+				GrpcCompression: GrpcCompressionGzip{},
+			},
+			wantCompression: "gzip",
+		},
+		{
+			name: "none",
+			connectionOptions: ConnectionOptions{
+				GrpcCompression: GrpcCompressionNone{},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv, err := startTestGRPCServer()
+			require.NoError(t, err)
+			defer srv.Stop()
+
+			client, err := DialClient(context.Background(), ClientOptions{
+				HostPort:          srv.addr,
+				ConnectionOptions: tc.connectionOptions,
+			})
+			require.NoError(t, err)
+			defer client.Close()
+
+			_, err = client.WorkflowService().SignalWorkflowExecution(context.Background(),
+				&workflowservice.SignalWorkflowExecutionRequest{
+					Namespace:  "test-namespace",
+					SignalName: strings.Repeat("test-signal", 100),
+				},
+			)
+			require.NoError(t, err)
+
+			require.Equal(t,
+				tc.wantCompression,
+				srv.statsHandler.compressionForMethod(
+					"/"+workflowservice.WorkflowService_ServiceDesc.ServiceName+"/SignalWorkflowExecution",
+				),
+			)
+		})
+	}
+}
+
 func TestCustomResolver(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -605,6 +661,7 @@ type testGRPCServer struct {
 	*grpc.Server
 	addr                                 string
 	healthServer                         *health.Server
+	statsHandler                         *compressionStatsHandler
 	sigWfCount                           int32
 	getSystemInfoRequestContext          context.Context
 	getSystemInfoResponse                workflowservice.GetSystemInfoResponse
@@ -619,10 +676,12 @@ func startTestGRPCServer() (*testGRPCServer, error) {
 	if err != nil {
 		return nil, err
 	}
+	statsHandler := &compressionStatsHandler{}
 	t := &testGRPCServer{
-		Server:       grpc.NewServer(),
+		Server:       grpc.NewServer(grpc.StatsHandler(statsHandler)),
 		addr:         l.Addr().String(),
 		healthServer: health.NewServer(),
+		statsHandler: statsHandler,
 	}
 	workflowservice.RegisterWorkflowServiceServer(t.Server, t)
 	grpc_health_v1.RegisterHealthServer(t.Server, t.healthServer)
@@ -683,4 +742,38 @@ func (t *testGRPCServer) signalWorkflowInvokeCount() int {
 
 func (t *testGRPCServer) resetSignalWorkflowInvokeCount() {
 	atomic.StoreInt32(&t.sigWfCount, 0)
+}
+
+type compressionStatsHandler struct {
+	mu                  sync.Mutex
+	compressionByMethod map[string]string
+}
+
+func (h *compressionStatsHandler) TagRPC(ctx context.Context, _ *stats.RPCTagInfo) context.Context {
+	return ctx
+}
+
+func (h *compressionStatsHandler) HandleRPC(_ context.Context, s stats.RPCStats) {
+	inHeader, ok := s.(*stats.InHeader)
+	if !ok {
+		return
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.compressionByMethod == nil {
+		h.compressionByMethod = make(map[string]string)
+	}
+	h.compressionByMethod[inHeader.FullMethod] = inHeader.Compression
+}
+
+func (h *compressionStatsHandler) TagConn(ctx context.Context, _ *stats.ConnTagInfo) context.Context {
+	return ctx
+}
+
+func (h *compressionStatsHandler) HandleConn(context.Context, stats.ConnStats) {}
+
+func (h *compressionStatsHandler) compressionForMethod(method string) string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.compressionByMethod[method]
 }

--- a/internal/grpc_dialer_test.go
+++ b/internal/grpc_dialer_test.go
@@ -350,14 +350,14 @@ func TestGrpcCompression(t *testing.T) {
 		{
 			name: "explicit gzip",
 			connectionOptions: ConnectionOptions{
-				GrpcCompression: GrpcCompressionGzip{},
+				GrpcCompression: &GrpcCompressionGzip{},
 			},
 			wantCompression: "gzip",
 		},
 		{
 			name: "none",
 			connectionOptions: ConnectionOptions{
-				GrpcCompression: GrpcCompressionNone{},
+				GrpcCompression: &GrpcCompressionNone{},
 			},
 		},
 	} {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Add and default enable transport-level gzip compression

## Why?
Saves wire space, being done in all SDKs

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
Simple test that headers are enabled. Core has more comprehensive tests confirming server actually responds with compressed values when such headers are set. We could replicate those here too if we feel it's necessary.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
