### PR TITLE
Use configured deadlock timeout in error message

### DIFF
--- a/internal/internal_coroutines_test.go
+++ b/internal/internal_coroutines_test.go
@@ -1225,7 +1225,21 @@ func TestDeadlockDetectorAndAwaitRace(t *testing.T) {
 	defer d.Close()
 	// Expecting deadlock detection timeout instead of a data race.
 	err := d.ExecuteUntilAllBlocked(defaultDeadlockDetectionTimeout)
-	require.EqualError(t, err, "[TMPRL1101] Potential deadlock detected: workflow goroutine \"root\" didn't yield for over a second")
+	require.EqualError(t, err, "[TMPRL1101] Potential deadlock detected: workflow goroutine \"root\" didn't yield for over 1s")
+}
+
+func TestDeadlockDetectorUsesConfiguredTimeoutInMessage(t *testing.T) {
+	timeout := 1500 * time.Millisecond
+	d := createNewDispatcher(func(ctx Context) {
+		_ = Await(ctx, func() bool {
+			time.Sleep(timeout + 100*time.Millisecond)
+			return false
+		})
+	})
+	defer d.Close()
+
+	err := d.ExecuteUntilAllBlocked(timeout)
+	require.EqualError(t, err, `[TMPRL1101] Potential deadlock detected: workflow goroutine "root" didn't yield for over 1.5s`)
 }
 
 func TestAwaitCancellation(t *testing.T) {
@@ -1936,7 +1950,7 @@ func TestDeadlockDetectorStackTrace(t *testing.T) {
 
 	var wfPanic *workflowPanicError
 	require.ErrorAs(t, err, &wfPanic)
-	require.Equal(t, `[TMPRL1101] Potential deadlock detected: workflow goroutine "sleeper" didn't yield for over a second`, wfPanic.Error())
+	require.Equal(t, `[TMPRL1101] Potential deadlock detected: workflow goroutine "sleeper" didn't yield for over 1s`, wfPanic.Error())
 	require.Regexp(t, `^coroutine sleeper \[running\]:\ntime\.Sleep\(0x[\da-f]+\)\n`, wfPanic.StackTrace())
 	require.Equal(t, 4, strings.Count(wfPanic.StackTrace(), "\n"), "2 stack frames expected")
 }

--- a/internal/internal_workflow.go
+++ b/internal/internal_workflow.go
@@ -1162,7 +1162,7 @@ func (s *coroutineState) call(timeout time.Duration) {
 			st = fmt.Sprintf("<%s>", err)
 		}
 		msg := fmt.Sprintf("[TMPRL1101] Potential deadlock detected: "+
-			"workflow goroutine %q didn't yield for over a second", s.name)
+			"workflow goroutine %q didn't yield for over %s", s.name, timeout)
 		s.closed.Store(true)
 		s.panicError = newWorkflowPanicError(msg, st)
 	}


### PR DESCRIPTION
## What was changed

This PR updates the workflow deadlock detection error message to report the configured deadlock detection timeout instead of always saying “a second”.

Specifically, the deadlock message now formats the timeout value passed into the coroutine execution path, so non-default `DeadlockDetectionTimeout` values are reflected in the emitted error.

A regression test was added with a non-default timeout to verify that the error message includes the configured duration.

## Why?

The deadlock detector already uses the configured timeout when deciding when to trigger. However, the error message was still hardcoded to say the workflow goroutine did not yield for over “a second”.

This could be misleading when users configure a different deadlock detection timeout.

## Checklist

1. Closes #2418

2. How was this tested:

* `go test ./internal -run 'TestDeadlockDetectorAndAwaitRace|TestDeadlockDetectorUsesConfiguredTimeoutInMessage|TestDeadlockDetectorStackTrace' -count=1`
* `go test ./internal -run 'TestDeadlockDetectorUsesConfiguredTimeoutInMessage' -count=5`
* `go test ./internal -run 'TestDeadlockDetector' -count=1`
* `go test ./internal -count=1`

3. Any docs updates needed?

No docs updates needed. This only updates the internal deadlock error message to reflect the configured timeout.
