### PR TITLE
NEXUS-474: Support UpdateWorkflow as a Nexus Operation

### DIFF
--- a/.github/workflows/docker/dynamic-config-custom.yaml
+++ b/.github/workflows/docker/dynamic-config-custom.yaml
@@ -48,6 +48,10 @@ history.enableChasm:
   - value: true
 history.enableTransitionHistory:
   - value: true
+history.enableUpdateCallbacks:
+  - value: true
+history.enableCHASMCallbacks:
+  - value: true
 component.nexusoperations.useSystemCallbackURL:
   - value: false
 frontend.WorkerHeartbeatsEnabled:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ to docs, or any other relevant information.
 # Changelog
 
 ## [Unreleased]
+- Add support for Workflow Updates as Nexus Operations 
 
 ### Added
 

--- a/internal/client.go
+++ b/internal/client.go
@@ -1841,32 +1841,19 @@ func (e *WorkflowUpdateServiceTimeoutOrCanceledError) Error() string {
 
 func (e *WorkflowUpdateServiceTimeoutOrCanceledError) Unwrap() error { return e.cause }
 
-// SetRequestIDOnStartWorkflowOptions is an internal only method for setting a requestID on StartWorkflowOptions.
-// RequestID is purposefully not exposed to users for the time being.
-func SetRequestIDOnStartWorkflowOptions(opts *StartWorkflowOptions, requestID string) {
-	opts.requestID = requestID
-}
-
-// SetCallbacksOnStartWorkflowOptions is an internal only method for setting callbacks on StartWorkflowOptions.
-// Callbacks are purposefully not exposed to users for the time being.
-func SetCallbacksOnStartWorkflowOptions(opts *StartWorkflowOptions, callbacks []*commonpb.Callback) {
-	opts.callbacks = callbacks
-}
-
-// SetLinksOnStartWorkflowOptions is an internal only method for setting links on StartWorkflowOptions.
-// Links are purposefully not exposed to users for the time being.
-func SetLinksOnStartWorkflowOptions(opts *StartWorkflowOptions, links []*commonpb.Link) {
-	opts.links = links
-}
-
 // interface utility wrapper to allow setting links and callbacks
-// on temporal primitive operation options (UpdateWorkflowOptions, etc)
-// draft-review: set it on StartWorkflowOptions above as well
+// on temporal primitive operation options (UpdateWorkflowOptions, StartWorkflowOptions)
 type nexusTemporalOperationOptions interface {
 	setRequestID(requestID string)
 	setLinks(links []*commonpb.Link)
 	setCallbacks(callbacks []*commonpb.Callback)
 }
+
+// nexusTemporalOperationOptions conforming interfaces
+var (
+	_ nexusTemporalOperationOptions = (*UpdateWorkflowOptions)(nil)
+	_ nexusTemporalOperationOptions = (*StartWorkflowOptions)(nil)
+)
 
 // Set links on any [nexusTemporalOperationOptions] interface via the setLinks API.
 //

--- a/internal/client.go
+++ b/internal/client.go
@@ -1862,17 +1862,38 @@ func SetLinksOnStartWorkflowOptions(opts *StartWorkflowOptions, links []*commonp
 // interface utility wrapper to allow setting links and callbacks
 // on temporal primitive operation options (UpdateWorkflowOptions, etc)
 // draft-review: set it on StartWorkflowOptions above as well
-type nexusOperationOptions interface {
+type nexusTemporalOperationOptions interface {
+	setRequestID(requestID string)
 	setLinks(links []*commonpb.Link)
 	setCallbacks(callbacks []*commonpb.Callback)
 }
 
-func SetLinksOnNexusOperation(opts nexusOperationOptions, links []*commonpb.Link) {
+// Set links on any [nexusTemporalOperationOptions] interface via the setLinks API.
+//
+// Intended to be used only internally as a consistent way of setting
+// links on all Nexus Operations
+func SetLinksOnNexusOperation(opts nexusTemporalOperationOptions, links []*commonpb.Link) {
 	opts.setLinks(links)
 }
 
-func SetCallbacksOnNexusOperation(opts nexusOperationOptions, callbacks []*commonpb.Callback) {
+// Set callbacks on any [nexusTemporalOperationOptions] interface via the setCallbacks API.
+//
+// Intended to be used only internally as a consistent way of setting
+// callbacks on all Nexus Operations
+func SetCallbacksOnNexusOperation(opts nexusTemporalOperationOptions, callbacks []*commonpb.Callback) {
 	opts.setCallbacks(callbacks)
+}
+
+// Set non-empty requestID on any [nexusTemporalOperationOptions] interface via the setRequestID API.
+// Used for deduping requests server-side
+//
+// Intended to be used only internally as a consistent way of setting
+// requestIDs on all Nexus Operations
+func SetRequestIDOnNexusOperation(opts nexusTemporalOperationOptions, requestID string) {
+	if requestID == "" {
+		return
+	}
+	opts.setRequestID(requestID)
 }
 
 // SetOnConflictOptionsOnStartWorkflowOptions is an internal only method for setting conflict

--- a/internal/client.go
+++ b/internal/client.go
@@ -1859,6 +1859,22 @@ func SetLinksOnStartWorkflowOptions(opts *StartWorkflowOptions, links []*commonp
 	opts.links = links
 }
 
+// interface utility wrapper to allow setting links and callbacks
+// on temporal primitive operation options (UpdateWorkflowOptions, etc)
+// draft-review: set it on StartWorkflowOptions above as well
+type nexusOperationOptions interface {
+	setLinks(links []*commonpb.Link)
+	setCallbacks(callbacks []*commonpb.Callback)
+}
+
+func SetLinksOnNexusOperation(opts nexusOperationOptions, links []*commonpb.Link) {
+	opts.setLinks(links)
+}
+
+func SetCallbacksOnNexusOperation(opts nexusOperationOptions, callbacks []*commonpb.Callback) {
+	opts.setCallbacks(callbacks)
+}
+
 // SetOnConflictOptionsOnStartWorkflowOptions is an internal only method for setting conflict
 // options on StartWorkflowOptions.
 // OnConflictOptions are purposefully not exposed to users for the time being.
@@ -1876,6 +1892,16 @@ func SetOnConflictOptionsOnStartWorkflowOptions(opts *StartWorkflowOptions) {
 func SetResponseInfoOnStartWorkflowOptions(opts *StartWorkflowOptions) *startWorkflowResponseInfo {
 	if opts.responseInfo == nil {
 		opts.responseInfo = &startWorkflowResponseInfo{}
+	}
+	return opts.responseInfo
+}
+
+// SetResponseInfoOnUpdateWorkflowOptions is an internal only method to set and return a
+// responseInfo pointer. This is done to capture links from the response RPC to be used
+// for nexus forward links on UpdateWorkflow Nexus Operations
+func SetResponseInfoOnUpdateWorkflowOptions(opts *UpdateWorkflowOptions) *updateWorkflowResponseInfo {
+	if opts.responseInfo == nil {
+		opts.responseInfo = &updateWorkflowResponseInfo{}
 	}
 	return opts.responseInfo
 }

--- a/internal/cmd/build/main.go
+++ b/internal/cmd/build/main.go
@@ -165,9 +165,10 @@ func (b *builder) integrationTest() error {
 				"--dynamic-config-value", `component.nexusoperations.useSystemCallbackURL=false`,
 				"--dynamic-config-value", `component.nexusoperations.callback.endpoint.template="http://localhost:7243/namespaces/{{.NamespaceName}}/nexus/callback"`,
 				"--dynamic-config-value", "nexusoperation.enableStandalone=true",
-				"--dynamic-config-value", "history.enableChasmCallbacks=true",
+				"--dynamic-config-value", "history.enableCHASMCallbacks=true",
 				"--dynamic-config-value", "frontend.ListWorkersEnabled=true",
 				"--dynamic-config-value", "activity.startDelayEnabled=true",
+				"--dynamic-config-value", "history.enableUpdateCallbacks=true",
 			},
 		})
 		if err != nil {

--- a/internal/interceptor.go
+++ b/internal/interceptor.go
@@ -511,9 +511,11 @@ type ClientUpdateWorkflowInput struct {
 	// WaitForStage is the stage to wait for.
 	WaitForStage        WorkflowUpdateStage
 
-	// links. Only settable by the SDK - e.g. [temporalnexus.workflowRunOperation].
+	// request ID for server de-duplication. Only settable by the SDK - e.g. [temporalnexus.updateWorkflowOperation].
+	requestID string
+	// links. Only settable by the SDK - e.g. [temporalnexus.updateWorkflowOperation].
 	links     []*commonpb.Link
-	// for backward links from the target namespace sent via operation options. Only settable by the SDK - e.g. [temporalnexus.workflowRunOperation].
+	// callbacks. Only settable by the SDK - e.g. [temporalnexus.updateWorkflowOperation].
 	callbacks []*commonpb.Callback
 	// gRPC request response trap for nexus forward links
 	responseInfo *updateWorkflowResponseInfo

--- a/internal/interceptor.go
+++ b/internal/interceptor.go
@@ -510,6 +510,13 @@ type ClientUpdateWorkflowInput struct {
 	FirstExecutionRunID string
 	// WaitForStage is the stage to wait for.
 	WaitForStage        WorkflowUpdateStage
+
+	// links. Only settable by the SDK - e.g. [temporalnexus.workflowRunOperation].
+	links     []*commonpb.Link
+	// for backward links from the target namespace sent via operation options. Only settable by the SDK - e.g. [temporalnexus.workflowRunOperation].
+	callbacks []*commonpb.Callback
+	// gRPC request response trap for nexus forward links
+	responseInfo *updateWorkflowResponseInfo
 }
 
 // Exposed as: [go.temporal.io/sdk/interceptor.ClientUpdateWithStartWorkflowInput]

--- a/internal/internal_update.go
+++ b/internal/internal_update.go
@@ -30,6 +30,12 @@ const (
 	WorkflowUpdateStageCompleted
 )
 
+// workflow is async iff update stage is WorkflowUpdateStageAccepted-
+// as WorkflowUpdateStageCompleted blocks on UpdateWorkflow itself
+func (w WorkflowUpdateStage) IsAsyncUpdateWorkflow() bool {
+	return w == WorkflowUpdateStageAccepted
+}
+
 const (
 	updateStateNew              updateState = "New"
 	updateStateRequestInitiated updateState = "RequestScheduled"

--- a/internal/internal_update.go
+++ b/internal/internal_update.go
@@ -30,12 +30,6 @@ const (
 	WorkflowUpdateStageCompleted
 )
 
-// workflow is async iff update stage is WorkflowUpdateStageAccepted-
-// as WorkflowUpdateStageCompleted blocks on UpdateWorkflow itself
-func (w WorkflowUpdateStage) IsAsyncUpdateWorkflow() bool {
-	return w == WorkflowUpdateStageAccepted
-}
-
 const (
 	updateStateNew              updateState = "New"
 	updateStateRequestInitiated updateState = "RequestScheduled"

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -995,6 +995,26 @@ type UpdateWorkflowOptions struct {
 	// then the server will reject the update request with an error.
 	// Note that it is incompatible with UpdateWithStartWorkflowOperation.
 	FirstExecutionRunID string
+
+	// workflow completion callback. Only settable by the SDK - e.g. [temporalnexus.workflowRunOperation].
+	callbacks []*commonpb.Callback
+	// for backward links from the target namespace sent via operation options. Only settable by the SDK - e.g. [temporalnexus.workflowRunOperation].
+	links []*commonpb.Link
+	// gRPC request response trap for nexus forward links
+	responseInfo *updateWorkflowResponseInfo
+}
+
+type updateWorkflowResponseInfo struct {
+	// Link to the workflow event.
+	Link *commonpb.Link
+}
+
+func (u *UpdateWorkflowOptions) setLinks(links []*commonpb.Link) {
+	u.links = links
+}
+
+func (u *UpdateWorkflowOptions) setCallbacks(callbacks []*commonpb.Callback) {
+	u.callbacks = callbacks
 }
 
 // UpdateWithStartWorkflowOptions encapsulates the parameters used by UpdateWithStartWorkflow.
@@ -2846,6 +2866,10 @@ func (w *workflowClientInterceptor) UpdateWorkflow(
 		return nil, err
 	}
 
+	if responseInfo := in.responseInfo; responseInfo != nil {
+		responseInfo.Link = resp.GetLink()
+	}
+
 	// Here we know the update is at least accepted
 	desiredLifecycleStage := updateLifeCycleStageToProto(in.WaitForStage)
 	return w.updateHandleFromResponse(ctx, desiredLifecycleStage, resp)
@@ -2873,6 +2897,12 @@ func createUpdateWorkflowInput(options *UpdateWorkflowOptions) (*ClientUpdateWor
 		return nil, errors.New("WaitForStage WorkflowUpdateStageAdmitted is not supported")
 	}
 
+	// draft-review: check if this could be valid for some edge cases 
+	if options.WaitForStage == WorkflowUpdateStageCompleted && len(options.callbacks) > 0 {
+		return nil, errors.New("WaitForStage WorkflowUpdateStageCompleted does not support callbacks " +
+			"as it is already a synchronous operation")
+	}
+
 	return &ClientUpdateWorkflowInput{
 		UpdateID:            updateID,
 		WorkflowID:          options.WorkflowID,
@@ -2881,6 +2911,9 @@ func createUpdateWorkflowInput(options *UpdateWorkflowOptions) (*ClientUpdateWor
 		RunID:               options.RunID,
 		FirstExecutionRunID: options.FirstExecutionRunID,
 		WaitForStage:        options.WaitForStage,
+		links:               options.links,
+		callbacks:           options.callbacks,
+		responseInfo:        options.responseInfo,
 	}, nil
 }
 
@@ -2915,6 +2948,9 @@ func (w *workflowClientInterceptor) createUpdateWorkflowRequest(
 		},
 		FirstExecutionRunId: in.FirstExecutionRunID,
 		Request: &updatepb.Request{
+			RequestId:           in.UpdateID,
+			CompletionCallbacks: in.callbacks,
+			Links:               in.links,
 			Meta: &updatepb.Meta{
 				UpdateId: in.UpdateID,
 				Identity: w.client.identity,

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -1023,6 +1023,18 @@ func (u *UpdateWorkflowOptions) setRequestID(requestID string) {
 	u.requestID = requestID
 }
 
+func (s *StartWorkflowOptions) setLinks(links []*commonpb.Link) {
+	s.links = links
+}
+
+func (s *StartWorkflowOptions) setCallbacks(callbacks []*commonpb.Callback) {
+	s.callbacks = callbacks
+}
+
+func (s *StartWorkflowOptions) setRequestID(requestID string) {
+	s.requestID = requestID
+}
+
 // UpdateWithStartWorkflowOptions encapsulates the parameters used by UpdateWithStartWorkflow.
 // See UpdateWithStartWorkflow and NewWithStartWorkflowOperation.
 type UpdateWithStartWorkflowOptions struct {
@@ -1086,7 +1098,6 @@ type lazyUpdateHandle struct {
 // completed. Used for Nexus operations that back into operations at a later stage
 // in a non-retriable manner. Eg. UpdateWorkflow could fail at Accepted(failed validation)
 // but its still Admitted and isnt captured in the rpc errors and keeps getting retried
-// draft-review: is there a better way to do it instead?
 func IsUpdateWorkflowCompleted(handle WorkflowUpdateHandle) bool {
 	_, ok := handle.(*completedUpdateHandle)
 	return ok

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -996,9 +996,11 @@ type UpdateWorkflowOptions struct {
 	// Note that it is incompatible with UpdateWithStartWorkflowOperation.
 	FirstExecutionRunID string
 
-	// workflow completion callback. Only settable by the SDK - e.g. [temporalnexus.workflowRunOperation].
+	// request ID for de-duplication during server processing. Only settable by the SDK - e.g. [temporalnexus.updateWorkflowOperation].
+	requestID string
+	// callbacks. Only settable by the SDK - e.g. [temporalnexus.updateWorkflowOperation].
 	callbacks []*commonpb.Callback
-	// for backward links from the target namespace sent via operation options. Only settable by the SDK - e.g. [temporalnexus.workflowRunOperation].
+	// for backward links from the target namespace sent via operation options. Only settable by the SDK - e.g. [temporalnexus.updateWorkflowOperation].
 	links []*commonpb.Link
 	// gRPC request response trap for nexus forward links
 	responseInfo *updateWorkflowResponseInfo
@@ -1015,6 +1017,10 @@ func (u *UpdateWorkflowOptions) setLinks(links []*commonpb.Link) {
 
 func (u *UpdateWorkflowOptions) setCallbacks(callbacks []*commonpb.Callback) {
 	u.callbacks = callbacks
+}
+
+func (u *UpdateWorkflowOptions) setRequestID(requestID string) {
+	u.requestID = requestID
 }
 
 // UpdateWithStartWorkflowOptions encapsulates the parameters used by UpdateWithStartWorkflow.
@@ -1074,6 +1080,16 @@ type completedUpdateHandle struct {
 type lazyUpdateHandle struct {
 	baseUpdateHandle
 	client *WorkflowClient
+}
+
+// IsUpdateWorkflowCompleted is a utility to detect if an operation has immediately
+// completed. Used for Nexus operations that back into operations at a later stage
+// in a non-retriable manner. Eg. UpdateWorkflow could fail at Accepted(failed validation)
+// but its still Admitted and isnt captured in the rpc errors and keeps getting retried
+// draft-review: is there a better way to do it instead?
+func IsUpdateWorkflowCompleted(handle WorkflowUpdateHandle) bool {
+	_, ok := handle.(*completedUpdateHandle)
+	return ok
 }
 
 // QueryWorkflowWithOptionsRequest is the request to QueryWorkflowWithOptions
@@ -2897,12 +2913,6 @@ func createUpdateWorkflowInput(options *UpdateWorkflowOptions) (*ClientUpdateWor
 		return nil, errors.New("WaitForStage WorkflowUpdateStageAdmitted is not supported")
 	}
 
-	// draft-review: check if this could be valid for some edge cases 
-	if options.WaitForStage == WorkflowUpdateStageCompleted && len(options.callbacks) > 0 {
-		return nil, errors.New("WaitForStage WorkflowUpdateStageCompleted does not support callbacks " +
-			"as it is already a synchronous operation")
-	}
-
 	return &ClientUpdateWorkflowInput{
 		UpdateID:            updateID,
 		WorkflowID:          options.WorkflowID,
@@ -2914,6 +2924,7 @@ func createUpdateWorkflowInput(options *UpdateWorkflowOptions) (*ClientUpdateWor
 		links:               options.links,
 		callbacks:           options.callbacks,
 		responseInfo:        options.responseInfo,
+		requestID:           options.requestID,
 	}, nil
 }
 
@@ -2948,7 +2959,7 @@ func (w *workflowClientInterceptor) createUpdateWorkflowRequest(
 		},
 		FirstExecutionRunId: in.FirstExecutionRunID,
 		Request: &updatepb.Request{
-			RequestId:           in.UpdateID,
+			RequestId:           in.requestID,
 			CompletionCallbacks: in.callbacks,
 			Links:               in.links,
 			Meta: &updatepb.Meta{

--- a/internal/link_converter.go
+++ b/internal/link_converter.go
@@ -80,7 +80,10 @@ func ConvertLinkWorkflowEventToNexusLink(we *commonpb.Link_WorkflowEvent) nexus.
 	}
 }
 
-func ConvertWorkflowlinkToNexusLink(wl *commonpb.Link_Workflow) nexus.Link {
+// ConvertWorkflowLinkToNexusLink converts a Link_Workflow into a Nexus Link.
+//
+// NOTE: Experimental
+func ConvertWorkflowLinkToNexusLink(wl *commonpb.Link_Workflow) nexus.Link {
 	return nexus.Link{
 		URL: &url.URL{
 			Scheme: urlSchemeTemporalKey,

--- a/internal/link_converter.go
+++ b/internal/link_converter.go
@@ -80,6 +80,22 @@ func ConvertLinkWorkflowEventToNexusLink(we *commonpb.Link_WorkflowEvent) nexus.
 	}
 }
 
+func ConvertWorkflowlinkToNexusLink(wl *commonpb.Link_Workflow) nexus.Link {
+	return nexus.Link{
+		URL: &url.URL{
+			Scheme: urlSchemeTemporalKey,
+			Path:   fmt.Sprintf(urlPathWorkflowEventTemplate, wl.GetNamespace(), wl.GetWorkflowId(), wl.GetRunId()),
+			RawPath: fmt.Sprintf(
+				urlPathWorkflowEventTemplate,
+				url.PathEscape(wl.GetNamespace()),
+				url.PathEscape(wl.GetWorkflowId()),
+				url.PathEscape(wl.GetRunId()),
+			),
+		},
+		Type: string(wl.ProtoReflect().Descriptor().FullName()),
+	}
+}
+
 // ConvertNexusLinkToLinkWorkflowEvent converts a Nexus Link to Link_WorkflowEvent.
 //
 // NOTE: Experimental

--- a/internal/nexus_operations.go
+++ b/internal/nexus_operations.go
@@ -215,6 +215,14 @@ func NexusOperationContextFromGoContext(ctx context.Context) (nctx *NexusOperati
 	return
 }
 
+// ContextWithNexusOperationContext adds the [NexusOperationContext] into the given [context.Context]
+func ContextWithNexusOperationContext(ctx context.Context, nctx *NexusOperationContext) context.Context {
+	if nctx == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, nexusOperationContextKey, nctx)
+}
+
 // nexusMiddleware constructs an adapter from Temporal WorkerInterceptors to a Nexus MiddlewareFunc.
 func nexusMiddleware(interceptors []WorkerInterceptor) nexus.MiddlewareFunc {
 	return func(ctx context.Context, next nexus.OperationHandler[any, any]) (nexus.OperationHandler[any, any], error) {

--- a/temporalnexus/link_converter.go
+++ b/temporalnexus/link_converter.go
@@ -34,3 +34,23 @@ func ConvertLinkNexusOperationToNexusLink(no *commonpb.Link_NexusOperation) nexu
 func ConvertNexusLinkToLinkNexusOperation(link nexus.Link) (*commonpb.Link_NexusOperation, error) {
 	return internal.ConvertNexusLinkToLinkNexusOperation(link)
 }
+
+// ConvertWorkflowlinkToNexusLink converts a Link_Workflow to a Nexus Link.
+//
+// NOTE: Experimental
+func ConvertWorkflowlinkToNexusLink(workflowLink *commonpb.Link_Workflow) nexus.Link {
+	return internal.ConvertWorkflowlinkToNexusLink(workflowLink)
+}
+
+// ConvertCommonLinkToNexusLink converts a Common Link to a Nexus Link. Will be used
+// to safely point to non-workflow event links for cases where Nexus operations fail.
+// Eg. UpdateWorkflow fails validation -> point to Workflow instead of WorkflowEvent
+// as there will not be a history event.
+//
+// NOTE: Experimental
+func ConvertCommonLinkToNexusLink(commonLink *commonpb.Link) nexus.Link {
+	if commonLink.GetWorkflowEvent() == nil {
+		return ConvertWorkflowlinkToNexusLink(commonLink.GetWorkflow())
+	}
+	return ConvertLinkWorkflowEventToNexusLink(commonLink.GetWorkflowEvent())
+}

--- a/temporalnexus/link_converter.go
+++ b/temporalnexus/link_converter.go
@@ -35,22 +35,27 @@ func ConvertNexusLinkToLinkNexusOperation(link nexus.Link) (*commonpb.Link_Nexus
 	return internal.ConvertNexusLinkToLinkNexusOperation(link)
 }
 
-// ConvertWorkflowlinkToNexusLink converts a Link_Workflow to a Nexus Link.
+// ConvertWorkflowLinkToNexusLink converts a Link_Workflow to a Nexus Link.
 //
 // NOTE: Experimental
-func ConvertWorkflowlinkToNexusLink(workflowLink *commonpb.Link_Workflow) nexus.Link {
-	return internal.ConvertWorkflowlinkToNexusLink(workflowLink)
+func ConvertWorkflowLinkToNexusLink(workflowLink *commonpb.Link_Workflow) nexus.Link {
+	return internal.ConvertWorkflowLinkToNexusLink(workflowLink)
 }
 
 // ConvertCommonLinkToNexusLink converts a Common Link to a Nexus Link. Will be used
 // to safely point to non-workflow event links for cases where Nexus operations fail.
 // Eg. UpdateWorkflow fails validation -> point to Workflow instead of WorkflowEvent
-// as there will not be a history event.
+// as there will not be a history event. Returns an empty link if commonLink is neither
+// a WorkflowEventLink nor a WorkflowLink
 //
 // NOTE: Experimental
 func ConvertCommonLinkToNexusLink(commonLink *commonpb.Link) nexus.Link {
-	if commonLink.GetWorkflowEvent() == nil {
-		return ConvertWorkflowlinkToNexusLink(commonLink.GetWorkflow())
+	switch commonLink.GetVariant().(type) {
+	case *commonpb.Link_WorkflowEvent_:
+		return ConvertLinkWorkflowEventToNexusLink(commonLink.GetWorkflowEvent())
+	case *commonpb.Link_Workflow_:
+		return ConvertWorkflowLinkToNexusLink(commonLink.GetWorkflow())
+	default:
+		return nexus.Link{}
 	}
-	return ConvertLinkWorkflowEventToNexusLink(commonLink.GetWorkflowEvent())
 }

--- a/temporalnexus/operation.go
+++ b/temporalnexus/operation.go
@@ -307,7 +307,7 @@ func ExecuteUntypedWorkflow[R any](
 	}
 
 	if nexusOptions.RequestID != "" {
-		internal.SetRequestIDOnStartWorkflowOptions(&startWorkflowOptions, nexusOptions.RequestID)
+		internal.SetRequestIDOnNexusOperation(&startWorkflowOptions, nexusOptions.RequestID)
 	}
 
 	links, err := convertNexusLinks(nexusOptions.Links, GetLogger(ctx))
@@ -331,7 +331,7 @@ func ExecuteUntypedWorkflow[R any](
 		// This field is expected to be populated by servers older than 1.27.0.
 		nexusOptions.CallbackHeader.Set("nexus-operation-id", encodedToken)
 		nexusOptions.CallbackHeader.Set(nexus.HeaderOperationToken, encodedToken)
-		internal.SetCallbacksOnStartWorkflowOptions(&startWorkflowOptions, []*common.Callback{
+		internal.SetCallbacksOnNexusOperation(&startWorkflowOptions, []*common.Callback{
 			{
 				Variant: &common.Callback_Nexus_{
 					Nexus: &common.Callback_Nexus{
@@ -346,7 +346,7 @@ func ExecuteUntypedWorkflow[R any](
 
 	// Links are duplicated in startWorkflowOptions to backwards compatibility with older servers that
 	// don't support links in callbacks.
-	internal.SetLinksOnStartWorkflowOptions(&startWorkflowOptions, links)
+	internal.SetLinksOnNexusOperation(&startWorkflowOptions, links)
 	internal.SetOnConflictOptionsOnStartWorkflowOptions(&startWorkflowOptions)
 	responseInfo := internal.SetResponseInfoOnStartWorkflowOptions(&startWorkflowOptions)
 

--- a/temporalnexus/temporal_operation.go
+++ b/temporalnexus/temporal_operation.go
@@ -7,9 +7,14 @@ import (
 	"sync/atomic"
 
 	"github.com/nexus-rpc/sdk-go/nexus"
+	"go.temporal.io/api/common/v1"
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/internal"
 	"go.temporal.io/sdk/workflow"
+)
+
+const (
+	nexusHeaderOperationId = "nexus-operation-id" // draft-review: check if this belongs in some other package/use this in workflow as well
 )
 
 // StartTemporalOperationOptions are options provided to the Start callback of a Temporal Nexus operation.
@@ -153,6 +158,98 @@ func StartUntypedWorkflow[R any](
 	}
 	nexus.AddHandlerLinks(ctx, handle.link())
 	return NewAsyncResult[R](handle.token()), nil
+}
+
+func StartUpdateWorkflow[R any](
+	ctx context.Context,
+	nc NexusClient,
+	updateWorkflowOptions client.UpdateWorkflowOptions,
+) (TemporalOperationResult[R], error) {
+	var encodedToken string
+	isAsyncUpdate := updateWorkflowOptions.WaitForStage.IsAsyncUpdateWorkflow()
+	asyncOpFailed := true
+	if isAsyncUpdate {
+		if nc.startOperationOptions.CallbackURL == "" {
+			return TemporalOperationResult[R]{}, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest,
+				"callback URL required for async UpdateWorkflow operation invocations")
+		}
+		if nc.asyncStarted != nil && !nc.asyncStarted.CompareAndSwap(false, true) {
+			return TemporalOperationResult[R]{}, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest,
+				"only one async operation can be started per operation invocation")
+		}
+		token, err := generateUpdateOperationToken()
+		if err != nil {
+			return TemporalOperationResult[R]{}, err
+		}
+		encodedToken = token
+		defer func() {
+			if asyncOpFailed && nc.asyncStarted != nil {
+				nc.asyncStarted.Store(false)
+			}
+		}()
+	}
+
+	links, err := convertNexusLinks(nc.startOperationOptions.Links, GetLogger(ctx))
+	if err != nil {
+		return TemporalOperationResult[R]{}, &nexus.HandlerError{
+			Type:    nexus.HandlerErrorTypeBadRequest,
+			Message: "could not convert links for update workflow",
+			Cause:   err,
+		}
+	}
+	internal.SetLinksOnNexusOperation(&updateWorkflowOptions, links)
+
+	// unsure what this means, check in review
+	// ctx = context.WithValue(ctx, internal.IsWorkflowRunOpContextKey, true)
+
+	// set callbacks only for async
+	if isAsyncUpdate {
+		if nc.startOperationOptions.CallbackHeader == nil {
+			nc.startOperationOptions.CallbackHeader = make(nexus.Header)
+		}
+		// This field is expected to be populated by servers older than 1.27.0.
+		// draft-review: can this check be removed now? at least for UpdateWorkflow
+		nc.startOperationOptions.CallbackHeader.Set(nexusHeaderOperationId, encodedToken)
+		nc.startOperationOptions.CallbackHeader.Set(nexus.HeaderOperationToken, encodedToken)
+		internal.SetCallbacksOnNexusOperation(&updateWorkflowOptions, []*common.Callback{
+			{
+				Variant: &common.Callback_Nexus_{
+					Nexus: &common.Callback_Nexus{
+						Url:    nc.startOperationOptions.CallbackURL,
+						Header: nc.startOperationOptions.CallbackHeader,
+					},
+				},
+				Links: links,
+			},
+		})
+	}
+
+	responseInfo := internal.SetResponseInfoOnUpdateWorkflowOptions(&updateWorkflowOptions)
+
+	handle, err := GetClient(ctx).UpdateWorkflow(ctx, updateWorkflowOptions)
+	if err != nil {
+		return TemporalOperationResult[R]{}, err
+	}
+
+	if responseInfo.Link == nil {
+		return TemporalOperationResult[R]{}, &nexus.HandlerError{
+			Type:  nexus.HandlerErrorTypeInternal,
+			Cause: errors.New("unexpected error retrieving links from UpdateWorkflow response"),
+		}
+	}
+
+	nexus.AddHandlerLinks(ctx, ConvertLinkWorkflowEventToNexusLink(responseInfo.Link.GetWorkflowEvent()))
+
+	if isAsyncUpdate {
+		asyncOpFailed = false
+		return NewAsyncResult[R](encodedToken), nil
+	} else {
+		var result R
+		if err := handle.Get(ctx, &result); err != nil {
+			return TemporalOperationResult[R]{}, err
+		}
+		return NewSyncResult(result), nil
+	}
 }
 
 // TemporalOperationOptions configures a generic Temporal Nexus operation.
@@ -299,6 +396,11 @@ func (o *temporalOperation[I, O]) Cancel(ctx context.Context, token string, opti
 		return o.options.CancelWorkflowRun(ctx, GetClient(ctx), CancelTemporalWorkflowRunOptions{
 			WorkflowID: wfToken.WorkflowID,
 		}, options)
+	case operationTokenTypeUpdateWorkflow:
+		return &nexus.HandlerError{
+			Type:  nexus.HandlerErrorTypeBadRequest,
+			Cause: errors.New("cannot cancel an UpdateWorkflow operation"),
+		}
 	default:
 		return nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "unknown operation token type: %d", tokenType)
 	}

--- a/temporalnexus/temporal_operation.go
+++ b/temporalnexus/temporal_operation.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"sync/atomic"
 
+	"github.com/google/uuid"
 	"github.com/nexus-rpc/sdk-go/nexus"
 	"go.temporal.io/api/common/v1"
 	"go.temporal.io/sdk/client"
@@ -13,8 +14,11 @@ import (
 	"go.temporal.io/sdk/workflow"
 )
 
-const (
-	nexusHeaderOperationId = "nexus-operation-id" // draft-review: check if this belongs in some other package/use this in workflow as well
+var (
+	ErrCannotCancelWorkflowUpdate = &nexus.HandlerError{
+		Type:  nexus.HandlerErrorTypeNotImplemented,
+		Cause: errors.New("cannot cancel an UpdateWorkflow operation"),
+	}
 )
 
 // StartTemporalOperationOptions are options provided to the Start callback of a Temporal Nexus operation.
@@ -46,6 +50,19 @@ type StartTemporalOperationOptions struct {
 type CancelTemporalWorkflowRunOptions struct {
 	// WorkflowID extracted from the operation token.
 	WorkflowID string
+}
+
+// CancelTemporalUpdateWorkflowOptions are options provided to CancelWorkflowUpdate callback
+// of a Temporal Nexus Operation
+//
+// NOTE: Experimental
+type CancelTemporalUpdateWorkflowOptions struct {
+	// WorkflowID extracted from the operation token.
+	WorkflowID string
+	// UpdateID to be cancelled.
+	UpdateID string
+	// RunID of the workflow
+	RunID string
 }
 
 // TemporalOperationResult encapsulates either a synchronous result or an asynchronous operation token.
@@ -160,33 +177,64 @@ func StartUntypedWorkflow[R any](
 	return NewAsyncResult[R](handle.token()), nil
 }
 
+// StartUpdateWorkflow starts a type-safe workflow update run for a Nexus operation
+// linking the execution chain to the Nexus operation (callbacks, links, request ID).
+// It returns either an async result with a workflow-run operation token for pending
+// operations or a sync response if the update is already completed(retried updates)
+//
+// These are free functions because Go does not allow generic methods on non-generic structs.
+//
+// NOTE: Experimental
 func StartUpdateWorkflow[R any](
 	ctx context.Context,
 	nc NexusClient,
 	updateWorkflowOptions client.UpdateWorkflowOptions,
 ) (TemporalOperationResult[R], error) {
-	var encodedToken string
-	isAsyncUpdate := updateWorkflowOptions.WaitForStage.IsAsyncUpdateWorkflow()
-	asyncOpFailed := true
-	if isAsyncUpdate {
-		if nc.startOperationOptions.CallbackURL == "" {
-			return TemporalOperationResult[R]{}, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest,
-				"callback URL required for async UpdateWorkflow operation invocations")
+	if updateWorkflowOptions.UpdateID == "" {
+		// If an Update ID is not provided, use the RequestID. This is done to protect
+		// against cases where an unset UpdateID request with the same RequestID is
+		// retried due to n/w failure and gets new IDs in createUpdateWorkflowInput
+		updateWorkflowOptions.UpdateID = nc.startOperationOptions.RequestID
+	}
+
+	if err := validateUpdateWorkflowNexusOperation(updateWorkflowOptions); err != nil {
+		return TemporalOperationResult[R]{}, &nexus.OperationError{
+			State:   nexus.OperationStateFailed,
+			Message: err.Error(),
+			Cause:   err,
 		}
-		if nc.asyncStarted != nil && !nc.asyncStarted.CompareAndSwap(false, true) {
-			return TemporalOperationResult[R]{}, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest,
-				"only one async operation can be started per operation invocation")
+	}
+
+	nctx, ok := internal.NexusOperationContextFromGoContext(ctx)
+	if !ok {
+		return TemporalOperationResult[R]{}, nexus.NewHandlerErrorf(
+			nexus.HandlerErrorTypeInternal, "internal error")
+	}
+
+	opFailed := true
+	if nc.startOperationOptions.CallbackURL == "" {
+		return TemporalOperationResult[R]{}, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest,
+			"callback URL required for async UpdateWorkflow operation invocations")
+	}
+	if nc.asyncStarted == nil {
+		return TemporalOperationResult[R]{}, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeInternal,
+			"unexpected error initializing async UpdateWorkflow operation")
+	}
+	if !nc.asyncStarted.CompareAndSwap(false, true) {
+		return TemporalOperationResult[R]{}, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest,
+			"only one async operation can be started per operation invocation")
+	}
+	defer func() {
+		if opFailed {
+			nc.asyncStarted.Store(false)
 		}
-		token, err := generateUpdateOperationToken()
-		if err != nil {
-			return TemporalOperationResult[R]{}, err
-		}
-		encodedToken = token
-		defer func() {
-			if asyncOpFailed && nc.asyncStarted != nil {
-				nc.asyncStarted.Store(false)
-			}
-		}()
+	}()
+	token, err := generateUpdateOperationToken(nctx.Namespace,
+		updateWorkflowOptions.WorkflowID,
+		updateWorkflowOptions.RunID,
+		updateWorkflowOptions.UpdateID)
+	if err != nil {
+		return TemporalOperationResult[R]{}, err
 	}
 
 	links, err := convertNexusLinks(nc.startOperationOptions.Links, GetLogger(ctx))
@@ -198,31 +246,23 @@ func StartUpdateWorkflow[R any](
 		}
 	}
 	internal.SetLinksOnNexusOperation(&updateWorkflowOptions, links)
-
-	// unsure what this means, check in review
-	// ctx = context.WithValue(ctx, internal.IsWorkflowRunOpContextKey, true)
-
-	// set callbacks only for async
-	if isAsyncUpdate {
-		if nc.startOperationOptions.CallbackHeader == nil {
-			nc.startOperationOptions.CallbackHeader = make(nexus.Header)
-		}
-		// This field is expected to be populated by servers older than 1.27.0.
-		// draft-review: can this check be removed now? at least for UpdateWorkflow
-		nc.startOperationOptions.CallbackHeader.Set(nexusHeaderOperationId, encodedToken)
-		nc.startOperationOptions.CallbackHeader.Set(nexus.HeaderOperationToken, encodedToken)
-		internal.SetCallbacksOnNexusOperation(&updateWorkflowOptions, []*common.Callback{
-			{
-				Variant: &common.Callback_Nexus_{
-					Nexus: &common.Callback_Nexus{
-						Url:    nc.startOperationOptions.CallbackURL,
-						Header: nc.startOperationOptions.CallbackHeader,
-					},
-				},
-				Links: links,
-			},
-		})
+	internal.SetRequestIDOnNexusOperation(&updateWorkflowOptions, nc.startOperationOptions.RequestID)
+	header := nc.startOperationOptions.CallbackHeader
+	if header == nil {
+		header = make(nexus.Header)
 	}
+	header.Set(nexus.HeaderOperationToken, token)
+	internal.SetCallbacksOnNexusOperation(&updateWorkflowOptions, []*common.Callback{
+		{
+			Variant: &common.Callback_Nexus_{
+				Nexus: &common.Callback_Nexus{
+					Url:    nc.startOperationOptions.CallbackURL,
+					Header: header,
+				},
+			},
+			Links: links,
+		},
+	})
 
 	responseInfo := internal.SetResponseInfoOnUpdateWorkflowOptions(&updateWorkflowOptions)
 
@@ -238,17 +278,57 @@ func StartUpdateWorkflow[R any](
 		}
 	}
 
-	nexus.AddHandlerLinks(ctx, ConvertLinkWorkflowEventToNexusLink(responseInfo.Link.GetWorkflowEvent()))
+	nexus.AddHandlerLinks(ctx, ConvertCommonLinkToNexusLink(responseInfo.Link))
 
-	if isAsyncUpdate {
-		asyncOpFailed = false
-		return NewAsyncResult[R](encodedToken), nil
-	} else {
+	if internal.IsUpdateWorkflowCompleted(handle) {
+		// If the update workflow handle is completed already, return a sync response.
 		var result R
 		if err := handle.Get(ctx, &result); err != nil {
-			return TemporalOperationResult[R]{}, err
+			// Failure case: If workflow handle is completed and it has an error => its
+			// an unretriable error like validation failing on the update handler.
+			return TemporalOperationResult[R]{}, &nexus.OperationError{
+				State:   nexus.OperationStateFailed,
+				Message: err.Error(),
+				Cause:   err,
+			}
 		}
+		// Success case: Required for correctness on retried UpdateWorkflow rpc with same updateID.
 		return NewSyncResult(result), nil
+	}
+	opFailed = false
+	// regenerate token so it has the actual run ID that update is running on
+	// previous generation is only to handle completion before handle is returned
+	token, err = generateUpdateOperationToken(nctx.Namespace,
+		updateWorkflowOptions.WorkflowID,
+		handle.RunID(),
+		updateWorkflowOptions.UpdateID)
+	if err != nil {
+		// should not happen, this is all in SDK
+		return TemporalOperationResult[R]{}, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeInternal,
+			"unexpected error reconstructing token %w",
+			err,
+		)
+	}
+	return NewAsyncResult[R](token), nil
+}
+
+// Validations to be performed specifically for UpdateWorkflow as a Nexus Operation.
+// Currently only guards against a sync Update being passed to the server. Invalid
+// updates - missing workflowID/updateName/etc - are expected to be retried forever.
+// NOTE: UpdateID will never be empty now that RequestID for nexus op is generated if empty
+// TBD: confirm one more time if retry-forever-on-invalid-config is ok before merge
+// and/or set WaitForStage after receiving the options (not done now to avoid silently
+// overwriting user provided options)
+func validateUpdateWorkflowNexusOperation(u client.UpdateWorkflowOptions) error {
+	switch {
+	// case u.WorkflowID == "":
+	// 	return errors.New("workflow ID cannot be empty")
+	// case u.UpdateName == "":
+	// 	return errors.New("update name cannot be empty")
+	case u.WaitForStage != client.WorkflowUpdateStageAccepted:
+		return errors.New("nexus op workflow updates only support WorkflowUpdateStageAccepted for async updates")
+	default:
+		return nil
 	}
 }
 
@@ -286,6 +366,10 @@ type TemporalOperationOptions[I, O any] struct {
 	// It receives the Temporal client, the workflow-run options extracted from the token, and the
 	// Nexus cancel options. If nil, defaults to cancelling the workflow via the Temporal client.
 	CancelWorkflowRun func(ctx context.Context, c client.Client, options CancelTemporalWorkflowRunOptions, cancelOptions nexus.CancelOperationOptions) error
+	// CancelWorkflowUpdate handles cancel for UpdateWorkflow operation tokens.
+	// It receives the Temporal client, the update-workflow options extracted from the token, and the
+	// Nexus cancel options. If nil, will error out with [ErrCannotCancelWorkflowUpdate] as there is no default behavior for cancelling an UpdateWorkflow.
+	CancelWorkflowUpdate func(ctx context.Context, c client.Client, options CancelTemporalUpdateWorkflowOptions, cancelOptions nexus.CancelOperationOptions) error
 }
 
 // NewTemporalOperation creates a generic Nexus operation backed by Temporal.
@@ -305,6 +389,9 @@ func NewTemporalOperation[I, O any](opts TemporalOperationOptions[I, O]) (nexus.
 	if opts.CancelWorkflowRun == nil {
 		opts.CancelWorkflowRun = defaultCancelWorkflowRun
 	}
+	if opts.CancelWorkflowUpdate == nil {
+		opts.CancelWorkflowUpdate = defaultCancelWorkflowUpdate
+	}
 	return &temporalOperation[I, O]{options: opts}, nil
 }
 
@@ -323,6 +410,11 @@ func MustNewTemporalOperation[I, O any](opts TemporalOperationOptions[I, O]) nex
 // defaultCancelWorkflowRun is the default cancel handler for workflow-run operation tokens.
 func defaultCancelWorkflowRun(ctx context.Context, c client.Client, options CancelTemporalWorkflowRunOptions, _ nexus.CancelOperationOptions) error {
 	return c.CancelWorkflow(ctx, options.WorkflowID, "")
+}
+
+// default cancel function for UpdateWorkflow returns an error
+func defaultCancelWorkflowUpdate(ctx context.Context, c client.Client, options CancelTemporalUpdateWorkflowOptions, _ nexus.CancelOperationOptions) error {
+	return ErrCannotCancelWorkflowUpdate
 }
 
 // temporalOperation implements nexus.Operation[I, O] for a generic Temporal-backed operation.
@@ -347,6 +439,10 @@ func (o *temporalOperation[I, O]) Start(
 
 	if _, ok := internal.NexusOperationContextFromGoContext(ctx); !ok {
 		return nil, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeInternal, "internal error")
+	}
+
+	if options.RequestID == "" {
+		options.RequestID = uuid.NewString()
 	}
 
 	nc := NexusClient{
@@ -397,10 +493,19 @@ func (o *temporalOperation[I, O]) Cancel(ctx context.Context, token string, opti
 			WorkflowID: wfToken.WorkflowID,
 		}, options)
 	case operationTokenTypeUpdateWorkflow:
-		return &nexus.HandlerError{
-			Type:  nexus.HandlerErrorTypeBadRequest,
-			Cause: errors.New("cannot cancel an UpdateWorkflow operation"),
+		uwfToken, err := loadUpdateWorkflowOperationToken(token)
+		if err != nil {
+			return &nexus.HandlerError{
+				Type:    nexus.HandlerErrorTypeBadRequest,
+				Message: "invalid operation token",
+				Cause:   err,
+			}
 		}
+		return o.options.CancelWorkflowUpdate(ctx, GetClient(ctx), CancelTemporalUpdateWorkflowOptions{
+			WorkflowID: uwfToken.WorkflowID,
+			RunID:      uwfToken.RunID,
+			UpdateID:   uwfToken.UpdateID,
+		}, options)
 	default:
 		return nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "unknown operation token type: %d", tokenType)
 	}

--- a/temporalnexus/temporal_operation.go
+++ b/temporalnexus/temporal_operation.go
@@ -179,8 +179,8 @@ func StartUntypedWorkflow[R any](
 
 // StartUpdateWorkflow starts a type-safe workflow update run for a Nexus operation
 // linking the execution chain to the Nexus operation (callbacks, links, request ID).
-// It returns either an async result with a workflow-run operation token for pending
-// operations or a sync response if the update is already completed(retried updates)
+// It returns either an async result with a workflow update operation token for pending
+// operations or a sync response if the update is already completed.
 //
 // These are free functions because Go does not allow generic methods on non-generic structs.
 //
@@ -193,16 +193,13 @@ func StartUpdateWorkflow[R any](
 	if updateWorkflowOptions.UpdateID == "" {
 		// If an Update ID is not provided, use the RequestID. This is done to protect
 		// against cases where an unset UpdateID request with the same RequestID is
-		// retried due to n/w failure and gets new IDs in createUpdateWorkflowInput
+		// retried due to network glitch and gets new IDs in createUpdateWorkflowInput
 		updateWorkflowOptions.UpdateID = nc.startOperationOptions.RequestID
 	}
 
 	if err := validateUpdateWorkflowNexusOperation(updateWorkflowOptions); err != nil {
-		return TemporalOperationResult[R]{}, &nexus.OperationError{
-			State:   nexus.OperationStateFailed,
-			Message: err.Error(),
-			Cause:   err,
-		}
+		return TemporalOperationResult[R]{}, nexus.NewHandlerErrorf(
+			nexus.HandlerErrorTypeInternal, "invalid update request: %w", err)
 	}
 
 	nctx, ok := internal.NexusOperationContextFromGoContext(ctx)
@@ -313,18 +310,13 @@ func StartUpdateWorkflow[R any](
 }
 
 // Validations to be performed specifically for UpdateWorkflow as a Nexus Operation.
-// Currently only guards against a sync Update being passed to the server. Invalid
-// updates - missing workflowID/updateName/etc - are expected to be retried forever.
 // NOTE: UpdateID will never be empty now that RequestID for nexus op is generated if empty
-// TBD: confirm one more time if retry-forever-on-invalid-config is ok before merge
-// and/or set WaitForStage after receiving the options (not done now to avoid silently
-// overwriting user provided options)
 func validateUpdateWorkflowNexusOperation(u client.UpdateWorkflowOptions) error {
 	switch {
-	// case u.WorkflowID == "":
-	// 	return errors.New("workflow ID cannot be empty")
-	// case u.UpdateName == "":
-	// 	return errors.New("update name cannot be empty")
+	case u.WorkflowID == "":
+		return errors.New("workflow ID cannot be empty")
+	case u.UpdateName == "":
+		return errors.New("update name cannot be empty")
 	case u.WaitForStage != client.WorkflowUpdateStageAccepted:
 		return errors.New("nexus op workflow updates only support WorkflowUpdateStageAccepted for async updates")
 	default:

--- a/temporalnexus/temporal_operation_test.go
+++ b/temporalnexus/temporal_operation_test.go
@@ -198,9 +198,9 @@ func TestStartUpdateWorkflowGuards(t *testing.T) {
 			UpdateName: "upd",
 		},
 	)
-	var opError *nexus.OperationError
+	var opError *nexus.HandlerError
 	require.ErrorAs(t, err, &opError)
-	require.Equal(t, opError.Message, "nexus op workflow updates only support WorkflowUpdateStageAccepted for async updates")
+	require.Equal(t, opError.Cause.Error(), "nexus op workflow updates only support WorkflowUpdateStageAccepted for async updates")
 }
 
 func strPtr(s string) *string {

--- a/temporalnexus/temporal_operation_test.go
+++ b/temporalnexus/temporal_operation_test.go
@@ -116,9 +116,8 @@ func TestLoadTokenType(t *testing.T) {
 
 	// Unknown type=99
 	unknownToken := base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString([]byte(`{"t":99}`))
-	tokenType, err = loadTokenType(unknownToken)
-	require.NoError(t, err)
-	require.Equal(t, operationTokenType(99), tokenType)
+	_, err = loadTokenType(unknownToken)
+	require.EqualError(t, err, "invalid operation token: 99")
 
 	// Empty token
 	_, err = loadTokenType("")
@@ -136,7 +135,7 @@ func TestLoadTokenType(t *testing.T) {
 	// Missing type field (t=0)
 	missingType := base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString([]byte(`{"ns":"ns"}`))
 	_, err = loadTokenType(missingType)
-	require.ErrorContains(t, err, "missing or zero token type")
+	require.ErrorContains(t, err, "invalid operation token: 0")
 }
 
 func TestDoubleStartGuard(t *testing.T) {
@@ -153,6 +152,35 @@ func TestDoubleStartGuard(t *testing.T) {
 	_, err = StartWorkflow(context.Background(), nc, client.StartWorkflowOptions{}, func(_ workflow.Context, _ string) (string, error) { return "", nil }, "ignored")
 	require.ErrorAs(t, err, &handlerErr)
 	require.Equal(t, nexus.HandlerErrorTypeBadRequest, handlerErr.Type)
+}
+
+func TestStartUpdateWorkflowGuards(t *testing.T) {
+	nc := NexusClient{
+		asyncStarted:          &atomic.Bool{},
+		startOperationOptions: nexus.StartOperationOptions{CallbackURL: "temporal://dummy"},
+	}
+	// attempt running async with an exhuasted nexusClient handler
+	nc.asyncStarted.Store(true)
+	_, err := StartUpdateWorkflow[string](context.Background(), nc, client.UpdateWorkflowOptions{
+		WaitForStage: client.WorkflowUpdateStageAccepted,
+	})
+	var handlerErr *nexus.HandlerError
+	require.ErrorAs(t, err, &handlerErr)
+	require.Equal(t, nexus.HandlerErrorTypeBadRequest, handlerErr.Type)
+	require.ErrorContains(t, err, "only one async operation")
+	// attempt to run async without callback
+	_, err = StartUpdateWorkflow[string](
+		context.Background(),
+		NexusClient{
+			asyncStarted: &atomic.Bool{},
+		},
+		client.UpdateWorkflowOptions{
+			WaitForStage: client.WorkflowUpdateStageAccepted,
+		},
+	)
+	require.ErrorAs(t, err, &handlerErr)
+	require.Equal(t, nexus.HandlerErrorTypeBadRequest, handlerErr.Type)
+	require.ErrorContains(t, err, "callback URL required")
 }
 
 func strPtr(s string) *string {

--- a/temporalnexus/temporal_operation_test.go
+++ b/temporalnexus/temporal_operation_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/nexus-rpc/sdk-go/nexus"
 	"github.com/stretchr/testify/require"
 	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/internal"
 	"go.temporal.io/sdk/workflow"
 )
 
@@ -161,7 +162,10 @@ func TestStartUpdateWorkflowGuards(t *testing.T) {
 	}
 	// attempt running async with an exhuasted nexusClient handler
 	nc.asyncStarted.Store(true)
-	_, err := StartUpdateWorkflow[string](context.Background(), nc, client.UpdateWorkflowOptions{
+	ctx := internal.ContextWithNexusOperationContext(context.Background(), &internal.NexusOperationContext{})
+	_, err := StartUpdateWorkflow[string](ctx, nc, client.UpdateWorkflowOptions{
+		WorkflowID:   "emptyWorkflowID!",
+		UpdateName:   "upd",
 		WaitForStage: client.WorkflowUpdateStageAccepted,
 	})
 	var handlerErr *nexus.HandlerError
@@ -170,17 +174,33 @@ func TestStartUpdateWorkflowGuards(t *testing.T) {
 	require.ErrorContains(t, err, "only one async operation")
 	// attempt to run async without callback
 	_, err = StartUpdateWorkflow[string](
-		context.Background(),
+		ctx,
 		NexusClient{
 			asyncStarted: &atomic.Bool{},
 		},
 		client.UpdateWorkflowOptions{
+			WorkflowID:   "anotherEmptyWorkflowID!",
+			UpdateName:   "upd",
 			WaitForStage: client.WorkflowUpdateStageAccepted,
 		},
 	)
 	require.ErrorAs(t, err, &handlerErr)
 	require.Equal(t, nexus.HandlerErrorTypeBadRequest, handlerErr.Type)
 	require.ErrorContains(t, err, "callback URL required")
+	// attempt running an invalid update
+	_, err = StartUpdateWorkflow[string](
+		ctx,
+		NexusClient{
+			asyncStarted: &atomic.Bool{},
+		},
+		client.UpdateWorkflowOptions{
+			WorkflowID: "dontTriggerValidation",
+			UpdateName: "upd",
+		},
+	)
+	var opError *nexus.OperationError
+	require.ErrorAs(t, err, &opError)
+	require.Equal(t, opError.Message, "nexus op workflow updates only support WorkflowUpdateStageAccepted for async updates")
 }
 
 func strPtr(s string) *string {

--- a/temporalnexus/token.go
+++ b/temporalnexus/token.go
@@ -10,31 +10,63 @@ import (
 type operationTokenType int
 
 const (
-	operationTokenTypeWorkflowRun = operationTokenType(1)
+	operationTokenTypeReserved operationTokenType = iota
+	operationTokenTypeWorkflowRun
+	operationTokenTypeUpdateWorkflow
+	// also Update With Start, Get Workflow Result, Stand Alone Activities
+	operationTokenTypeMaxVal
 )
 
-// workflowRunOperationToken is the decoded form of the workflow run operation token.
-type workflowRunOperationToken struct {
+func (o operationTokenType) IsValid() bool {
+	return 0 < o && o < operationTokenTypeMaxVal
+}
+
+// commmon meta for all operation token types
+type operationToken struct {
 	// Version of the token, by default we assume we're on version 1, this field is not emitted as part of the output,
 	// it's only used to reject newer token versions on load.
 	Version int `json:"v,omitempty"`
-	// Type of the operation. Must be operationTypeWorkflowRun.
-	Type          operationTokenType `json:"t"`
-	NamespaceName string             `json:"ns"`
-	WorkflowID    string             `json:"wid"`
+	// Type of the operation.
+	Type operationTokenType `json:"t"`
+}
+
+// workflowRunOperationToken is the decoded form of the workflow run operation token.
+type workflowRunOperationToken struct {
+	operationToken
+	NamespaceName string `json:"ns"`
+	WorkflowID    string `json:"wid"`
+}
+
+// updateWorkflow contains only meta - because it cannot be cancelled
+type updateWorkflowOperationToken struct {
+	operationToken
 }
 
 func generateWorkflowRunOperationToken(namespace, workflowID string) (string, error) {
 	token := workflowRunOperationToken{
-		Type:          operationTokenTypeWorkflowRun,
 		NamespaceName: namespace,
 		WorkflowID:    workflowID,
 	}
+	token.Type = operationTokenTypeWorkflowRun
 	data, err := json.Marshal(token)
 	if err != nil {
 		return "", fmt.Errorf("failed to marshal workflow run operation token: %w", err)
 	}
-	return base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString(data), nil
+	return base64EncodedString(data), nil
+}
+
+func generateUpdateOperationToken() (string, error) {
+	token := updateWorkflowOperationToken{}
+	token.Type = operationTokenTypeUpdateWorkflow
+	data, err := json.Marshal(token)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal operation token: %w", err)
+	}
+	return base64EncodedString(data), nil
+}
+
+func base64EncodedString(data []byte) string {
+	return base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString(data)
 }
 
 // loadTokenType decodes just the type field from an operation token without full validation.
@@ -53,8 +85,8 @@ func loadTokenType(data string) (operationTokenType, error) {
 	if err := json.Unmarshal(b, &partial); err != nil {
 		return 0, fmt.Errorf("failed to unmarshal operation token: %w", err)
 	}
-	if partial.Type == 0 {
-		return 0, errors.New("invalid operation token: missing or zero token type")
+	if !partial.Type.IsValid() {
+		return 0, fmt.Errorf("invalid operation token: %d", partial.Type)
 	}
 	return partial.Type, nil
 }

--- a/temporalnexus/token.go
+++ b/temporalnexus/token.go
@@ -12,12 +12,16 @@ type operationTokenType int
 const (
 	operationTokenTypeReserved operationTokenType = iota
 	operationTokenTypeWorkflowRun
+	operationTokenTypeActivity
 	operationTokenTypeUpdateWorkflow
 	// also Update With Start, Get Workflow Result, Stand Alone Activities
 	operationTokenTypeMaxVal
 )
 
 func (o operationTokenType) IsValid() bool {
+	if o == operationTokenTypeActivity { // temporary until activity is added
+		return false
+	}
 	return 0 < o && o < operationTokenTypeMaxVal
 }
 
@@ -27,27 +31,48 @@ type operationToken struct {
 	// it's only used to reject newer token versions on load.
 	Version int `json:"v,omitempty"`
 	// Type of the operation.
-	Type operationTokenType `json:"t"`
+	Type          operationTokenType `json:"t"`
+	NamespaceName string             `json:"ns"`
+}
+
+type operationTokenI interface {
+	getOperationToken() operationToken
 }
 
 // workflowRunOperationToken is the decoded form of the workflow run operation token.
 type workflowRunOperationToken struct {
 	operationToken
-	NamespaceName string `json:"ns"`
-	WorkflowID    string `json:"wid"`
+	WorkflowID string `json:"wid"`
+}
+
+func (w workflowRunOperationToken) getOperationToken() operationToken {
+	return w.operationToken
 }
 
 // updateWorkflow contains only meta - because it cannot be cancelled
 type updateWorkflowOperationToken struct {
 	operationToken
+	WorkflowID string `json:"wid"`
+	RunID      string `json:"rid"`
+	UpdateID   string `json:"uid"`
+}
+
+func (w updateWorkflowOperationToken) getOperationToken() operationToken {
+	return w.operationToken
+}
+
+func generateOperationToken(opType operationTokenType, namespace string) operationToken {
+	return operationToken{
+		Type:          opType,
+		NamespaceName: namespace,
+	}
 }
 
 func generateWorkflowRunOperationToken(namespace, workflowID string) (string, error) {
 	token := workflowRunOperationToken{
-		NamespaceName: namespace,
-		WorkflowID:    workflowID,
+		WorkflowID: workflowID,
 	}
-	token.Type = operationTokenTypeWorkflowRun
+	token.operationToken = generateOperationToken(operationTokenTypeWorkflowRun, namespace)
 	data, err := json.Marshal(token)
 	if err != nil {
 		return "", fmt.Errorf("failed to marshal workflow run operation token: %w", err)
@@ -55,9 +80,17 @@ func generateWorkflowRunOperationToken(namespace, workflowID string) (string, er
 	return base64EncodedString(data), nil
 }
 
-func generateUpdateOperationToken() (string, error) {
-	token := updateWorkflowOperationToken{}
+func generateUpdateOperationToken(namespace, workflowID, runID, updateID string) (string, error) {
+	if namespace == "" || workflowID == "" || updateID == "" {
+		return "", fmt.Errorf("missing required param[s]: ns %s, wid: %s, uid: %s", namespace, workflowID, updateID)
+	}
+	token := updateWorkflowOperationToken{
+		WorkflowID: workflowID,
+		RunID:      runID,
+		UpdateID:   updateID,
+	}
 	token.Type = operationTokenTypeUpdateWorkflow
+	token.operationToken = generateOperationToken(operationTokenTypeUpdateWorkflow, namespace)
 	data, err := json.Marshal(token)
 	if err != nil {
 		return "", fmt.Errorf("failed to marshal operation token: %w", err)
@@ -93,25 +126,61 @@ func loadTokenType(data string) (operationTokenType, error) {
 
 func loadWorkflowRunOperationToken(data string) (workflowRunOperationToken, error) {
 	var token workflowRunOperationToken
-	if len(data) == 0 {
-		return token, errors.New("invalid workflow run token: token is empty")
-	}
-	b, err := base64.URLEncoding.WithPadding(base64.NoPadding).DecodeString(data)
-	if err != nil {
-		return token, fmt.Errorf("failed to decode token: %w", err)
-	}
-	if err := json.Unmarshal(b, &token); err != nil {
-		return token, fmt.Errorf("failed to unmarshal workflow run operation token: %w", err)
-	}
-	if token.Type != operationTokenTypeWorkflowRun {
-		return token, fmt.Errorf("invalid workflow token type: %v, expected: %v", token.Type, operationTokenTypeWorkflowRun)
-	}
-	if token.Version != 0 {
-		return token, fmt.Errorf(`invalid workflow run token: "v" field should not be present`)
+	if err := loadOperationToken(data, &token); err != nil {
+		return token, err
 	}
 	if token.WorkflowID == "" {
 		return token, errors.New("invalid workflow run token: missing workflow ID (wid)")
 	}
-
 	return token, nil
+}
+
+func loadUpdateWorkflowOperationToken(data string) (updateWorkflowOperationToken, error) {
+	var token updateWorkflowOperationToken
+	if err := loadOperationToken(data, &token); err != nil {
+		return token, err
+	}
+	if token.WorkflowID == "" {
+		return token, errors.New("invalid token: missing workflow ID (wid)")
+	}
+	if token.UpdateID == "" {
+		return token, errors.New("invalid token: missing update ID (uid)")
+	}
+	return token, nil
+}
+
+func loadOperationToken(data string, token any) error {
+	if len(data) == 0 {
+		return errors.New("invalid token: token is empty")
+	}
+	var opType operationTokenType
+	switch token.(type) {
+	case *workflowRunOperationToken:
+		opType = operationTokenTypeWorkflowRun
+	case *updateWorkflowOperationToken:
+		opType = operationTokenTypeUpdateWorkflow
+	default:
+		return errors.New("unknown op token type")
+	}
+	b, err := base64.URLEncoding.WithPadding(base64.NoPadding).DecodeString(data)
+	if err != nil {
+		return fmt.Errorf("failed to decode token: %w", err)
+	}
+	if err := json.Unmarshal(b, token); err != nil {
+		return fmt.Errorf("failed to unmarshal operation token: %w", err)
+	}
+	tokenOpMeta, ok := token.(operationTokenI)
+	if !ok {
+		return errors.New("failed to load operation token metadata")
+	}
+	if tokenOpMeta.getOperationToken().Version != 0 {
+		return fmt.Errorf(`invalid token: "v" field should not be present`)
+	}
+	if tokenOpMeta.getOperationToken().NamespaceName == "" {
+		return errors.New("invalid token: missing namespace")
+	}
+	if tokenOpMeta.getOperationToken().Type != opType {
+		return fmt.Errorf("invalid token type: %v, expected: %v", tokenOpMeta.getOperationToken().Type, opType)
+	}
+	return nil
 }

--- a/temporalnexus/token_test.go
+++ b/temporalnexus/token_test.go
@@ -10,7 +10,9 @@ import (
 
 func TestEncodeDecodeWorkflowRunOperationToken(t *testing.T) {
 	wrt := workflowRunOperationToken{
-		Type:          operationTokenTypeWorkflowRun,
+		operationToken: operationToken{
+			Type: operationTokenTypeWorkflowRun,
+		},
 		NamespaceName: "ns",
 		WorkflowID:    "w",
 	}
@@ -50,9 +52,9 @@ func TestDecodeWorkflowRunOperationTokenErrors(t *testing.T) {
 	_, err = loadWorkflowRunOperationToken(invalidJSONToken)
 	require.ErrorContains(t, err, "failed to unmarshal workflow run operation token: invalid character 'i' looking for beginning of value")
 
-	invalidTypeToken := base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString([]byte(`{"t":2}`))
+	invalidTypeToken := base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString([]byte(`{"t":3}`))
 	_, err = loadWorkflowRunOperationToken(invalidTypeToken)
-	require.ErrorContains(t, err, "invalid workflow token type: 2, expected: 1")
+	require.ErrorContains(t, err, "invalid workflow token type")
 
 	missingWIDToken := base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString([]byte(`{"t":1}`))
 	_, err = loadWorkflowRunOperationToken(missingWIDToken)

--- a/temporalnexus/token_test.go
+++ b/temporalnexus/token_test.go
@@ -11,10 +11,10 @@ import (
 func TestEncodeDecodeWorkflowRunOperationToken(t *testing.T) {
 	wrt := workflowRunOperationToken{
 		operationToken: operationToken{
-			Type: operationTokenTypeWorkflowRun,
+			Type:          operationTokenTypeWorkflowRun,
+			NamespaceName: "ns",
 		},
-		NamespaceName: "ns",
-		WorkflowID:    "w",
+		WorkflowID: "w",
 	}
 	token, err := generateWorkflowRunOperationToken("ns", "w")
 	require.NoError(t, err)
@@ -39,28 +39,45 @@ func TestEncodeWorkflowRunOperationTokenDoesNotIncludeVersion(t *testing.T) {
 	require.Equal(t, "w", token["wid"], "workflow ID should match")
 }
 
+func TestEncodeDecodeUpdateWorkflowOperationToken(t *testing.T) {
+	uwt := updateWorkflowOperationToken{
+		operationToken: operationToken{
+			Type:          operationTokenTypeUpdateWorkflow,
+			NamespaceName: "ns",
+		},
+		WorkflowID: "w",
+		RunID:      "r",
+		UpdateID:   "u",
+	}
+	token, err := generateUpdateOperationToken("ns", "w", "r", "u")
+	require.NoError(t, err)
+	decoded, err := loadUpdateWorkflowOperationToken(token)
+	require.NoError(t, err)
+	require.Equal(t, uwt, decoded)
+}
+
 func TestDecodeWorkflowRunOperationTokenErrors(t *testing.T) {
 	var err error
 
 	_, err = loadWorkflowRunOperationToken("")
-	require.ErrorContains(t, err, "invalid workflow run token: token is empty")
+	require.ErrorContains(t, err, "invalid token: token is empty")
 
 	_, err = loadWorkflowRunOperationToken("not-base64!@#$")
 	require.ErrorContains(t, err, "failed to decode token: illegal base64 data at input byte 1")
 
 	invalidJSONToken := base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString([]byte("invalid json"))
 	_, err = loadWorkflowRunOperationToken(invalidJSONToken)
-	require.ErrorContains(t, err, "failed to unmarshal workflow run operation token: invalid character 'i' looking for beginning of value")
+	require.ErrorContains(t, err, "failed to unmarshal operation token: invalid character 'i' looking for beginning of value")
 
-	invalidTypeToken := base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString([]byte(`{"t":3}`))
+	invalidTypeToken := base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString([]byte(`{"ns": "abc", "t":3}`))
 	_, err = loadWorkflowRunOperationToken(invalidTypeToken)
-	require.ErrorContains(t, err, "invalid workflow token type")
+	require.ErrorContains(t, err, "invalid token type")
 
-	missingWIDToken := base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString([]byte(`{"t":1}`))
+	missingWIDToken := base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString([]byte(`{"ns": "abc", "t":1}`))
 	_, err = loadWorkflowRunOperationToken(missingWIDToken)
 	require.ErrorContains(t, err, "invalid workflow run token: missing workflow ID (wid)")
 
 	versionedToken := base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString([]byte(`{"v":1, "t":1,"wid": "workflow-id"}`))
 	_, err = loadWorkflowRunOperationToken(versionedToken)
-	require.ErrorContains(t, err, `invalid workflow run token: "v" field should not be present`)
+	require.ErrorContains(t, err, `invalid token: "v" field should not be present`)
 }

--- a/test/nexus_update_op_test.go
+++ b/test/nexus_update_op_test.go
@@ -21,6 +21,10 @@ import (
 	"go.temporal.io/sdk/workflow"
 )
 
+const (
+	nexusUpdateTestTimeout = 20 * time.Second
+)
+
 var (
 	invalidIncrementError = errors.New("invalid increment")
 )
@@ -47,7 +51,7 @@ const (
 )
 
 func (ts *IntegrationTestSuite) TestNexusUpdateWorkflowOperation() {
-	ctx, cancel := context.WithTimeout(context.TODO(), defaultNexusTestTimeout)
+	ctx, cancel := context.WithTimeout(context.TODO(), nexusUpdateTestTimeout)
 	defer cancel()
 
 	addOp, err := temporalnexus.NewTemporalOperation(temporalnexus.TemporalOperationOptions[updateAddInput, updateAddOutput]{
@@ -250,7 +254,7 @@ func (ts *IntegrationTestSuite) TestNexusUpdateWorkflowOperation() {
 
 // separate from [IntegrationTestSuite.TestNexusUpdateWorkflowOperation] as this is a more complicated scenario
 func (ts *IntegrationTestSuite) TestNexusUpdateWorkflowDelayedOperation() {
-	ctx, cancel := context.WithTimeout(context.TODO(), defaultNexusTestTimeout)
+	ctx, cancel := context.WithTimeout(context.TODO(), nexusUpdateTestTimeout)
 	defer cancel()
 
 	handlerTaskQueue, callerTaskQueue := "counterTQ", "updaterTQ"

--- a/test/nexus_update_op_test.go
+++ b/test/nexus_update_op_test.go
@@ -1,0 +1,153 @@
+package test_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/nexus-rpc/sdk-go/nexus"
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/temporalnexus"
+	"go.temporal.io/sdk/worker"
+	"go.temporal.io/sdk/workflow"
+)
+
+type updateAddInput struct {
+	CounterID string
+	Amount    int
+}
+
+type updateAddOutput struct {
+	NewValue int
+}
+
+const (
+	serviceName  = "counter-update-service"
+	addOperation = "addOperation"
+	addUpdate    = "addUpdate"
+	doneSignal   = "done"
+)
+
+func TestAsyncUpdateWorkflowOperation(t *testing.T) {
+	testUpdateWorkflowOperation(t, true)
+}
+
+func TestSyncUpdateWorkflowOperation(t *testing.T) {
+	testUpdateWorkflowOperation(t, false)
+}
+
+// run both via "go run . integration-test -dev-server -run UpdateWorkflowOperation"
+func testUpdateWorkflowOperation(t *testing.T, isAsync bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultNexusTestTimeout)
+	defer cancel()
+	tc := newTestContext(t, ctx)
+
+	addOp, err := getAddOperation(isAsync)
+	require.NoError(t, err)
+
+	callerWorkflow := getCallerWorkflow(tc, addOp, isAsync)
+
+	w := worker.New(tc.client, tc.taskQueue, worker.Options{})
+	service := nexus.NewService(serviceName)
+	require.NoError(t, service.Register(addOp))
+
+	w.RegisterNexusService(service)
+	w.RegisterWorkflow(counterWorkflow)
+	w.RegisterWorkflow(callerWorkflow)
+	require.NoError(t, w.Start())
+	defer w.Stop()
+
+	counterWorkflowID := "counter-" + uuid.NewString()
+	counterRun, err := tc.client.ExecuteWorkflow(ctx, client.StartWorkflowOptions{
+		ID:        counterWorkflowID,
+		TaskQueue: tc.taskQueue,
+	}, counterWorkflow)
+	require.NoError(t, err)
+
+	defer func() {
+		require.NoError(t, tc.client.SignalWorkflow(ctx, counterWorkflowID, "", doneSignal, nil))
+		require.NoError(t, counterRun.Get(ctx, nil))
+	}()
+
+	counterUpdateWorkflowRun, err := tc.client.ExecuteWorkflow(ctx, client.StartWorkflowOptions{
+		ID:                  "caller-" + uuid.NewString(),
+		TaskQueue:           tc.taskQueue,
+		WorkflowTaskTimeout: time.Second,
+	}, callerWorkflow, updateAddInput{CounterID: counterWorkflowID, Amount: 5})
+	require.NoError(t, err)
+
+	var out updateAddOutput
+	require.NoError(t, counterUpdateWorkflowRun.Get(ctx, &out))
+	require.Equal(t, 5, out.NewValue)
+}
+
+func counterWorkflow(ctx workflow.Context) (int, error) {
+	counter := 0
+
+	if err := workflow.SetUpdateHandler(ctx, addUpdate, func(ctx workflow.Context, amount int) (updateAddOutput, error) {
+		counter += amount
+		_ = workflow.Sleep(ctx, time.Second)
+		return updateAddOutput{NewValue: counter}, nil
+	}); err != nil {
+		return 0, err
+	}
+
+	workflow.GetSignalChannel(ctx, doneSignal).Receive(ctx, nil)
+	workflow.GetLogger(ctx).Info("finished workflow, exiting now...", "final counter", counter)
+	return counter, nil
+}
+
+func getAddOperation(isAsync bool) (nexus.Operation[updateAddInput, updateAddOutput], error) {
+	updateStage := client.WorkflowUpdateStageCompleted
+	if isAsync {
+		updateStage = client.WorkflowUpdateStageAccepted
+	}
+	return temporalnexus.NewTemporalOperation(temporalnexus.TemporalOperationOptions[updateAddInput, updateAddOutput]{
+		Name: addOperation,
+		Start: func(ctx context.Context, nc temporalnexus.NexusClient, input updateAddInput, _ temporalnexus.StartTemporalOperationOptions) (temporalnexus.TemporalOperationResult[updateAddOutput], error) {
+			return temporalnexus.StartUpdateWorkflow[updateAddOutput](ctx, nc, client.UpdateWorkflowOptions{
+				WorkflowID:   input.CounterID,
+				UpdateName:   addUpdate,
+				Args:         []any{input.Amount},
+				WaitForStage: updateStage,
+			})
+		},
+	})
+}
+
+// caller workflow that does sync/async specific checks
+func getCallerWorkflow(
+	tc *testContext,
+	addOp nexus.Operation[updateAddInput, updateAddOutput],
+	isAsync bool,
+) func(workflow.Context, updateAddInput) (updateAddOutput, error) {
+	return func(ctx workflow.Context, input updateAddInput) (updateAddOutput, error) {
+		nc := workflow.NewNexusClient(tc.endpoint, serviceName)
+		fut := nc.ExecuteOperation(ctx, addOp, input, workflow.NexusOperationOptions{})
+
+		var exec workflow.NexusOperationExecution
+		if err := fut.GetNexusOperationExecution().Get(ctx, &exec); err != nil {
+			return updateAddOutput{}, err
+		}
+
+		if isAsync {
+			if exec.OperationToken == "" {
+				return updateAddOutput{}, errors.New("expected a non-empty async operation token")
+			}
+		} else {
+			if exec.OperationToken != "" {
+				return updateAddOutput{}, errors.New("unexpected operation token on a sync operation")
+			}
+		}
+
+		var out updateAddOutput
+		if err := fut.Get(ctx, &out); err != nil {
+			return updateAddOutput{}, err
+		}
+
+		return out, nil
+	}
+}

--- a/test/nexus_update_op_test.go
+++ b/test/nexus_update_op_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"slices"
 	"sync"
 	"time"
@@ -22,7 +23,7 @@ import (
 )
 
 const (
-	nexusUpdateTestTimeout = 20 * time.Second
+	nexusUpdateTestTimeout = 30 * time.Second
 )
 
 var (
@@ -51,6 +52,9 @@ const (
 )
 
 func (ts *IntegrationTestSuite) TestNexusUpdateWorkflowOperation() {
+	if os.Getenv("DISABLE_STANDALONE_NEXUS_TESTS") != "" {
+		ts.T().SkipNow()
+	}
 	ctx, cancel := context.WithTimeout(context.TODO(), nexusUpdateTestTimeout)
 	defer cancel()
 
@@ -254,6 +258,9 @@ func (ts *IntegrationTestSuite) TestNexusUpdateWorkflowOperation() {
 
 // separate from [IntegrationTestSuite.TestNexusUpdateWorkflowOperation] as this is a more complicated scenario
 func (ts *IntegrationTestSuite) TestNexusUpdateWorkflowDelayedOperation() {
+	if os.Getenv("DISABLE_STANDALONE_NEXUS_TESTS") != "" {
+		ts.T().SkipNow()
+	}
 	ctx, cancel := context.WithTimeout(context.TODO(), nexusUpdateTestTimeout)
 	defer cancel()
 

--- a/test/nexus_update_op_test.go
+++ b/test/nexus_update_op_test.go
@@ -3,25 +3,38 @@ package test_test
 import (
 	"context"
 	"errors"
-	"testing"
+	"fmt"
+	"slices"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/nexus-rpc/sdk-go/nexus"
-	"github.com/stretchr/testify/require"
+	"go.temporal.io/api/common/v1"
+	"go.temporal.io/api/enums/v1"
+	"go.temporal.io/api/history/v1"
+	nexuspb "go.temporal.io/api/nexus/v1"
+	"go.temporal.io/api/operatorservice/v1"
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/temporalnexus"
 	"go.temporal.io/sdk/worker"
 	"go.temporal.io/sdk/workflow"
 )
 
+var (
+	invalidIncrementError = errors.New("invalid increment")
+)
+
 type updateAddInput struct {
-	CounterID string
-	Amount    int
+	UpdateID           string
+	WorkflowID         string
+	Amount             int
+	SleepDuration      time.Duration
+	ExpectSyncResponse bool // hint to the caller workflow that the async token will not be set (a retried completed update is sync)
 }
 
 type updateAddOutput struct {
-	NewValue int
+	Count int
 }
 
 const (
@@ -29,69 +42,321 @@ const (
 	addOperation = "addOperation"
 	addUpdate    = "addUpdate"
 	doneSignal   = "done"
+
+	taskQueue = "nexusOpUpdateWorkflowTQ"
 )
 
-func TestAsyncUpdateWorkflowOperation(t *testing.T) {
-	testUpdateWorkflowOperation(t, true)
-}
-
-func TestSyncUpdateWorkflowOperation(t *testing.T) {
-	testUpdateWorkflowOperation(t, false)
-}
-
-// run both via "go run . integration-test -dev-server -run UpdateWorkflowOperation"
-func testUpdateWorkflowOperation(t *testing.T, isAsync bool) {
-	ctx, cancel := context.WithTimeout(context.Background(), defaultNexusTestTimeout)
+func (ts *IntegrationTestSuite) TestNexusUpdateWorkflowOperation() {
+	ctx, cancel := context.WithTimeout(context.TODO(), defaultNexusTestTimeout)
 	defer cancel()
-	tc := newTestContext(t, ctx)
 
-	addOp, err := getAddOperation(isAsync)
-	require.NoError(t, err)
+	addOp, err := temporalnexus.NewTemporalOperation(temporalnexus.TemporalOperationOptions[updateAddInput, updateAddOutput]{
+		Name: addOperation,
+		Start: func(ctx context.Context, nc temporalnexus.NexusClient, input updateAddInput, opts temporalnexus.StartTemporalOperationOptions) (temporalnexus.TemporalOperationResult[updateAddOutput], error) {
+			return temporalnexus.StartUpdateWorkflow[updateAddOutput](ctx, nc, client.UpdateWorkflowOptions{
+				WorkflowID:   input.WorkflowID,
+				UpdateID:     input.UpdateID,
+				UpdateName:   addUpdate,
+				Args:         []any{input.Amount, input.SleepDuration},
+				WaitForStage: client.WorkflowUpdateStageAccepted,
+			})
+		},
+	})
+	ts.NoError(err)
 
-	callerWorkflow := getCallerWorkflow(tc, addOp, isAsync)
+	endpoint := "update-workflow-backed-nexus-ep-" + uuid.NewString()
+	_, err = ts.client.OperatorService().CreateNexusEndpoint(ctx, &operatorservice.CreateNexusEndpointRequest{
+		Spec: &nexuspb.EndpointSpec{
+			Name: endpoint,
+			Target: &nexuspb.EndpointTarget{
+				Variant: &nexuspb.EndpointTarget_Worker_{
+					Worker: &nexuspb.EndpointTarget_Worker{
+						Namespace: ts.config.Namespace,
+						TaskQueue: taskQueue,
+					},
+				},
+			},
+		},
+	})
+	ts.NoError(err)
 
-	w := worker.New(tc.client, tc.taskQueue, worker.Options{})
+	callerWorkflow := getCallerWorkflow(addOp, endpoint)
+
+	w := worker.New(ts.client, taskQueue, worker.Options{})
 	service := nexus.NewService(serviceName)
-	require.NoError(t, service.Register(addOp))
+	ts.NoError(service.Register(addOp))
 
 	w.RegisterNexusService(service)
 	w.RegisterWorkflow(counterWorkflow)
 	w.RegisterWorkflow(callerWorkflow)
-	require.NoError(t, w.Start())
+	ts.NoError(w.Start())
 	defer w.Stop()
 
+	defaultSleep := 1 * time.Second
+
 	counterWorkflowID := "counter-" + uuid.NewString()
-	counterRun, err := tc.client.ExecuteWorkflow(ctx, client.StartWorkflowOptions{
+	counterWorkflowRun, err := ts.client.ExecuteWorkflow(ctx, client.StartWorkflowOptions{
 		ID:        counterWorkflowID,
-		TaskQueue: tc.taskQueue,
+		TaskQueue: taskQueue,
 	}, counterWorkflow)
-	require.NoError(t, err)
+	ts.NoError(err)
 
-	defer func() {
-		require.NoError(t, tc.client.SignalWorkflow(ctx, counterWorkflowID, "", doneSignal, nil))
-		require.NoError(t, counterRun.Get(ctx, nil))
-	}()
+	stopCounterWorkflow := func() {
+		ts.NoError(ts.client.SignalWorkflow(ctx, counterWorkflowID, "", doneSignal, nil))
+		ts.NoError(counterWorkflowRun.Get(ctx, nil))
+	}
 
-	counterUpdateWorkflowRun, err := tc.client.ExecuteWorkflow(ctx, client.StartWorkflowOptions{
-		ID:                  "caller-" + uuid.NewString(),
-		TaskQueue:           tc.taskQueue,
+	ts.Run("Verify operation doesnt retry on validation failure", func() {
+		invalidUpdateWorkflowRun, err := ts.client.ExecuteWorkflow(ctx, client.StartWorkflowOptions{
+			ID:                  "validation-failure-" + uuid.NewString(),
+			TaskQueue:           taskQueue,
+			WorkflowTaskTimeout: time.Second,
+		}, callerWorkflow, updateAddInput{WorkflowID: counterWorkflowID, Amount: 6, SleepDuration: defaultSleep})
+		ts.NoError(err, invalidIncrementError)
+		ts.ErrorContains(invalidUpdateWorkflowRun.Get(ctx, nil), invalidIncrementError.Error())
+	})
+
+	ts.Run("Verify valid update operation succeeds and has links", func() {
+		var out updateAddOutput
+
+		counterUpdateWorkflowRun, err := ts.client.ExecuteWorkflow(ctx, client.StartWorkflowOptions{
+			ID:                  "caller-" + uuid.NewString(),
+			TaskQueue:           taskQueue,
+			WorkflowTaskTimeout: time.Second,
+		}, callerWorkflow, updateAddInput{WorkflowID: counterWorkflowID, Amount: 5, UpdateID: "BasicSuccessfulUpdate",
+			SleepDuration: defaultSleep})
+		ts.NoError(err)
+		ts.NoError(counterUpdateWorkflowRun.Get(ctx, &out))
+		ts.Equal(5, out.Count)
+
+		eventsFilter := func(e *history.HistoryEvent) bool {
+			filterOpTypes := []enums.EventType{
+				enums.EVENT_TYPE_NEXUS_OPERATION_STARTED,            // for forward events links on caller
+				enums.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_ACCEPTED, // for backward events links on handler
+			}
+			return slices.Contains(filterOpTypes, e.EventType)
+		}
+		callerRequestID, err := getNexusOpRequestID(ctx, ts.client, counterUpdateWorkflowRun)
+		ts.NoError(err)
+		// from caller ns to target ns
+		forwardLink := &common.Link{Variant: &common.Link_WorkflowEvent_{WorkflowEvent: &common.Link_WorkflowEvent{
+			Namespace:  ts.config.Namespace,
+			WorkflowId: counterWorkflowID,
+			RunId:      counterWorkflowRun.GetRunID(),
+			Reference: &common.Link_WorkflowEvent_RequestIdRef{RequestIdRef: &common.Link_WorkflowEvent_RequestIdReference{
+				RequestId: callerRequestID,
+				EventType: enums.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_ACCEPTED,
+			}},
+		}}}
+		// from target ns back to caller ns
+		backwardLink := &common.Link{Variant: &common.Link_WorkflowEvent_{WorkflowEvent: &common.Link_WorkflowEvent{
+			Namespace:  ts.config.Namespace,
+			WorkflowId: counterUpdateWorkflowRun.GetID(),
+			RunId:      counterUpdateWorkflowRun.GetRunID(),
+			Reference: &common.Link_WorkflowEvent_EventRef{EventRef: &common.Link_WorkflowEvent_EventReference{
+				EventId:   getEventIDByType(ctx, ts.client, counterUpdateWorkflowRun, enums.EVENT_TYPE_NEXUS_OPERATION_SCHEDULED),
+				EventType: enums.EVENT_TYPE_NEXUS_OPERATION_SCHEDULED,
+			}},
+		}}}
+		counterWorkflowLinks := getEventLinks(ctx, ts.client, counterWorkflowRun, eventsFilter)
+		callerWorkflowLinks := getEventLinks(ctx, ts.client, counterUpdateWorkflowRun, eventsFilter)
+		ts.True(checkForLink(counterWorkflowLinks, backwardLink))
+		ts.True(checkForLink(callerWorkflowLinks, forwardLink))
+	})
+
+	ts.Run("Verify sequential updates with same UpdateID are idempotent", func() {
+		var out updateAddOutput
+		updateID := "consistentIDForRetries"
+
+		counterUpdateWorkflowRun, err := ts.client.ExecuteWorkflow(ctx, client.StartWorkflowOptions{
+			ID:                  "caller-" + uuid.NewString(),
+			TaskQueue:           taskQueue,
+			WorkflowTaskTimeout: time.Second,
+		}, callerWorkflow, updateAddInput{WorkflowID: counterWorkflowID, Amount: 5, UpdateID: updateID})
+		ts.NoError(err)
+		ts.NoError(counterUpdateWorkflowRun.Get(ctx, &out))
+		ts.Equal(10, out.Count)
+
+		counterUpdateWorkflowRun, err = ts.client.ExecuteWorkflow(ctx, client.StartWorkflowOptions{
+			ID:                  "caller-" + uuid.NewString(),
+			TaskQueue:           taskQueue,
+			WorkflowTaskTimeout: time.Second,
+		}, callerWorkflow, updateAddInput{WorkflowID: counterWorkflowID, Amount: 5, UpdateID: updateID, ExpectSyncResponse: true})
+		ts.NoError(err)
+		ts.NoError(counterUpdateWorkflowRun.Get(ctx, &out))
+		ts.Equal(10, out.Count) // shouldnt increment again as its same updateID
+	})
+
+	ts.Run("Verify concurrent Updates with same UpdateID are idempotent and finish", func() {
+		// simulate multiple updates with same ID hitting at same time
+		// the counter sleeps for second so all of them should get
+		// an async result- dont set the ExpectSyncResponse for that reason
+		gate := make(chan struct{})
+		wg := sync.WaitGroup{}
+		parallelUpdateID := "consistent-" + uuid.NewString()
+		numParallelUpdates := 3
+		wg.Add(numParallelUpdates)
+		errs := make([]error, numParallelUpdates)
+		vals := make([]updateAddOutput, numParallelUpdates)
+		for i := range numParallelUpdates {
+			go func(i int) {
+				defer wg.Done()
+				<-gate
+				run, err := ts.client.ExecuteWorkflow(ctx, client.StartWorkflowOptions{
+					ID:                  fmt.Sprintf("parallel-caller-%d", i),
+					TaskQueue:           taskQueue,
+					WorkflowTaskTimeout: time.Second,
+				}, callerWorkflow, updateAddInput{WorkflowID: counterWorkflowID, Amount: 5, UpdateID: parallelUpdateID,
+					SleepDuration: defaultSleep})
+				if err != nil {
+					errs[i] = err
+					return
+				}
+				errs[i] = run.Get(ctx, &vals[i])
+			}(i)
+		}
+		close(gate)
+		wg.Wait()
+		for i := range numParallelUpdates {
+			ts.NoError(errs[i])
+			ts.Equal(15, vals[i].Count)
+		}
+	})
+
+	ts.Run("Verify immediate returns are still async", func() {
+		// See NEXUS-489 for details.
+		var out updateAddOutput
+		counterUpdateWorkflowRun, err := ts.client.ExecuteWorkflow(ctx, client.StartWorkflowOptions{
+			ID:        "immediate-return" + uuid.NewString(),
+			TaskQueue: taskQueue,
+		}, callerWorkflow, updateAddInput{WorkflowID: counterWorkflowID, Amount: 5, SleepDuration: 0})
+		ts.NoError(err)
+		ts.NoError(counterUpdateWorkflowRun.Get(ctx, &out))
+		ts.Equal(20, out.Count)
+	})
+
+	ts.Run("Verify updates on completed workflows fail", func() {
+		stopCounterWorkflow()
+		// updates on finished workflows should fail
+		counterUpdateWorkflowRun, err := ts.client.ExecuteWorkflow(ctx, client.StartWorkflowOptions{
+			ID:                  "failing-caller-" + uuid.NewString(),
+			TaskQueue:           taskQueue,
+			WorkflowTaskTimeout: time.Second,
+		}, callerWorkflow, updateAddInput{WorkflowID: counterWorkflowID, Amount: 5})
+		ts.NoError(err)
+		ts.Error(counterUpdateWorkflowRun.Get(ctx, nil))
+	})
+}
+
+// separate from [IntegrationTestSuite.TestNexusUpdateWorkflowOperation] as this is a more complicated scenario
+func (ts *IntegrationTestSuite) TestNexusUpdateWorkflowDelayedOperation() {
+	ctx, cancel := context.WithTimeout(context.TODO(), defaultNexusTestTimeout)
+	defer cancel()
+
+	handlerTaskQueue, callerTaskQueue := "counterTQ", "updaterTQ"
+
+	addOp, err := temporalnexus.NewTemporalOperation(temporalnexus.TemporalOperationOptions[updateAddInput, updateAddOutput]{
+		Name: addOperation,
+		Start: func(ctx context.Context, nc temporalnexus.NexusClient, input updateAddInput, opts temporalnexus.StartTemporalOperationOptions) (temporalnexus.TemporalOperationResult[updateAddOutput], error) {
+			return temporalnexus.StartUpdateWorkflow[updateAddOutput](ctx, nc, client.UpdateWorkflowOptions{
+				WorkflowID:   input.WorkflowID,
+				UpdateID:     input.UpdateID,
+				UpdateName:   addUpdate,
+				Args:         []any{input.Amount, input.SleepDuration},
+				WaitForStage: client.WorkflowUpdateStageAccepted,
+			})
+		},
+	})
+	ts.NoError(err)
+
+	endpoint := "update-workflow-backed-nexus-ep-" + uuid.NewString()
+	_, err = ts.client.OperatorService().CreateNexusEndpoint(ctx, &operatorservice.CreateNexusEndpointRequest{
+		Spec: &nexuspb.EndpointSpec{
+			Name: endpoint,
+			Target: &nexuspb.EndpointTarget{
+				Variant: &nexuspb.EndpointTarget_Worker_{
+					Worker: &nexuspb.EndpointTarget_Worker{
+						Namespace: ts.config.Namespace,
+						TaskQueue: handlerTaskQueue,
+					},
+				},
+			},
+		},
+	})
+	ts.NoError(err)
+
+	callerWorkflow := getCallerWorkflow(addOp, endpoint)
+
+	callerWorker := worker.New(ts.client, callerTaskQueue, worker.Options{})
+
+	callerWorker.RegisterWorkflow(callerWorkflow)
+	ts.NoError(callerWorker.Start())
+	defer callerWorker.Stop()
+
+	// run the counter workflow
+	handlerWorkflowID := "counter-" + uuid.NewString()
+	handlerWorkflowRun, err := ts.client.ExecuteWorkflow(ctx, client.StartWorkflowOptions{
+		ID:        handlerWorkflowID,
+		TaskQueue: handlerTaskQueue,
+	}, counterWorkflow)
+	ts.NoError(err)
+
+	stopCounterWf := func() {
+		ts.NoError(ts.client.SignalWorkflow(ctx, handlerWorkflowID, "", doneSignal, nil))
+		ts.NoError(handlerWorkflowRun.Get(ctx, nil))
+	}
+
+	// start the update, it will get admitted
+	callerWorkflowRun, err := ts.client.ExecuteWorkflow(ctx, client.StartWorkflowOptions{
+		ID:                  "delayed-" + uuid.NewString(),
+		TaskQueue:           callerTaskQueue,
 		WorkflowTaskTimeout: time.Second,
-	}, callerWorkflow, updateAddInput{CounterID: counterWorkflowID, Amount: 5})
-	require.NoError(t, err)
+	}, callerWorkflow, updateAddInput{WorkflowID: handlerWorkflowID, Amount: 5})
+	ts.NoError(err)
 
+	// now, start the worker so that counter workflow can actually handle the update
+	handlerWorker := worker.New(ts.client, handlerTaskQueue, worker.Options{})
+	handlerWorker.RegisterWorkflow(counterWorkflow)
+	service := nexus.NewService(serviceName)
+	ts.NoError(service.Register(addOp))
+	handlerWorker.RegisterNexusService(service)
+	ts.NoError(handlerWorker.Start())
+	defer handlerWorker.Stop()
+	defer stopCounterWf()
+
+	// verify count, no errors
 	var out updateAddOutput
-	require.NoError(t, counterUpdateWorkflowRun.Get(ctx, &out))
-	require.Equal(t, 5, out.NewValue)
+	ts.NoError(callerWorkflowRun.Get(ctx, &out))
+	ts.Equal(out.Count, 5)
 }
 
 func counterWorkflow(ctx workflow.Context) (int, error) {
 	counter := 0
 
-	if err := workflow.SetUpdateHandler(ctx, addUpdate, func(ctx workflow.Context, amount int) (updateAddOutput, error) {
+	updateHandler := func(ctx workflow.Context, amount int, sleepDuration time.Duration) (updateAddOutput, error) {
 		counter += amount
-		_ = workflow.Sleep(ctx, time.Second)
-		return updateAddOutput{NewValue: counter}, nil
-	}); err != nil {
+		newCounterVal := counter
+		if sleepDuration != 0 {
+			_ = workflow.Sleep(ctx, sleepDuration)
+		}
+		return updateAddOutput{Count: newCounterVal}, nil
+	}
+
+	// used for testing invalid updates
+	updateValidator := func(ctx workflow.Context, amount int, sleepDuration time.Duration) error {
+		if amount%5 != 0 {
+			return invalidIncrementError
+		}
+		return nil
+	}
+
+	if err := workflow.SetUpdateHandlerWithOptions(ctx,
+		addUpdate,
+		updateHandler,
+		workflow.UpdateHandlerOptions{
+			Validator: updateValidator,
+		},
+	); err != nil {
 		return 0, err
 	}
 
@@ -100,46 +365,29 @@ func counterWorkflow(ctx workflow.Context) (int, error) {
 	return counter, nil
 }
 
-func getAddOperation(isAsync bool) (nexus.Operation[updateAddInput, updateAddOutput], error) {
-	updateStage := client.WorkflowUpdateStageCompleted
-	if isAsync {
-		updateStage = client.WorkflowUpdateStageAccepted
-	}
-	return temporalnexus.NewTemporalOperation(temporalnexus.TemporalOperationOptions[updateAddInput, updateAddOutput]{
-		Name: addOperation,
-		Start: func(ctx context.Context, nc temporalnexus.NexusClient, input updateAddInput, _ temporalnexus.StartTemporalOperationOptions) (temporalnexus.TemporalOperationResult[updateAddOutput], error) {
-			return temporalnexus.StartUpdateWorkflow[updateAddOutput](ctx, nc, client.UpdateWorkflowOptions{
-				WorkflowID:   input.CounterID,
-				UpdateName:   addUpdate,
-				Args:         []any{input.Amount},
-				WaitForStage: updateStage,
-			})
-		},
-	})
-}
-
-// caller workflow that does sync/async specific checks
+// caller workflow
 func getCallerWorkflow(
-	tc *testContext,
 	addOp nexus.Operation[updateAddInput, updateAddOutput],
-	isAsync bool,
+	endpoint string,
 ) func(workflow.Context, updateAddInput) (updateAddOutput, error) {
 	return func(ctx workflow.Context, input updateAddInput) (updateAddOutput, error) {
-		nc := workflow.NewNexusClient(tc.endpoint, serviceName)
-		fut := nc.ExecuteOperation(ctx, addOp, input, workflow.NexusOperationOptions{})
+		nc := workflow.NewNexusClient(endpoint, serviceName)
+		fut := nc.ExecuteOperation(ctx, addOp, input, workflow.NexusOperationOptions{
+			Summary: "TODO",
+		})
 
 		var exec workflow.NexusOperationExecution
 		if err := fut.GetNexusOperationExecution().Get(ctx, &exec); err != nil {
 			return updateAddOutput{}, err
 		}
 
-		if isAsync {
-			if exec.OperationToken == "" {
-				return updateAddOutput{}, errors.New("expected a non-empty async operation token")
-			}
-		} else {
+		if input.ExpectSyncResponse {
 			if exec.OperationToken != "" {
 				return updateAddOutput{}, errors.New("unexpected operation token on a sync operation")
+			}
+		} else {
+			if exec.OperationToken == "" {
+				return updateAddOutput{}, errors.New("expected a non-empty async operation token")
 			}
 		}
 
@@ -150,4 +398,69 @@ func getCallerWorkflow(
 
 		return out, nil
 	}
+}
+
+func checkForLink(links []*common.Link, requiredLink *common.Link) bool {
+	for _, link := range links {
+		if link.Equal(requiredLink) {
+			return true
+		}
+	}
+	return false
+}
+
+func getEventLinks(ctx context.Context,
+	c client.Client, workflowRun client.WorkflowRun,
+	filter func(e *history.HistoryEvent) bool,
+) []*common.Link {
+	events := getEvents(ctx, c, workflowRun, filter)
+	eventLinks := make([]*common.Link, 0, len(events))
+	for _, event := range events {
+		eventLinks = append(eventLinks, event.GetLinks()...)
+	}
+	return eventLinks
+}
+
+func getEventIDByType(ctx context.Context, c client.Client, workflowRun client.WorkflowRun, eventType enums.EventType) int64 {
+	events := getEvents(ctx, c, workflowRun, func(e *history.HistoryEvent) bool {
+		return e.GetEventType() == eventType
+	})
+	if len(events) == 0 {
+		return -1
+	}
+	return events[0].EventId
+}
+
+// get the request ID of the singular nexus op in this workflow run
+func getNexusOpRequestID(ctx context.Context, c client.Client, workflowRun client.WorkflowRun) (string, error) {
+	events := getEvents(ctx, c, workflowRun, func(e *history.HistoryEvent) bool {
+		return e.GetEventType() == enums.EVENT_TYPE_NEXUS_OPERATION_SCHEDULED
+	})
+	if len(events) == 0 {
+		return "", errors.New("no nexus op event found")
+	}
+	if len(events) > 1 {
+		return "", errors.New("multiple nexus ops events found, cannot determine specific requestID")
+	}
+	return events[0].GetNexusOperationScheduledEventAttributes().RequestId, nil
+}
+
+func getEvents(ctx context.Context,
+	c client.Client, workflowRun client.WorkflowRun,
+	filter func(e *history.HistoryEvent) bool,
+) []*history.HistoryEvent {
+	iter := c.GetWorkflowHistory(ctx,
+		workflowRun.GetID(), workflowRun.GetRunID(),
+		false, enums.HISTORY_EVENT_FILTER_TYPE_ALL_EVENT)
+	events := []*history.HistoryEvent{}
+	for iter.HasNext() {
+		event, err := iter.Next()
+		if err != nil {
+			continue
+		}
+		if filter(event) {
+			events = append(events, event)
+		}
+	}
+	return events
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Adds support for UpdateWorkflow as a Nexus operation

## Why?
<!-- Tell your future self why have you made these changes -->
Part of effort to expose all Temporal primitives via Nexus operations 

## Checklist
<!--- add/delete as needed --->

1. Closes NEXUS-474

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

- [x] added integration tests - run as `go run . integration-test -dev-server -run UpdateWorkflowOperation`

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

- [ ] TBD 