### PR TITLE
Add SideEffectWithOptions and MutableSideEffectWithOptions to workflowcheck allowlist

### DIFF
--- a/contrib/tools/workflowcheck/workflow/checker.go
+++ b/contrib/tools/workflowcheck/workflow/checker.go
@@ -9,9 +9,10 @@ import (
 	"regexp"
 	"strings"
 
-	"go.temporal.io/sdk/contrib/tools/workflowcheck/determinism"
 	"golang.org/x/tools/go/analysis"
 	"gopkg.in/yaml.v2"
+
+	"go.temporal.io/sdk/contrib/tools/workflowcheck/determinism"
 )
 
 // DefaultIdentRefs are additional overrides of determinism.DefaultIdentRefs for
@@ -79,11 +80,16 @@ func NewChecker(config Config) *Checker {
 		Debug:               config.Debug,
 		IncludePosOnMessage: config.IncludePosOnMessage,
 		Determinism: determinism.NewChecker(determinism.Config{
-			IdentRefs:                         config.IdentRefs,
-			DebugfFunc:                        config.DebugfFunc,
-			Debug:                             config.DeterminismDebug,
-			EnableObjectFacts:                 config.EnableObjectFacts,
-			AcceptsNonDeterministicParameters: map[string][]string{"go.temporal.io/sdk/workflow": {"SideEffect", "MutableSideEffect"}},
+			IdentRefs:         config.IdentRefs,
+			DebugfFunc:        config.DebugfFunc,
+			Debug:             config.DeterminismDebug,
+			EnableObjectFacts: config.EnableObjectFacts,
+			AcceptsNonDeterministicParameters: map[string][]string{
+				"go.temporal.io/sdk/workflow": {
+					"SideEffect", "SideEffectWithOptions",
+					"MutableSideEffect", "MutableSideEffectWithOptions",
+				},
+			},
 		}),
 	}
 }

--- a/contrib/tools/workflowcheck/workflow/testdata/src/a/workflow.go
+++ b/contrib/tools/workflowcheck/workflow/testdata/src/a/workflow.go
@@ -33,6 +33,51 @@ func WorkflowCallTimeInSideEffectAndNot(ctx workflow.Context) error { // want "a
 	return nil
 }
 
