### PR TITLE
Populate Priority on ScheduleWorkflowAction returned by Describe

### DIFF
--- a/internal/internal_schedule_client.go
+++ b/internal/internal_schedule_client.go
@@ -761,6 +761,7 @@ func convertFromPBScheduleAction(
 			VersioningOverride:       versioningOverrideFromProto(workflow.VersioningOverride),
 			StaticSummary:            *convertedSummary,
 			StaticDetails:            *convertedDetails,
+			Priority:                 convertFromPBPriority(workflow.GetPriority()),
 		}, nil
 	default:
 		// TODO maybe just panic instead?

--- a/internal/internal_schedule_client_test.go
+++ b/internal/internal_schedule_client_test.go
@@ -7,8 +7,11 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/suite"
+	commonpb "go.temporal.io/api/common/v1"
 	schedulepb "go.temporal.io/api/schedule/v1"
 	"go.temporal.io/api/serviceerror"
+	taskqueuepb "go.temporal.io/api/taskqueue/v1"
+	workflowpb "go.temporal.io/api/workflow/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/api/workflowservicemock/v1"
 	"go.temporal.io/sdk/converter"
@@ -320,4 +323,36 @@ func (s *scheduleClientTestSuite) TestCreateScheduleWorkflowMemoUserAndDefaultCo
 		s.True(sdkFlagsAllowed[SDKFlagMemoUserDCEncode])
 		testFn()
 	})
+}
+
+func (s *scheduleClientTestSuite) TestDescribeSchedulePopulatesPriority() {
+	describeResponse := &workflowservice.DescribeScheduleResponse{
+		Schedule: &schedulepb.Schedule{
+			Action: &schedulepb.ScheduleAction{
+				Action: &schedulepb.ScheduleAction_StartWorkflow{
+					StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
+						WorkflowId:   workflowID,
+						WorkflowType: &commonpb.WorkflowType{Name: "wf-type"},
+						TaskQueue:    &taskqueuepb.TaskQueue{Name: taskqueue},
+						Priority: &commonpb.Priority{
+							PriorityKey:    3,
+							FairnessKey:    "fairness-key",
+							FairnessWeight: 2.5,
+						},
+					},
+				},
+			},
+		},
+		Info: &schedulepb.ScheduleInfo{},
+	}
+	s.service.EXPECT().DescribeSchedule(gomock.Any(), gomock.Any(), gomock.Any()).Return(describeResponse, nil).Times(1)
+
+	description, err := s.client.ScheduleClient().GetHandle(context.Background(), scheduleID).Describe(context.Background())
+	s.NoError(err)
+
+	action, ok := description.Schedule.Action.(*ScheduleWorkflowAction)
+	s.True(ok)
+	s.Equal(3, action.Priority.PriorityKey)
+	s.Equal("fairness-key", action.Priority.FairnessKey)
+	s.Equal(float32(2.5), action.Priority.FairnessWeight)
 }


### PR DESCRIPTION
## What was changed

`ScheduleHandle.Describe()` now returns the `Priority` set on a schedule's `ScheduleWorkflowAction`.

`convertFromPBScheduleAction` built the `ScheduleWorkflowAction` struct from the proto without populating `Priority`, so a schedule created with priority/fairness settings came back from `Describe()` with a zero-value `Priority`. The create path (`convertToPBScheduleAction`) already serializes `Priority`, so this was a read-side gap.

The fix populates the field using the existing `convertFromPBPriority` helper, mirroring the write path:

```go
Priority: convertFromPBPriority(workflow.GetPriority()),
```

## Why

`Describe()` should round-trip the schedule's action faithfully. Dropping `Priority` meant callers could not read back the priority/fairness configuration they created a schedule with.

## Tests

Added `TestDescribeSchedulePopulatesPriority`, which mocks a `DescribeSchedule` response carrying a `Priority` and asserts the returned `ScheduleWorkflowAction.Priority` round-trips (`PriorityKey`, `FairnessKey`, `FairnessWeight`). The test fails before the change and passes after; the full `TestScheduleClientSuite` passes under `-race`.

Closes #2345
