### PR TITLE
Add some missing comments for struct methods

### DIFF
--- a/internal/error.go
+++ b/internal/error.go
@@ -193,12 +193,13 @@ type (
 	// Exposed as: [go.temporal.io/sdk/workflow.ContinueAsNewError]
 	ContinueAsNewError struct {
 		// params *ExecuteWorkflowParams
-		WorkflowType         *WorkflowType
-		Input                *commonpb.Payloads
-		Header               *commonpb.Header
-		TaskQueueName        string
-		WorkflowRunTimeout   time.Duration
-		WorkflowTaskTimeout  time.Duration
+		WorkflowType        *WorkflowType
+		Input               *commonpb.Payloads
+		Header              *commonpb.Header
+		TaskQueueName       string
+		WorkflowRunTimeout  time.Duration
+		WorkflowTaskTimeout time.Duration
+		// BackoffStartInterval is the initial backoff before the continued workflow execution starts.
 		BackoffStartInterval time.Duration
 
 		// Deprecated: WorkflowExecutionTimeout is deprecated and is never set or

--- a/internal/interceptor.go
+++ b/internal/interceptor.go
@@ -707,11 +707,16 @@ type ClientPollActivityResultOutput struct {
 //
 // Exposed as: [go.temporal.io/sdk/interceptor.ClientExecuteNexusOperationInput]
 type ClientExecuteNexusOperationInput struct {
-	Options       *ClientStartNexusOperationOptions
-	Endpoint      string
-	Service       string
+	// Options are the options for starting the Nexus operation.
+	Options *ClientStartNexusOperationOptions
+	// Endpoint is the Nexus endpoint to invoke.
+	Endpoint string
+	// Service is the Nexus service to invoke.
+	Service string
+	// OperationType is the Nexus operation type to invoke.
 	OperationType string
-	Input         interface{}
+	// Input is the input to the Nexus operation.
+	Input interface{}
 	// NexusHeader is the Nexus header to attach to the operation request.
 	// Interceptors may read and write this header.
 	NexusHeader nexus.Header
@@ -724,8 +729,10 @@ type ClientExecuteNexusOperationInput struct {
 //
 // Exposed as: [go.temporal.io/sdk/interceptor.ClientGetNexusOperationHandleInput]
 type ClientGetNexusOperationHandleInput struct {
+	// OperationID is the ID of the Nexus operation.
 	OperationID string
-	RunID       string
+	// RunID is the run ID of the Nexus operation.
+	RunID string
 }
 
 // ClientCancelNexusOperationInput is the input to
@@ -735,9 +742,12 @@ type ClientGetNexusOperationHandleInput struct {
 //
 // Exposed as: [go.temporal.io/sdk/interceptor.ClientCancelNexusOperationInput]
 type ClientCancelNexusOperationInput struct {
+	// OperationID is the ID of the Nexus operation.
 	OperationID string
-	RunID       string
-	Reason      string
+	// RunID is the run ID of the Nexus operation to cancel.
+	RunID string
+	// Reason is the reason for cancellation.
+	Reason string
 }
 
 // ClientTerminateNexusOperationInput is the input to
@@ -747,9 +757,12 @@ type ClientCancelNexusOperationInput struct {
 //
 // Exposed as: [go.temporal.io/sdk/interceptor.ClientTerminateNexusOperationInput]
 type ClientTerminateNexusOperationInput struct {
+	// OperationID is the ID of the Nexus operation.
 	OperationID string
-	RunID       string
-	Reason      string
+	// RunID is the run ID of the Nexus operation to terminate.
+	RunID string
+	// Reason is the reason for termination.
+	Reason string
 }
 
 // ClientDescribeNexusOperationInput is the input to
@@ -759,8 +772,10 @@ type ClientTerminateNexusOperationInput struct {
 //
 // Exposed as: [go.temporal.io/sdk/interceptor.ClientDescribeNexusOperationInput]
 type ClientDescribeNexusOperationInput struct {
+	// OperationID is the ID of the Nexus operation.
 	OperationID string
-	RunID       string
+	// RunID is the run ID of the Nexus operation to describe.
+	RunID string
 }
 
 // ClientDescribeNexusOperationOutput is the output of
@@ -770,6 +785,7 @@ type ClientDescribeNexusOperationInput struct {
 //
 // Exposed as: [go.temporal.io/sdk/interceptor.ClientDescribeNexusOperationOutput]
 type ClientDescribeNexusOperationOutput struct {
+	// Description is the description of the Nexus operation.
 	Description *ClientNexusOperationExecutionDescription
 }
 
@@ -780,8 +796,10 @@ type ClientDescribeNexusOperationOutput struct {
 //
 // Exposed as: [go.temporal.io/sdk/interceptor.ClientPollNexusOperationResultInput]
 type ClientPollNexusOperationResultInput struct {
+	// OperationID is the ID of the Nexus operation.
 	OperationID string
-	RunID       string
+	// RunID is the run ID of the Nexus operation to poll results for.
+	RunID string
 }
 
 // ClientPollNexusOperationResultOutput is the output of


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->
Added some more comments

## Why?
<!-- Tell your future self why have you made these changes -->
Unblock https://github.com/temporalio/sdk-go/pull/2232

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only changes with no functional or API behavior impact.
> 
> **Overview**
> Adds **godoc comments** on struct fields so generated docs and downstream tooling (e.g. PR #2232) have documented APIs—no runtime behavior changes.
> 
> In `internal/error.go`, documents `ContinueAsNewError.BackoffStartInterval` and slightly reformats field alignment on that struct.
> 
> In `internal/interceptor.go`, documents fields on experimental **client Nexus operation** interceptor input/output types (`ClientExecuteNexusOperationInput`, handle/cancel/terminate/describe/poll types) so each field (`Options`, `Endpoint`, `OperationID`, `RunID`, `Reason`, etc.) has a short description consistent with other interceptor structs in the file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3237ebbf0cd1c2d8f3e6cb0b74e3cf6def209279. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->