### PR TITLE
fix(otel): use monotonic Int64Counter for Counter metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,3 +23,11 @@ to docs, or any other relevant information.
 
 * Exposed `BackoffStartInterval` when continuing as new, which will delay the first task of the
   continued workflow by the configured interval.
+
+### Fixed
+
+* `contrib/opentelemetry`: counter metrics are now emitted as a monotonic OpenTelemetry
+  counter (`Int64Counter`) instead of an up/down counter (`Int64UpDownCounter`). Previously
+  Temporal SDK counters such as `temporal_workflow_completed` were reported downstream as
+  gauges (e.g. in Prometheus and Datadog) rather than counts, which could cause metric type
+  conflicts. (#2140)

--- a/contrib/opentelemetry/handler.go
+++ b/contrib/opentelemetry/handler.go
@@ -95,8 +95,13 @@ func (m MetricsHandler) WithTags(tags map[string]string) client.MetricsHandler {
 	}
 }
 
+// Counter returns a monotonic counter. The underlying OpenTelemetry instrument
+// is an Int64Counter, so the series reported downstream is a monotonic sum
+// (e.g. a Prometheus counter, a Datadog count) rather than a gauge. Negative
+// deltas are not valid for a monotonic counter; their handling is delegated to
+// the OpenTelemetry SDK (the wrapper does not panic on them).
 func (m MetricsHandler) Counter(name string) client.MetricsCounter {
-	c, err := m.meter.Int64UpDownCounter(name)
+	c, err := m.meter.Int64Counter(name)
 	if err != nil {
 		m.onError(err)
 		return client.MetricsNopHandler.Counter(name)

--- a/contrib/opentelemetry/handler_test.go
+++ b/contrib/opentelemetry/handler_test.go
@@ -37,7 +37,7 @@ func TestTags(t *testing.T) {
 		Name: "testCounter",
 		Data: metricdata.Sum[int64]{
 			Temporality: metricdata.CumulativeTemporality,
-			IsMonotonic: false,
+			IsMonotonic: true,
 			DataPoints: []metricdata.DataPoint[int64]{
 				{
 					Attributes: attribute.NewSet(attribute.String("tag1", "value1")),
@@ -64,7 +64,6 @@ func TestCounterHandler(t *testing.T) {
 	testCounter := handler.WithTags(map[string]string{"tag1": "value1"}).Counter("testCounter")
 	testCounter.Inc(1)
 	testCounter.Inc(1)
-	testCounter.Inc(-1)
 	// Emit some values with different tags
 	testCounter2 := handler.WithTags(map[string]string{"tag1": "value2"}).Counter("testCounter")
 	testCounter2.Inc(5)
@@ -78,10 +77,10 @@ func TestCounterHandler(t *testing.T) {
 		Name: "testCounter",
 		Data: metricdata.Sum[int64]{
 			Temporality: metricdata.CumulativeTemporality,
-			IsMonotonic: false,
+			IsMonotonic: true,
 			DataPoints: []metricdata.DataPoint[int64]{
 				{
-					Value:      1,
+					Value:      2,
 					Attributes: attribute.NewSet(attribute.String("tag1", "value1")),
 				},
 				{
@@ -92,6 +91,46 @@ func TestCounterHandler(t *testing.T) {
 		},
 	}
 	metricdatatest.AssertEqual(t, want, metrics[0], metricdatatest.IgnoreTimestamp())
+}
+
+// TestCounterHandlerNegativeDeltaDoesNotPanic verifies that a negative increment
+// on a monotonic counter is handled gracefully under the default handler options.
+// The default OnError panics, so this exercises that path: a negative delta must
+// not be routed through OnError. The exact recorded value is governed by the
+// OpenTelemetry SDK and intentionally not asserted; what matters is that the
+// instrument stays monotonic and emission never panics.
+func TestCounterHandlerNegativeDeltaDoesNotPanic(t *testing.T) {
+	ctx := context.Background()
+	metricReader := metric.NewManualReader()
+	meterProvider := metric.NewMeterProvider(metric.WithReader(metricReader))
+	// Default options: OnError defaults to panic. A negative delta must not reach it.
+	handler := opentelemetry.NewMetricsHandler(opentelemetry.MetricsHandlerOptions{
+		Meter: meterProvider.Meter("test"),
+	})
+	testCounter := handler.WithTags(map[string]string{"tag1": "value1"}).Counter("testCounter")
+	assert.NotPanics(t, func() {
+		testCounter.Inc(1)
+		testCounter.Inc(-1) // not valid for a monotonic counter; must not panic
+		testCounter.Inc(2)
+	})
+	var rm metricdata.ResourceMetrics
+	metricReader.Collect(ctx, &rm)
+	assert.Len(t, rm.ScopeMetrics, 1)
+	metrics := rm.ScopeMetrics[0].Metrics
+	assert.Len(t, metrics, 1)
+	want := metricdata.Metrics{
+		Name: "testCounter",
+		Data: metricdata.Sum[int64]{
+			Temporality: metricdata.CumulativeTemporality,
+			IsMonotonic: true,
+			DataPoints: []metricdata.DataPoint[int64]{
+				{
+					Attributes: attribute.NewSet(attribute.String("tag1", "value1")),
+				},
+			},
+		},
+	}
+	metricdatatest.AssertEqual(t, want, metrics[0], metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreValue())
 }
 
 func TestGaugeHandler(t *testing.T) {


### PR DESCRIPTION
## Problem

The OpenTelemetry metrics handler implements `Counter()` using `Int64UpDownCounter`, which produces a non-monotonic `Sum` (`IsMonotonic: false`). Temporal counter metrics (e.g. `temporal_workflow_completed`) only ever increase, so this is the wrong instrument — downstream systems that classify series by monotonicity then treat them as gauges rather than counters:

- **Prometheus**: exported without the `_total` suffix and treated as a gauge rather than a counter (see #2140).
- **Datadog** and other OTLP backends: registered as a `gauge` rather than a `count`.

Fixes #2140. Supersedes #2340.

## Solution

Use `Int64Counter` (monotonic) for `Counter()`. Counter semantics are inherently monotonic — a counter only ever goes up. `Int64UpDownCounter` is the correct instrument for metrics that can decrease (queue depth, active connections, etc.), and Temporal already has a separate `UpDownCounter` concept for that.

This differs from #2340, which added an opt-in `UseMonotonicCounters bool` flag defaulting to `false` (preserving the broken behavior). Making `Int64Counter` the default is the correct fix — there is no valid use case for a non-monotonic `Counter`, and no user should have to opt in to correct behavior.

Negative deltas are not valid for a monotonic counter. Their handling is delegated to the OpenTelemetry SDK (the handler does not panic on them).

## Changes

- `handler.go`: `Int64UpDownCounter` → `Int64Counter`; documented the monotonic semantics on `Counter()`.
- `handler_test.go`: updated `IsMonotonic` expectations to `true`; removed the `Inc(-1)` decrement assertion (not valid for a monotonic counter); added `TestCounterHandlerNegativeDeltaDoesNotPanic` to verify a negative delta under default options (where `OnError` panics) does not panic and the instrument stays monotonic.
- `CHANGELOG.md`: added an `[Unreleased] / Fixed` entry for the gauge→count downstream behavior change.

## Testing

Unit tests:

```
go test ./contrib/opentelemetry/...
ok  go.temporal.io/sdk/contrib/opentelemetry
```

End-to-end against a local Temporal dev server (`temporal server start-dev`, v1.7.2) with a Go harness wiring this handler to a Prometheus OTel exporter (`go.opentelemetry.io/otel/exporters/prometheus`). The harness registers a trivial workflow, executes it 3 times, and scrapes `/metrics`. It was built against this branch via `go.mod` `replace` directives, so no released SDK version was involved.

**Before** (`Int64UpDownCounter`) — exported as a gauge, no `_total` suffix, and the non-monotonic value fails to accumulate (reads `1` after 3 completions):

```
# TYPE temporal_workflow_completed gauge
temporal_workflow_completed{...,workflow_type="SimpleWorkflow"} 1
```

**After** (`Int64Counter`, this PR) — exported as a proper Prometheus counter with the `_total` suffix, correctly accumulating to `3`:

```
# TYPE temporal_workflow_completed_total counter
temporal_workflow_completed_total{...,workflow_type="SimpleWorkflow"} 3
```

The `_total` suffix is appended automatically by the Prometheus OTel bridge when the instrument is a monotonic counter, confirming the metric is now rate-queryable as a counter rather than misclassified as a gauge.

## Additional notes
- Implemented via claude code + reviewed via OpenAI codex