### PR TITLE
Add nexus headers to SANO interceptor

### DIFF
--- a/internal/interceptor.go
+++ b/internal/interceptor.go
@@ -712,6 +712,9 @@ type ClientExecuteNexusOperationInput struct {
 	Service       string
 	OperationType string
 	Input         interface{}
+	// NexusHeader is the Nexus header to attach to the operation request.
+	// Interceptors may read and write this header.
+	NexusHeader nexus.Header
 }
 
 // ClientGetNexusOperationHandleInput is the input to

--- a/internal/internal_nexus_client.go
+++ b/internal/internal_nexus_client.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/nexus-rpc/sdk-go/nexus"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	failurepb "go.temporal.io/api/failure/v1"
@@ -432,6 +433,7 @@ func (nc *nexusClientImpl) ExecuteOperation(ctx context.Context, operation any, 
 		Service:       nc.service,
 		OperationType: operationName,
 		Input:         input,
+		NexusHeader:   nexus.Header{},
 	})
 }
 
@@ -702,6 +704,7 @@ func (w *workflowClientInterceptor) ExecuteNexusOperation(
 		IdConflictPolicy: in.Options.IDConflictPolicy,
 		SearchAttributes: searchAttrs,
 		UserMetadata:     userMetadata,
+		NexusHeader:      in.NexusHeader,
 	}
 	if in.Options.ScheduleToCloseTimeout > 0 {
 		request.ScheduleToCloseTimeout = durationpb.New(in.Options.ScheduleToCloseTimeout)

--- a/internal/internal_nexus_client_test.go
+++ b/internal/internal_nexus_client_test.go
@@ -65,6 +65,60 @@ func TestExecuteNexusOperationHeaderAvailableToInterceptors(t *testing.T) {
 		"Header should be set on context before interceptor chain runs")
 }
 
+// nexusHeaderWriteInterceptor verifies NexusHeader is non-nil on the input and
+// allows interceptors to write to it.
+type nexusHeaderWriteInterceptor struct {
+	ClientInterceptorBase
+	nexusHeaderWasPresent bool
+	writtenValue          string
+}
+
+func (h *nexusHeaderWriteInterceptor) InterceptClient(next ClientOutboundInterceptor) ClientOutboundInterceptor {
+	return &nexusHeaderWriteOutbound{
+		ClientOutboundInterceptorBase: ClientOutboundInterceptorBase{Next: next},
+		parent:                        h,
+	}
+}
+
+type nexusHeaderWriteOutbound struct {
+	ClientOutboundInterceptorBase
+	parent *nexusHeaderWriteInterceptor
+}
+
+func (h *nexusHeaderWriteOutbound) ExecuteNexusOperation(
+	ctx context.Context,
+	in *ClientExecuteNexusOperationInput,
+) (ClientNexusOperationHandle, error) {
+	h.parent.nexusHeaderWasPresent = in.NexusHeader != nil
+	if in.NexusHeader != nil {
+		in.NexusHeader["x-test-key"] = "test-value"
+		h.parent.writtenValue = in.NexusHeader["x-test-key"]
+	}
+	return nil, fmt.Errorf("short-circuit")
+}
+
+func TestExecuteNexusOperationNexusHeaderAvailableToInterceptors(t *testing.T) {
+	interceptor := &nexusHeaderWriteInterceptor{}
+
+	client := NewServiceClient(nil, nil, ClientOptions{
+		Interceptors: []ClientInterceptor{interceptor},
+	})
+	client.capabilities = &workflowservice.GetSystemInfoResponse_Capabilities{}
+
+	nexusClient, err := client.NewNexusClient(ClientNexusClientOptions{
+		Endpoint: "test-endpoint",
+		Service:  "test-service",
+	})
+	require.NoError(t, err)
+
+	_, err = nexusClient.ExecuteOperation(context.Background(), "test-op", "test-input", ClientStartNexusOperationOptions{
+		ID: "test-op-id",
+	})
+	require.ErrorContains(t, err, "short-circuit")
+	require.True(t, interceptor.nexusHeaderWasPresent, "NexusHeader should be non-nil in interceptor input")
+	require.Equal(t, "test-value", interceptor.writtenValue, "interceptor should be able to write to NexusHeader")
+}
+
 func TestNexusClientValidation(t *testing.T) {
 	client := NewServiceClient(nil, nil, ClientOptions{})
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Expose Nexus Headers in the interceptor for SANO

## Why?
So interceptors can access the headers

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small additive change to experimental Nexus client/interceptor APIs; behavior only changes when interceptors populate NexusHeader.
> 
> **Overview**
> **Standalone Nexus operation (client) interceptors** can now read and mutate Nexus RPC headers on `ExecuteNexusOperation`, matching the workflow-side `ExecuteNexusOperation` interceptor shape.
> 
> `ClientExecuteNexusOperationInput` gains a **`NexusHeader`** field (`nexus.Header`). `NexusClient.ExecuteOperation` seeds it with an empty map before the client interceptor chain runs, and the default client interceptor forwards that map into **`StartNexusOperationExecutionRequest.NexusHeader`** so interceptor-written entries reach Temporal.
> 
> A unit test confirms interceptors see a non-nil header and can write key/value pairs before the call is short-circuited.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 908e51dab1c5fa1a792dea17a15839e58183b9c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->