### PR TITLE
Fix more test flakes, and autoscaling startup race

### DIFF
--- a/internal/internal_worker_base.go
+++ b/internal/internal_worker_base.go
@@ -218,12 +218,12 @@ type (
 
 	// baseWorker that wraps worker activities.
 	baseWorker struct {
-		options              baseWorkerOptions
-		isWorkerStarted      bool
+		options         baseWorkerOptions
+		isWorkerStarted bool
 		// stopCh is created by newBaseWorker and closed by baseWorker.Stop().
 		// It is internal to baseWorker and stops its poller, dispatcher, autoscaler,
 		// and throttling/backoff loops.
-		stopCh chan struct{}
+		stopCh               chan struct{}
 		stopWG               sync.WaitGroup // The WaitGroup for stopping existing routines.
 		pollLimiter          *rate.Limiter
 		taskLimiter          *rate.Limiter
@@ -421,11 +421,13 @@ func (bw *baseWorker) Start() {
 
 	bw.metricsHandler.Counter(metrics.WorkerStartCounter).Inc(1)
 
-	for _, taskWorker := range bw.options.taskPollers {
-		if bw.pollerBalancer != nil {
+	if bw.pollerBalancer != nil {
+		for _, taskWorker := range bw.options.taskPollers {
 			bw.pollerBalancer.registerPollerType(taskWorker.taskPollerType)
 		}
+	}
 
+	for _, taskWorker := range bw.options.taskPollers {
 		if taskWorker.autoscalingRunner != nil {
 			bw.stopWG.Add(1)
 			bw.pollerWG.Add(1)

--- a/internal/internal_worker_base_test.go
+++ b/internal/internal_worker_base_test.go
@@ -817,7 +817,7 @@ func TestTaskNotProcessedDuringLegacyShutdown(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			taskProcessed := make(chan struct{}, 1)
-			pollStarted := make(chan struct{})
+			pollStarted := make(chan struct{}, 1)
 
 			// This poller simulates a poll returning a task after shutdown has
 			// already started. Legacy shutdown should not dispatch that task.

--- a/internal/internal_worker_base_test.go
+++ b/internal/internal_worker_base_test.go
@@ -842,7 +842,11 @@ func TestTaskNotProcessedDuringLegacyShutdown(t *testing.T) {
 			})
 
 			bw.Start()
-			<-pollStarted
+			select {
+			case <-pollStarted:
+			case <-time.After(5 * time.Second):
+				t.Fatal("poller did not start in time")
+			}
 
 			// AggregatedWorker.Stop sets noRepoll before stopping base workers.
 			bw.noRepoll.Store(true)

--- a/internal/internal_worker_base_test.go
+++ b/internal/internal_worker_base_test.go
@@ -306,10 +306,11 @@ func (s *ScalableTaskPollerSuite) TestAutoscalingScalesDownToMinimum() {
 
 	eventuallyAutoscalingPollerState(s.T(), poller.autoscalingRunner, 1, "expected concurrency to reduce to minimum")
 
-	require.Never(s.T(), func() bool {
-		blockingPoller.Allow(readAutoscalingPollerState(poller.autoscalingRunner))
-		return readAutoscalingPollerState(poller.autoscalingRunner) == 0
-	}, 200*time.Millisecond, 10*time.Millisecond, "should not scale below minimum")
+	for range 5 {
+		assert.Equal(s.T(), int64(1), poller.pollerAutoscaler.target.Load(), "should not scale target below minimum")
+		blockingPoller.Allow(1)
+		eventuallyAutoscalingPollerState(s.T(), poller.autoscalingRunner, 1, "expected concurrency to recover to minimum")
+	}
 }
 
 func (s *ScalableTaskPollerSuite) TestAutoscalingDoesNotHoldSlotWhileWaitingForPollCapacity() {

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -584,19 +584,19 @@ func (ts *IntegrationTestSuite) TestLongRunningActivityWithHB() {
 
 func (ts *IntegrationTestSuite) TestLongRunningActivityWithHBAndGrpcRetries() {
 	var expected []string
-	// Fail every other HB attempt, otherwise it's too easy to exceed the HB timeout
-	ts.trafficController.AddError("RecordActivityTaskHeartbeat", errors.New("call not allowed"), 1, 3, 5)
+	// Fail every other HB attempt, otherwise it's too easy to exceed the HB timeout.
+	ts.trafficController.AddError("RecordActivityTaskHeartbeat", errors.New("call not allowed"), 1, 3)
 	err := ts.executeWorkflow("test-long-running-activity-with-hb", ts.workflows.LongRunningActivityWithHB, &expected)
 	ts.NoError(err)
 	ts.EqualValues(expected, ts.activities.invoked())
-	// we induce 3 failures, but they all should be retried
+	// we induce 2 failures, but they all should be retried
 	ts.assertReportedOperationCount("temporal_request_failure", "RecordActivityTaskHeartbeat", 0)
-	// expect 3 retry attempts
-	ts.assertReportedOperationCount("temporal_request_failure_attempt", "RecordActivityTaskHeartbeat", 3)
+	// expect 2 retry attempts
+	ts.assertReportedOperationCount("temporal_request_failure_attempt", "RecordActivityTaskHeartbeat", 2)
 	// save number of heartbeats sent to the server
 	totalHeartbeats := ts.getReportedOperationCount("temporal_request", "RecordActivityTaskHeartbeat")
-	// and make sure that number of reported attempts is 3 more, because of retries.
-	ts.assertReportedOperationCount("temporal_request_attempt", "RecordActivityTaskHeartbeat", int(totalHeartbeats+3))
+	// and make sure that number of reported attempts is 2 more, because of retries.
+	ts.assertReportedOperationCount("temporal_request_attempt", "RecordActivityTaskHeartbeat", int(totalHeartbeats+2))
 }
 
 func (ts *IntegrationTestSuite) TestHeartbeatOnActivityFailure() {

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -2633,10 +2633,13 @@ func (ts *IntegrationTestSuite) TestGracefulActivityCompletion() {
 
 func (ts *IntegrationTestSuite) TestLocalActivityTaskTimeoutHeartbeat() {
 	// FYI, setup of this test allows the worker to wait to stop for 10 seconds
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
 	defer cancel()
 
+	localActivityStarted := make(chan struct{})
+	var localActivityStartedOnce sync.Once
 	localActivityFn := func(ctx context.Context) error {
+		localActivityStartedOnce.Do(func() { close(localActivityStarted) })
 		// wait for worker shutdown to be started and WorkflowTaskTimeout to be hit
 		<-activity.GetWorkerStopChannel(ctx)
 		time.Sleep(1500 * time.Millisecond) // 1.5 seconds
@@ -2669,8 +2672,14 @@ func (ts *IntegrationTestSuite) TestLocalActivityTaskTimeoutHeartbeat() {
 	run, err := ts.client.ExecuteWorkflow(ctx, startOptions, workflowFn)
 	ts.NoError(err)
 
-	// Stop the worker
-	time.Sleep(100 * time.Millisecond)
+	select {
+	case <-localActivityStarted:
+	case <-ctx.Done():
+		ts.FailNow("timed out waiting for local activity to start", ctx.Err().Error())
+	}
+
+	// Stop the worker after the local activity is blocked on worker shutdown so
+	// shutdown reliably overlaps the workflow task timeout.
 	ts.worker.Stop()
 	ts.workerStopped = true
 
@@ -2678,7 +2687,7 @@ func (ts *IntegrationTestSuite) TestLocalActivityTaskTimeoutHeartbeat() {
 	var laCompleted, started int
 	var wfeCompleted bool
 	iter := ts.client.GetWorkflowHistory(ctx, run.GetID(), run.GetRunID(),
-		true, enumspb.HISTORY_EVENT_FILTER_TYPE_ALL_EVENT)
+		false, enumspb.HISTORY_EVENT_FILTER_TYPE_ALL_EVENT)
 	for iter.HasNext() {
 		event, err := iter.Next()
 		ts.NoError(err)

--- a/test/nexus_test.go
+++ b/test/nexus_test.go
@@ -1534,7 +1534,7 @@ func TestAsyncOperationFromWorkflow_CancellationTypes(t *testing.T) {
 	}
 
 	t.Run("Abandon", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), defaultNexusTestTimeout)
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 		tc := newTestContext(t, ctx)
 

--- a/test/worker_deployment_test.go
+++ b/test/worker_deployment_test.go
@@ -93,30 +93,27 @@ func (ts *WorkerDeploymentTestSuite) waitForWorkerDeploymentRoutingConfigPropaga
 	expectedCurrentBuildID string,
 	expectedRampingBuildID string,
 ) {
+	dHandle := ts.client.WorkerDeploymentClient().GetHandle(deploymentName)
 	ts.Eventually(func() bool {
-		resp, err := ts.client.WorkflowService().DescribeWorkerDeployment(ctx, &workflowservice.DescribeWorkerDeploymentRequest{
-			Namespace:      ts.config.Namespace,
-			DeploymentName: deploymentName,
-		})
+		desc, err := dHandle.Describe(ctx, client.WorkerDeploymentDescribeOptions{})
 		if err != nil {
 			return false
 		}
-		if resp.GetWorkerDeploymentInfo().GetRoutingConfig().GetCurrentDeploymentVersion().GetBuildId() != expectedCurrentBuildID {
+		if buildIDFromWorkerDeploymentVersion(desc.Info.RoutingConfig.CurrentVersion) != expectedCurrentBuildID {
 			return false
 		}
-		if resp.GetWorkerDeploymentInfo().GetRoutingConfig().GetRampingDeploymentVersion().GetBuildId() != expectedRampingBuildID {
+		if buildIDFromWorkerDeploymentVersion(desc.Info.RoutingConfig.RampingVersion) != expectedRampingBuildID {
 			return false
 		}
-		switch resp.GetWorkerDeploymentInfo().GetRoutingConfigUpdateState() {
-		case enumspb.ROUTING_CONFIG_UPDATE_STATE_COMPLETED:
-			return true
-		case enumspb.ROUTING_CONFIG_UPDATE_STATE_UNSPECIFIED:
-			return true // not implemented
-		case enumspb.ROUTING_CONFIG_UPDATE_STATE_IN_PROGRESS:
-			return false
-		}
-		return false
-	}, 10*time.Second, 100*time.Millisecond)
+		return true
+	}, 30*time.Second, 100*time.Millisecond)
+}
+
+func buildIDFromWorkerDeploymentVersion(version *worker.WorkerDeploymentVersion) string {
+	if version == nil {
+		return ""
+	}
+	return version.BuildID
 }
 
 func (ts *WorkerDeploymentTestSuite) waitForWorkflowRunning(ctx context.Context, handle client.WorkflowRun) {
@@ -437,7 +434,7 @@ func (ts *WorkerDeploymentTestSuite) TestPinnedBehaviorThreeWorkers() {
 	handle1, err := ts.client.ExecuteWorkflow(ctx, ts.startWorkflowOptions("1"), "WaitSignalToStartVersioned")
 	ts.NoError(err)
 
-	ts.waitForWorkflowRunning(ctx, handle1)
+	ts.waitForWorkflowRunningOnVersion(ctx, handle1, v1.BuildID)
 
 	ts.waitForWorkerDeploymentVersion(ctx, dHandle, v2)
 
@@ -452,7 +449,7 @@ func (ts *WorkerDeploymentTestSuite) TestPinnedBehaviorThreeWorkers() {
 	handle2, err := ts.client.ExecuteWorkflow(ctx, ts.startWorkflowOptions("2"), "WaitSignalToStartVersioned")
 	ts.NoError(err)
 
-	ts.waitForWorkflowRunning(ctx, handle2)
+	ts.waitForWorkflowRunningOnVersion(ctx, handle2, v2.BuildID)
 
 	ts.waitForWorkerDeploymentVersion(ctx, dHandle, v3)
 
@@ -489,7 +486,7 @@ func (ts *WorkerDeploymentTestSuite) TestPinnedBehaviorThreeWorkers() {
 	handle3, err := ts.client.ExecuteWorkflow(ctx, ts.startWorkflowOptions("3"), "WaitSignalToStartVersioned")
 	ts.NoError(err)
 
-	ts.waitForWorkflowRunning(ctx, handle3)
+	ts.waitForWorkflowRunningOnVersion(ctx, handle3, v3.BuildID)
 
 	// finish them all
 	ts.NoError(ts.client.SignalWorkflow(ctx, handle1.GetID(), handle1.GetRunID(), "start-signal", "prefix"))

--- a/test/workflow_test.go
+++ b/test/workflow_test.go
@@ -234,7 +234,7 @@ func (w *Workflows) ActivityRetryOnTimeout(ctx workflow.Context, timeoutType enu
 
 func (w *Workflows) LongRunningActivityWithHB(ctx workflow.Context) ([]string, error) {
 	opts := w.defaultActivityOptionsWithRetry()
-	opts.HeartbeatTimeout = 2 * time.Second
+	opts.HeartbeatTimeout = 3 * time.Second
 	opts.ScheduleToCloseTimeout = time.Second * 12
 	opts.StartToCloseTimeout = time.Second * 12
 	opts.RetryPolicy = &internal.RetryPolicy{

--- a/testsuite/devserver_test.go
+++ b/testsuite/devserver_test.go
@@ -22,7 +22,7 @@ func TestStartDevServer_Defaults(t *testing.T) {
 }
 
 func TestStartDevServer_SpecificVersion(t *testing.T) {
-	server, err := testsuite.StartDevServer(context.Background(), testsuite.DevServerOptions{CachedDownload: testsuite.CachedDownload{Version: "v0.3.0"}})
+	server, err := testsuite.StartDevServer(context.Background(), testsuite.DevServerOptions{CachedDownload: testsuite.CachedDownload{Version: "v1.6.1"}})
 	require.NoError(t, err)
 	defer func() { _ = server.Stop() }()
 	info, err := server.Client().WorkflowService().GetSystemInfo(context.Background(), &workflowservice.GetSystemInfoRequest{})


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->
Fixed a few tests flakes:
  - Worker poller startup/shutdown: fixed a non-test race in worker startup where autoscaling pollers could begin running before every poller type was registered with the balancer. We now register all poller types before starting any poller goroutines, so one poller type cannot temporarily consume slots before the balancer knows about them.

  - TestAutoscalingScalesDownToMinimum: The flake was a race between the test assertion and the asynchronous autoscaling control loop. Now we only assert after we actually observe/apply the minimum state, instead of a potential transient state of 0 failing our tests, even though the effective poller count never goes below 1

  - TestLocalActivityTaskTimeoutHeartbeat: The flake was stopping the worker the LA was reliably blocked on shutdown, and we were also waiting on `GetWorkflowHistory` indefinitely, potentially up to `15m`. Now we send an explicit signal after LA has started, and added a bounded ctx, and stopped long polling for WF history.

  - TestStartDevServer_SpecificVersion: stopped pinning the obsolete Temporal CLI v0.3.0, whose embedded server can crash during startup with a tchannel-go concurrent map read/write panic. The test now uses CLI v1.6.1, which is still an explicit older version and verifies the specific-version download path without relying on a crash-prone release.

  - TestTaskNotProcessedDuringLegacyShutdown: replaced an unbounded wait for the fake poller to start with a 5s timeout. If the poller never starts, the test now fails locally with a useful error instead of hanging until the whole package times out.

  - TestAsyncOperationFromWorkflow_CancellationTypes/Abandon: increased the context timeout for the Abandon case from 10s to 30s. CI hit the test context deadline before run.Get could observe the workflow cancellation result.

  - TestPinnedBehaviorThreeWorkers: The test now verifies routing config through the SDK client’s normalized Describe response instead of reading a single raw proto field. This matches the public API behavior and avoids an always-false wait when the server represents the same routing version through the fallback wire field.

  - TestLongRunningActivityWithHBAndGrpcRetries: reduced induced heartbeat RPC failures from 3 to 2 and raised the heartbeat timeout from 2s to 3s. This still verifies heartbeat retry metrics, but avoids Windows CI timing out the activity while the test is intentionally delaying heartbeat calls.

## Why?
<!-- Tell your future self why have you made these changes -->
More reliable CI

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> The only runtime change is ordering in worker startup; remaining edits are test-only timing, assertions, and client API usage for waits.
> 
> **Overview**
> Fixes a **worker startup race** where autoscaling pollers could begin polling before every poller type was registered with the balancer. `baseWorker.Start` now **registers all poller types first**, then starts poller goroutines, so one type cannot consume slots before the balancer knows about the others.
> 
> The rest of the PR **hardens flaky tests** without changing product behavior: autoscaling minimum-concurrency assertions wait on stable state; legacy shutdown tests use bounded waits for poller startup; local-activity shutdown timing waits for the LA to start, uses a bounded context, and avoids long-polling workflow history; heartbeat/grpc-retry integration tests use fewer induced failures and a slightly longer heartbeat timeout; Nexus abandon cancellation gets a longer test timeout; worker deployment routing waits use the SDK `Describe` API and version-aware “running” checks; dev server version pin moves from crash-prone CLI **v0.3.0** to **v1.6.1**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d220f5e6175ad742c6a165f1b689e56db5746e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->