### PR TITLE
contrib/workflowstreams: bump Go SDK to v1.45.0

### DIFF
--- a/contrib/workflowstreams/go.mod
+++ b/contrib/workflowstreams/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/stretchr/testify v1.11.1
 	go.temporal.io/api v1.62.12
-	go.temporal.io/sdk v1.44.1
+	go.temporal.io/sdk v1.45.0
 	google.golang.org/protobuf v1.36.11
 )
 


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->
Bump Go SDK dep to v1.45.0

## Why?
<!-- Tell your future self why have you made these changes -->
initial package changed code in `internal/`, now that changes are released, need to point to released version

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency version-only change in a contrib module; no application logic modified in this diff.
> 
> **Overview**
> Updates the **`contrib/workflowstreams`** module’s direct dependency on **`go.temporal.io/sdk`** from **v1.44.1** to **v1.45.0**, aligning the contrib package with the released SDK that includes the **`internal/`** changes this module relies on (previously only available via the local **`replace`** to the repo root).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eab282f4097efdf0dc12ebd4a9d886c11a9275f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->