### PR TITLE
Release SDK v1.45.0

### DIFF
--- a/internal/version.go
+++ b/internal/version.go
@@ -8,7 +8,7 @@ const (
 	// Server validates if SDKVersion fits its supported range and rejects request if it doesn't.
 	//
 	// Exposed as: [go.temporal.io/sdk/temporal.SDKVersion]
-	SDKVersion = "1.44.1"
+	SDKVersion = "1.45.0"
 
 	// SDKName represents the name of the SDK.
 	SDKName = clientNameHeaderValue


### PR DESCRIPTION
Release SDK v1.45.0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single constant version bump with no logic or compatibility range changes.
> 
> **Overview**
> Bumps the embedded **SDK version** from `1.44.1` to **`1.45.0`** in `internal/version.go`. That constant is sent on every RPC to Temporal Server for version compatibility checks; no other metadata in this file changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f58c988319f75207223305b63992de41eb3eaba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->