### PR TITLE
Test poller target halves on ResourceExhausted

### DIFF
--- a/internal/internal_worker_base_test.go
+++ b/internal/internal_worker_base_test.go
@@ -222,6 +222,60 @@ func (s *ScalableTaskPollerSuite) TestAutoscalingScalesDownToMinimum() {
 	}, 200*time.Millisecond, 10*time.Millisecond, "should not scale below minimum")
 }
 
+// TestAutoscalingHalvesOnResourceExhausted verifies that a ResourceExhausted poll
+// error HALVES the poller target (t/2) - as opposed to the -1 decrement applied to
+// other errors - and that the halved value reaches the live pollerSemaphore via the
+// scaleCallback wiring. Asserting the exact step sequence (16 -> 8 -> 4, then 4 -> 3
+// for a non-RE error, then 3 -> 1) is what distinguishes halving from a plain
+// scale-down: a -1 decrement would yield 15, 7, etc., failing these assertions.
+//
+// PollScalerReportHandleSuite.TestErrorScaleDown covers the same arithmetic against
+// a mock scaleCallback; this test additionally proves the real semaphore is resized.
+func (s *ScalableTaskPollerSuite) TestAutoscalingHalvesOnResourceExhausted() {
+	const initialPollers = 16
+	behavior := &pollerBehaviorAutoscaling{
+		initialNumberOfPollers: initialPollers,
+		maximumNumberOfPollers: 100,
+		minimumNumberOfPollers: 1,
+	}
+
+	// The server advertising poller autoscaling is what enables error-driven
+	// scale-down (the everSawScalingDecision || serverSupportsAutoscaling guard
+	// in handleError). Simulate that here.
+	serverSupportsAutoscaling := &atomic.Bool{}
+	serverSupportsAutoscaling.Store(true)
+
+	poller := newScalableTaskPoller(&semaphoreProbeTaskPoller{}, ilog.NewNopLogger(), behavior, serverSupportsAutoscaling)
+	handle := poller.pollerAutoscalerReportHandle
+
+	resourceExhausted := serviceerror.NewResourceExhausted(enumspb.RESOURCE_EXHAUSTED_CAUSE_CONCURRENT_LIMIT, "injected resource exhausted")
+	otherError := serviceerror.NewInternal("some other failure")
+
+	assertMaxPermits := func(want int) {
+		_, max := readSemaphoreState(poller.pollerSemaphore)
+		require.Equal(s.T(), want, max)
+	}
+
+	assertMaxPermits(initialPollers) // 16, before any error
+
+	handle.handleError(resourceExhausted)
+	assertMaxPermits(8) // 16 / 2 (halve)
+
+	handle.handleError(resourceExhausted)
+	assertMaxPermits(4) // 8 / 2 (halve)
+
+	// A non-ResourceExhausted error only decrements: 4 -> 3, NOT 4 / 2 == 2.
+	// This is the assertion that proves ResourceExhausted specifically halves.
+	handle.handleError(otherError)
+	assertMaxPermits(3)
+
+	handle.handleError(resourceExhausted)
+	assertMaxPermits(1) // 3 / 2 == 1, clamped at the configured minimum
+
+	handle.handleError(resourceExhausted)
+	assertMaxPermits(1) // already at minimum, stays clamped
+}
+
 type semaphoreProbeTaskPoller struct {
 	signals chan struct{}
 	done    chan struct{}


### PR DESCRIPTION
## What

Adds `TestAutoscalingHalvesOnResourceExhausted` to `ScalableTaskPollerSuite` in `internal/internal_worker_base_test.go`.

The test drives `pollScalerReportHandle.handleError` (built through the production `newScalableTaskPoller` wiring) and asserts the **live `pollerSemaphore` max permits** follow the halving sequence:

| Error | Target | maxPermits |
|---|---|---|
| `ResourceExhausted` | 16 → 8 | 8 |
| `ResourceExhausted` | 8 → 4 | 4 |
| other (`Internal`) | 4 → 3 | 3 |
| `ResourceExhausted` | 3 → 1 | 1 (clamped at min) |
| `ResourceExhausted` | 1 → 1 | 1 |

## Why

Asserting the exact step size — `16→8→4` for `ResourceExhausted` versus `4→3` for a non-`ResourceExhausted` error — is what distinguishes **halving (`t/2`)** from a plain `-1` decrement. A regression in either direction (RE stops halving, or halving leaks to other error types) fails the test.

This complements the existing `PollScalerReportHandleSuite.TestErrorScaleDown`, which asserts the same arithmetic against a **mock `scaleCallback`**. The new test additionally verifies the halved value reaches the **real `pollerSemaphore`** through the `scaleCallback → updatePermits` wiring that `newScalableTaskPoller` sets up.

## Notes

- Deterministic and fast; no Temporal server required.
- Reuses the suite's existing `semaphoreProbeTaskPoller` and `readSemaphoreState` helpers; no production code changes.

## Test

```
go test ./internal/ -run 'TestScalableTaskPollerSuite/TestAutoscalingHalvesOnResourceExhausted' -count=1
```