### PR TITLE
Add Standalone nexus operation links

### DIFF
--- a/internal/internal_nexus_task_handler.go
+++ b/internal/internal_nexus_task_handler.go
@@ -190,7 +190,7 @@ func (h *nexusTaskHandler) handleStartOperation(
 	nexusLinks := make([]nexus.Link, 0, len(req.GetLinks()))
 	// requestLinks holds the inbound links in common.v1.Link form so the RPCs the handler
 	// issues (e.g. signal, signalWithStart) can attach them to their request's links field, linking
-	// the callee's history events back to the caller workflow.
+	// the callee's history events back to the caller.
 	var requestLinks []*common.Link
 	for _, link := range req.GetLinks() {
 		if link == nil {
@@ -205,9 +205,7 @@ func (h *nexusTaskHandler) handleStartOperation(
 			URL:  linkURL,
 			Type: link.GetType(),
 		})
-		// Only WorkflowEvent-shaped links can be forwarded onto the RPCs the handler issues; other
-		// link shapes come back unconvertible and are intentionally skipped.
-		if commonLink, ok := nexusLinkToWorkflowEventLink(link); ok {
+		if commonLink, ok := nexusLinkToCommonLink(link); ok {
 			requestLinks = append(requestLinks, commonLink)
 		}
 	}
@@ -364,7 +362,7 @@ func (h *nexusTaskHandler) handleStartOperation(
 
 // responseLinks converts the response links accumulated on the operation context (from outbound RPCs
 // the handler issued, such as signal or signalWithStart) into nexus.v1.Links to attach to the
-// StartOperationResponse. Non-WorkflowEvent links are skipped.
+// StartOperationResponse. Unsupported variants are skipped.
 func (h *nexusTaskHandler) responseLinks(nctx *NexusOperationContext) []*nexuspb.Link {
 	responseLinks := nctx.ResponseLinks()
 	if len(responseLinks) == 0 {
@@ -372,8 +370,7 @@ func (h *nexusTaskHandler) responseLinks(nctx *NexusOperationContext) []*nexuspb
 	}
 	out := make([]*nexuspb.Link, 0, len(responseLinks))
 	for _, responseLink := range responseLinks {
-		nexusLink, ok := workflowEventLinkToNexusLink(responseLink)
-		if ok {
+		if nexusLink, ok := commonLinkToNexusLink(responseLink); ok {
 			out = append(out, nexusLink)
 		}
 	}

--- a/internal/link_converter.go
+++ b/internal/link_converter.go
@@ -5,6 +5,7 @@
 package internal
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"regexp"
@@ -17,11 +18,13 @@ import (
 )
 
 const (
-	urlSchemeTemporalKey = "temporal"
-	urlPathNamespaceKey  = "namespace"
-	urlPathWorkflowIDKey = "workflowID"
-	urlPathRunIDKey      = "runID"
-	urlPathTemplate      = "/namespaces/%s/workflows/%s/%s/history"
+	urlSchemeTemporalKey          = "temporal"
+	urlPathNamespaceKey           = "namespace"
+	urlPathWorkflowIDKey          = "workflowID"
+	urlPathOperationIDKey         = "operationID"
+	urlPathRunIDKey               = "runID"
+	urlPathWorkflowEventTemplate  = "/namespaces/%s/workflows/%s/%s/history"
+	urlPathNexusOperationTemplate = "/namespaces/%s/nexus-operations/%s/%s/details"
 
 	linkWorkflowEventReferenceTypeKey = "referenceType"
 	linkEventIDKey                    = "eventID"
@@ -30,13 +33,20 @@ const (
 )
 
 var (
-	rePatternNamespace  = fmt.Sprintf(`(?P<%s>[^/]+)`, urlPathNamespaceKey)
-	rePatternWorkflowID = fmt.Sprintf(`(?P<%s>[^/]+)`, urlPathWorkflowIDKey)
-	rePatternRunID      = fmt.Sprintf(`(?P<%s>[^/]+)`, urlPathRunIDKey)
-	urlPathRE           = regexp.MustCompile(fmt.Sprintf(
+	rePatternNamespace   = fmt.Sprintf(`(?P<%s>[^/]+)`, urlPathNamespaceKey)
+	rePatternWorkflowID  = fmt.Sprintf(`(?P<%s>[^/]+)`, urlPathWorkflowIDKey)
+	rePatternOperationID = fmt.Sprintf(`(?P<%s>[^/]+)`, urlPathOperationIDKey)
+	rePatternRunID       = fmt.Sprintf(`(?P<%s>[^/]+)`, urlPathRunIDKey)
+	urlPathRE            = regexp.MustCompile(fmt.Sprintf(
 		`^/namespaces/%s/workflows/%s/%s/history$`,
 		rePatternNamespace,
 		rePatternWorkflowID,
+		rePatternRunID,
+	))
+	urlPathNexusOperationRE = regexp.MustCompile(fmt.Sprintf(
+		`^/namespaces/%s/nexus-operations/%s/%s/details$`,
+		rePatternNamespace,
+		rePatternOperationID,
 		rePatternRunID,
 	))
 	eventReferenceType     = string((&commonpb.Link_WorkflowEvent_EventReference{}).ProtoReflect().Descriptor().Name())
@@ -49,9 +59,9 @@ var (
 func ConvertLinkWorkflowEventToNexusLink(we *commonpb.Link_WorkflowEvent) nexus.Link {
 	u := &url.URL{
 		Scheme: urlSchemeTemporalKey,
-		Path:   fmt.Sprintf(urlPathTemplate, we.GetNamespace(), we.GetWorkflowId(), we.GetRunId()),
+		Path:   fmt.Sprintf(urlPathWorkflowEventTemplate, we.GetNamespace(), we.GetWorkflowId(), we.GetRunId()),
 		RawPath: fmt.Sprintf(
-			urlPathTemplate,
+			urlPathWorkflowEventTemplate,
 			url.PathEscape(we.GetNamespace()),
 			url.PathEscape(we.GetWorkflowId()),
 			url.PathEscape(we.GetRunId()),
@@ -142,6 +152,70 @@ func ConvertNexusLinkToLinkWorkflowEvent(link nexus.Link) (*commonpb.Link_Workfl
 	return we, nil
 }
 
+// ConvertLinkNexusOperationToNexusLink converts a Link_NexusOperation type to Nexus Link.
+//
+// NOTE: Experimental
+func ConvertLinkNexusOperationToNexusLink(no *commonpb.Link_NexusOperation) nexus.Link {
+	u := &url.URL{
+		Scheme: urlSchemeTemporalKey,
+		Path:   fmt.Sprintf(urlPathNexusOperationTemplate, no.GetNamespace(), no.GetOperationId(), no.GetRunId()),
+		RawPath: fmt.Sprintf(
+			urlPathNexusOperationTemplate,
+			url.PathEscape(no.GetNamespace()),
+			url.PathEscape(no.GetOperationId()),
+			url.PathEscape(no.GetRunId()),
+		),
+	}
+	return nexus.Link{
+		URL:  u,
+		Type: string(no.ProtoReflect().Descriptor().FullName()),
+	}
+}
+
+// ConvertNexusLinkToLinkNexusOperation converts a Nexus Link to Link_NexusOperation.
+//
+// NOTE: Experimental
+func ConvertNexusLinkToLinkNexusOperation(link nexus.Link) (*commonpb.Link_NexusOperation, error) {
+	no := &commonpb.Link_NexusOperation{}
+	if link.Type != string(no.ProtoReflect().Descriptor().FullName()) {
+		return nil, fmt.Errorf(
+			"cannot parse link type %q to %q",
+			link.Type,
+			no.ProtoReflect().Descriptor().FullName(),
+		)
+	}
+
+	if link.URL.Scheme != urlSchemeTemporalKey {
+		return nil, fmt.Errorf(
+			"failed to parse link to Link_NexusOperation: invalid scheme: %s",
+			link.URL.Scheme,
+		)
+	}
+
+	matches := urlPathNexusOperationRE.FindStringSubmatch(link.URL.EscapedPath())
+	if len(matches) != 4 {
+		return nil, errors.New("failed to parse link to Link_NexusOperation: malformed URL path")
+	}
+
+	var err error
+	no.Namespace, err = url.PathUnescape(matches[urlPathNexusOperationRE.SubexpIndex(urlPathNamespaceKey)])
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse link to Link_NexusOperation: %w", err)
+	}
+
+	no.OperationId, err = url.PathUnescape(matches[urlPathNexusOperationRE.SubexpIndex(urlPathOperationIDKey)])
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse link to Link_NexusOperation: %w", err)
+	}
+
+	no.RunId, err = url.PathUnescape(matches[urlPathNexusOperationRE.SubexpIndex(urlPathRunIDKey)])
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse link to Link_NexusOperation: %w", err)
+	}
+
+	return no, nil
+}
+
 func convertLinkWorkflowEventEventReferenceToURLQuery(eventRef *commonpb.Link_WorkflowEvent_EventReference) string {
 	values := url.Values{}
 	values.Set(linkWorkflowEventReferenceTypeKey, eventReferenceType)
@@ -189,27 +263,14 @@ func convertURLQueryToLinkWorkflowEventRequestIdReference(queryValues url.Values
 	return requestIDRef, nil
 }
 
-// workflowEventLinkToNexusLink converts a common.v1.Link with a WorkflowEvent variant into a
-// nexus.v1.Link (URL + Type). The task handler uses it to drain response links onto the
-// StartOperationResponse. It returns (nil, false) when the link is not a convertible WorkflowEvent
-// link.
-func workflowEventLinkToNexusLink(link *commonpb.Link) (*nexuspb.Link, bool) {
-	we := link.GetWorkflowEvent()
-	if we == nil {
-		return nil, false
-	}
-	nexusLink := ConvertLinkWorkflowEventToNexusLink(we)
-	return &nexuspb.Link{
-		Url:  nexusLink.URL.String(),
-		Type: nexusLink.Type,
-	}, true
-}
+var (
+	workflowEventLinkType  = string((&commonpb.Link_WorkflowEvent{}).ProtoReflect().Descriptor().FullName())
+	nexusOperationLinkType = string((&commonpb.Link_NexusOperation{}).ProtoReflect().Descriptor().FullName())
+)
 
-// nexusLinkToWorkflowEventLink converts an inbound nexus.v1.Link into a common.v1.Link with a
-// WorkflowEvent variant. The task handler uses it to forward inbound Nexus task links onto the RPCs
-// (e.g. signal, signalWithStart) the handler issues. It returns (nil, false) when the link is not a
-// parseable WorkflowEvent link.
-func nexusLinkToWorkflowEventLink(link *nexuspb.Link) (*commonpb.Link, bool) {
+// nexusLinkToCommonLink converts a nexus.v1.Link into a common.v1.Link, dispatching on link.Type.
+// Returns (nil, false) for any link type not handled here.
+func nexusLinkToCommonLink(link *nexuspb.Link) (*commonpb.Link, bool) {
 	nexusLink := nexus.Link{Type: link.GetType()}
 	if link.GetUrl() != "" {
 		u, err := url.Parse(link.GetUrl())
@@ -218,11 +279,39 @@ func nexusLinkToWorkflowEventLink(link *nexuspb.Link) (*commonpb.Link, bool) {
 		}
 		nexusLink.URL = u
 	}
-	we, err := ConvertNexusLinkToLinkWorkflowEvent(nexusLink)
-	if err != nil {
+	switch nexusLink.Type {
+	case workflowEventLinkType:
+		we, err := ConvertNexusLinkToLinkWorkflowEvent(nexusLink)
+		if err != nil {
+			return nil, false
+		}
+		return &commonpb.Link{
+			Variant: &commonpb.Link_WorkflowEvent_{WorkflowEvent: we},
+		}, true
+	case nexusOperationLinkType:
+		no, err := ConvertNexusLinkToLinkNexusOperation(nexusLink)
+		if err != nil {
+			return nil, false
+		}
+		return &commonpb.Link{
+			Variant: &commonpb.Link_NexusOperation_{NexusOperation: no},
+		}, true
+	default:
 		return nil, false
 	}
-	return &commonpb.Link{
-		Variant: &commonpb.Link_WorkflowEvent_{WorkflowEvent: we},
-	}, true
+}
+
+// commonLinkToNexusLink converts a common.v1.Link into a nexus.v1.Link, dispatching on the link's
+// variant. Returns (nil, false) for any variant not handled here.
+func commonLinkToNexusLink(link *commonpb.Link) (*nexuspb.Link, bool) {
+	switch v := link.GetVariant().(type) {
+	case *commonpb.Link_WorkflowEvent_:
+		nexusLink := ConvertLinkWorkflowEventToNexusLink(v.WorkflowEvent)
+		return &nexuspb.Link{Url: nexusLink.URL.String(), Type: nexusLink.Type}, true
+	case *commonpb.Link_NexusOperation_:
+		nexusLink := ConvertLinkNexusOperationToNexusLink(v.NexusOperation)
+		return &nexuspb.Link{Url: nexusLink.URL.String(), Type: nexusLink.Type}, true
+	default:
+		return nil, false
+	}
 }

--- a/internal/link_converter.go
+++ b/internal/link_converter.go
@@ -312,11 +312,18 @@ func commonLinkToNexusLink(link *commonpb.Link) (*nexuspb.Link, bool) {
 	if variant == nil {
 		return nil, false
 	}
+
 	switch v := variant.(type) {
 	case *commonpb.Link_WorkflowEvent_:
+		if v.WorkflowEvent == nil {
+			return nil, false
+		}
 		nexusLink := ConvertLinkWorkflowEventToNexusLink(v.WorkflowEvent)
 		return &nexuspb.Link{Url: nexusLink.URL.String(), Type: nexusLink.Type}, true
 	case *commonpb.Link_NexusOperation_:
+		if v.NexusOperation == nil {
+			return nil, false
+		}
 		nexusLink := ConvertLinkNexusOperationToNexusLink(v.NexusOperation)
 		return &nexuspb.Link{Url: nexusLink.URL.String(), Type: nexusLink.Type}, true
 	default:

--- a/internal/link_converter.go
+++ b/internal/link_converter.go
@@ -204,17 +204,17 @@ func ConvertNexusLinkToLinkNexusOperation(link nexus.Link) (*commonpb.Link_Nexus
 	var err error
 	no.Namespace, err = url.PathUnescape(matches[urlPathNexusOperationRE.SubexpIndex(urlPathNamespaceKey)])
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse link to Link_NexusOperation: %w", err)
+		return nil, fmt.Errorf("failed to parse namespace in Link_NexusOperation: %w", err)
 	}
 
 	no.OperationId, err = url.PathUnescape(matches[urlPathNexusOperationRE.SubexpIndex(urlPathOperationIDKey)])
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse link to Link_NexusOperation: %w", err)
+		return nil, fmt.Errorf("failed to parse operation id in Link_NexusOperation: %w", err)
 	}
 
 	no.RunId, err = url.PathUnescape(matches[urlPathNexusOperationRE.SubexpIndex(urlPathRunIDKey)])
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse link to Link_NexusOperation: %w", err)
+		return nil, fmt.Errorf("failed to parse run id in Link_NexusOperation: %w", err)
 	}
 
 	return no, nil
@@ -308,7 +308,11 @@ func nexusLinkToCommonLink(link *nexuspb.Link) (*commonpb.Link, bool) {
 // commonLinkToNexusLink converts a common.v1.Link into a nexus.v1.Link, dispatching on the link's
 // variant. Returns (nil, false) for any variant not handled here.
 func commonLinkToNexusLink(link *commonpb.Link) (*nexuspb.Link, bool) {
-	switch v := link.GetVariant().(type) {
+	variant := link.GetVariant()
+	if variant == nil {
+		return nil, false
+	}
+	switch v := variant.(type) {
 	case *commonpb.Link_WorkflowEvent_:
 		nexusLink := ConvertLinkWorkflowEventToNexusLink(v.WorkflowEvent)
 		return &nexuspb.Link{Url: nexusLink.URL.String(), Type: nexusLink.Type}, true

--- a/internal/link_converter.go
+++ b/internal/link_converter.go
@@ -185,6 +185,10 @@ func ConvertNexusLinkToLinkNexusOperation(link nexus.Link) (*commonpb.Link_Nexus
 		)
 	}
 
+	if link.URL == nil {
+		return nil, fmt.Errorf("failed to parse link to Link_NexusOperation: empty URL")
+	}
+
 	if link.URL.Scheme != urlSchemeTemporalKey {
 		return nil, fmt.Errorf(
 			"failed to parse link to Link_NexusOperation: invalid scheme: %s",

--- a/temporalnexus/link_converter.go
+++ b/temporalnexus/link_converter.go
@@ -20,3 +20,17 @@ func ConvertLinkWorkflowEventToNexusLink(we *commonpb.Link_WorkflowEvent) nexus.
 func ConvertNexusLinkToLinkWorkflowEvent(link nexus.Link) (*commonpb.Link_WorkflowEvent, error) {
 	return internal.ConvertNexusLinkToLinkWorkflowEvent(link)
 }
+
+// ConvertLinkNexusOperationToNexusLink converts a Link_NexusOperation type to Nexus Link.
+//
+// NOTE: Experimental
+func ConvertLinkNexusOperationToNexusLink(no *commonpb.Link_NexusOperation) nexus.Link {
+	return internal.ConvertLinkNexusOperationToNexusLink(no)
+}
+
+// ConvertNexusLinkToLinkNexusOperation converts a Nexus Link to Link_NexusOperation.
+//
+// NOTE: Experimental
+func ConvertNexusLinkToLinkNexusOperation(link nexus.Link) (*commonpb.Link_NexusOperation, error) {
+	return internal.ConvertNexusLinkToLinkNexusOperation(link)
+}

--- a/temporalnexus/link_converter_test.go
+++ b/temporalnexus/link_converter_test.go
@@ -455,3 +455,148 @@ func TestConvertNexusLinkToLinkWorkflowEvent(t *testing.T) {
 		})
 	}
 }
+
+func TestConvertLinkNexusOperationToNexusLink(t *testing.T) {
+	type testcase struct {
+		name      string
+		input     *commonpb.Link_NexusOperation
+		output    nexus.Link
+		outputURL string
+	}
+
+	cases := []testcase{
+		{
+			name: "valid",
+			input: &commonpb.Link_NexusOperation{
+				Namespace:   "ns",
+				OperationId: "op-id",
+				RunId:       "run-id",
+			},
+			output: nexus.Link{
+				URL: &url.URL{
+					Scheme:  "temporal",
+					Path:    "/namespaces/ns/nexus-operations/op-id/run-id/details",
+					RawPath: "/namespaces/ns/nexus-operations/op-id/run-id/details",
+				},
+				Type: "temporal.api.common.v1.Link.NexusOperation",
+			},
+			outputURL: "temporal:///namespaces/ns/nexus-operations/op-id/run-id/details",
+		},
+		{
+			name: "valid with slash in operation id",
+			input: &commonpb.Link_NexusOperation{
+				Namespace:   "ns",
+				OperationId: "op/id",
+				RunId:       "run-id",
+			},
+			output: nexus.Link{
+				URL: &url.URL{
+					Scheme:  "temporal",
+					Path:    "/namespaces/ns/nexus-operations/op/id/run-id/details",
+					RawPath: "/namespaces/ns/nexus-operations/op%2Fid/run-id/details",
+				},
+				Type: "temporal.api.common.v1.Link.NexusOperation",
+			},
+			outputURL: "temporal:///namespaces/ns/nexus-operations/op%2Fid/run-id/details",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			output := temporalnexus.ConvertLinkNexusOperationToNexusLink(tc.input)
+			require.Equal(t, tc.output, output)
+			require.Equal(t, tc.outputURL, output.URL.String())
+		})
+	}
+}
+
+func TestConvertNexusLinkToLinkNexusOperation(t *testing.T) {
+	type testcase struct {
+		name   string
+		input  nexus.Link
+		output *commonpb.Link_NexusOperation
+		errMsg string
+	}
+
+	cases := []testcase{
+		{
+			name: "valid",
+			input: nexus.Link{
+				URL: &url.URL{
+					Scheme:  "temporal",
+					Path:    "/namespaces/ns/nexus-operations/op-id/run-id/details",
+					RawPath: "/namespaces/ns/nexus-operations/op-id/run-id/details",
+				},
+				Type: "temporal.api.common.v1.Link.NexusOperation",
+			},
+			output: &commonpb.Link_NexusOperation{
+				Namespace:   "ns",
+				OperationId: "op-id",
+				RunId:       "run-id",
+			},
+		},
+		{
+			name: "valid with encoded slash in operation id",
+			input: nexus.Link{
+				URL: &url.URL{
+					Scheme:  "temporal",
+					Path:    "/namespaces/ns/nexus-operations/op/id/run-id/details",
+					RawPath: "/namespaces/ns/nexus-operations/op%2Fid/run-id/details",
+				},
+				Type: "temporal.api.common.v1.Link.NexusOperation",
+			},
+			output: &commonpb.Link_NexusOperation{
+				Namespace:   "ns",
+				OperationId: "op/id",
+				RunId:       "run-id",
+			},
+		},
+		{
+			name: "wrong link type",
+			input: nexus.Link{
+				URL: &url.URL{
+					Scheme: "temporal",
+					Path:   "/namespaces/ns/nexus-operations/op-id/run-id/details",
+				},
+				Type: "temporal.api.common.v1.Link.WorkflowEvent",
+			},
+			errMsg: "cannot parse link type",
+		},
+		{
+			name: "invalid scheme",
+			input: nexus.Link{
+				URL: &url.URL{
+					Scheme: "random",
+					Path:   "/namespaces/ns/nexus-operations/op-id/run-id/details",
+				},
+				Type: "temporal.api.common.v1.Link.NexusOperation",
+			},
+			errMsg: "failed to parse link to Link_NexusOperation: invalid scheme",
+		},
+		{
+			name: "malformed path",
+			input: nexus.Link{
+				URL: &url.URL{
+					Scheme: "temporal",
+					Path:   "/namespaces/ns/nexus-operations/op-id/run-id/",
+				},
+				Type: "temporal.api.common.v1.Link.NexusOperation",
+			},
+			errMsg: "failed to parse link to Link_NexusOperation: malformed URL path",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			output, err := temporalnexus.ConvertNexusLinkToLinkNexusOperation(tc.input)
+			if tc.errMsg != "" {
+				require.ErrorContains(t, err, tc.errMsg)
+			} else {
+				require.NoError(t, err)
+				if diff := cmp.Diff(tc.output, output, protocmp.Transform()); diff != "" {
+					assert.Fail(t, "Proto mismatch (-want +got):\n", diff)
+				}
+			}
+		})
+	}
+}

--- a/temporalnexus/operation.go
+++ b/temporalnexus/operation.go
@@ -384,7 +384,15 @@ func convertNexusLinks(nexusLinks []nexus.Link, log log.Logger) ([]*common.Link,
 				},
 			})
 		case string((&common.Link_NexusOperation{}).ProtoReflect().Descriptor().FullName()):
-			// TODO: forward Link_NexusOperation variants once frontend validateLinks accepts them.
+			link, err := ConvertNexusLinkToLinkNexusOperation(nexusLink)
+			if err != nil {
+				return nil, err
+			}
+			links = append(links, &common.Link{
+				Variant: &common.Link_NexusOperation_{
+					NexusOperation: link,
+				},
+			})
 		default:
 			log.Warn("ignoring unsupported link data type", "LinkType", nexusLink.Type)
 		}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -7251,7 +7251,26 @@ func (ts *IntegrationTestSuite) registerStandaloneNexusOperations(w worker.Worke
 			return client.StartWorkflowOptions{ID: "nexus-async-echo-" + uuid.NewString()}, nil
 		},
 	)
-	ts.NoError(service.Register(syncOp, asyncOp, asyncEchoOp))
+	// linkEchoOp uses the input string as the workflow ID so tests can predict it.
+	linkEchoOp := temporalnexus.NewWorkflowRunOperation(
+		"link-echo-op",
+		echoWf,
+		func(ctx context.Context, input string, opts nexus.StartOperationOptions) (client.StartWorkflowOptions, error) {
+			return client.StartWorkflowOptions{ID: "nexus-link-echo-" + input}, nil
+		},
+	)
+	// signalEchoOp signals the workflow named by its input, exercising the bi-directional
+	// Link_NexusOperation <-> Link_WorkflowEvent flow between the SANO record and the signal event.
+	signalEchoOp := nexus.NewSyncOperation(
+		"signal-echo-op",
+		func(ctx context.Context, input string, _ nexus.StartOperationOptions) (string, error) {
+			if err := temporalnexus.GetClient(ctx).SignalWorkflow(ctx, input, "", "nexus-signal", input); err != nil {
+				return "", err
+			}
+			return input, nil
+		},
+	)
+	ts.NoError(service.Register(syncOp, asyncOp, asyncEchoOp, linkEchoOp, signalEchoOp))
 	w.RegisterNexusService(service)
 }
 
@@ -9598,6 +9617,124 @@ func (ts *IntegrationTestSuite) TestExecuteNexusOperationSuite() {
 		_, err = ts.client.NewNexusClient(client.NexusClientOptions{Endpoint: "ep"})
 		ts.Error(err)
 		ts.Contains(err.Error(), "service is required")
+	})
+
+	ts.Run("Link_NexusOperation forwarded to workflow completion callback", func() {
+		// Use operation ID as workflow input so we can derive the workflow ID.
+		opID := uuid.NewString()
+		workflowID := "nexus-link-echo-" + opID
+
+		handle := executeNexusOpWithRetry("link-echo-op", opID, client.StartNexusOperationOptions{
+			ID:                     opID,
+			ScheduleToCloseTimeout: 30 * time.Second,
+		})
+		ts.NotEmpty(handle.GetID())
+		ts.NotEmpty(handle.GetRunID())
+
+		err := handle.Get(ctx, nil)
+		ts.NoError(err)
+
+		// The link-echo-op handler starts a workflow; verify that the
+		// Link_NexusOperation pointing back to the SANO record is present
+		// in the workflow's completion callback links.
+		iter := ts.client.GetWorkflowHistory(ctx, workflowID, "", false, enumspb.HISTORY_EVENT_FILTER_TYPE_ALL_EVENT)
+		var nexusOpLink *commonpb.Link_NexusOperation
+		for iter.HasNext() {
+			event, err := iter.Next()
+			ts.NoError(err)
+			if event.GetEventType() != enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED {
+				continue
+			}
+			for _, cb := range event.GetWorkflowExecutionStartedEventAttributes().GetCompletionCallbacks() {
+				for _, link := range cb.GetLinks() {
+					if l := link.GetNexusOperation(); l != nil {
+						nexusOpLink = l
+					}
+				}
+			}
+			break
+		}
+		ts.Require().NotNil(nexusOpLink, "expected Link_NexusOperation in workflow completion callback")
+		ts.Equal(ts.config.Namespace, nexusOpLink.GetNamespace())
+		ts.Equal(opID, nexusOpLink.GetOperationId())
+		ts.Equal(handle.GetRunID(), nexusOpLink.GetRunId())
+	})
+
+	ts.Run("Bi-directional Signal+SANO links", func() {
+		// Start a target workflow that just needs to be alive to receive the signal.
+		targetWfID := "nexus-sano-signal-target-" + uuid.NewString()
+		targetRun, err := ts.client.ExecuteWorkflow(ctx,
+			client.StartWorkflowOptions{ID: targetWfID, TaskQueue: ts.taskQueueName},
+			"block-forever-wf",
+			targetWfID,
+		)
+		ts.NoError(err)
+		defer func() {
+			_ = ts.client.TerminateWorkflow(ctx, targetWfID, targetRun.GetRunID(), "test cleanup")
+		}()
+
+		handle := executeNexusOpWithRetry("signal-echo-op", targetWfID, client.StartNexusOperationOptions{
+			ID:                     uuid.NewString(),
+			ScheduleToCloseTimeout: 30 * time.Second,
+		})
+		ts.NotEmpty(handle.GetID())
+
+		var result string
+		err = handle.Get(ctx, &result)
+		ts.NoError(err)
+		ts.Equal(targetWfID, result)
+
+		// Signal -> SANO direction: target workflow's WorkflowExecutionSignaled event should carry a
+		// Link_NexusOperation pointing back to the SANO record.
+		iter := ts.client.GetWorkflowHistory(ctx, targetWfID, targetRun.GetRunID(), false, enumspb.HISTORY_EVENT_FILTER_TYPE_ALL_EVENT)
+		var sanoBacklink *commonpb.Link_NexusOperation
+		var signalEvent *historypb.HistoryEvent
+		for iter.HasNext() {
+			event, err := iter.Next()
+			ts.NoError(err)
+			if event.GetEventType() != enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_SIGNALED {
+				continue
+			}
+			signalEvent = event
+			for _, link := range event.GetLinks() {
+				if l := link.GetNexusOperation(); l != nil {
+					sanoBacklink = l
+				}
+			}
+		}
+		ts.Require().NotNil(signalEvent, "expected WorkflowExecutionSignaled event in target workflow")
+		ts.Require().NotNil(sanoBacklink, "expected Link_NexusOperation on signal event pointing back to SANO")
+		ts.Equal(ts.config.Namespace, sanoBacklink.GetNamespace())
+		ts.Equal(handle.GetID(), sanoBacklink.GetOperationId())
+		ts.Equal(handle.GetRunID(), sanoBacklink.GetRunId())
+
+		// SANO -> Signal direction: SANO record should carry a Link_WorkflowEvent pointing to the
+		// signal event in the target workflow's history.
+		description, err := handle.Describe(ctx, client.DescribeNexusOperationOptions{})
+		ts.NoError(err)
+		var signalEventLink *commonpb.Link_WorkflowEvent
+		for _, link := range description.RawInfo.GetLinks() {
+			if l := link.GetWorkflowEvent(); l != nil && l.GetWorkflowId() == targetWfID {
+				signalEventLink = l
+			}
+		}
+		ts.Require().NotNil(signalEventLink, "expected Link_WorkflowEvent on SANO pointing to signal event")
+		ts.Equal(ts.config.Namespace, signalEventLink.GetNamespace())
+		ts.Equal(targetWfID, signalEventLink.GetWorkflowId())
+		ts.Equal(targetRun.GetRunID(), signalEventLink.GetRunId())
+		// The server may return either an EventRef (with EventId) or a RequestIdRef (with RequestId),
+		// depending on history.enableRequestIdRefLinks. Either way, the referenced event type must
+		// identify the signal event we delivered.
+		switch ref := signalEventLink.GetReference().(type) {
+		case *commonpb.Link_WorkflowEvent_EventRef:
+			ts.Equal(signalEvent.GetEventId(), ref.EventRef.GetEventId())
+			ts.Equal(enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_SIGNALED, ref.EventRef.GetEventType())
+		case *commonpb.Link_WorkflowEvent_RequestIdRef:
+			ts.NotEmpty(ref.RequestIdRef.GetRequestId())
+			ts.Equal(enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_SIGNALED, ref.RequestIdRef.GetEventType())
+		default:
+			ts.Failf("unexpected reference type", "got %T", ref)
+		}
 	})
 }
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Add Standalone nexus operation links

## Why?
So SANO has nice links in the UI

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Nexus link forwarding on workflow start, signal, and start-operation responses; incorrect parsing or dropping links could break UI cross-links, but behavior is additive with tests and unsupported types still skipped.
> 
> **Overview**
> Adds **standalone Nexus operation (`Link_NexusOperation`)** support end-to-end so SANO records and related history events can carry UI-friendly backlinks, not only `Link_WorkflowEvent`.
> 
> **Link conversion** gains bidirectional `temporal://…/nexus-operations/{op}/{run}/details` encoding/decoding (with path escaping), public wrappers in `temporalnexus`, and generic `nexusLinkToCommonLink` / `commonLinkToNexusLink` dispatch in the Nexus task handler so inbound links can be forwarded on handler RPCs and outbound response links can be returned on start-operation responses.
> 
> **Workflow starts from Nexus handlers** now convert and attach `Link_NexusOperation` on completion callbacks (replacing the previous TODO/skip). **Integration tests** cover forwarding SANO links into workflow completion callbacks and bi-directional SANO ↔ signal `WorkflowEvent` links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 725ae3064004d1f36c1659eb01a9bc333283c505. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->