### PR TITLE
VLN-1614: remediate checkout-below-v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ${{ matrix.runsOn || matrix.os }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: recursive
 
@@ -64,7 +64,7 @@ jobs:
     runs-on: ${{ matrix.runsOn || matrix.os }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: recursive
 
@@ -97,7 +97,7 @@ jobs:
     runs-on: ${{ matrix.runsOn || matrix.os }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: recursive
 
@@ -118,7 +118,7 @@ jobs:
       statuses: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: recursive
 
@@ -128,7 +128,7 @@ jobs:
           go-version: stable
 
       - name: Docker compose - checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: temporalio/samples-server
           path: ./samples-server
@@ -170,7 +170,7 @@ jobs:
       GODEBUG: ${{ matrix.fips && 'fips140=on' || '' }}
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: recursive
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -9,7 +9,7 @@ jobs:
   govulncheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: go.mod


### PR DESCRIPTION
> 🏕️ This pull request was created by [camper](https://github.com/temporalio/camper), an automated security campaign tool.

## Finding

<table>
  <tr><td><strong>Rule</strong></td><td><code>checkout-below-v7</code></td></tr>
  <tr><td><strong>Severity</strong></td><td>MEDIUM</td></tr>
  <tr><td><strong>Repository</strong></td><td><code>temporalio/sdk-go</code></td></tr>
  <tr><td><strong>Ticket</strong></td><td><a href="https://temporalio.atlassian.net/browse/VLN-1614">VLN-1614</a></td></tr>
</table>

## Summary

- `.github/workflows/ci.yml`: Pinned all `actions/checkout` usages to the v7.0.0 commit SHA, leaving other action references unchanged.
- `.github/workflows/govulncheck.yml`: Pinned the `actions/checkout` usage to the v7.0.0 commit SHA, leaving other action references unchanged.

## Instructions

- **Approve** to merge this fix
- **Request changes** to trigger a new remediation attempt
- `/camper rebase` — rebase onto the base branch
- `/camper close` — close this PR without merging
- `/camper retry` — regenerate the fix from scratch against the current base