### PR TITLE
Declare workflow outcome counters during worker start

### DIFF
--- a/internal/common/metrics/declare.go
+++ b/internal/common/metrics/declare.go
@@ -1,0 +1,23 @@
+package metrics
+
+var workflowOutcomeCounters = []string{
+	WorkflowCompletedCounter,
+	WorkflowCanceledCounter,
+	WorkflowFailedCounter,
+	WorkflowContinueAsNewCounter,
+}
+
+// DeclareRegisteredWorkflowOutcomeCounters initializes workflow outcome counters to
+// zero for each provided workflow type so they appear in metric scrapes before the
+// first corresponding event.
+func DeclareRegisteredWorkflowOutcomeCounters(handler Handler, workflowTypes []string) {
+	if handler == NopHandler || len(workflowTypes) == 0 {
+		return
+	}
+	for _, wfType := range workflowTypes {
+		tagged := handler.WithTags(WorkflowTags(wfType))
+		for _, counter := range workflowOutcomeCounters {
+			tagged.Counter(counter).Inc(0)
+		}
+	}
+}

--- a/internal/common/metrics/declare_test.go
+++ b/internal/common/metrics/declare_test.go
@@ -1,0 +1,53 @@
+package metrics_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/internal/common/metrics"
+)
+
+func TestDeclareRegisteredWorkflowOutcomeCounters(t *testing.T) {
+	capture := metrics.NewCapturingHandler()
+	metrics.DeclareRegisteredWorkflowOutcomeCounters(capture, []string{"OrderWorkflow", "PaymentWorkflow"})
+
+	require.Len(t, capture.Counters(), 8)
+
+	counterNames := map[string]int{
+		metrics.WorkflowCompletedCounter:     0,
+		metrics.WorkflowCanceledCounter:      0,
+		metrics.WorkflowFailedCounter:        0,
+		metrics.WorkflowContinueAsNewCounter: 0,
+	}
+	workflowTypes := map[string]int{
+		"OrderWorkflow":   0,
+		"PaymentWorkflow": 0,
+	}
+
+	for _, counter := range capture.Counters() {
+		require.Equal(t, int64(0), counter.Value())
+		counterNames[counter.Name]++
+		wfType := counter.Tags[metrics.WorkflowTypeNameTagName]
+		require.Contains(t, workflowTypes, wfType)
+		workflowTypes[wfType]++
+	}
+
+	for name, count := range counterNames {
+		require.Equal(t, 2, count, "expected 2 counters named %s", name)
+	}
+	for wfType, count := range workflowTypes {
+		require.Equal(t, 4, count, "expected 4 counters for workflow type %s", wfType)
+	}
+}
+
+func TestDeclareRegisteredWorkflowOutcomeCounters_NopHandler(t *testing.T) {
+	capture := metrics.NewCapturingHandler()
+	metrics.DeclareRegisteredWorkflowOutcomeCounters(metrics.NopHandler, []string{"OrderWorkflow"})
+	require.Empty(t, capture.Counters())
+}
+
+func TestDeclareRegisteredWorkflowOutcomeCounters_EmptyWorkflowTypes(t *testing.T) {
+	capture := metrics.NewCapturingHandler()
+	metrics.DeclareRegisteredWorkflowOutcomeCounters(capture, nil)
+	require.Empty(t, capture.Counters())
+}

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -1374,6 +1374,10 @@ func (aw *AggregatedWorker) start() error {
 	}
 
 	if !util.IsInterfaceNil(aw.workflowWorker) {
+		metrics.DeclareRegisteredWorkflowOutcomeCounters(
+			aw.executionParams.MetricsHandler,
+			aw.registry.getRegisteredWorkflowTypes(),
+		)
 		if err := aw.workflowWorker.Start(); err != nil {
 			return err
 		}

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -1780,6 +1780,48 @@ func (s *internalWorkerTestSuite) TestCreateWorker() {
 	assert.False(s.T(), worker.workflowWorker.worker.isWorkerStarted)
 }
 
+func (s *internalWorkerTestSuite) TestWorkflowOutcomeCountersDeclaredOnStart() {
+	capture := metrics.NewCapturingHandler()
+	namespace := "testNamespace"
+	setupPollingMocks(namespace, s.service, 0.0)
+	s.service.EXPECT().ShutdownWorker(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(&workflowservice.ShutdownWorkerResponse{}, nil).AnyTimes()
+
+	client := NewServiceClient(s.service, nil, ClientOptions{
+		Namespace:      namespace,
+		MetricsHandler: capture,
+	})
+	worker := NewAggregatedWorker(client, "testGroupName2", WorkerOptions{
+		WorkerActivitiesPerSecond: 20,
+		EnableSessionWorker:       true,
+	})
+	const workflowType = "MyOrderWorkflow"
+	worker.RegisterWorkflowWithOptions(testWorkflowReturnStruct, RegisterWorkflowOptions{Name: workflowType})
+
+	err := worker.Start()
+	require.NoError(s.T(), err)
+	worker.Stop()
+
+	outcomeCounters := map[string]bool{
+		metrics.WorkflowCompletedCounter:     false,
+		metrics.WorkflowCanceledCounter:      false,
+		metrics.WorkflowFailedCounter:        false,
+		metrics.WorkflowContinueAsNewCounter: false,
+	}
+	for _, counter := range capture.Counters() {
+		if counter.Tags[metrics.WorkflowTypeNameTagName] != workflowType {
+			continue
+		}
+		if _, ok := outcomeCounters[counter.Name]; ok {
+			require.Equal(s.T(), int64(0), counter.Value())
+			outcomeCounters[counter.Name] = true
+		}
+	}
+	for name, found := range outcomeCounters {
+		require.True(s.T(), found, "counter %s not declared for workflow type %s", name, workflowType)
+	}
+}
+
 func (s *internalWorkerTestSuite) TestCreateWorkerWithDataConverter() {
 	worker := createWorkerWithDataConverter(s.service)
 	worker.RegisterActivity(testActivityNoResult)


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Initialize to 0 known workflow outcome metrics at worker startup

## Why?

Fixes some metrics affected by this: https://github.com/temporalio/sdk-go/issues/2401

## Checklist

1. Closes #2401 

2. How was this tested:

I added unit tests and tested this locally with one of my apps. The /metrics contains at startup: 
```
# HELP temporal_workflow_canceled_total temporal_workflow_canceled_total counter
# TYPE temporal_workflow_canceled_total counter
temporal_workflow_canceled_total{activity_type="none",client_name="temporal_go",namespace="default",task_queue="xxx",worker_type="none",workflow_type="aaa"} 0
temporal_workflow_canceled_total{activity_type="none",client_name="temporal_go",namespace="default",task_queue="xxx",worker_type="none",workflow_type="bbb"} 0

# HELP temporal_workflow_completed_total temporal_workflow_completed_total counter
# TYPE temporal_workflow_completed_total counter
temporal_workflow_completed_total{activity_type="none",client_name="temporal_go",namespace="default",task_queue="xxx",worker_type="none",workflow_type="aaa"} 0
temporal_workflow_completed_total{activity_type="none",client_name="temporal_go",namespace="default",task_queue="xxx",worker_type="none",workflow_type="bbb"} 0
# HELP temporal_workflow_continue_as_new_total temporal_workflow_continue_as_new_total counter
# TYPE temporal_workflow_continue_as_new_total counter
temporal_workflow_continue_as_new_total{activity_type="none",client_name="temporal_go",namespace="default",task_queue="xxx",worker_type="none",workflow_type="aaa"} 0
temporal_workflow_continue_as_new_total{activity_type="none",client_name="temporal_go",namespace="default",task_queue="xxx",worker_type="none",workflow_type="bbb"} 0
# HELP temporal_workflow_failed_total temporal_workflow_failed_total counter
# TYPE temporal_workflow_failed_total counter
temporal_workflow_failed_total{activity_type="none",client_name="temporal_go",namespace="default",task_queue="xxx",worker_type="none",workflow_type="aaa"} 0
temporal_workflow_failed_total{activity_type="none",client_name="temporal_go",namespace="default",task_queue="xxx",worker_type="none",workflow_type="bbb"} 0

```