+func WorkflowCallTimeInSideEffectWithOptions(ctx workflow.Context) error {
+	workflow.SideEffectWithOptions(ctx, workflow.SideEffectOptions{}, func(ctx workflow.Context) interface{} {
+		return time.Now()
+	})
+	return nil
+}
+
+func WorkflowCallTimeInSideEffectWithOptionsAndNot(ctx workflow.Context) error { // want "a.WorkflowCallTimeInSideEffectWithOptionsAndNot is non-deterministic, reason: calls non-deterministic function time.Now"
+	workflow.SideEffectWithOptions(ctx, workflow.SideEffectOptions{}, func(ctx workflow.Context) interface{} {
+		return time.Now()
+	})
+	time.Now()
+	return nil
+}
+
+func WorkflowCallTimeInMutableSideEffect(ctx workflow.Context) error {
+	workflow.MutableSideEffect(ctx, "id", func(ctx workflow.Context) interface{} {
+		return time.Now()
+	}, func(a, b interface{}) bool { return a == b })
+	return nil
+}
+
+func WorkflowCallTimeInMutableSideEffectAndNot(ctx workflow.Context) error { // want "a.WorkflowCallTimeInMutableSideEffectAndNot is non-deterministic, reason: calls non-deterministic function time.Now"
+	workflow.MutableSideEffect(ctx, "id", func(ctx workflow.Context) interface{} {
+		return time.Now()
+	}, func(a, b interface{}) bool { return a == b })
+	time.Now()
+	return nil
+}
+
+func WorkflowCallTimeInMutableSideEffectWithOptions(ctx workflow.Context) error {
+	workflow.MutableSideEffectWithOptions(ctx, "id", workflow.MutableSideEffectOptions{}, func(ctx workflow.Context) interface{} {
+		return time.Now()
+	}, func(a, b interface{}) bool { return a == b })
+	return nil
+}
+
+func WorkflowCallTimeInMutableSideEffectWithOptionsAndNot(ctx workflow.Context) error { // want "a.WorkflowCallTimeInMutableSideEffectWithOptionsAndNot is non-deterministic, reason: calls non-deterministic function time.Now"
+	workflow.MutableSideEffectWithOptions(ctx, "id", workflow.MutableSideEffectOptions{}, func(ctx workflow.Context) interface{} {
+		return time.Now()
+	}, func(a, b interface{}) bool { return a == b })
+	time.Now()
+	return nil
+}
+
 func WorkflowCallTimeTransitively(ctx workflow.Context) error { // want "a.WorkflowCallTimeTransitively is non-deterministic, reason: calls non-deterministic function a.SomeTimeCall"
 	SomeTimeCall()
 	return nil
@@ -71,34 +116,4 @@ func NotWorkflow(ctx context.Context) {
 func WorkflowWithSearchAttributes(workflow.Context) {
 	sa := temporal.SearchAttributes{}
 	_ = sa.Copy()
-}
-
-func WorkflowCallTimeInSideEffectWithOptions(ctx workflow.Context) error {
-	workflow.SideEffectWithOptions(ctx, workflow.SideEffectOptions{}, func(ctx workflow.Context) interface{} {
-		return time.Now()
-	})
-	return nil
-}
-
-func WorkflowCallTimeInSideEffectWithOptionsAndNot(ctx workflow.Context) error { // want "a.WorkflowCallTimeInSideEffectWithOptionsAndNot is non-deterministic, reason: calls non-deterministic function time.Now"
-	workflow.SideEffectWithOptions(ctx, workflow.SideEffectOptions{}, func(ctx workflow.Context) interface{} {
-		return time.Now()
-	})
-	time.Now()
-	return nil
-}
-
-func WorkflowCallTimeInMutableSideEffectWithOptions(ctx workflow.Context) error {
-	workflow.MutableSideEffectWithOptions(ctx, "id", workflow.MutableSideEffectOptions{}, func(ctx workflow.Context) interface{} {
-		return time.Now()
-	}, func(a, b interface{}) bool { return a == b })
-	return nil
-}
-
-func WorkflowCallTimeInMutableSideEffectWithOptionsAndNot(ctx workflow.Context) error { // want "a.WorkflowCallTimeInMutableSideEffectWithOptionsAndNot is non-deterministic, reason: calls non-deterministic function time.Now"
-	workflow.MutableSideEffectWithOptions(ctx, "id", workflow.MutableSideEffectOptions{}, func(ctx workflow.Context) interface{} {
-		return time.Now()
-	}, func(a, b interface{}) bool { return a == b })
-	time.Now()
-	return nil
 }

--- a/contrib/tools/workflowcheck/workflow/testdata/src/a/workflow.go
+++ b/contrib/tools/workflowcheck/workflow/testdata/src/a/workflow.go
@@ -72,3 +72,33 @@ func WorkflowWithSearchAttributes(workflow.Context) {
 	sa := temporal.SearchAttributes{}
 	_ = sa.Copy()
 }
+
+func WorkflowCallTimeInSideEffectWithOptions(ctx workflow.Context) error {
+	workflow.SideEffectWithOptions(ctx, workflow.SideEffectOptions{}, func(ctx workflow.Context) interface{} {
+		return time.Now()
+	})
+	return nil
+}
+
+func WorkflowCallTimeInSideEffectWithOptionsAndNot(ctx workflow.Context) error { // want "a.WorkflowCallTimeInSideEffectWithOptionsAndNot is non-deterministic, reason: calls non-deterministic function time.Now"
+	workflow.SideEffectWithOptions(ctx, workflow.SideEffectOptions{}, func(ctx workflow.Context) interface{} {
+		return time.Now()
+	})
+	time.Now()
+	return nil
+}
+
+func WorkflowCallTimeInMutableSideEffectWithOptions(ctx workflow.Context) error {
+	workflow.MutableSideEffectWithOptions(ctx, "id", workflow.MutableSideEffectOptions{}, func(ctx workflow.Context) interface{} {
+		return time.Now()
+	}, func(a, b interface{}) bool { return a == b })
+	return nil
+}
+
+func WorkflowCallTimeInMutableSideEffectWithOptionsAndNot(ctx workflow.Context) error { // want "a.WorkflowCallTimeInMutableSideEffectWithOptionsAndNot is non-deterministic, reason: calls non-deterministic function time.Now"
+	workflow.MutableSideEffectWithOptions(ctx, "id", workflow.MutableSideEffectOptions{}, func(ctx workflow.Context) interface{} {
+		return time.Now()
+	}, func(a, b interface{}) bool { return a == b })
+	time.Now()
+	return nil
+}

--- a/contrib/tools/workflowcheck/workflow/testdata/src/go.temporal.io/sdk/workflow/workflow.go
+++ b/contrib/tools/workflowcheck/workflow/testdata/src/go.temporal.io/sdk/workflow/workflow.go
@@ -16,6 +16,22 @@ func AwaitWithTimeout(ctx Context, timeout time.Duration, condition func() bool)
 	return false, nil
 }
 
+type SideEffectOptions struct{}
+
+type MutableSideEffectOptions struct{}
+
 func SideEffect(ctx Context, f func(ctx Context) interface{}) interface{} {
+	return nil
+}
+
+func SideEffectWithOptions(ctx Context, options SideEffectOptions, f func(ctx Context) interface{}) interface{} {
+	return nil
+}
+
+func MutableSideEffect(ctx Context, id string, f func(ctx Context) interface{}, equals func(a, b interface{}) bool) interface{} {
+	return nil
+}
+
+func MutableSideEffectWithOptions(ctx Context, id string, options MutableSideEffectOptions, f func(ctx Context) interface{}, equals func(a, b interface{}) bool) interface{} {
 	return nil
 }


### PR DESCRIPTION
## What changed

- Added `SideEffectWithOptions` and `MutableSideEffectWithOptions` to `AcceptsNonDeterministicParameters` in the workflow determinism checker so non-deterministic callbacks inside these functions are not incorrectly flagged.
- Added testdata stubs and test cases for both functions mirroring the existing `SideEffect` coverage.

## Why

These two functions were added to the SDK but omitted from the checker's allowlist, so callers using them with non-deterministic callbacks would get false-positive violations.

## Testing

Existing `analysistest`-based tests extended to cover both the allowed case (non-determinism only inside the callback) and the disallowed case (non-determinism outside the callback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only affect the workflowcheck static analyzer and its testdata; no runtime SDK workflow execution behavior.
> 
> **Overview**
> Extends **workflowcheck** so `SideEffectWithOptions` and `MutableSideEffectWithOptions` are treated like the existing `SideEffect` / `MutableSideEffect` APIs: non-deterministic code inside their callback arguments is ignored, while non-determinism elsewhere in the workflow still fails.
> 
> The determinism checker’s `AcceptsNonDeterministicParameters` map for `go.temporal.io/sdk/workflow` now lists all four function names. **analysistest** coverage adds stub SDK symbols and workflow tests for the allowed (callback-only) and disallowed (callback + `time.Now()` outside) cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d96efd65e0054406805b0d168c952f738427becd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->