### PR TITLE
Initial group ID support for pollers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,10 @@ to docs, or any other relevant information.
   environment. This lets host processes that register a single shared factory (e.g.
   `roadrunner-temporal` / the PHP SDK) use dynamic workflows.
 - Merged link-converter class in the server and sdk-go and moved it to api-go
+- Added poller-group-aware autoscaling for multi-cell namespaces. Autoscaling workers maintain poll
+  coverage for every server-provided group and distribute additional polls according to the provided weights. 
+  Required group coverage may exceed the configured maximum poller count; workflow normal and sticky pollers
+  maintain coverage independently.
 - Nexus operations with `NexusOperationCancellationTypeAbandon` no longer panic the workflow task when
   the operation later starts or completes after the caller is canceled.
 - Session worker: stopping a worker while it is at its maximum concurrent session count no longer blocks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ to docs, or any other relevant information.
   environment. This lets host processes that register a single shared factory (e.g.
   `roadrunner-temporal` / the PHP SDK) use dynamic workflows.
 - Merged link-converter class in the server and sdk-go and moved it to api-go
+- Added poller-group-aware autoscaling for multi-cell namespaces. Autoscaling workers maintain poll coverage for every server-provided group and distribute additional polls according to the provided weights.
 
 ## [1.46.0] - 2026-07-07
 

--- a/internal/client.go
+++ b/internal/client.go
@@ -1644,6 +1644,7 @@ func NewServiceClient(workflowServiceClient workflowservice.WorkflowServiceClien
 		getSystemInfoTimeout:    options.ConnectionOptions.GetSystemInfoTimeout,
 		workerHeartbeatInterval: heartbeatInterval,
 		workerGroupingKey:       uuid.NewString(),
+		pollerGroupInfoStore:    newPollerGroupInfoStore(),
 		storageParams:           storageParams,
 		storageDriverTypes:      storageDriverTypes,
 		payloadWarningLimits:    payloadWarningLimits,

--- a/internal/client.go
+++ b/internal/client.go
@@ -1727,6 +1727,7 @@ func NewServiceClient(workflowServiceClient workflowservice.WorkflowServiceClien
 		getSystemInfoTimeout:    options.ConnectionOptions.GetSystemInfoTimeout,
 		workerHeartbeatInterval: heartbeatInterval,
 		workerGroupingKey:       uuid.NewString(),
+		pollerGroupInfoStore:    newPollerGroupInfoStore(),
 		sdkName:                 sdkName,
 		sdkVersion:              sdkVersion,
 		storageParams:           storageParams,

--- a/internal/grpc_dialer.go
+++ b/internal/grpc_dialer.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/retry"
+	"go.temporal.io/api/proxy"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/sdk/internal/common/metrics"
 	"go.temporal.io/sdk/internal/common/retry"
@@ -23,6 +24,7 @@ import (
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 )
 
 type (
@@ -178,8 +180,8 @@ func requiredInterceptors(
 			interceptors = append(interceptors, interceptor)
 		}
 	}
-	// Add namespace provider interceptor
-	interceptors = append(interceptors, namespaceProviderInterceptor())
+	// Add temporal header interceptor (namespace + resource ID)
+	interceptors = append(interceptors, temporalHeaderInterceptor())
 	return interceptors
 }
 
@@ -213,12 +215,16 @@ func appendIdentityCompressor(opts []grpc.CallOption) []grpc.CallOption {
 	return append(identityOpts, grpc.UseCompressor(encoding.Identity))
 }
 
-func namespaceProviderInterceptor() grpc.UnaryClientInterceptor {
+func temporalHeaderInterceptor() grpc.UnaryClientInterceptor {
 	return func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
-		if nsReq, ok := req.(interface{ GetNamespace() string }); ok {
-			// Only add namespace if it doesn't already exist
-			if md, _ := metadata.FromOutgoingContext(ctx); len(md.Get(temporalNamespaceHeaderKey)) == 0 {
-				ctx = metadata.AppendToOutgoingContext(ctx, temporalNamespaceHeaderKey, nsReq.GetNamespace())
+		var extractOpts proxy.ExtractHeadersOptions
+		extractOpts.Request, _ = req.(proto.Message)
+		extractOpts.ExistingMetadata, _ = metadata.FromOutgoingContext(ctx)
+		if extractOpts.Request != nil {
+			if headers, err := proxy.ExtractTemporalRequestHeaders(ctx, extractOpts); err != nil {
+				return err
+			} else if len(headers) > 0 {
+				ctx = metadata.AppendToOutgoingContext(ctx, headers...)
 			}
 		}
 		return invoker(ctx, method, req, reply, cc, opts...)

--- a/internal/grpc_dialer_test.go
+++ b/internal/grpc_dialer_test.go
@@ -684,7 +684,7 @@ func TestExistingContextMetadataJoinedWithSDKHeaders(t *testing.T) {
 	)
 }
 
-func TestNamespaceInterceptor(t *testing.T) {
+func TestTemporalHeaderInterceptor(t *testing.T) {
 	srv, err := startTestGRPCServer()
 	require.NoError(t, err)
 	defer srv.Stop()
@@ -703,11 +703,17 @@ func TestNamespaceInterceptor(t *testing.T) {
 		metadata.ValueFromIncomingContext(srv.getSystemInfoRequestContext, temporalNamespaceHeaderKey),
 	)
 	// Verify namespace header is set on a request that does have namespace on the request
-	require.NoError(t, client.SignalWorkflow(t.Context(), "workflowid", "runid", "signalname", nil))
+	require.NoError(t, client.SignalWorkflow(t.Context(), "test-workflow-id", "runid", "signalname", nil))
 	require.Equal(
 		t,
 		[]string{"test-namespace"},
 		metadata.ValueFromIncomingContext(srv.lastSignalWorkflowExecutionContext, temporalNamespaceHeaderKey),
+	)
+	// Verify resource-id header is also set
+	require.Equal(
+		t,
+		[]string{"workflow:test-workflow-id"},
+		metadata.ValueFromIncomingContext(srv.lastSignalWorkflowExecutionContext, "temporal-resource-id"),
 	)
 }
 

--- a/internal/internal_nexus_task_handler.go
+++ b/internal/internal_nexus_task_handler.go
@@ -95,9 +95,10 @@ func newNexusTaskHandler(
 
 func (h *nexusTaskHandler) Execute(task *workflowservice.PollNexusTaskQueueResponse) (*workflowservice.RespondNexusTaskCompletedRequest, *workflowservice.RespondNexusTaskFailedRequest, error) {
 	failureReasonSupport := getEffectiveTemporalFailureResponses(task.GetRequest().GetCapabilities().GetTemporalFailureResponses())
+	pollerGroupID := task.GetPollerGroupId()
 	nctx, handlerErr := h.newNexusOperationContext(task)
 	if handlerErr != nil {
-		failureRequest, err := h.fillInFailure(task.TaskToken, handlerErr, failureReasonSupport)
+		failureRequest, err := h.fillInFailure(task.TaskToken, handlerErr, failureReasonSupport, pollerGroupID)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -108,13 +109,13 @@ func (h *nexusTaskHandler) Execute(task *workflowservice.PollNexusTaskQueueRespo
 		return nil, nil, err
 	}
 	if handlerErr != nil {
-		failureRequest, err := h.fillInFailure(task.TaskToken, handlerErr, failureReasonSupport)
+		failureRequest, err := h.fillInFailure(task.TaskToken, handlerErr, failureReasonSupport, pollerGroupID)
 		if err != nil {
 			return nil, nil, err
 		}
 		return nil, failureRequest, nil
 	}
-	completedRequest, err := h.fillInCompletion(task.TaskToken, res, failureReasonSupport)
+	completedRequest, err := h.fillInCompletion(task.TaskToken, res, failureReasonSupport, pollerGroupID)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -123,18 +124,19 @@ func (h *nexusTaskHandler) Execute(task *workflowservice.PollNexusTaskQueueRespo
 
 func (h *nexusTaskHandler) ExecuteContext(nctx *NexusOperationContext, task *workflowservice.PollNexusTaskQueueResponse) (*workflowservice.RespondNexusTaskCompletedRequest, *workflowservice.RespondNexusTaskFailedRequest, error) {
 	failureReasonSupport := getEffectiveTemporalFailureResponses(task.GetRequest().GetCapabilities().GetTemporalFailureResponses())
+	pollerGroupID := task.GetPollerGroupId()
 	res, handlerErr, err := h.execute(nctx, task)
 	if err != nil {
 		return nil, nil, err
 	}
 	if handlerErr != nil {
-		failureRequest, err := h.fillInFailure(task.TaskToken, handlerErr, failureReasonSupport)
+		failureRequest, err := h.fillInFailure(task.TaskToken, handlerErr, failureReasonSupport, pollerGroupID)
 		if err != nil {
 			return nil, nil, err
 		}
 		return nil, failureRequest, nil
 	}
-	completedRequest, err := h.fillInCompletion(task.TaskToken, res, failureReasonSupport)
+	completedRequest, err := h.fillInCompletion(task.TaskToken, res, failureReasonSupport, pollerGroupID)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -489,7 +491,7 @@ func (h *nexusTaskHandler) newNexusOperationContext(response *workflowservice.Po
 	}, nil
 }
 
-func (h *nexusTaskHandler) fillInCompletion(taskToken []byte, res *nexuspb.Response, failureReasonSupport bool) (*workflowservice.RespondNexusTaskCompletedRequest, error) {
+func (h *nexusTaskHandler) fillInCompletion(taskToken []byte, res *nexuspb.Response, failureReasonSupport bool, pollerGroupID string) (*workflowservice.RespondNexusTaskCompletedRequest, error) {
 	// Handle conversion of Failure to OperationError for backwards compatibility with old servers.
 	if res.GetStartOperation().GetFailure() != nil && !failureReasonSupport {
 		// Convert to operation error for backwards compatibility.
@@ -518,18 +520,20 @@ func (h *nexusTaskHandler) fillInCompletion(taskToken []byte, res *nexuspb.Respo
 		}
 	}
 	return &workflowservice.RespondNexusTaskCompletedRequest{
-		Identity:  h.identity,
-		Namespace: h.namespace,
-		TaskToken: taskToken,
-		Response:  res,
+		Identity:      h.identity,
+		Namespace:     h.namespace,
+		TaskToken:     taskToken,
+		Response:      res,
+		PollerGroupId: pollerGroupID,
 	}, nil
 }
 
-func (h *nexusTaskHandler) fillInFailure(taskToken []byte, handlerError *nexus.HandlerError, failureReasonSupport bool) (*workflowservice.RespondNexusTaskFailedRequest, error) {
+func (h *nexusTaskHandler) fillInFailure(taskToken []byte, handlerError *nexus.HandlerError, failureReasonSupport bool, pollerGroupID string) (*workflowservice.RespondNexusTaskFailedRequest, error) {
 	r := &workflowservice.RespondNexusTaskFailedRequest{
-		Identity:  h.identity,
-		Namespace: h.namespace,
-		TaskToken: taskToken,
+		Identity:      h.identity,
+		Namespace:     h.namespace,
+		TaskToken:     taskToken,
+		PollerGroupId: pollerGroupID,
 	}
 	if failureReasonSupport {
 		r.Failure = h.failureConverter.ErrorToFailure(handlerError)

--- a/internal/internal_nexus_task_handler.go
+++ b/internal/internal_nexus_task_handler.go
@@ -95,9 +95,10 @@ func newNexusTaskHandler(
 
 func (h *nexusTaskHandler) Execute(task *workflowservice.PollNexusTaskQueueResponse) (*workflowservice.RespondNexusTaskCompletedRequest, *workflowservice.RespondNexusTaskFailedRequest, error) {
 	failureReasonSupport := getEffectiveTemporalFailureResponses(task.GetRequest().GetCapabilities().GetTemporalFailureResponses())
+	pollerGroupID := task.GetPollerGroupId()
 	nctx, handlerErr := h.newNexusOperationContext(task)
 	if handlerErr != nil {
-		failureRequest, err := h.fillInFailure(task.TaskToken, handlerErr, failureReasonSupport)
+		failureRequest, err := h.fillInFailure(task.TaskToken, handlerErr, failureReasonSupport, pollerGroupID)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -108,13 +109,13 @@ func (h *nexusTaskHandler) Execute(task *workflowservice.PollNexusTaskQueueRespo
 		return nil, nil, err
 	}
 	if handlerErr != nil {
-		failureRequest, err := h.fillInFailure(task.TaskToken, handlerErr, failureReasonSupport)
+		failureRequest, err := h.fillInFailure(task.TaskToken, handlerErr, failureReasonSupport, pollerGroupID)
 		if err != nil {
 			return nil, nil, err
 		}
 		return nil, failureRequest, nil
 	}
-	completedRequest, err := h.fillInCompletion(task.TaskToken, res, failureReasonSupport)
+	completedRequest, err := h.fillInCompletion(task.TaskToken, res, failureReasonSupport, pollerGroupID)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -123,18 +124,19 @@ func (h *nexusTaskHandler) Execute(task *workflowservice.PollNexusTaskQueueRespo
 
 func (h *nexusTaskHandler) ExecuteContext(nctx *NexusOperationContext, task *workflowservice.PollNexusTaskQueueResponse) (*workflowservice.RespondNexusTaskCompletedRequest, *workflowservice.RespondNexusTaskFailedRequest, error) {
 	failureReasonSupport := getEffectiveTemporalFailureResponses(task.GetRequest().GetCapabilities().GetTemporalFailureResponses())
+	pollerGroupID := task.GetPollerGroupId()
 	res, handlerErr, err := h.execute(nctx, task)
 	if err != nil {
 		return nil, nil, err
 	}
 	if handlerErr != nil {
-		failureRequest, err := h.fillInFailure(task.TaskToken, handlerErr, failureReasonSupport)
+		failureRequest, err := h.fillInFailure(task.TaskToken, handlerErr, failureReasonSupport, pollerGroupID)
 		if err != nil {
 			return nil, nil, err
 		}
 		return nil, failureRequest, nil
 	}
-	completedRequest, err := h.fillInCompletion(task.TaskToken, res, failureReasonSupport)
+	completedRequest, err := h.fillInCompletion(task.TaskToken, res, failureReasonSupport, pollerGroupID)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -489,7 +491,7 @@ func (h *nexusTaskHandler) newNexusOperationContext(response *workflowservice.Po
 	}, nil
 }
 
-func (h *nexusTaskHandler) fillInCompletion(taskToken []byte, res *nexuspb.Response, failureReasonSupport bool) (*workflowservice.RespondNexusTaskCompletedRequest, error) {
+func (h *nexusTaskHandler) fillInCompletion(taskToken []byte, res *nexuspb.Response, failureReasonSupport bool, pollerGroupID string) (*workflowservice.RespondNexusTaskCompletedRequest, error) {
 	// Handle conversion of Failure to OperationError for backwards compatibility with old servers.
 	if res.GetStartOperation().GetFailure() != nil && !failureReasonSupport {
 		// Convert to operation error for backwards compatibility.
@@ -519,18 +521,20 @@ func (h *nexusTaskHandler) fillInCompletion(taskToken []byte, res *nexuspb.Respo
 		}
 	}
 	return &workflowservice.RespondNexusTaskCompletedRequest{
-		Identity:  h.identity,
-		Namespace: h.namespace,
-		TaskToken: taskToken,
-		Response:  res,
+		Identity:      h.identity,
+		Namespace:     h.namespace,
+		TaskToken:     taskToken,
+		Response:      res,
+		PollerGroupId: pollerGroupID,
 	}, nil
 }
 
-func (h *nexusTaskHandler) fillInFailure(taskToken []byte, handlerError *nexus.HandlerError, failureReasonSupport bool) (*workflowservice.RespondNexusTaskFailedRequest, error) {
+func (h *nexusTaskHandler) fillInFailure(taskToken []byte, handlerError *nexus.HandlerError, failureReasonSupport bool, pollerGroupID string) (*workflowservice.RespondNexusTaskFailedRequest, error) {
 	r := &workflowservice.RespondNexusTaskFailedRequest{
-		Identity:  h.identity,
-		Namespace: h.namespace,
-		TaskToken: taskToken,
+		Identity:      h.identity,
+		Namespace:     h.namespace,
+		TaskToken:     taskToken,
+		PollerGroupId: pollerGroupID,
 	}
 	if failureReasonSupport {
 		r.Failure = h.failureConverter.ErrorToFailure(handlerError)

--- a/internal/internal_nexus_task_handler_response_link_test.go
+++ b/internal/internal_nexus_task_handler_response_link_test.go
@@ -4,13 +4,18 @@ import (
 	"context"
 	"testing"
 
+	"github.com/golang/mock/gomock"
 	"github.com/nexus-rpc/sdk-go/nexus"
 	"github.com/stretchr/testify/require"
 
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	nexuspb "go.temporal.io/api/nexus/v1"
+	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/api/workflowservicemock/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"go.temporal.io/sdk/converter"
 	"go.temporal.io/sdk/internal/common/metrics"
@@ -163,6 +168,64 @@ func TestNexusCompletionForwardsPollerGroupID(t *testing.T) {
 	require.Nil(t, failed)
 	require.NotNil(t, completed)
 	require.Equal(t, "nexus-pg-complete", completed.PollerGroupId)
+}
+
+func TestNexusPollerCompletionUsesResponsePollerGroupID(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	service := workflowservicemock.NewMockWorkflowServiceClient(ctrl)
+	const (
+		requestGroupID  = "request-poller-group"
+		responseGroupID = "response-poller-group"
+		namespace       = "test-ns"
+		taskQueue       = "test-task-queue"
+		identity        = "test-worker"
+	)
+
+	task := responseLinkTestTask(t, "input")
+	task.PollerGroupId = responseGroupID
+	task.Request.ScheduledTime = timestamppb.Now()
+
+	service.EXPECT().PollNexusTaskQueue(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, req *workflowservice.PollNexusTaskQueueRequest, _ ...grpc.CallOption) (*workflowservice.PollNexusTaskQueueResponse, error) {
+			require.Equal(t, requestGroupID, req.GetPollerGroupId())
+			return task, nil
+		})
+	service.EXPECT().RespondNexusTaskCompleted(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, req *workflowservice.RespondNexusTaskCompletedRequest, _ ...grpc.CallOption) (*workflowservice.RespondNexusTaskCompletedResponse, error) {
+			require.Equal(t, responseGroupID, req.GetPollerGroupId())
+			return &workflowservice.RespondNexusTaskCompletedResponse{}, nil
+		})
+
+	pollerGroups := newPollerGroupManager(false)
+	pollerGroups.updateGroups([]*taskqueuepb.PollerGroupInfo{
+		{Id: requestGroupID, Weight: 1},
+	})
+	handler := newResponseLinkTestTaskHandler(t, false)
+	handler.client = &WorkflowClient{
+		workflowService: service,
+		identity:        identity,
+	}
+	poller := &nexusTaskPoller{
+		basePoller: basePoller{
+			metricsHandler:  metrics.NopHandler,
+			pollTimeTracker: &pollTimeTracker{},
+		},
+		namespace:       namespace,
+		taskQueueName:   taskQueue,
+		identity:        identity,
+		service:         service,
+		taskHandler:     handler,
+		logger:          ilog.NewDefaultLogger(),
+		numPollerMetric: newNumPollerMetric(metrics.NopHandler, metrics.PollerTypeNexusTask),
+		pollerGroups:    pollerGroups,
+	}
+
+	polledTask, err := poller.poll(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, polledTask)
+	require.NoError(t, poller.ProcessTask(polledTask))
 }
 
 func TestNexusFailureForwardsPollerGroupID(t *testing.T) {

--- a/internal/internal_nexus_task_handler_response_link_test.go
+++ b/internal/internal_nexus_task_handler_response_link_test.go
@@ -198,10 +198,10 @@ func TestNexusPollerCompletionUsesResponsePollerGroupID(t *testing.T) {
 			return &workflowservice.RespondNexusTaskCompletedResponse{}, nil
 		})
 
-	pollerGroups := newPollerGroupManager(false)
-	pollerGroups.updateGroups([]*taskqueuepb.PollerGroupInfo{
+	pollerGroups := newPollerGroupManager(false, nil)
+	pollerGroups.updateGroups(testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{
 		{Id: requestGroupID, Weight: 1},
-	})
+	}))
 	handler := newResponseLinkTestTaskHandler(t, false)
 	handler.client = &WorkflowClient{
 		workflowService: service,

--- a/internal/internal_nexus_task_handler_response_link_test.go
+++ b/internal/internal_nexus_task_handler_response_link_test.go
@@ -150,3 +150,43 @@ func TestResponseOmitsResponseLinksWhenNoneStashed(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, completed.GetResponse().GetStartOperation().GetSyncSuccess().GetLinks())
 }
+
+func TestNexusCompletionForwardsPollerGroupID(t *testing.T) {
+	h := newResponseLinkTestTaskHandler(t, false)
+	task := responseLinkTestTask(t, "input")
+	task.PollerGroupId = "nexus-pg-complete"
+
+	nctx, handlerErr := h.newNexusOperationContext(task)
+	require.Nil(t, handlerErr)
+	completed, failed, err := h.ExecuteContext(nctx, task)
+	require.NoError(t, err)
+	require.Nil(t, failed)
+	require.NotNil(t, completed)
+	require.Equal(t, "nexus-pg-complete", completed.PollerGroupId)
+}
+
+func TestNexusFailureForwardsPollerGroupID(t *testing.T) {
+	h := newNexusTaskHandler(
+		nil,
+		"identity",
+		signalLinkTestNamespace,
+		"tq",
+		nil,
+		converter.GetDefaultDataConverter(),
+		GetDefaultFailureConverter(),
+		ilog.NewDefaultLogger(),
+		metrics.NopHandler,
+		newRegistry(),
+	)
+	task := &workflowservice.PollNexusTaskQueueResponse{
+		TaskToken:     []byte("token"),
+		PollerGroupId: "nexus-pg-fail",
+		Request:       &nexuspb.Request{},
+	}
+
+	completed, failed, err := h.Execute(task)
+	require.NoError(t, err)
+	require.Nil(t, completed)
+	require.NotNil(t, failed)
+	require.Equal(t, "nexus-pg-fail", failed.PollerGroupId)
+}

--- a/internal/internal_nexus_task_handler_response_link_test.go
+++ b/internal/internal_nexus_task_handler_response_link_test.go
@@ -7,13 +7,18 @@ import (
 	"log/slog"
 	"testing"
 
+	"github.com/golang/mock/gomock"
 	"github.com/nexus-rpc/sdk-go/nexus"
 	"github.com/stretchr/testify/require"
 
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	nexuspb "go.temporal.io/api/nexus/v1"
+	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/api/workflowservicemock/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"go.temporal.io/sdk/converter"
 	"go.temporal.io/sdk/internal/common/metrics"
@@ -177,4 +182,104 @@ func TestMalformedRequestLinkLogsStructuredFields(t *testing.T) {
 	require.Equal(t, `parse "https://example.com/%zz": invalid URL escape "%zz"`, entry[tagError])
 	require.NotContains(t, entry, "!BADKEY")
 	require.NotContains(t, entry, malformedURL)
+}
+
+func TestNexusCompletionForwardsPollerGroupID(t *testing.T) {
+	h := newResponseLinkTestTaskHandler(t, false)
+	task := responseLinkTestTask(t, "input")
+	task.PollerGroupId = "nexus-pg-complete"
+
+	nctx, handlerErr := h.newNexusOperationContext(task)
+	require.Nil(t, handlerErr)
+	completed, failed, err := h.ExecuteContext(nctx, task)
+	require.NoError(t, err)
+	require.Nil(t, failed)
+	require.NotNil(t, completed)
+	require.Equal(t, "nexus-pg-complete", completed.PollerGroupId)
+}
+
+func TestNexusPollerCompletionUsesResponsePollerGroupID(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	service := workflowservicemock.NewMockWorkflowServiceClient(ctrl)
+	const (
+		requestGroupID  = "request-poller-group"
+		responseGroupID = "response-poller-group"
+		namespace       = "test-ns"
+		taskQueue       = "test-task-queue"
+		identity        = "test-worker"
+	)
+
+	task := responseLinkTestTask(t, "input")
+	task.PollerGroupId = responseGroupID
+	task.Request.ScheduledTime = timestamppb.Now()
+
+	service.EXPECT().PollNexusTaskQueue(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, req *workflowservice.PollNexusTaskQueueRequest, _ ...grpc.CallOption) (*workflowservice.PollNexusTaskQueueResponse, error) {
+			require.Equal(t, requestGroupID, req.GetPollerGroupId())
+			return task, nil
+		})
+	service.EXPECT().RespondNexusTaskCompleted(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, req *workflowservice.RespondNexusTaskCompletedRequest, _ ...grpc.CallOption) (*workflowservice.RespondNexusTaskCompletedResponse, error) {
+			require.Equal(t, responseGroupID, req.GetPollerGroupId())
+			return &workflowservice.RespondNexusTaskCompletedResponse{}, nil
+		})
+
+	pollerGroups := newPollerGroupManager(pollerGroupModeNonWorkflow, nil)
+	pollerGroups.updateGroups(testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{
+		{Id: requestGroupID, Weight: 1},
+	}))
+	lease := pollerGroups.reserve()
+	defer lease.release()
+	handler := newResponseLinkTestTaskHandler(t, false)
+	handler.client = &WorkflowClient{
+		workflowService: service,
+		identity:        identity,
+	}
+	poller := &nexusTaskPoller{
+		basePoller: basePoller{
+			metricsHandler:  metrics.NopHandler,
+			pollTimeTracker: &pollTimeTracker{},
+		},
+		namespace:       namespace,
+		taskQueueName:   taskQueue,
+		identity:        identity,
+		service:         service,
+		taskHandler:     handler,
+		logger:          ilog.NewDefaultLogger(),
+		numPollerMetric: newNumPollerMetric(metrics.NopHandler, metrics.PollerTypeNexusTask),
+		pollerGroups:    pollerGroups,
+	}
+
+	polledTask, err := poller.PollTask(lease)
+	require.NoError(t, err)
+	require.NotNil(t, polledTask)
+	require.NoError(t, poller.ProcessTask(polledTask))
+}
+
+func TestNexusFailureForwardsPollerGroupID(t *testing.T) {
+	h := newNexusTaskHandler(
+		nil,
+		"identity",
+		signalLinkTestNamespace,
+		"tq",
+		nil,
+		converter.GetDefaultDataConverter(),
+		GetDefaultFailureConverter(),
+		ilog.NewDefaultLogger(),
+		metrics.NopHandler,
+		newRegistry(),
+	)
+	task := &workflowservice.PollNexusTaskQueueResponse{
+		TaskToken:     []byte("token"),
+		PollerGroupId: "nexus-pg-fail",
+		Request:       &nexuspb.Request{},
+	}
+
+	completed, failed, err := h.Execute(task)
+	require.NoError(t, err)
+	require.Nil(t, completed)
+	require.NotNil(t, failed)
+	require.Equal(t, "nexus-pg-fail", failed.PollerGroupId)
 }

--- a/internal/internal_nexus_task_poller.go
+++ b/internal/internal_nexus_task_poller.go
@@ -88,7 +88,7 @@ func (ntp *nexusTaskPoller) poll(ctx context.Context) (taskForWorker, error) {
 		WorkerInstanceKey: ntp.workerInstanceKey,
 	}
 
-	lease := ntp.pollerGroups.reserve(enumspb.TASK_QUEUE_KIND_NORMAL)
+	lease := ntp.pollerGroups.reserve()
 	defer lease.release()
 	request.PollerGroupId = lease.groupIDOrEmpty()
 

--- a/internal/internal_nexus_task_poller.go
+++ b/internal/internal_nexus_task_poller.go
@@ -47,6 +47,7 @@ func newNexusTaskPoller(
 			capabilities:                 params.capabilities,
 			pollTimeTracker:              params.pollTimeTracker,
 			workerInstanceKey:            params.workerInstanceKey,
+			pollerGroupInfoStore:         params.pollerGroupInfoStore,
 			workerPollCompleteOnShutdown: params.workerPollCompleteOnShutdown,
 		},
 		taskHandler:     taskHandler,
@@ -97,7 +98,7 @@ func (ntp *nexusTaskPoller) poll(ctx context.Context) (taskForWorker, error) {
 		return nil, err
 	}
 	if response != nil {
-		ntp.pollerGroups.updateGroups(response.GetPollerGroupInfos())
+		ntp.updatePollerGroups(ntp.pollerGroups, response.GetPollerGroupsInfo())
 	}
 	if response == nil || len(response.TaskToken) == 0 {
 		// No operation info is available on empty poll. Emit using base scope.

--- a/internal/internal_nexus_task_poller.go
+++ b/internal/internal_nexus_task_poller.go
@@ -22,6 +22,7 @@ type nexusTaskPoller struct {
 	taskHandler     *nexusTaskHandler
 	logger          log.Logger
 	numPollerMetric *numPollerMetric
+	pollerGroups    *pollerGroupManager
 }
 
 type nexusTask struct {
@@ -34,6 +35,7 @@ func newNexusTaskPoller(
 	taskHandler *nexusTaskHandler,
 	service workflowservice.WorkflowServiceClient,
 	params workerExecutionParameters,
+	pollerGroups *pollerGroupManager,
 ) *nexusTaskPoller {
 	return &nexusTaskPoller{
 		basePoller: basePoller{
@@ -54,6 +56,7 @@ func newNexusTaskPoller(
 		identity:        params.Identity,
 		logger:          params.Logger,
 		numPollerMetric: newNumPollerMetric(params.MetricsHandler, metrics.PollerTypeNexusTask),
+		pollerGroups:    pollerGroups,
 	}
 }
 
@@ -85,9 +88,16 @@ func (ntp *nexusTaskPoller) poll(ctx context.Context) (taskForWorker, error) {
 		WorkerInstanceKey: ntp.workerInstanceKey,
 	}
 
+	lease := ntp.pollerGroups.reserve(enumspb.TASK_QUEUE_KIND_NORMAL)
+	defer lease.release()
+	request.PollerGroupId = lease.groupIDOrEmpty()
+
 	response, err := ntp.pollNexusTaskQueue(ctx, request)
 	if err != nil {
 		return nil, err
+	}
+	if response != nil {
+		ntp.pollerGroups.updateGroups(response.GetPollerGroupInfos())
 	}
 	if response == nil || len(response.TaskToken) == 0 {
 		// No operation info is available on empty poll. Emit using base scope.
@@ -131,7 +141,7 @@ func (ntp *nexusTaskPoller) ProcessTask(task interface{}) error {
 	nctx, handlerErr := ntp.taskHandler.newNexusOperationContext(response)
 	if handlerErr != nil {
 		// context wasn't propagated to us, use a background context.
-		failedRequest, err := ntp.taskHandler.fillInFailure(response.TaskToken, handlerErr, getEffectiveTemporalFailureResponses(response.GetRequest().GetCapabilities().GetTemporalFailureResponses()))
+		failedRequest, err := ntp.taskHandler.fillInFailure(response.TaskToken, handlerErr, getEffectiveTemporalFailureResponses(response.GetRequest().GetCapabilities().GetTemporalFailureResponses()), response.GetPollerGroupId())
 		if err != nil {
 			return err
 		}

--- a/internal/internal_nexus_task_poller.go
+++ b/internal/internal_nexus_task_poller.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/nexus-rpc/sdk-go/nexus"
@@ -25,6 +26,7 @@ type nexusTaskPoller struct {
 	inboundPayloadVisitor  PayloadVisitor
 	outboundPayloadVisitor PayloadVisitor
 	backgroundContext      context.Context
+	pollerGroups           *pollerGroupManager
 }
 
 type nexusTask struct {
@@ -37,6 +39,7 @@ func newNexusTaskPoller(
 	taskHandler *nexusTaskHandler,
 	service workflowservice.WorkflowServiceClient,
 	params workerExecutionParameters,
+	pollerGroups *pollerGroupManager,
 ) *nexusTaskPoller {
 	backgroundContext := params.BackgroundContext
 	if backgroundContext == nil {
@@ -52,6 +55,7 @@ func newNexusTaskPoller(
 			capabilities:                 params.capabilities,
 			pollTimeTracker:              params.pollTimeTracker,
 			workerInstanceKey:            params.workerInstanceKey,
+			pollerGroupInfoStore:         params.pollerGroupInfoStore,
 			workerPollCompleteOnShutdown: params.workerPollCompleteOnShutdown,
 		},
 		taskHandler:     taskHandler,
@@ -65,6 +69,7 @@ func newNexusTaskPoller(
 		inboundPayloadVisitor:  params.inboundPayloadVisitor,
 		outboundPayloadVisitor: params.outboundPayloadVisitor,
 		backgroundContext:      backgroundContext,
+		pollerGroups:           pollerGroups,
 	}
 }
 
@@ -77,6 +82,15 @@ func (ntp *nexusTaskPoller) pollNexusTaskQueue(ctx context.Context, request *wor
 }
 
 func (ntp *nexusTaskPoller) poll(ctx context.Context) (taskForWorker, error) {
+	lease := ntp.pollerGroups.reserve()
+	defer lease.release()
+	return ntp.pollWithLease(ctx, lease)
+}
+
+func (ntp *nexusTaskPoller) pollWithLease(
+	ctx context.Context,
+	lease pollerGroupLease,
+) (taskForWorker, error) {
 	traceLog(func() {
 		ntp.logger.Debug("nexusTaskPoller::Poll")
 	})
@@ -97,9 +111,14 @@ func (ntp *nexusTaskPoller) poll(ctx context.Context) (taskForWorker, error) {
 		WorkerInstanceKey: ntp.workerInstanceKey,
 	}
 
+	request.PollerGroupId = lease.groupIDOrEmpty()
+
 	response, err := ntp.pollNexusTaskQueue(ctx, request)
 	if err != nil {
 		return nil, err
+	}
+	if response != nil {
+		ntp.updatePollerGroups(ntp.pollerGroups, response.GetPollerGroupsInfo())
 	}
 	if response == nil || len(response.TaskToken) == 0 {
 		// No operation info is available on empty poll. Emit using base scope.
@@ -113,8 +132,17 @@ func (ntp *nexusTaskPoller) poll(ctx context.Context) (taskForWorker, error) {
 }
 
 // PollTask polls a new task
-func (ntp *nexusTaskPoller) PollTask() (taskForWorker, error) {
-	return ntp.doPoll(ntp.poll)
+func (ntp *nexusTaskPoller) PollTask(lease pollerGroupLease) (taskForWorker, error) {
+	poll := ntp.poll
+	if lease.manager != nil {
+		if lease.manager != ntp.pollerGroups {
+			return nil, errors.New("nexus poller-group lease belongs to a different manager")
+		}
+		poll = func(ctx context.Context) (taskForWorker, error) {
+			return ntp.pollWithLease(ctx, lease)
+		}
+	}
+	return ntp.doPoll(poll)
 }
 
 // ProcessTask processes a new task
@@ -143,7 +171,7 @@ func (ntp *nexusTaskPoller) ProcessTask(task any) error {
 	nctx, handlerErr := ntp.taskHandler.newNexusOperationContext(response)
 	if handlerErr != nil {
 		// context wasn't propagated to us, use a background context.
-		failedRequest, err := ntp.taskHandler.fillInFailure(response.TaskToken, handlerErr, getEffectiveTemporalFailureResponses(response.GetRequest().GetCapabilities().GetTemporalFailureResponses()))
+		failedRequest, err := ntp.taskHandler.fillInFailure(response.TaskToken, handlerErr, getEffectiveTemporalFailureResponses(response.GetRequest().GetCapabilities().GetTemporalFailureResponses()), response.GetPollerGroupId())
 		if err != nil {
 			return err
 		}
@@ -280,6 +308,7 @@ func (ntp *nexusTaskPoller) reportExternalStorageFailure(
 		response.TaskToken,
 		handlerErr,
 		getEffectiveTemporalFailureResponses(response.GetRequest().GetCapabilities().GetTemporalFailureResponses()),
+		response.GetPollerGroupId(),
 	)
 	if err != nil {
 		return err

--- a/internal/internal_nexus_worker.go
+++ b/internal/internal_nexus_worker.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"github.com/nexus-rpc/sdk-go/nexus"
 	enumspb "go.temporal.io/api/enums/v1"
+	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/sdk/internal/common/metrics"
 )
@@ -19,6 +20,7 @@ type nexusWorker struct {
 	executionParameters workerExecutionParameters
 	workflowService     workflowservice.WorkflowServiceClient
 	worker              *baseWorker
+	pollerGroups        *pollerGroupManager
 	// stopC is created by newNexusWorker, exposed to the Nexus task poller through
 	// WorkerStopChannel, and closed by nexusWorker.Stop() during shutdown.
 	stopC chan struct{}
@@ -29,6 +31,10 @@ func newNexusWorker(opts nexusWorkerOptions) (*nexusWorker, error) {
 	params := opts.executionParameters
 	params.WorkerStopChannel = getReadOnlyChannel(workerStopChannel)
 	ensureRequiredParams(&params)
+	var pollerGroups *pollerGroupManager
+	if _, ok := params.NexusTaskPollerBehavior.(*pollerBehaviorAutoscaling); ok {
+		pollerGroups = newPollerGroupManager(false)
+	}
 	poller := newNexusTaskPoller(
 		newNexusTaskHandler(
 			opts.handler,
@@ -44,6 +50,7 @@ func newNexusWorker(opts nexusWorkerOptions) (*nexusWorker, error) {
 		),
 		opts.workflowService,
 		params,
+		pollerGroups,
 	)
 
 	bwo := baseWorkerOptions{
@@ -57,6 +64,7 @@ func newNexusWorker(opts nexusWorkerOptions) (*nexusWorker, error) {
 				params.NexusTaskPollerBehavior,
 				metrics.PollerTypeNexusTask,
 				params.serverSupportsAutoscaling,
+				pollerGroups,
 			),
 		},
 		taskProcessor:                poller,
@@ -81,8 +89,16 @@ func newNexusWorker(opts nexusWorkerOptions) (*nexusWorker, error) {
 		executionParameters: opts.executionParameters,
 		workflowService:     opts.workflowService,
 		worker:              baseWorker,
+		pollerGroups:        pollerGroups,
 		stopC:               workerStopChannel,
 	}, nil
+}
+
+func (w *nexusWorker) seedPollerGroupInfos(groups []*taskqueuepb.PollerGroupInfo) {
+	if w == nil || w.pollerGroups == nil || len(groups) == 0 {
+		return
+	}
+	w.pollerGroups.updateGroups(groups)
 }
 
 // Start the worker.

--- a/internal/internal_nexus_worker.go
+++ b/internal/internal_nexus_worker.go
@@ -3,7 +3,6 @@ package internal
 import (
 	"github.com/nexus-rpc/sdk-go/nexus"
 	enumspb "go.temporal.io/api/enums/v1"
-	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/sdk/internal/common/metrics"
 )
@@ -33,7 +32,11 @@ func newNexusWorker(opts nexusWorkerOptions) (*nexusWorker, error) {
 	ensureRequiredParams(&params)
 	var pollerGroups *pollerGroupManager
 	if _, ok := params.NexusTaskPollerBehavior.(*pollerBehaviorAutoscaling); ok {
-		pollerGroups = newPollerGroupManager(false)
+		var groupInfos *pollerGroupInfoStore
+		if client, ok := opts.client.(*WorkflowClient); ok {
+			groupInfos = client.pollerGroupInfoStore
+		}
+		pollerGroups = newPollerGroupManager(false, groupInfos)
 	}
 	poller := newNexusTaskPoller(
 		newNexusTaskHandler(
@@ -92,13 +95,6 @@ func newNexusWorker(opts nexusWorkerOptions) (*nexusWorker, error) {
 		pollerGroups:        pollerGroups,
 		stopC:               workerStopChannel,
 	}, nil
-}
-
-func (w *nexusWorker) seedPollerGroupInfos(groups []*taskqueuepb.PollerGroupInfo) {
-	if w == nil || w.pollerGroups == nil || len(groups) == 0 {
-		return
-	}
-	w.pollerGroups.updateGroups(groups)
 }
 
 // Start the worker.

--- a/internal/internal_nexus_worker.go
+++ b/internal/internal_nexus_worker.go
@@ -29,6 +29,14 @@ func newNexusWorker(opts nexusWorkerOptions) (*nexusWorker, error) {
 	params := opts.executionParameters
 	params.WorkerStopChannel = getReadOnlyChannel(workerStopChannel)
 	ensureRequiredParams(&params)
+	var pollerGroups *pollerGroupManager
+	if _, ok := params.NexusTaskPollerBehavior.(*pollerBehaviorAutoscaling); ok {
+		var groupInfos *pollerGroupInfoStore
+		if client, ok := opts.client.(*WorkflowClient); ok {
+			groupInfos = client.pollerGroupInfoStore
+		}
+		pollerGroups = newPollerGroupManager(pollerGroupModeNonWorkflow, groupInfos)
+	}
 	poller := newNexusTaskPoller(
 		newNexusTaskHandler(
 			opts.handler,
@@ -44,6 +52,7 @@ func newNexusWorker(opts nexusWorkerOptions) (*nexusWorker, error) {
 		),
 		opts.workflowService,
 		params,
+		pollerGroups,
 	)
 
 	bwo := baseWorkerOptions{
@@ -57,6 +66,7 @@ func newNexusWorker(opts nexusWorkerOptions) (*nexusWorker, error) {
 				params.NexusTaskPollerBehavior,
 				metrics.PollerTypeNexusTask,
 				params.serverSupportsAutoscaling,
+				pollerGroups,
 			),
 		},
 		taskProcessor:                poller,

--- a/internal/internal_poller_groups.go
+++ b/internal/internal_poller_groups.go
@@ -66,15 +66,14 @@ func (m *pollerGroupManager) requiredMin(queueKind enumspb.TaskQueueKind) int {
 	return m.tracker.requiredMin(queueKind)
 }
 
-func (m *pollerGroupManager) reserve(queueKind enumspb.TaskQueueKind) pollerGroupLease {
+func (m *pollerGroupManager) reserve() pollerGroupLease {
 	if m == nil || m.tracker == nil {
 		return pollerGroupLease{}
 	}
-	groupID := m.tracker.reserve(queueKind)
+	groupID := m.tracker.reserve()
 	return pollerGroupLease{
-		manager:   m,
-		groupID:   groupID,
-		queueKind: queueKind,
+		manager: m,
+		groupID: groupID,
 	}
 }
 
@@ -170,7 +169,7 @@ func (t *pollerGroupTracker) requiredMin(queueKind enumspb.TaskQueueKind) int {
 	}
 }
 
-func (t *pollerGroupTracker) reserve(queueKind enumspb.TaskQueueKind) string {
+func (t *pollerGroupTracker) reserve() string {
 	if t == nil {
 		return ""
 	}
@@ -183,7 +182,7 @@ func (t *pollerGroupTracker) reserve(queueKind enumspb.TaskQueueKind) string {
 
 	candidates := make(map[string]*pollerGroupState, len(t.groups))
 	for groupID, group := range t.groups {
-		if t.pendingCount(group, queueKind) == 0 {
+		if group.pendingPollCount == 0 {
 			candidates[groupID] = group
 		}
 	}
@@ -195,7 +194,7 @@ func (t *pollerGroupTracker) reserve(queueKind enumspb.TaskQueueKind) string {
 	if groupID == "" {
 		return ""
 	}
-	t.incrementPending(t.groups[groupID], queueKind)
+	t.groups[groupID].pendingPollCount++
 	return groupID
 }
 
@@ -216,18 +215,23 @@ func (t *pollerGroupTracker) reserveWorkflowPoll(preferredQueueKind enumspb.Task
 		return "", preferredQueueKind
 	}
 
-	if groupID := chooseHighestWeightPollerGroup(t.workflowCoverageCandidates(stickyEnabled)); groupID != "" {
-		queueKind := t.workflowCoverageQueueKind(t.groups[groupID], preferredQueueKind, stickyEnabled)
-		t.incrementPending(t.groups[groupID], queueKind)
-		return groupID, queueKind
+	groupID := chooseHighestWeightPollerGroup(t.workflowCoverageCandidates(stickyEnabled))
+	var queueKind enumspb.TaskQueueKind
+	if groupID != "" {
+		queueKind = t.workflowCoverageQueueKind(t.groups[groupID], preferredQueueKind, stickyEnabled)
+	} else {
+		groupID = choosePollerGroup(t.groups)
+		if groupID == "" {
+			return "", preferredQueueKind
+		}
+		queueKind = t.workflowFloatingQueueKind(t.groups[groupID], stickyEnabled)
 	}
 
-	groupID := choosePollerGroup(t.groups)
-	if groupID == "" {
-		return "", preferredQueueKind
+	if queueKind == enumspb.TASK_QUEUE_KIND_STICKY {
+		t.groups[groupID].workflowPendingSticky++
+	} else {
+		t.groups[groupID].workflowPendingNormal++
 	}
-	queueKind := t.workflowFloatingQueueKind(t.groups[groupID], stickyEnabled)
-	t.incrementPending(t.groups[groupID], queueKind)
 	return groupID, queueKind
 }
 
@@ -334,34 +338,6 @@ func (t *pollerGroupTracker) workflowFloatingQueueKind(group *pollerGroupState, 
 		return enumspb.TASK_QUEUE_KIND_STICKY
 	}
 	return enumspb.TASK_QUEUE_KIND_NORMAL
-}
-
-func (t *pollerGroupTracker) pendingCount(group *pollerGroupState, queueKind enumspb.TaskQueueKind) int {
-	if group == nil {
-		return 0
-	}
-	if !t.workflow {
-		return group.pendingPollCount
-	}
-	if queueKind == enumspb.TASK_QUEUE_KIND_STICKY {
-		return group.workflowPendingSticky
-	}
-	return group.workflowPendingNormal
-}
-
-func (t *pollerGroupTracker) incrementPending(group *pollerGroupState, queueKind enumspb.TaskQueueKind) {
-	if group == nil {
-		return
-	}
-	if !t.workflow {
-		group.pendingPollCount++
-		return
-	}
-	if queueKind == enumspb.TASK_QUEUE_KIND_STICKY {
-		group.workflowPendingSticky++
-	} else {
-		group.workflowPendingNormal++
-	}
 }
 
 func (t *pollerGroupTracker) decrementPending(group *pollerGroupState, queueKind enumspb.TaskQueueKind) {

--- a/internal/internal_poller_groups.go
+++ b/internal/internal_poller_groups.go
@@ -1,0 +1,424 @@
+package internal
+
+import (
+	"math/rand"
+	"sync"
+
+	enumspb "go.temporal.io/api/enums/v1"
+	taskqueuepb "go.temporal.io/api/taskqueue/v1"
+)
+
+type (
+	// pollerGroupManager gives concrete pollers a lease-based API for assigning
+	// poll requests to groups. This gives autoscaling runners access to the
+	// MCN-required minimum, and notifies registered listeners when poller group membership changes. The
+	// underlying tracker still owns the synchronized group state and selection
+	// algorithm.
+	pollerGroupManager struct {
+		tracker *pollerGroupTracker
+
+		listenersMu sync.Mutex
+		listeners   []func()
+	}
+
+	// pollerGroupLease represents the SDK-local group reservation for one
+	// poll request RPC. The lease tracks the request group ID only; response group IDs are
+	// handled separately because the server may return a different group ID for
+	// follow-up routing or sticky backlog attribution.
+	pollerGroupLease struct {
+		manager   *pollerGroupManager
+		groupID   string
+		queueKind enumspb.TaskQueueKind
+	}
+
+	pollerGroupTracker struct {
+		workflow bool
+		mu       sync.Mutex
+		groups   map[string]*pollerGroupState
+	}
+
+	pollerGroupState struct {
+		weight float32
+
+		// Activity/Nexus use total pending
+		pendingPollCount int
+
+		// Workflow uses queue-kind-specific pending counts
+		workflowPendingNormal int
+		workflowPendingSticky int
+
+		// Workflow-only. Updated from sticky poll responses using the response
+		// group ID, which may differ from the request group ID.
+		workflowStickyBacklog int64
+	}
+)
+
+func newPollerGroupManager(workflow bool) *pollerGroupManager {
+	return &pollerGroupManager{
+		tracker: newPollerGroupTracker(workflow),
+	}
+}
+
+func (m *pollerGroupManager) requiredMin(queueKind enumspb.TaskQueueKind) int {
+	if m == nil || m.tracker == nil {
+		return 0
+	}
+	return m.tracker.requiredMin(queueKind)
+}
+
+func (m *pollerGroupManager) reserve(queueKind enumspb.TaskQueueKind) pollerGroupLease {
+	if m == nil || m.tracker == nil {
+		return pollerGroupLease{}
+	}
+	groupID := m.tracker.reserve(queueKind)
+	return pollerGroupLease{
+		manager:   m,
+		groupID:   groupID,
+		queueKind: queueKind,
+	}
+}
+
+func (m *pollerGroupManager) reserveWorkflowPoll(preferredQueueKind enumspb.TaskQueueKind, stickyEnabled bool) pollerGroupLease {
+	if m == nil || m.tracker == nil {
+		return pollerGroupLease{queueKind: preferredQueueKind}
+	}
+	groupID, queueKind := m.tracker.reserveWorkflowPoll(preferredQueueKind, stickyEnabled)
+	return pollerGroupLease{
+		manager:   m,
+		groupID:   groupID,
+		queueKind: queueKind,
+	}
+}
+
+func (m *pollerGroupManager) updateGroups(groups []*taskqueuepb.PollerGroupInfo) {
+	if m == nil || m.tracker == nil || len(groups) == 0 {
+		return
+	}
+	if m.tracker.updateGroups(groups) {
+		m.signal()
+	}
+}
+
+func (m *pollerGroupManager) updateStickyBacklog(groupID string, backlogCountHint int64) {
+	if m == nil || m.tracker == nil || groupID == "" {
+		return
+	}
+	m.tracker.updateStickyBacklog(groupID, backlogCountHint)
+}
+
+func (m *pollerGroupManager) addListener(fn func()) {
+	if m == nil || fn == nil {
+		return
+	}
+	m.listenersMu.Lock()
+	defer m.listenersMu.Unlock()
+	m.listeners = append(m.listeners, fn)
+}
+
+func (m *pollerGroupManager) signal() {
+	m.listenersMu.Lock()
+	listeners := append([]func(){}, m.listeners...)
+	m.listenersMu.Unlock()
+
+	for _, fn := range listeners {
+		fn()
+	}
+}
+
+func (l pollerGroupLease) groupIDOrEmpty() string {
+	return l.groupID
+}
+
+func (l pollerGroupLease) queueKindOr(fallback enumspb.TaskQueueKind) enumspb.TaskQueueKind {
+	if l.queueKind == enumspb.TASK_QUEUE_KIND_UNSPECIFIED {
+		return fallback
+	}
+	return l.queueKind
+}
+
+func (l pollerGroupLease) release() {
+	if l.manager == nil || l.manager.tracker == nil || l.groupID == "" {
+		return
+	}
+	l.manager.tracker.release(l.groupID, l.queueKind)
+}
+
+func newPollerGroupTracker(workflow bool) *pollerGroupTracker {
+	return &pollerGroupTracker{
+		workflow: workflow,
+		mu:       sync.Mutex{},
+		groups:   make(map[string]*pollerGroupState),
+	}
+}
+
+func (t *pollerGroupTracker) requiredMin(queueKind enumspb.TaskQueueKind) int {
+	if t == nil {
+		return 0
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if !t.workflow {
+		return len(t.groups)
+	}
+
+	switch queueKind {
+	case enumspb.TASK_QUEUE_KIND_NORMAL, enumspb.TASK_QUEUE_KIND_STICKY:
+		return len(t.groups)
+	default:
+		return 0
+	}
+}
+
+func (t *pollerGroupTracker) reserve(queueKind enumspb.TaskQueueKind) string {
+	if t == nil {
+		return ""
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if len(t.groups) == 0 {
+		return ""
+	}
+
+	candidates := make(map[string]*pollerGroupState, len(t.groups))
+	for groupID, group := range t.groups {
+		if t.pendingCount(group, queueKind) == 0 {
+			candidates[groupID] = group
+		}
+	}
+	if len(candidates) == 0 {
+		candidates = t.groups
+	}
+
+	groupID := choosePollerGroup(candidates)
+	if groupID == "" {
+		return ""
+	}
+	t.incrementPending(t.groups[groupID], queueKind)
+	return groupID
+}
+
+// reserveWorkflowPoll first satisfies per-group MCN coverage by selecting a
+// group that is missing normal or sticky coverage. For that selected group, it
+// uses preferredQueueKind first when that kind's coverage is missing, then
+// fills whichever required kind is still missing. Once coverage is met, it
+// chooses a group by server-provided weight and then chooses that group's
+// workflow queue kind from its sticky backlog state.
+func (t *pollerGroupTracker) reserveWorkflowPoll(preferredQueueKind enumspb.TaskQueueKind, stickyEnabled bool) (string, enumspb.TaskQueueKind) {
+	if t == nil {
+		return "", preferredQueueKind
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if len(t.groups) == 0 {
+		return "", preferredQueueKind
+	}
+
+	if groupID := choosePollerGroup(t.workflowCoverageCandidates(stickyEnabled)); groupID != "" {
+		queueKind := t.workflowCoverageQueueKind(t.groups[groupID], preferredQueueKind, stickyEnabled)
+		t.incrementPending(t.groups[groupID], queueKind)
+		return groupID, queueKind
+	}
+
+	groupID := choosePollerGroup(t.groups)
+	if groupID == "" {
+		return "", preferredQueueKind
+	}
+	queueKind := t.workflowFloatingQueueKind(t.groups[groupID], stickyEnabled)
+	t.incrementPending(t.groups[groupID], queueKind)
+	return groupID, queueKind
+}
+
+func (t *pollerGroupTracker) release(groupID string, queueKind enumspb.TaskQueueKind) {
+	if t == nil || groupID == "" {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	group, ok := t.groups[groupID]
+	if !ok {
+		return
+	}
+	t.decrementPending(group, queueKind)
+}
+
+func (t *pollerGroupTracker) updateGroups(groups []*taskqueuepb.PollerGroupInfo) bool {
+	if t == nil || len(groups) == 0 {
+		return false
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.groups == nil {
+		t.groups = make(map[string]*pollerGroupState)
+	}
+
+	seen := make(map[string]struct{}, len(groups))
+	membershipChanged := false
+	for _, incoming := range groups {
+		groupID := incoming.GetId()
+		if groupID == "" {
+			continue
+		}
+		seen[groupID] = struct{}{}
+
+		if existing, ok := t.groups[groupID]; ok {
+			existing.weight = incoming.GetWeight()
+			continue
+		}
+		t.groups[groupID] = &pollerGroupState{weight: incoming.GetWeight()}
+		membershipChanged = true
+	}
+
+	for groupID := range t.groups {
+		if _, ok := seen[groupID]; !ok {
+			delete(t.groups, groupID)
+			membershipChanged = true
+		}
+	}
+
+	return membershipChanged
+}
+
+func (t *pollerGroupTracker) updateStickyBacklog(groupID string, backlogCountHint int64) {
+	if t == nil || !t.workflow || groupID == "" {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	group, ok := t.groups[groupID]
+	if !ok {
+		return
+	}
+	group.workflowStickyBacklog = backlogCountHint
+}
+
+func (t *pollerGroupTracker) workflowCoverageCandidates(stickyEnabled bool) map[string]*pollerGroupState {
+	candidates := make(map[string]*pollerGroupState)
+	for groupID, group := range t.groups {
+		if group.workflowPendingNormal == 0 || stickyEnabled && group.workflowPendingSticky == 0 {
+			candidates[groupID] = group
+		}
+	}
+	return candidates
+}
+
+func (t *pollerGroupTracker) workflowCoverageQueueKind(
+	group *pollerGroupState,
+	preferredQueueKind enumspb.TaskQueueKind,
+	stickyEnabled bool,
+) enumspb.TaskQueueKind {
+	if stickyEnabled && preferredQueueKind == enumspb.TASK_QUEUE_KIND_STICKY && group.workflowPendingSticky == 0 {
+		return enumspb.TASK_QUEUE_KIND_STICKY
+	}
+	if group.workflowPendingNormal == 0 {
+		return enumspb.TASK_QUEUE_KIND_NORMAL
+	}
+	if stickyEnabled && group.workflowPendingSticky == 0 {
+		return enumspb.TASK_QUEUE_KIND_STICKY
+	}
+	return preferredQueueKind
+}
+
+func (t *pollerGroupTracker) workflowFloatingQueueKind(group *pollerGroupState, stickyEnabled bool) enumspb.TaskQueueKind {
+	if stickyEnabled && group.workflowStickyBacklog > int64(group.workflowPendingSticky) {
+		return enumspb.TASK_QUEUE_KIND_STICKY
+	}
+	return enumspb.TASK_QUEUE_KIND_NORMAL
+}
+
+func (t *pollerGroupTracker) pendingCount(group *pollerGroupState, queueKind enumspb.TaskQueueKind) int {
+	if group == nil {
+		return 0
+	}
+	if !t.workflow {
+		return group.pendingPollCount
+	}
+	if queueKind == enumspb.TASK_QUEUE_KIND_STICKY {
+		return group.workflowPendingSticky
+	}
+	return group.workflowPendingNormal
+}
+
+func (t *pollerGroupTracker) incrementPending(group *pollerGroupState, queueKind enumspb.TaskQueueKind) {
+	if group == nil {
+		return
+	}
+	if !t.workflow {
+		group.pendingPollCount++
+		return
+	}
+	if queueKind == enumspb.TASK_QUEUE_KIND_STICKY {
+		group.workflowPendingSticky++
+	} else {
+		group.workflowPendingNormal++
+	}
+}
+
+func (t *pollerGroupTracker) decrementPending(group *pollerGroupState, queueKind enumspb.TaskQueueKind) {
+	if group == nil {
+		return
+	}
+	if !t.workflow {
+		if group.pendingPollCount > 0 {
+			group.pendingPollCount--
+		}
+		return
+	}
+	if queueKind == enumspb.TASK_QUEUE_KIND_STICKY {
+		if group.workflowPendingSticky > 0 {
+			group.workflowPendingSticky--
+		}
+	} else if group.workflowPendingNormal > 0 {
+		group.workflowPendingNormal--
+	}
+}
+
+// choosePollerGroup picks a random group using the configured weights.
+// If all weights are zero or negative, it picks uniformly from all groups.
+// If floating-point rounding prevents the weighted walk from selecting a group,
+// it falls back to the last positive-weight candidate encountered.
+func choosePollerGroup(groups map[string]*pollerGroupState) string {
+	if len(groups) == 0 {
+		return ""
+	}
+
+	totalWeight := float32(0)
+	for _, group := range groups {
+		if group.weight > 0 {
+			totalWeight += group.weight
+		}
+	}
+
+	// if all weights are 0, pick randomly
+	if totalWeight <= 0 {
+		selected := rand.Intn(len(groups))
+		for groupID := range groups {
+			if selected == 0 {
+				return groupID
+			}
+			selected--
+		}
+		return ""
+	}
+
+	point := rand.Float32() * totalWeight
+	var lastCandidate string
+	for groupID, group := range groups {
+		if group.weight <= 0 {
+			continue
+		}
+		lastCandidate = groupID
+		if point < group.weight {
+			return groupID
+		}
+		point -= group.weight
+	}
+
+	// Floating-point rounding fallback.
+	return lastCandidate
+}

--- a/internal/internal_poller_groups.go
+++ b/internal/internal_poller_groups.go
@@ -9,16 +9,19 @@ import (
 )
 
 type (
-	// pollerGroupManager gives concrete pollers a lease-based API for assigning
-	// poll requests to groups. This gives autoscaling runners access to the
-	// MCN-required minimum, and notifies registered listeners when poller group membership changes. The
-	// underlying tracker still owns the synchronized group state and selection
-	// algorithm.
-	pollerGroupManager struct {
-		tracker *pollerGroupTracker
+	pollerGroupInfoStore struct {
+		mu         sync.RWMutex
+		weights    map[string]float32
+		version    int64
+		versionSet bool
+	}
 
-		listenersMu sync.Mutex
-		listeners   []func()
+	// pollerGroupManager gives concrete pollers a lease-based API for assigning
+	// poll requests to groups. Group membership and weights are shared across
+	// managers, while each tracker owns its poll coverage and sticky backlog.
+	pollerGroupManager struct {
+		groupInfos *pollerGroupInfoStore
+		tracker    *pollerGroupTracker
 	}
 
 	// pollerGroupLease represents the SDK-local group reservation for one
@@ -38,8 +41,6 @@ type (
 	}
 
 	pollerGroupState struct {
-		weight float32
-
 		// Activity/Nexus use total pending
 		pendingPollCount int
 
@@ -53,24 +54,35 @@ type (
 	}
 )
 
-func newPollerGroupManager(workflow bool) *pollerGroupManager {
+func newPollerGroupInfoStore() *pollerGroupInfoStore {
+	return &pollerGroupInfoStore{weights: make(map[string]float32)}
+}
+
+func newPollerGroupManager(workflow bool, groupInfos *pollerGroupInfoStore) *pollerGroupManager {
+	if groupInfos == nil {
+		groupInfos = newPollerGroupInfoStore()
+	}
 	return &pollerGroupManager{
-		tracker: newPollerGroupTracker(workflow),
+		groupInfos: groupInfos,
+		tracker:    newPollerGroupTracker(workflow),
 	}
 }
 
 func (m *pollerGroupManager) requiredMin(queueKind enumspb.TaskQueueKind) int {
-	if m == nil || m.tracker == nil {
+	if m == nil || m.groupInfos == nil || m.tracker == nil {
 		return 0
 	}
-	return m.tracker.requiredMin(queueKind)
+	if m.tracker.workflow && queueKind != enumspb.TASK_QUEUE_KIND_NORMAL && queueKind != enumspb.TASK_QUEUE_KIND_STICKY {
+		return 0
+	}
+	return m.groupInfos.len()
 }
 
 func (m *pollerGroupManager) reserve() pollerGroupLease {
-	if m == nil || m.tracker == nil {
+	if m == nil || m.groupInfos == nil || m.tracker == nil {
 		return pollerGroupLease{}
 	}
-	groupID := m.tracker.reserve()
+	groupID := m.tracker.reserve(m.groupInfos.snapshot())
 	return pollerGroupLease{
 		manager: m,
 		groupID: groupID,
@@ -78,10 +90,10 @@ func (m *pollerGroupManager) reserve() pollerGroupLease {
 }
 
 func (m *pollerGroupManager) reserveWorkflowPoll(preferredQueueKind enumspb.TaskQueueKind, stickyEnabled bool) pollerGroupLease {
-	if m == nil || m.tracker == nil {
+	if m == nil || m.groupInfos == nil || m.tracker == nil {
 		return pollerGroupLease{queueKind: preferredQueueKind}
 	}
-	groupID, queueKind := m.tracker.reserveWorkflowPoll(preferredQueueKind, stickyEnabled)
+	groupID, queueKind := m.tracker.reserveWorkflowPoll(m.groupInfos.snapshot(), preferredQueueKind, stickyEnabled)
 	return pollerGroupLease{
 		manager:   m,
 		groupID:   groupID,
@@ -89,39 +101,18 @@ func (m *pollerGroupManager) reserveWorkflowPoll(preferredQueueKind enumspb.Task
 	}
 }
 
-func (m *pollerGroupManager) updateGroups(groups []*taskqueuepb.PollerGroupInfo) {
-	if m == nil || m.tracker == nil {
+func (m *pollerGroupManager) updateGroups(info *taskqueuepb.PollerGroupsInfo) {
+	if m == nil || m.groupInfos == nil {
 		return
 	}
-	if m.tracker.updateGroups(groups) {
-		m.signal()
-	}
+	m.groupInfos.updateGroups(info)
 }
 
 func (m *pollerGroupManager) updateStickyBacklog(groupID string, backlogCountHint int64) {
-	if m == nil || m.tracker == nil || groupID == "" {
+	if m == nil || m.groupInfos == nil || m.tracker == nil || groupID == "" {
 		return
 	}
-	m.tracker.updateStickyBacklog(groupID, backlogCountHint)
-}
-
-func (m *pollerGroupManager) addListener(fn func()) {
-	if m == nil || fn == nil {
-		return
-	}
-	m.listenersMu.Lock()
-	defer m.listenersMu.Unlock()
-	m.listeners = append(m.listeners, fn)
-}
-
-func (m *pollerGroupManager) signal() {
-	m.listenersMu.Lock()
-	listeners := append([]func(){}, m.listeners...)
-	m.listenersMu.Unlock()
-
-	for _, fn := range listeners {
-		fn()
-	}
+	m.tracker.updateStickyBacklog(m.groupInfos.snapshot(), groupID, backlogCountHint)
 }
 
 func (l pollerGroupLease) groupIDOrEmpty() string {
@@ -150,44 +141,26 @@ func newPollerGroupTracker(workflow bool) *pollerGroupTracker {
 	}
 }
 
-func (t *pollerGroupTracker) requiredMin(queueKind enumspb.TaskQueueKind) int {
-	if t == nil {
-		return 0
-	}
-	t.mu.Lock()
-	defer t.mu.Unlock()
-
-	if !t.workflow {
-		return len(t.groups)
-	}
-
-	switch queueKind {
-	case enumspb.TASK_QUEUE_KIND_NORMAL, enumspb.TASK_QUEUE_KIND_STICKY:
-		return len(t.groups)
-	default:
-		return 0
-	}
-}
-
-func (t *pollerGroupTracker) reserve() string {
+func (t *pollerGroupTracker) reserve(weights map[string]float32) string {
 	if t == nil {
 		return ""
 	}
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	t.syncGroups(weights)
 
 	if len(t.groups) == 0 {
 		return ""
 	}
 
-	candidates := make(map[string]*pollerGroupState, len(t.groups))
+	candidates := make(map[string]float32, len(t.groups))
 	for groupID, group := range t.groups {
 		if group.pendingPollCount == 0 {
-			candidates[groupID] = group
+			candidates[groupID] = weights[groupID]
 		}
 	}
 	if len(candidates) == 0 {
-		candidates = t.groups
+		candidates = weights
 	}
 
 	groupID := choosePollerGroup(candidates)
@@ -204,23 +177,28 @@ func (t *pollerGroupTracker) reserve() string {
 // missing, then fills whichever required kind is still missing. Once coverage
 // is met, it chooses a group by server-provided weight and then chooses that
 // group's workflow queue kind from its sticky backlog state.
-func (t *pollerGroupTracker) reserveWorkflowPoll(preferredQueueKind enumspb.TaskQueueKind, stickyEnabled bool) (string, enumspb.TaskQueueKind) {
+func (t *pollerGroupTracker) reserveWorkflowPoll(
+	weights map[string]float32,
+	preferredQueueKind enumspb.TaskQueueKind,
+	stickyEnabled bool,
+) (string, enumspb.TaskQueueKind) {
 	if t == nil {
 		return "", preferredQueueKind
 	}
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	t.syncGroups(weights)
 
 	if len(t.groups) == 0 {
 		return "", preferredQueueKind
 	}
 
-	groupID := chooseHighestWeightPollerGroup(t.workflowCoverageCandidates(stickyEnabled))
+	groupID := chooseHighestWeightPollerGroup(t.workflowCoverageCandidates(weights, stickyEnabled))
 	var queueKind enumspb.TaskQueueKind
 	if groupID != "" {
 		queueKind = t.workflowCoverageQueueKind(t.groups[groupID], preferredQueueKind, stickyEnabled)
 	} else {
-		groupID = choosePollerGroup(t.groups)
+		groupID = choosePollerGroup(weights)
 		if groupID == "" {
 			return "", preferredQueueKind
 		}
@@ -249,55 +227,13 @@ func (t *pollerGroupTracker) release(groupID string, queueKind enumspb.TaskQueue
 	t.decrementPending(group, queueKind)
 }
 
-func (t *pollerGroupTracker) updateGroups(groups []*taskqueuepb.PollerGroupInfo) bool {
-	if t == nil {
-		return false
-	}
-	t.mu.Lock()
-	defer t.mu.Unlock()
-
-	if t.groups == nil {
-		t.groups = make(map[string]*pollerGroupState)
-	}
-	if len(groups) == 0 {
-		membershipChanged := len(t.groups) > 0
-		t.groups = make(map[string]*pollerGroupState)
-		return membershipChanged
-	}
-
-	seen := make(map[string]struct{}, len(groups))
-	membershipChanged := false
-	for _, incoming := range groups {
-		groupID := incoming.GetId()
-		if groupID == "" {
-			continue
-		}
-		seen[groupID] = struct{}{}
-
-		if existing, ok := t.groups[groupID]; ok {
-			existing.weight = incoming.GetWeight()
-			continue
-		}
-		t.groups[groupID] = &pollerGroupState{weight: incoming.GetWeight()}
-		membershipChanged = true
-	}
-
-	for groupID := range t.groups {
-		if _, ok := seen[groupID]; !ok {
-			delete(t.groups, groupID)
-			membershipChanged = true
-		}
-	}
-
-	return membershipChanged
-}
-
-func (t *pollerGroupTracker) updateStickyBacklog(groupID string, backlogCountHint int64) {
+func (t *pollerGroupTracker) updateStickyBacklog(weights map[string]float32, groupID string, backlogCountHint int64) {
 	if t == nil || !t.workflow || groupID == "" {
 		return
 	}
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	t.syncGroups(weights)
 
 	group, ok := t.groups[groupID]
 	if !ok {
@@ -306,11 +242,27 @@ func (t *pollerGroupTracker) updateStickyBacklog(groupID string, backlogCountHin
 	group.workflowStickyBacklog = backlogCountHint
 }
 
-func (t *pollerGroupTracker) workflowCoverageCandidates(stickyEnabled bool) map[string]*pollerGroupState {
-	candidates := make(map[string]*pollerGroupState)
+func (t *pollerGroupTracker) syncGroups(weights map[string]float32) {
+	if t.groups == nil {
+		t.groups = make(map[string]*pollerGroupState)
+	}
+	for groupID := range weights {
+		if _, ok := t.groups[groupID]; !ok {
+			t.groups[groupID] = &pollerGroupState{}
+		}
+	}
+	for groupID := range t.groups {
+		if _, ok := weights[groupID]; !ok {
+			delete(t.groups, groupID)
+		}
+	}
+}
+
+func (t *pollerGroupTracker) workflowCoverageCandidates(weights map[string]float32, stickyEnabled bool) map[string]float32 {
+	candidates := make(map[string]float32)
 	for groupID, group := range t.groups {
 		if group.workflowPendingNormal == 0 || stickyEnabled && group.workflowPendingSticky == 0 {
-			candidates[groupID] = group
+			candidates[groupID] = weights[groupID]
 		}
 	}
 	return candidates
@@ -359,16 +311,13 @@ func (t *pollerGroupTracker) decrementPending(group *pollerGroupState, queueKind
 	}
 }
 
-func chooseHighestWeightPollerGroup(groups map[string]*pollerGroupState) string {
+func chooseHighestWeightPollerGroup(groups map[string]float32) string {
 	var selectedID string
 	var selectedWeight float32
-	for groupID, group := range groups {
-		if group == nil {
-			continue
-		}
-		if selectedID == "" || group.weight > selectedWeight {
+	for groupID, weight := range groups {
+		if selectedID == "" || weight > selectedWeight {
 			selectedID = groupID
-			selectedWeight = group.weight
+			selectedWeight = weight
 		}
 	}
 	return selectedID
@@ -378,15 +327,15 @@ func chooseHighestWeightPollerGroup(groups map[string]*pollerGroupState) string 
 // If all weights are zero or negative, it picks uniformly from all groups.
 // If floating-point rounding prevents the weighted walk from selecting a group,
 // it falls back to the last positive-weight candidate encountered.
-func choosePollerGroup(groups map[string]*pollerGroupState) string {
+func choosePollerGroup(groups map[string]float32) string {
 	if len(groups) == 0 {
 		return ""
 	}
 
 	totalWeight := float32(0)
-	for _, group := range groups {
-		if group.weight > 0 {
-			totalWeight += group.weight
+	for _, weight := range groups {
+		if weight > 0 {
+			totalWeight += weight
 		}
 	}
 
@@ -404,17 +353,63 @@ func choosePollerGroup(groups map[string]*pollerGroupState) string {
 
 	point := rand.Float32() * totalWeight
 	var lastCandidate string
-	for groupID, group := range groups {
-		if group.weight <= 0 {
+	for groupID, weight := range groups {
+		if weight <= 0 {
 			continue
 		}
 		lastCandidate = groupID
-		if point < group.weight {
+		if point < weight {
 			return groupID
 		}
-		point -= group.weight
+		point -= weight
 	}
 
 	// Floating-point rounding fallback.
 	return lastCandidate
+}
+
+func (s *pollerGroupInfoStore) len() int {
+	if s == nil {
+		return 0
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.weights)
+}
+
+func (s *pollerGroupInfoStore) snapshot() map[string]float32 {
+	if s == nil {
+		return nil
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	weights := make(map[string]float32, len(s.weights))
+	for groupID, weight := range s.weights {
+		weights[groupID] = weight
+	}
+	return weights
+}
+
+func (s *pollerGroupInfoStore) updateGroups(info *taskqueuepb.PollerGroupsInfo) {
+	if s == nil || info == nil {
+		return
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.versionSet && info.GetVersion() <= s.version {
+		return
+	}
+
+	weights := make(map[string]float32, len(info.GetPollerGroups()))
+	for _, group := range info.GetPollerGroups() {
+		if groupID := group.GetId(); groupID != "" {
+			weights[groupID] = group.GetWeight()
+		}
+	}
+
+	s.weights = weights
+	s.version = info.GetVersion()
+	s.versionSet = true
 }

--- a/internal/internal_poller_groups.go
+++ b/internal/internal_poller_groups.go
@@ -91,7 +91,7 @@ func (m *pollerGroupManager) reserveWorkflowPoll(preferredQueueKind enumspb.Task
 }
 
 func (m *pollerGroupManager) updateGroups(groups []*taskqueuepb.PollerGroupInfo) {
-	if m == nil || m.tracker == nil || len(groups) == 0 {
+	if m == nil || m.tracker == nil {
 		return
 	}
 	if m.tracker.updateGroups(groups) {
@@ -199,12 +199,12 @@ func (t *pollerGroupTracker) reserve(queueKind enumspb.TaskQueueKind) string {
 	return groupID
 }
 
-// reserveWorkflowPoll first satisfies per-group MCN coverage by selecting a
-// group that is missing normal or sticky coverage. For that selected group, it
-// uses preferredQueueKind first when that kind's coverage is missing, then
-// fills whichever required kind is still missing. Once coverage is met, it
-// chooses a group by server-provided weight and then chooses that group's
-// workflow queue kind from its sticky backlog state.
+// reserveWorkflowPoll first satisfies per-group MCN coverage by selecting the
+// highest-weight group that is missing normal or sticky coverage. For that
+// selected group, it uses preferredQueueKind first when that kind's coverage is
+// missing, then fills whichever required kind is still missing. Once coverage
+// is met, it chooses a group by server-provided weight and then chooses that
+// group's workflow queue kind from its sticky backlog state.
 func (t *pollerGroupTracker) reserveWorkflowPoll(preferredQueueKind enumspb.TaskQueueKind, stickyEnabled bool) (string, enumspb.TaskQueueKind) {
 	if t == nil {
 		return "", preferredQueueKind
@@ -216,7 +216,7 @@ func (t *pollerGroupTracker) reserveWorkflowPoll(preferredQueueKind enumspb.Task
 		return "", preferredQueueKind
 	}
 
-	if groupID := choosePollerGroup(t.workflowCoverageCandidates(stickyEnabled)); groupID != "" {
+	if groupID := chooseHighestWeightPollerGroup(t.workflowCoverageCandidates(stickyEnabled)); groupID != "" {
 		queueKind := t.workflowCoverageQueueKind(t.groups[groupID], preferredQueueKind, stickyEnabled)
 		t.incrementPending(t.groups[groupID], queueKind)
 		return groupID, queueKind
@@ -246,7 +246,7 @@ func (t *pollerGroupTracker) release(groupID string, queueKind enumspb.TaskQueue
 }
 
 func (t *pollerGroupTracker) updateGroups(groups []*taskqueuepb.PollerGroupInfo) bool {
-	if t == nil || len(groups) == 0 {
+	if t == nil {
 		return false
 	}
 	t.mu.Lock()
@@ -254,6 +254,11 @@ func (t *pollerGroupTracker) updateGroups(groups []*taskqueuepb.PollerGroupInfo)
 
 	if t.groups == nil {
 		t.groups = make(map[string]*pollerGroupState)
+	}
+	if len(groups) == 0 {
+		membershipChanged := len(t.groups) > 0
+		t.groups = make(map[string]*pollerGroupState)
+		return membershipChanged
 	}
 
 	seen := make(map[string]struct{}, len(groups))
@@ -376,6 +381,21 @@ func (t *pollerGroupTracker) decrementPending(group *pollerGroupState, queueKind
 	} else if group.workflowPendingNormal > 0 {
 		group.workflowPendingNormal--
 	}
+}
+
+func chooseHighestWeightPollerGroup(groups map[string]*pollerGroupState) string {
+	var selectedID string
+	var selectedWeight float32
+	for groupID, group := range groups {
+		if group == nil {
+			continue
+		}
+		if selectedID == "" || group.weight > selectedWeight {
+			selectedID = groupID
+			selectedWeight = group.weight
+		}
+	}
+	return selectedID
 }
 
 // choosePollerGroup picks a random group using the configured weights.

--- a/internal/internal_poller_groups.go
+++ b/internal/internal_poller_groups.go
@@ -1,0 +1,492 @@
+package internal
+
+import (
+	"math/rand"
+	"sync"
+
+	enumspb "go.temporal.io/api/enums/v1"
+	taskqueuepb "go.temporal.io/api/taskqueue/v1"
+)
+
+// Poller-group relationships:
+//
+// The client owns pollerGroupInfoStore, the shared routing snapshot. A manager
+// references that store and owns a pollerGroupTracker, which owns its local
+// pollerGroupState entries. Each in-flight poll owns a pollerGroupLease that
+// references its manager and selected state.
+//
+// Workflow normal and sticky pollers share one manager and tracker. Other
+// polling paths keep independent coverage trackers while sharing the store.
+type (
+	pollerGroupMode uint8
+
+	// pollerGroupInfoStore is the client-owned, versioned routing snapshot shared
+	// by pollerGroupManagers.
+	pollerGroupInfoStore struct {
+		mu      sync.RWMutex
+		current pollerGroupSnapshot
+		// changedCh is closed and replaced whenever a newer group snapshot is
+		// accepted. Runners use it to observe updates published through any
+		// manager sharing this store.
+		changedCh chan struct{}
+	}
+
+	// pollerGroupSnapshot is immutable after publication.
+	pollerGroupSnapshot struct {
+		weights    map[string]float32
+		version    int64
+		versionSet bool
+	}
+
+	// pollerGroupManager is owned by a polling path and combines shared routing
+	// state with its local coverage tracker.
+	pollerGroupManager struct {
+		groupInfos *pollerGroupInfoStore
+		tracker    *pollerGroupTracker
+
+		wakeMu sync.Mutex
+		// wakeFns notify runners attached to this manager to recheck admission.
+		// They do not correspond one-to-one with events and do not start or cancel
+		// poll RPCs themselves.
+		wakeFns []func()
+	}
+
+	// pollerGroupLease is owned by one in-flight poll and reserves its
+	// request-selected group in the manager's tracker.
+	pollerGroupLease struct {
+		manager *pollerGroupManager
+		// Retain the selected state for the unlikely case that its ID is removed
+		// and re-added before the lease is released.
+		group     *pollerGroupState
+		queueKind enumspb.TaskQueueKind
+	}
+
+	// pollerGroupTracker is the manager-owned pending-poll coverage accounting.
+	pollerGroupTracker struct {
+		mode   pollerGroupMode
+		mu     sync.Mutex
+		groups map[string]*pollerGroupState
+	}
+
+	// pollerGroupState is the tracker-owned pending-poll state for one group.
+	pollerGroupState struct {
+		groupID string
+
+		// Activity/Nexus use total pending
+		pendingPollCount int
+
+		// Workflow uses queue-kind-specific pending counts
+		workflowPendingNormal int
+		workflowPendingSticky int
+	}
+)
+
+const (
+	pollerGroupModeNonWorkflow pollerGroupMode = iota
+	pollerGroupModeWorkflow
+	pollerGroupModeWorkflowWithSticky
+)
+
+func newPollerGroupInfoStore() *pollerGroupInfoStore {
+	return &pollerGroupInfoStore{
+		current: pollerGroupSnapshot{weights: make(map[string]float32)},
+		changedCh: make(chan struct{}),
+	}
+}
+
+func newPollerGroupManager(mode pollerGroupMode, groupInfos *pollerGroupInfoStore) *pollerGroupManager {
+	if groupInfos == nil {
+		groupInfos = newPollerGroupInfoStore()
+	}
+	return &pollerGroupManager{
+		groupInfos: groupInfos,
+		tracker: &pollerGroupTracker{
+			mode:   mode,
+			groups: make(map[string]*pollerGroupState),
+		},
+	}
+}
+
+func (m *pollerGroupManager) requiredMin() int {
+	if m == nil || m.groupInfos == nil || m.tracker == nil {
+		return 0
+	}
+	return m.groupInfos.len()
+}
+
+func (m *pollerGroupManager) reserve() pollerGroupLease {
+	if m == nil || m.groupInfos == nil || m.tracker == nil {
+		return pollerGroupLease{}
+	}
+	group := m.tracker.reserve(m.groupInfos.snapshot().weights)
+	return pollerGroupLease{
+		manager: m,
+		group:   group,
+	}
+}
+
+// tryReserveRequired reserves only missing coverage for the requested queue
+// kind. It is used when ordinary autoscaling capacity is full but existing
+// polls no longer cover the current group snapshot.
+func (m *pollerGroupManager) tryReserveRequired(
+	queueKind enumspb.TaskQueueKind,
+) (pollerGroupLease, bool) {
+	if m == nil || m.groupInfos == nil || m.tracker == nil {
+		return pollerGroupLease{}, false
+	}
+	group := m.tracker.tryReserveRequired(m.groupInfos.snapshot().weights, queueKind)
+	if group == nil {
+		return pollerGroupLease{}, false
+	}
+	lease := pollerGroupLease{
+		manager:   m,
+		group:     group,
+		queueKind: queueKind,
+	}
+	m.signalWaiters()
+	return lease, true
+}
+
+func (m *pollerGroupManager) tryReserveWorkflowPoll(
+	queueKind enumspb.TaskQueueKind,
+) (pollerGroupLease, bool) {
+	if m == nil || m.groupInfos == nil || m.tracker == nil {
+		return pollerGroupLease{queueKind: queueKind}, true
+	}
+	group, ok := m.tracker.tryReserveWorkflowPoll(m.groupInfos.snapshot().weights, queueKind)
+	if !ok {
+		return pollerGroupLease{}, false
+	}
+	lease := pollerGroupLease{
+		manager:   m,
+		group:     group,
+		queueKind: queueKind,
+	}
+	m.signalWaiters()
+	return lease, true
+}
+
+func (m *pollerGroupManager) updateGroups(info *taskqueuepb.PollerGroupsInfo) {
+	if m == nil || m.groupInfos == nil {
+		return
+	}
+	m.groupInfos.updateGroups(info)
+}
+
+func (m *pollerGroupManager) registerWaiter(wake func()) {
+	if m == nil || wake == nil {
+		return
+	}
+	m.wakeMu.Lock()
+	m.wakeFns = append(m.wakeFns, wake)
+	m.wakeMu.Unlock()
+}
+
+func (m *pollerGroupManager) signalWaiters() {
+	if m == nil {
+		return
+	}
+	m.wakeMu.Lock()
+	wakeFns := append([]func(){}, m.wakeFns...)
+	m.wakeMu.Unlock()
+	for _, wake := range wakeFns {
+		wake()
+	}
+}
+
+func (l pollerGroupLease) groupIDOrEmpty() string {
+	if l.group == nil {
+		return ""
+	}
+	return l.group.groupID
+}
+
+func (l pollerGroupLease) release() {
+	if l.manager == nil || l.manager.tracker == nil || l.group == nil {
+		return
+	}
+	l.manager.tracker.release(l.group, l.queueKind)
+	l.manager.signalWaiters()
+}
+
+func (t *pollerGroupTracker) reserve(weights map[string]float32) *pollerGroupState {
+	if t == nil {
+		return nil
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.syncGroups(weights)
+
+	if len(t.groups) == 0 {
+		return nil
+	}
+
+	candidates := make(map[string]float32, len(t.groups))
+	for groupID, group := range t.groups {
+		if group.pendingPollCount == 0 {
+			candidates[groupID] = weights[groupID]
+		}
+	}
+	if len(candidates) == 0 {
+		candidates = weights
+	}
+
+	groupID := choosePollerGroup(candidates)
+	if groupID == "" {
+		return nil
+	}
+	group := t.groups[groupID]
+	group.pendingPollCount++
+	return group
+}
+
+func (t *pollerGroupTracker) tryReserveRequired(
+	weights map[string]float32,
+	queueKind enumspb.TaskQueueKind,
+) *pollerGroupState {
+	if t == nil {
+		return nil
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.syncGroups(weights)
+
+	var candidates map[string]float32
+	if t.mode == pollerGroupModeNonWorkflow {
+		candidates = make(map[string]float32)
+		for groupID, group := range t.groups {
+			if group.pendingPollCount == 0 {
+				candidates[groupID] = weights[groupID]
+			}
+		}
+	} else {
+		candidates = t.workflowCoverageCandidates(weights, queueKind)
+	}
+	groupID := choosePollerGroup(candidates)
+	if groupID == "" {
+		return nil
+	}
+	group := t.groups[groupID]
+	if t.mode == pollerGroupModeNonWorkflow {
+		group.pendingPollCount++
+	} else {
+		t.incrementWorkflowPending(group, queueKind)
+	}
+	return group
+}
+
+// tryReserveWorkflowPoll first satisfies per-group coverage for queueKind. It
+// blocks additional polls for that kind while the other required workflow kind
+// still has a coverage gap. Once both kinds are covered, it selects additional
+// polls using the server-provided weights.
+func (t *pollerGroupTracker) tryReserveWorkflowPoll(
+	weights map[string]float32,
+	queueKind enumspb.TaskQueueKind,
+) (*pollerGroupState, bool) {
+	if t == nil {
+		return nil, true
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.syncGroups(weights)
+
+	if len(t.groups) == 0 {
+		return nil, true
+	}
+
+	candidates := t.workflowCoverageCandidates(weights, queueKind)
+	if len(candidates) == 0 {
+		// The requested kind already covers every group. Do not admit an
+		// additional poll while another required workflow kind remains uncovered.
+		if t.workflowCoverageMissing() {
+			return nil, false
+		}
+		candidates = weights
+	}
+
+	groupID := choosePollerGroup(candidates)
+	if groupID == "" {
+		return nil, true
+	}
+	group := t.groups[groupID]
+	t.incrementWorkflowPending(group, queueKind)
+	return group, true
+}
+
+func (t *pollerGroupTracker) release(group *pollerGroupState, queueKind enumspb.TaskQueueKind) {
+	if t == nil || group == nil {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.decrementPending(group, queueKind)
+}
+
+func (t *pollerGroupTracker) syncGroups(weights map[string]float32) {
+	if t.groups == nil {
+		t.groups = make(map[string]*pollerGroupState)
+	}
+	for groupID := range weights {
+		if _, ok := t.groups[groupID]; !ok {
+			t.groups[groupID] = &pollerGroupState{groupID: groupID}
+		}
+	}
+	for groupID := range t.groups {
+		if _, ok := weights[groupID]; !ok {
+			delete(t.groups, groupID)
+		}
+	}
+}
+
+func (t *pollerGroupTracker) workflowCoverageCandidates(
+	weights map[string]float32,
+	queueKind enumspb.TaskQueueKind,
+) map[string]float32 {
+	candidates := make(map[string]float32)
+	for groupID, group := range t.groups {
+		stickyUncovered := queueKind == enumspb.TASK_QUEUE_KIND_STICKY && group.workflowPendingSticky == 0
+		normalUncovered := queueKind == enumspb.TASK_QUEUE_KIND_NORMAL && group.workflowPendingNormal == 0
+		if stickyUncovered || normalUncovered {
+			candidates[groupID] = weights[groupID]
+		}
+	}
+	return candidates
+}
+
+func (t *pollerGroupTracker) workflowCoverageMissing() bool {
+	for _, group := range t.groups {
+		if group.workflowPendingNormal == 0 {
+			return true
+		}
+		if t.mode == pollerGroupModeWorkflowWithSticky && group.workflowPendingSticky == 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func (t *pollerGroupTracker) incrementWorkflowPending(group *pollerGroupState, queueKind enumspb.TaskQueueKind) {
+	if queueKind == enumspb.TASK_QUEUE_KIND_STICKY {
+		group.workflowPendingSticky++
+	} else {
+		group.workflowPendingNormal++
+	}
+}
+
+func (t *pollerGroupTracker) decrementPending(group *pollerGroupState, queueKind enumspb.TaskQueueKind) {
+	if group == nil {
+		return
+	}
+	if t.mode == pollerGroupModeNonWorkflow {
+		if group.pendingPollCount > 0 {
+			group.pendingPollCount--
+		}
+		return
+	}
+	if queueKind == enumspb.TASK_QUEUE_KIND_STICKY {
+		if group.workflowPendingSticky > 0 {
+			group.workflowPendingSticky--
+		}
+	} else if group.workflowPendingNormal > 0 {
+		group.workflowPendingNormal--
+	}
+}
+
+// choosePollerGroup picks a random group using the configured weights.
+// If all weights are zero or negative, it picks uniformly from all groups.
+// If floating-point rounding prevents the weighted walk from selecting a group,
+// it falls back to the last positive-weight candidate encountered.
+func choosePollerGroup(groups map[string]float32) string {
+	if len(groups) == 0 {
+		return ""
+	}
+
+	totalWeight := float32(0)
+	for _, weight := range groups {
+		if weight > 0 {
+			totalWeight += weight
+		}
+	}
+
+	// if all weights are 0, pick randomly
+	if totalWeight <= 0 {
+		selected := rand.Intn(len(groups))
+		for groupID := range groups {
+			if selected == 0 {
+				return groupID
+			}
+			selected--
+		}
+		return ""
+	}
+
+	point := rand.Float32() * totalWeight
+	var lastCandidate string
+	for groupID, weight := range groups {
+		if weight <= 0 {
+			continue
+		}
+		lastCandidate = groupID
+		if point < weight {
+			return groupID
+		}
+		point -= weight
+	}
+
+	// Floating-point rounding fallback.
+	return lastCandidate
+}
+
+func (s *pollerGroupInfoStore) len() int {
+	if s == nil {
+		return 0
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.current.weights)
+}
+
+func (s *pollerGroupInfoStore) snapshot() pollerGroupSnapshot {
+	if s == nil {
+		return pollerGroupSnapshot{}
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.current
+}
+
+func (s *pollerGroupInfoStore) changed() <-chan struct{} {
+	if s == nil {
+		return nil
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.changedCh
+}
+
+func (s *pollerGroupInfoStore) updateGroups(info *taskqueuepb.PollerGroupsInfo) {
+	if s == nil || info == nil {
+		return
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.current.versionSet && info.GetVersion() <= s.current.version {
+		return
+	}
+
+	weights := make(map[string]float32, len(info.GetPollerGroups()))
+	for _, group := range info.GetPollerGroups() {
+		if groupID := group.GetId(); groupID != "" {
+			weights[groupID] = group.GetWeight()
+		}
+	}
+
+	s.current = pollerGroupSnapshot{
+		weights:    weights,
+		version:    info.GetVersion(),
+		versionSet: true,
+	}
+	close(s.changedCh)
+	s.changedCh = make(chan struct{})
+}

--- a/internal/internal_poller_groups.go
+++ b/internal/internal_poller_groups.go
@@ -171,8 +171,8 @@ func (t *pollerGroupTracker) reserve(weights map[string]float32) string {
 	return groupID
 }
 
-// reserveWorkflowPoll first satisfies per-group MCN coverage by selecting the
-// highest-weight group that is missing normal or sticky coverage. For that
+// reserveWorkflowPoll first satisfies per-group MCN coverage by selecting by
+// weight among groups that are missing normal or sticky coverage. For that
 // selected group, it uses preferredQueueKind first when that kind's coverage is
 // missing, then fills whichever required kind is still missing. Once coverage
 // is met, it chooses a group by server-provided weight and then chooses that
@@ -193,7 +193,7 @@ func (t *pollerGroupTracker) reserveWorkflowPoll(
 		return "", preferredQueueKind
 	}
 
-	groupID := chooseHighestWeightPollerGroup(t.workflowCoverageCandidates(weights, stickyEnabled))
+	groupID := choosePollerGroup(t.workflowCoverageCandidates(weights, stickyEnabled))
 	var queueKind enumspb.TaskQueueKind
 	if groupID != "" {
 		queueKind = t.workflowCoverageQueueKind(t.groups[groupID], preferredQueueKind, stickyEnabled)
@@ -309,18 +309,6 @@ func (t *pollerGroupTracker) decrementPending(group *pollerGroupState, queueKind
 	} else if group.workflowPendingNormal > 0 {
 		group.workflowPendingNormal--
 	}
-}
-
-func chooseHighestWeightPollerGroup(groups map[string]float32) string {
-	var selectedID string
-	var selectedWeight float32
-	for groupID, weight := range groups {
-		if selectedID == "" || weight > selectedWeight {
-			selectedID = groupID
-			selectedWeight = weight
-		}
-	}
-	return selectedID
 }
 
 // choosePollerGroup picks a random group using the configured weights.

--- a/internal/internal_poller_groups_test.go
+++ b/internal/internal_poller_groups_test.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -9,200 +10,220 @@ import (
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 )
 
-func TestPollerGroupTrackerReserveActivityNexusPollFillsCoverageBeforeWeights(t *testing.T) {
-	tracker := newPollerGroupTracker(false)
-	tracker.updateGroups([]*taskqueuepb.PollerGroupInfo{
-		{Id: "uncovered", Weight: 0},
-		{Id: "covered", Weight: 100},
-	})
-
-	groupID := tracker.reserve()
-	require.Equal(t, "covered", groupID)
-	require.Equal(t, 1, tracker.groups["covered"].pendingPollCount)
-
-	groupID = tracker.reserve()
-	require.Equal(t, "uncovered", groupID)
-	require.Equal(t, 1, tracker.groups["uncovered"].pendingPollCount)
-
-	groupID = tracker.reserve()
-	require.Equal(t, "covered", groupID)
-	require.Equal(t, 2, tracker.groups["covered"].pendingPollCount)
+func testPollerGroupsInfo(version int64, groups []*taskqueuepb.PollerGroupInfo) *taskqueuepb.PollerGroupsInfo {
+	return &taskqueuepb.PollerGroupsInfo{Version: version, PollerGroups: groups}
 }
 
-func TestPollerGroupTrackerEmptyUpdateClearsGroups(t *testing.T) {
-	tracker := newPollerGroupTracker(true)
-	require.False(t, tracker.updateGroups(nil))
+func TestPollerGroupManagerReserveActivityNexusPollFillsCoverageBeforeWeights(t *testing.T) {
+	manager := newPollerGroupManager(false, nil)
+	manager.updateGroups(testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{
+		{Id: "uncovered", Weight: 0},
+		{Id: "covered", Weight: 100},
+	}))
 
-	require.True(t, tracker.updateGroups([]*taskqueuepb.PollerGroupInfo{
+	lease := manager.reserve()
+	require.Equal(t, "covered", lease.groupIDOrEmpty())
+	require.Equal(t, 1, manager.tracker.groups["covered"].pendingPollCount)
+
+	lease = manager.reserve()
+	require.Equal(t, "uncovered", lease.groupIDOrEmpty())
+	require.Equal(t, 1, manager.tracker.groups["uncovered"].pendingPollCount)
+
+	lease = manager.reserve()
+	require.Equal(t, "covered", lease.groupIDOrEmpty())
+	require.Equal(t, 2, manager.tracker.groups["covered"].pendingPollCount)
+}
+
+func TestPollerGroupManagerEmptyUpdateClearsGroups(t *testing.T) {
+	manager := newPollerGroupManager(true, nil)
+	manager.updateGroups(testPollerGroupsInfo(1, nil))
+	require.Equal(t, 0, manager.requiredMin(enumspb.TASK_QUEUE_KIND_NORMAL))
+
+	manager.updateGroups(testPollerGroupsInfo(2, []*taskqueuepb.PollerGroupInfo{
 		{Id: "group-a", Weight: 1},
 	}))
-	require.Equal(t, 1, tracker.requiredMin(enumspb.TASK_QUEUE_KIND_NORMAL))
+	require.Equal(t, 1, manager.requiredMin(enumspb.TASK_QUEUE_KIND_NORMAL))
 
-	require.True(t, tracker.updateGroups(nil))
-	require.Equal(t, 0, tracker.requiredMin(enumspb.TASK_QUEUE_KIND_NORMAL))
+	manager.updateGroups(testPollerGroupsInfo(3, nil))
+	require.Equal(t, 0, manager.requiredMin(enumspb.TASK_QUEUE_KIND_NORMAL))
 
-	groupID, queueKind := tracker.reserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_NORMAL, true)
-	require.Empty(t, groupID)
-	require.Equal(t, enumspb.TASK_QUEUE_KIND_NORMAL, queueKind)
+	lease := manager.reserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_NORMAL, true)
+	require.Empty(t, lease.groupIDOrEmpty())
+	require.Equal(t, enumspb.TASK_QUEUE_KIND_NORMAL, lease.queueKind)
 }
 
-// Signaling is only needed when group membership changes, not when weight-only changes occur
-func TestPollerGroupManagerUpdateSignalsOnlyOnMembershipChanges(t *testing.T) {
-	manager := newPollerGroupManager(true)
-	signals := 0
-	manager.addListener(func() {
-		signals++
-	})
+func TestPollerGroupInfoStoreOnlyAppliesNewerVersions(t *testing.T) {
+	groupInfos := newPollerGroupInfoStore()
+	groupInfos.updateGroups(testPollerGroupsInfo(10, []*taskqueuepb.PollerGroupInfo{
+		{Id: "current", Weight: 1},
+	}))
 
-	manager.updateGroups([]*taskqueuepb.PollerGroupInfo{
+	groupInfos.updateGroups(testPollerGroupsInfo(9, []*taskqueuepb.PollerGroupInfo{
+		{Id: "stale", Weight: 1},
+	}))
+	groupInfos.updateGroups(testPollerGroupsInfo(10, []*taskqueuepb.PollerGroupInfo{
+		{Id: "duplicate", Weight: 1},
+	}))
+	groupInfos.updateGroups(nil)
+	require.Equal(t, map[string]float32{"current": 1}, groupInfos.snapshot())
+
+	groupInfos.updateGroups(testPollerGroupsInfo(11, []*taskqueuepb.PollerGroupInfo{
+		{Id: "new", Weight: 1},
+	}))
+	require.Equal(t, map[string]float32{"new": 1}, groupInfos.snapshot())
+}
+
+func TestPollerGroupInfoStoreAppliesFirstZeroVersion(t *testing.T) {
+	groupInfos := newPollerGroupInfoStore()
+	groupInfos.updateGroups(testPollerGroupsInfo(0, []*taskqueuepb.PollerGroupInfo{
+		{Id: "group-a", Weight: 1},
+	}))
+
+	require.Equal(t, map[string]float32{"group-a": 1}, groupInfos.snapshot())
+}
+
+func TestPollerGroupManagersShareWeightsAndKeepCoverageSeparate(t *testing.T) {
+	groupInfos := newPollerGroupInfoStore()
+	external := newPollerGroupManager(false, groupInfos)
+	internal := newPollerGroupManager(false, groupInfos)
+
+	external.updateGroups(testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{
 		{Id: "group-a", Weight: 100},
 		{Id: "group-b", Weight: 0},
-	})
-	require.Equal(t, 1, signals)
+	}))
 
-	manager.updateGroups([]*taskqueuepb.PollerGroupInfo{
+	externalLease := external.reserve()
+	defer externalLease.release()
+	require.Equal(t, "group-a", externalLease.groupIDOrEmpty())
+
+	internalALease := internal.reserve()
+	defer internalALease.release()
+	require.Equal(t, "group-a", internalALease.groupIDOrEmpty(), "external coverage must not satisfy internal coverage")
+
+	internalBLease := internal.reserve()
+	defer internalBLease.release()
+	require.Equal(t, "group-b", internalBLease.groupIDOrEmpty())
+
+	external.updateGroups(testPollerGroupsInfo(2, []*taskqueuepb.PollerGroupInfo{
 		{Id: "group-a", Weight: 0},
 		{Id: "group-b", Weight: 100},
-	})
-	require.Equal(t, 1, signals, "weight-only updates should not signal listeners")
+	}))
 
-	lease := manager.reserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_NORMAL, false)
-	defer lease.release()
-	require.Equal(t, "group-b", lease.groupIDOrEmpty(), "weight-only updates should affect future reservations")
-
-	manager.updateGroups([]*taskqueuepb.PollerGroupInfo{
-		{Id: "group-a", Weight: 0},
-		{Id: "group-b", Weight: 100},
-		{Id: "group-c", Weight: 1},
-	})
-	require.Equal(t, 2, signals, "adding a group should signal listeners")
-
-	manager.updateGroups([]*taskqueuepb.PollerGroupInfo{
-		{Id: "group-b", Weight: 100},
-		{Id: "group-c", Weight: 1},
-	})
-	require.Equal(t, 3, signals, "removing a group should signal listeners")
-
-	manager.updateGroups(nil)
-	require.Equal(t, 4, signals, "clearing groups should signal listeners")
-
-	manager.updateGroups(nil)
-	require.Equal(t, 4, signals, "empty update should not signal when groups are already empty")
+	floatingLease := internal.reserve()
+	defer floatingLease.release()
+	require.Equal(t, "group-b", floatingLease.groupIDOrEmpty(), "external weight update must affect the internal manager's next floating poll")
+	require.Equal(t, 1, external.tracker.groups["group-a"].pendingPollCount)
+	require.Equal(t, 1, internal.tracker.groups["group-a"].pendingPollCount)
+	require.Equal(t, 2, internal.tracker.groups["group-b"].pendingPollCount)
 }
 
-func TestPollerGroupTrackerReserveWorkflowPollSatisfiesCoverageFirst(t *testing.T) {
-	tracker := newPollerGroupTracker(true)
-	tracker.updateGroups([]*taskqueuepb.PollerGroupInfo{
-		{Id: "group-a", Weight: 1},
-	})
+func TestPollerGroupManagerReserveWorkflowPollSatisfiesCoverageFirst(t *testing.T) {
+	manager := newPollerGroupManager(true, nil)
+	manager.updateGroups(testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{{Id: "group-a", Weight: 1}}))
 
-	groupID, queueKind := tracker.reserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_NORMAL, true)
-	require.Equal(t, "group-a", groupID)
-	require.Equal(t, enumspb.TASK_QUEUE_KIND_NORMAL, queueKind)
+	lease := manager.reserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_NORMAL, true)
+	require.Equal(t, "group-a", lease.groupIDOrEmpty())
+	require.Equal(t, enumspb.TASK_QUEUE_KIND_NORMAL, lease.queueKind)
 
-	groupID, queueKind = tracker.reserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_NORMAL, true)
-	require.Equal(t, "group-a", groupID)
-	require.Equal(t, enumspb.TASK_QUEUE_KIND_STICKY, queueKind)
+	lease = manager.reserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_NORMAL, true)
+	require.Equal(t, "group-a", lease.groupIDOrEmpty())
+	require.Equal(t, enumspb.TASK_QUEUE_KIND_STICKY, lease.queueKind)
 }
 
-func TestPollerGroupTrackerReserveWorkflowPollFillsCoverageBeforeWeights(t *testing.T) {
-	tracker := newPollerGroupTracker(true)
-	tracker.updateGroups([]*taskqueuepb.PollerGroupInfo{
+func TestPollerGroupManagerReserveWorkflowPollFillsCoverageBeforeWeights(t *testing.T) {
+	manager := newPollerGroupManager(true, nil)
+	manager.updateGroups(testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{
 		{Id: "uncovered", Weight: 0},
 		{Id: "covered", Weight: 100},
-	})
+	}))
 
-	groupID, queueKind := tracker.reserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_NORMAL, true)
-	require.Equal(t, "covered", groupID)
-	require.Equal(t, enumspb.TASK_QUEUE_KIND_NORMAL, queueKind)
+	lease := manager.reserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_NORMAL, true)
+	require.Equal(t, "covered", lease.groupIDOrEmpty())
+	require.Equal(t, enumspb.TASK_QUEUE_KIND_NORMAL, lease.queueKind)
 
-	groupID, queueKind = tracker.reserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_NORMAL, true)
-	require.Equal(t, "covered", groupID)
-	require.Equal(t, enumspb.TASK_QUEUE_KIND_STICKY, queueKind)
+	lease = manager.reserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_NORMAL, true)
+	require.Equal(t, "covered", lease.groupIDOrEmpty())
+	require.Equal(t, enumspb.TASK_QUEUE_KIND_STICKY, lease.queueKind)
 
-	groupID, queueKind = tracker.reserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_NORMAL, true)
-	require.Equal(t, "uncovered", groupID)
-	require.Equal(t, enumspb.TASK_QUEUE_KIND_NORMAL, queueKind)
+	lease = manager.reserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_NORMAL, true)
+	require.Equal(t, "uncovered", lease.groupIDOrEmpty())
+	require.Equal(t, enumspb.TASK_QUEUE_KIND_NORMAL, lease.queueKind)
 
-	groupID, queueKind = tracker.reserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_NORMAL, true)
-	require.Equal(t, "uncovered", groupID)
-	require.Equal(t, enumspb.TASK_QUEUE_KIND_STICKY, queueKind)
+	lease = manager.reserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_NORMAL, true)
+	require.Equal(t, "uncovered", lease.groupIDOrEmpty())
+	require.Equal(t, enumspb.TASK_QUEUE_KIND_STICKY, lease.queueKind)
 
-	groupID, queueKind = tracker.reserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_NORMAL, true)
-	require.Equal(t, "covered", groupID)
-	require.Equal(t, enumspb.TASK_QUEUE_KIND_NORMAL, queueKind)
+	lease = manager.reserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_NORMAL, true)
+	require.Equal(t, "covered", lease.groupIDOrEmpty())
+	require.Equal(t, enumspb.TASK_QUEUE_KIND_NORMAL, lease.queueKind)
 }
 
-func TestPollerGroupTrackerReserveWorkflowPollPrefersFallbackKindForCoverage(t *testing.T) {
-	tracker := newPollerGroupTracker(true)
-	tracker.updateGroups([]*taskqueuepb.PollerGroupInfo{
-		{Id: "group-a", Weight: 1},
-	})
+func TestPollerGroupManagerReserveWorkflowPollPrefersFallbackKindForCoverage(t *testing.T) {
+	manager := newPollerGroupManager(true, nil)
+	manager.updateGroups(testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{{Id: "group-a", Weight: 1}}))
 
-	groupID, queueKind := tracker.reserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_STICKY, true)
-	require.Equal(t, "group-a", groupID)
-	require.Equal(t, enumspb.TASK_QUEUE_KIND_STICKY, queueKind)
+	lease := manager.reserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_STICKY, true)
+	require.Equal(t, "group-a", lease.groupIDOrEmpty())
+	require.Equal(t, enumspb.TASK_QUEUE_KIND_STICKY, lease.queueKind)
 
-	groupID, queueKind = tracker.reserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_NORMAL, true)
-	require.Equal(t, "group-a", groupID)
-	require.Equal(t, enumspb.TASK_QUEUE_KIND_NORMAL, queueKind)
+	lease = manager.reserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_NORMAL, true)
+	require.Equal(t, "group-a", lease.groupIDOrEmpty())
+	require.Equal(t, enumspb.TASK_QUEUE_KIND_NORMAL, lease.queueKind)
 }
 
-func TestPollerGroupTrackerReserveWorkflowPollStickyCoverageAfterNormalRelease(t *testing.T) {
-	tracker := newPollerGroupTracker(true)
-	tracker.updateGroups([]*taskqueuepb.PollerGroupInfo{
-		{Id: "group-a", Weight: 1},
-	})
+func TestPollerGroupManagerReserveWorkflowPollStickyCoverageAfterNormalRelease(t *testing.T) {
+	manager := newPollerGroupManager(true, nil)
+	manager.updateGroups(testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{{Id: "group-a", Weight: 1}}))
 
-	groupID, queueKind := tracker.reserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_NORMAL, true)
-	require.Equal(t, "group-a", groupID)
-	require.Equal(t, enumspb.TASK_QUEUE_KIND_NORMAL, queueKind)
-	tracker.release(groupID, queueKind)
+	lease := manager.reserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_NORMAL, true)
+	require.Equal(t, "group-a", lease.groupIDOrEmpty())
+	require.Equal(t, enumspb.TASK_QUEUE_KIND_NORMAL, lease.queueKind)
+	lease.release()
 
-	groupID, queueKind = tracker.reserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_STICKY, true)
-	require.Equal(t, "group-a", groupID)
-	require.Equal(t, enumspb.TASK_QUEUE_KIND_STICKY, queueKind)
+	lease = manager.reserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_STICKY, true)
+	require.Equal(t, "group-a", lease.groupIDOrEmpty())
+	require.Equal(t, enumspb.TASK_QUEUE_KIND_STICKY, lease.queueKind)
 }
 
-func TestPollerGroupTrackerReserveWorkflowPollUsesGroupStickyBacklogForFloatingPoll(t *testing.T) {
-	tracker := newPollerGroupTracker(true)
-	tracker.updateGroups([]*taskqueuepb.PollerGroupInfo{
+func TestPollerGroupManagerReserveWorkflowPollUsesGroupStickyBacklogForFloatingPoll(t *testing.T) {
+	manager := newPollerGroupManager(true, nil)
+	manager.updateGroups(testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{
 		{Id: "group-a", Weight: 0},
 		{Id: "group-b", Weight: 1},
-	})
-	tracker.groups["group-a"].workflowPendingNormal = 1
-	tracker.groups["group-a"].workflowPendingSticky = 1
-	tracker.groups["group-b"].workflowPendingNormal = 1
-	tracker.groups["group-b"].workflowPendingSticky = 1
-	tracker.groups["group-b"].workflowStickyBacklog = 2
+	}))
 
-	groupID, queueKind := tracker.reserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_NORMAL, true)
-	require.Equal(t, "group-b", groupID)
-	require.Equal(t, enumspb.TASK_QUEUE_KIND_STICKY, queueKind)
-	require.Equal(t, 2, tracker.groups["group-b"].workflowPendingSticky)
+	for range 4 {
+		manager.reserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_NORMAL, true)
+	}
+	manager.updateStickyBacklog("group-b", 2)
+
+	lease := manager.reserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_NORMAL, true)
+	require.Equal(t, "group-b", lease.groupIDOrEmpty())
+	require.Equal(t, enumspb.TASK_QUEUE_KIND_STICKY, lease.queueKind)
+	require.Equal(t, 2, manager.tracker.groups["group-b"].workflowPendingSticky)
 }
 
-func TestPollerGroupTrackerReserveWorkflowPollUsesNormalWhenStickyBacklogCovered(t *testing.T) {
-	tracker := newPollerGroupTracker(true)
-	tracker.updateGroups([]*taskqueuepb.PollerGroupInfo{
-		{Id: "group-a", Weight: 1},
-	})
-	tracker.groups["group-a"].workflowPendingNormal = 1
-	tracker.groups["group-a"].workflowPendingSticky = 2
-	tracker.groups["group-a"].workflowStickyBacklog = 2
+func TestPollerGroupManagerReserveWorkflowPollUsesNormalWhenStickyBacklogCovered(t *testing.T) {
+	manager := newPollerGroupManager(true, nil)
+	manager.updateGroups(testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{{Id: "group-a", Weight: 1}}))
 
-	groupID, queueKind := tracker.reserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_NORMAL, true)
-	require.Equal(t, "group-a", groupID)
-	require.Equal(t, enumspb.TASK_QUEUE_KIND_NORMAL, queueKind)
-	require.Equal(t, 2, tracker.groups["group-a"].workflowPendingNormal)
+	manager.reserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_NORMAL, true)
+	manager.reserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_STICKY, true)
+	manager.updateStickyBacklog("group-a", 2)
+	manager.reserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_NORMAL, true)
+
+	lease := manager.reserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_NORMAL, true)
+	require.Equal(t, "group-a", lease.groupIDOrEmpty())
+	require.Equal(t, enumspb.TASK_QUEUE_KIND_NORMAL, lease.queueKind)
+	require.Equal(t, 2, manager.tracker.groups["group-a"].workflowPendingNormal)
 }
 
 func TestPollerGroupManagerWorkflowStickyBacklogUsesResponseGroupID(t *testing.T) {
-	manager := newPollerGroupManager(true)
-	manager.updateGroups([]*taskqueuepb.PollerGroupInfo{
+	manager := newPollerGroupManager(true, nil)
+	manager.updateGroups(testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{
 		{Id: "request-group", Weight: 100},
 		{Id: "response-group", Weight: 0},
-	})
+	}))
 
 	requestNormalLease := manager.reserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_NORMAL, true)
 	defer requestNormalLease.release()
@@ -224,10 +245,10 @@ func TestPollerGroupManagerWorkflowStickyBacklogUsesResponseGroupID(t *testing.T
 	require.Equal(t, "response-group", responseStickyLease.groupIDOrEmpty())
 	require.Equal(t, enumspb.TASK_QUEUE_KIND_STICKY, responseStickyLease.queueKind)
 
-	manager.updateGroups([]*taskqueuepb.PollerGroupInfo{
+	manager.updateGroups(testPollerGroupsInfo(2, []*taskqueuepb.PollerGroupInfo{
 		{Id: "request-group", Weight: 0},
 		{Id: "response-group", Weight: 100},
-	})
+	}))
 	manager.updateStickyBacklog("response-group", 2)
 
 	require.Equal(t, int64(0), manager.tracker.groups["request-group"].workflowStickyBacklog)
@@ -240,42 +261,82 @@ func TestPollerGroupManagerWorkflowStickyBacklogUsesResponseGroupID(t *testing.T
 }
 
 func TestPollerGroupLeaseReleaseUsesRequestGroupID(t *testing.T) {
-	manager := newPollerGroupManager(true)
-	manager.updateGroups([]*taskqueuepb.PollerGroupInfo{
+	manager := newPollerGroupManager(true, nil)
+	manager.updateGroups(testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{
 		{Id: "request-group", Weight: 100},
 		{Id: "response-group", Weight: 0},
-	})
+	}))
 
 	lease := manager.reserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_NORMAL, true)
 	require.Equal(t, "request-group", lease.groupIDOrEmpty())
 	require.Equal(t, enumspb.TASK_QUEUE_KIND_NORMAL, lease.queueKind)
 
 	manager.tracker.groups["response-group"].workflowPendingNormal = 1
-
 	lease.release()
 
 	require.Equal(t, 0, manager.tracker.groups["request-group"].workflowPendingNormal)
 	require.Equal(t, 1, manager.tracker.groups["response-group"].workflowPendingNormal)
 }
 
-func TestPollerGroupTrackerUpdateStickyBacklogUsesKnownWorkflowGroup(t *testing.T) {
-	tracker := newPollerGroupTracker(true)
-	tracker.updateGroups([]*taskqueuepb.PollerGroupInfo{
+func TestPollerGroupManagerUpdateStickyBacklogUsesKnownWorkflowGroup(t *testing.T) {
+	manager := newPollerGroupManager(true, nil)
+	manager.updateGroups(testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{
 		{Id: "group-a", Weight: 1},
 		{Id: "group-b", Weight: 1},
-	})
+	}))
 
-	tracker.updateStickyBacklog("group-b", 42)
-	tracker.updateStickyBacklog("unknown", 100)
+	manager.updateStickyBacklog("group-b", 42)
+	manager.updateStickyBacklog("unknown", 100)
 
-	require.Equal(t, int64(0), tracker.groups["group-a"].workflowStickyBacklog)
-	require.Equal(t, int64(42), tracker.groups["group-b"].workflowStickyBacklog)
+	require.Equal(t, int64(0), manager.tracker.groups["group-a"].workflowStickyBacklog)
+	require.Equal(t, int64(42), manager.tracker.groups["group-b"].workflowStickyBacklog)
 }
 
-func TestPollerGroupTrackerReserveWorkflowPollFallsBackBeforeGroupsKnown(t *testing.T) {
-	tracker := newPollerGroupTracker(true)
+func TestPollerGroupManagerReserveWorkflowPollFallsBackBeforeGroupsKnown(t *testing.T) {
+	manager := newPollerGroupManager(true, nil)
 
-	groupID, queueKind := tracker.reserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_STICKY, true)
-	require.Empty(t, groupID)
-	require.Equal(t, enumspb.TASK_QUEUE_KIND_STICKY, queueKind)
+	lease := manager.reserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_STICKY, true)
+	require.Empty(t, lease.groupIDOrEmpty())
+	require.Equal(t, enumspb.TASK_QUEUE_KIND_STICKY, lease.queueKind)
+}
+
+func TestPollerGroupManagerRemovedGroupLeaseReleaseIsSafe(t *testing.T) {
+	manager := newPollerGroupManager(false, nil)
+	manager.updateGroups(testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{{Id: "group-a", Weight: 1}}))
+	lease := manager.reserve()
+
+	manager.updateGroups(testPollerGroupsInfo(2, nil))
+	require.Empty(t, manager.reserve().groupIDOrEmpty())
+	require.NotPanics(t, lease.release)
+}
+
+func TestPollerGroupManagersConcurrentSharedUpdatesAndReservations(t *testing.T) {
+	groupInfos := newPollerGroupInfoStore()
+	activity := newPollerGroupManager(false, groupInfos)
+	workflow := newPollerGroupManager(true, groupInfos)
+	groupInfos.updateGroups(testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{{Id: "group-a", Weight: 1}}))
+
+	var wg sync.WaitGroup
+	for i := range 100 {
+		wg.Add(3)
+		go func() {
+			defer wg.Done()
+			activity.reserve().release()
+		}()
+		go func() {
+			defer wg.Done()
+			workflow.reserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_NORMAL, true).release()
+		}()
+		go func() {
+			defer wg.Done()
+			groupInfos.updateGroups(testPollerGroupsInfo(int64(i+2), []*taskqueuepb.PollerGroupInfo{
+				{Id: "group-a", Weight: 1},
+				{Id: "group-b", Weight: 2},
+			}))
+		}()
+	}
+	wg.Wait()
+
+	require.Equal(t, 2, activity.requiredMin(enumspb.TASK_QUEUE_KIND_NORMAL))
+	require.Equal(t, 2, workflow.requiredMin(enumspb.TASK_QUEUE_KIND_NORMAL))
 }

--- a/internal/internal_poller_groups_test.go
+++ b/internal/internal_poller_groups_test.go
@@ -16,15 +16,15 @@ func TestPollerGroupTrackerReserveActivityNexusPollFillsCoverageBeforeWeights(t 
 		{Id: "covered", Weight: 100},
 	})
 
-	groupID := tracker.reserve(enumspb.TASK_QUEUE_KIND_NORMAL)
+	groupID := tracker.reserve()
 	require.Equal(t, "covered", groupID)
 	require.Equal(t, 1, tracker.groups["covered"].pendingPollCount)
 
-	groupID = tracker.reserve(enumspb.TASK_QUEUE_KIND_NORMAL)
+	groupID = tracker.reserve()
 	require.Equal(t, "uncovered", groupID)
 	require.Equal(t, 1, tracker.groups["uncovered"].pendingPollCount)
 
-	groupID = tracker.reserve(enumspb.TASK_QUEUE_KIND_NORMAL)
+	groupID = tracker.reserve()
 	require.Equal(t, "covered", groupID)
 	require.Equal(t, 2, tracker.groups["covered"].pendingPollCount)
 }

--- a/internal/internal_poller_groups_test.go
+++ b/internal/internal_poller_groups_test.go
@@ -1,0 +1,111 @@
+package internal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	enumspb "go.temporal.io/api/enums/v1"
+	taskqueuepb "go.temporal.io/api/taskqueue/v1"
+)
+
+func TestPollerGroupTrackerReserveWorkflowPollSatisfiesCoverageFirst(t *testing.T) {
+	tracker := newPollerGroupTracker(true)
+	tracker.updateGroups([]*taskqueuepb.PollerGroupInfo{
+		{Id: "group-a", Weight: 1},
+	})
+
+	groupID, queueKind := tracker.reserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_NORMAL, true)
+	require.Equal(t, "group-a", groupID)
+	require.Equal(t, enumspb.TASK_QUEUE_KIND_NORMAL, queueKind)
+
+	groupID, queueKind = tracker.reserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_NORMAL, true)
+	require.Equal(t, "group-a", groupID)
+	require.Equal(t, enumspb.TASK_QUEUE_KIND_STICKY, queueKind)
+}
+
+func TestPollerGroupTrackerReserveWorkflowPollPrefersFallbackKindForCoverage(t *testing.T) {
+	tracker := newPollerGroupTracker(true)
+	tracker.updateGroups([]*taskqueuepb.PollerGroupInfo{
+		{Id: "group-a", Weight: 1},
+	})
+
+	groupID, queueKind := tracker.reserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_STICKY, true)
+	require.Equal(t, "group-a", groupID)
+	require.Equal(t, enumspb.TASK_QUEUE_KIND_STICKY, queueKind)
+
+	groupID, queueKind = tracker.reserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_NORMAL, true)
+	require.Equal(t, "group-a", groupID)
+	require.Equal(t, enumspb.TASK_QUEUE_KIND_NORMAL, queueKind)
+}
+
+func TestPollerGroupTrackerReserveWorkflowPollStickyCoverageAfterNormalRelease(t *testing.T) {
+	tracker := newPollerGroupTracker(true)
+	tracker.updateGroups([]*taskqueuepb.PollerGroupInfo{
+		{Id: "group-a", Weight: 1},
+	})
+
+	groupID, queueKind := tracker.reserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_NORMAL, true)
+	require.Equal(t, "group-a", groupID)
+	require.Equal(t, enumspb.TASK_QUEUE_KIND_NORMAL, queueKind)
+	tracker.release(groupID, queueKind)
+
+	groupID, queueKind = tracker.reserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_STICKY, true)
+	require.Equal(t, "group-a", groupID)
+	require.Equal(t, enumspb.TASK_QUEUE_KIND_STICKY, queueKind)
+}
+
+func TestPollerGroupTrackerReserveWorkflowPollUsesGroupStickyBacklogForFloatingPoll(t *testing.T) {
+	tracker := newPollerGroupTracker(true)
+	tracker.updateGroups([]*taskqueuepb.PollerGroupInfo{
+		{Id: "group-a", Weight: 0},
+		{Id: "group-b", Weight: 1},
+	})
+	tracker.groups["group-a"].workflowPendingNormal = 1
+	tracker.groups["group-a"].workflowPendingSticky = 1
+	tracker.groups["group-b"].workflowPendingNormal = 1
+	tracker.groups["group-b"].workflowPendingSticky = 1
+	tracker.groups["group-b"].workflowStickyBacklog = 2
+
+	groupID, queueKind := tracker.reserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_NORMAL, true)
+	require.Equal(t, "group-b", groupID)
+	require.Equal(t, enumspb.TASK_QUEUE_KIND_STICKY, queueKind)
+	require.Equal(t, 2, tracker.groups["group-b"].workflowPendingSticky)
+}
+
+func TestPollerGroupTrackerReserveWorkflowPollUsesNormalWhenStickyBacklogCovered(t *testing.T) {
+	tracker := newPollerGroupTracker(true)
+	tracker.updateGroups([]*taskqueuepb.PollerGroupInfo{
+		{Id: "group-a", Weight: 1},
+	})
+	tracker.groups["group-a"].workflowPendingNormal = 1
+	tracker.groups["group-a"].workflowPendingSticky = 2
+	tracker.groups["group-a"].workflowStickyBacklog = 2
+
+	groupID, queueKind := tracker.reserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_NORMAL, true)
+	require.Equal(t, "group-a", groupID)
+	require.Equal(t, enumspb.TASK_QUEUE_KIND_NORMAL, queueKind)
+	require.Equal(t, 2, tracker.groups["group-a"].workflowPendingNormal)
+}
+
+func TestPollerGroupTrackerUpdateStickyBacklogUsesKnownWorkflowGroup(t *testing.T) {
+	tracker := newPollerGroupTracker(true)
+	tracker.updateGroups([]*taskqueuepb.PollerGroupInfo{
+		{Id: "group-a", Weight: 1},
+		{Id: "group-b", Weight: 1},
+	})
+
+	tracker.updateStickyBacklog("group-b", 42)
+	tracker.updateStickyBacklog("unknown", 100)
+
+	require.Equal(t, int64(0), tracker.groups["group-a"].workflowStickyBacklog)
+	require.Equal(t, int64(42), tracker.groups["group-b"].workflowStickyBacklog)
+}
+
+func TestPollerGroupTrackerReserveWorkflowPollFallsBackBeforeGroupsKnown(t *testing.T) {
+	tracker := newPollerGroupTracker(true)
+
+	groupID, queueKind := tracker.reserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_STICKY, true)
+	require.Empty(t, groupID)
+	require.Equal(t, enumspb.TASK_QUEUE_KIND_STICKY, queueKind)
+}

--- a/internal/internal_poller_groups_test.go
+++ b/internal/internal_poller_groups_test.go
@@ -9,6 +9,87 @@ import (
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 )
 
+func TestPollerGroupTrackerReserveActivityNexusPollFillsCoverageBeforeWeights(t *testing.T) {
+	tracker := newPollerGroupTracker(false)
+	tracker.updateGroups([]*taskqueuepb.PollerGroupInfo{
+		{Id: "uncovered", Weight: 0},
+		{Id: "covered", Weight: 100},
+	})
+
+	groupID := tracker.reserve(enumspb.TASK_QUEUE_KIND_NORMAL)
+	require.Equal(t, "covered", groupID)
+	require.Equal(t, 1, tracker.groups["covered"].pendingPollCount)
+
+	groupID = tracker.reserve(enumspb.TASK_QUEUE_KIND_NORMAL)
+	require.Equal(t, "uncovered", groupID)
+	require.Equal(t, 1, tracker.groups["uncovered"].pendingPollCount)
+
+	groupID = tracker.reserve(enumspb.TASK_QUEUE_KIND_NORMAL)
+	require.Equal(t, "covered", groupID)
+	require.Equal(t, 2, tracker.groups["covered"].pendingPollCount)
+}
+
+func TestPollerGroupTrackerEmptyUpdateClearsGroups(t *testing.T) {
+	tracker := newPollerGroupTracker(true)
+	require.False(t, tracker.updateGroups(nil))
+
+	require.True(t, tracker.updateGroups([]*taskqueuepb.PollerGroupInfo{
+		{Id: "group-a", Weight: 1},
+	}))
+	require.Equal(t, 1, tracker.requiredMin(enumspb.TASK_QUEUE_KIND_NORMAL))
+
+	require.True(t, tracker.updateGroups(nil))
+	require.Equal(t, 0, tracker.requiredMin(enumspb.TASK_QUEUE_KIND_NORMAL))
+
+	groupID, queueKind := tracker.reserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_NORMAL, true)
+	require.Empty(t, groupID)
+	require.Equal(t, enumspb.TASK_QUEUE_KIND_NORMAL, queueKind)
+}
+
+// Signaling is only needed when group membership changes, not when weight-only changes occur
+func TestPollerGroupManagerUpdateSignalsOnlyOnMembershipChanges(t *testing.T) {
+	manager := newPollerGroupManager(true)
+	signals := 0
+	manager.addListener(func() {
+		signals++
+	})
+
+	manager.updateGroups([]*taskqueuepb.PollerGroupInfo{
+		{Id: "group-a", Weight: 100},
+		{Id: "group-b", Weight: 0},
+	})
+	require.Equal(t, 1, signals)
+
+	manager.updateGroups([]*taskqueuepb.PollerGroupInfo{
+		{Id: "group-a", Weight: 0},
+		{Id: "group-b", Weight: 100},
+	})
+	require.Equal(t, 1, signals, "weight-only updates should not signal listeners")
+
+	lease := manager.reserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_NORMAL, false)
+	defer lease.release()
+	require.Equal(t, "group-b", lease.groupIDOrEmpty(), "weight-only updates should affect future reservations")
+
+	manager.updateGroups([]*taskqueuepb.PollerGroupInfo{
+		{Id: "group-a", Weight: 0},
+		{Id: "group-b", Weight: 100},
+		{Id: "group-c", Weight: 1},
+	})
+	require.Equal(t, 2, signals, "adding a group should signal listeners")
+
+	manager.updateGroups([]*taskqueuepb.PollerGroupInfo{
+		{Id: "group-b", Weight: 100},
+		{Id: "group-c", Weight: 1},
+	})
+	require.Equal(t, 3, signals, "removing a group should signal listeners")
+
+	manager.updateGroups(nil)
+	require.Equal(t, 4, signals, "clearing groups should signal listeners")
+
+	manager.updateGroups(nil)
+	require.Equal(t, 4, signals, "empty update should not signal when groups are already empty")
+}
+
 func TestPollerGroupTrackerReserveWorkflowPollSatisfiesCoverageFirst(t *testing.T) {
 	tracker := newPollerGroupTracker(true)
 	tracker.updateGroups([]*taskqueuepb.PollerGroupInfo{
@@ -22,6 +103,34 @@ func TestPollerGroupTrackerReserveWorkflowPollSatisfiesCoverageFirst(t *testing.
 	groupID, queueKind = tracker.reserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_NORMAL, true)
 	require.Equal(t, "group-a", groupID)
 	require.Equal(t, enumspb.TASK_QUEUE_KIND_STICKY, queueKind)
+}
+
+func TestPollerGroupTrackerReserveWorkflowPollFillsCoverageBeforeWeights(t *testing.T) {
+	tracker := newPollerGroupTracker(true)
+	tracker.updateGroups([]*taskqueuepb.PollerGroupInfo{
+		{Id: "uncovered", Weight: 0},
+		{Id: "covered", Weight: 100},
+	})
+
+	groupID, queueKind := tracker.reserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_NORMAL, true)
+	require.Equal(t, "covered", groupID)
+	require.Equal(t, enumspb.TASK_QUEUE_KIND_NORMAL, queueKind)
+
+	groupID, queueKind = tracker.reserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_NORMAL, true)
+	require.Equal(t, "covered", groupID)
+	require.Equal(t, enumspb.TASK_QUEUE_KIND_STICKY, queueKind)
+
+	groupID, queueKind = tracker.reserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_NORMAL, true)
+	require.Equal(t, "uncovered", groupID)
+	require.Equal(t, enumspb.TASK_QUEUE_KIND_NORMAL, queueKind)
+
+	groupID, queueKind = tracker.reserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_NORMAL, true)
+	require.Equal(t, "uncovered", groupID)
+	require.Equal(t, enumspb.TASK_QUEUE_KIND_STICKY, queueKind)
+
+	groupID, queueKind = tracker.reserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_NORMAL, true)
+	require.Equal(t, "covered", groupID)
+	require.Equal(t, enumspb.TASK_QUEUE_KIND_NORMAL, queueKind)
 }
 
 func TestPollerGroupTrackerReserveWorkflowPollPrefersFallbackKindForCoverage(t *testing.T) {
@@ -86,6 +195,67 @@ func TestPollerGroupTrackerReserveWorkflowPollUsesNormalWhenStickyBacklogCovered
 	require.Equal(t, "group-a", groupID)
 	require.Equal(t, enumspb.TASK_QUEUE_KIND_NORMAL, queueKind)
 	require.Equal(t, 2, tracker.groups["group-a"].workflowPendingNormal)
+}
+
+func TestPollerGroupManagerWorkflowStickyBacklogUsesResponseGroupID(t *testing.T) {
+	manager := newPollerGroupManager(true)
+	manager.updateGroups([]*taskqueuepb.PollerGroupInfo{
+		{Id: "request-group", Weight: 100},
+		{Id: "response-group", Weight: 0},
+	})
+
+	requestNormalLease := manager.reserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_NORMAL, true)
+	defer requestNormalLease.release()
+	require.Equal(t, "request-group", requestNormalLease.groupIDOrEmpty())
+	require.Equal(t, enumspb.TASK_QUEUE_KIND_NORMAL, requestNormalLease.queueKind)
+
+	requestStickyLease := manager.reserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_STICKY, true)
+	defer requestStickyLease.release()
+	require.Equal(t, "request-group", requestStickyLease.groupIDOrEmpty())
+	require.Equal(t, enumspb.TASK_QUEUE_KIND_STICKY, requestStickyLease.queueKind)
+
+	responseNormalLease := manager.reserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_NORMAL, true)
+	defer responseNormalLease.release()
+	require.Equal(t, "response-group", responseNormalLease.groupIDOrEmpty())
+	require.Equal(t, enumspb.TASK_QUEUE_KIND_NORMAL, responseNormalLease.queueKind)
+
+	responseStickyLease := manager.reserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_STICKY, true)
+	defer responseStickyLease.release()
+	require.Equal(t, "response-group", responseStickyLease.groupIDOrEmpty())
+	require.Equal(t, enumspb.TASK_QUEUE_KIND_STICKY, responseStickyLease.queueKind)
+
+	manager.updateGroups([]*taskqueuepb.PollerGroupInfo{
+		{Id: "request-group", Weight: 0},
+		{Id: "response-group", Weight: 100},
+	})
+	manager.updateStickyBacklog("response-group", 2)
+
+	require.Equal(t, int64(0), manager.tracker.groups["request-group"].workflowStickyBacklog)
+	require.Equal(t, int64(2), manager.tracker.groups["response-group"].workflowStickyBacklog)
+
+	floatingLease := manager.reserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_NORMAL, true)
+	defer floatingLease.release()
+	require.Equal(t, "response-group", floatingLease.groupIDOrEmpty())
+	require.Equal(t, enumspb.TASK_QUEUE_KIND_STICKY, floatingLease.queueKind)
+}
+
+func TestPollerGroupLeaseReleaseUsesRequestGroupID(t *testing.T) {
+	manager := newPollerGroupManager(true)
+	manager.updateGroups([]*taskqueuepb.PollerGroupInfo{
+		{Id: "request-group", Weight: 100},
+		{Id: "response-group", Weight: 0},
+	})
+
+	lease := manager.reserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_NORMAL, true)
+	require.Equal(t, "request-group", lease.groupIDOrEmpty())
+	require.Equal(t, enumspb.TASK_QUEUE_KIND_NORMAL, lease.queueKind)
+
+	manager.tracker.groups["response-group"].workflowPendingNormal = 1
+
+	lease.release()
+
+	require.Equal(t, 0, manager.tracker.groups["request-group"].workflowPendingNormal)
+	require.Equal(t, 1, manager.tracker.groups["response-group"].workflowPendingNormal)
 }
 
 func TestPollerGroupTrackerUpdateStickyBacklogUsesKnownWorkflowGroup(t *testing.T) {

--- a/internal/internal_poller_groups_test.go
+++ b/internal/internal_poller_groups_test.go
@@ -1,0 +1,352 @@
+package internal
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	enumspb "go.temporal.io/api/enums/v1"
+	taskqueuepb "go.temporal.io/api/taskqueue/v1"
+)
+
+func testPollerGroupsInfo(version int64, groups []*taskqueuepb.PollerGroupInfo) *taskqueuepb.PollerGroupsInfo {
+	return &taskqueuepb.PollerGroupsInfo{Version: version, PollerGroups: groups}
+}
+
+func requireWorkflowPollLease(
+	t *testing.T,
+	manager *pollerGroupManager,
+	queueKind enumspb.TaskQueueKind,
+) pollerGroupLease {
+	t.Helper()
+	lease, ok := manager.tryReserveWorkflowPoll(queueKind)
+	require.True(t, ok)
+	return lease
+}
+
+func TestPollerGroupManagerReserveActivityNexusPollFillsCoverageBeforeWeights(t *testing.T) {
+	manager := newPollerGroupManager(pollerGroupModeNonWorkflow, nil)
+	manager.updateGroups(testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{
+		{Id: "uncovered", Weight: 0},
+		{Id: "covered", Weight: 100},
+	}))
+
+	lease := manager.reserve()
+	require.Equal(t, "covered", lease.groupIDOrEmpty())
+	require.Equal(t, 1, manager.tracker.groups["covered"].pendingPollCount)
+
+	lease = manager.reserve()
+	require.Equal(t, "uncovered", lease.groupIDOrEmpty())
+	require.Equal(t, 1, manager.tracker.groups["uncovered"].pendingPollCount)
+
+	lease = manager.reserve()
+	require.Equal(t, "covered", lease.groupIDOrEmpty())
+	require.Equal(t, 2, manager.tracker.groups["covered"].pendingPollCount)
+}
+
+func TestPollerGroupManagerEmptyUpdateClearsGroups(t *testing.T) {
+	manager := newPollerGroupManager(pollerGroupModeWorkflowWithSticky, nil)
+	manager.updateGroups(testPollerGroupsInfo(1, nil))
+	require.Equal(t, 0, manager.requiredMin())
+
+	manager.updateGroups(testPollerGroupsInfo(2, []*taskqueuepb.PollerGroupInfo{
+		{Id: "group-a", Weight: 1},
+	}))
+	require.Equal(t, 1, manager.requiredMin())
+
+	manager.updateGroups(testPollerGroupsInfo(3, nil))
+	require.Equal(t, 0, manager.requiredMin())
+
+	lease := requireWorkflowPollLease(t, manager, enumspb.TASK_QUEUE_KIND_NORMAL)
+	require.Empty(t, lease.groupIDOrEmpty())
+	require.Equal(t, enumspb.TASK_QUEUE_KIND_NORMAL, lease.queueKind)
+}
+
+func TestPollerGroupInfoStoreOnlyAppliesNewerVersions(t *testing.T) {
+	groupInfos := newPollerGroupInfoStore()
+	groupInfos.updateGroups(testPollerGroupsInfo(10, []*taskqueuepb.PollerGroupInfo{
+		{Id: "current", Weight: 1},
+	}))
+	changed := groupInfos.changed()
+
+	groupInfos.updateGroups(testPollerGroupsInfo(9, []*taskqueuepb.PollerGroupInfo{
+		{Id: "stale", Weight: 1},
+	}))
+	groupInfos.updateGroups(testPollerGroupsInfo(10, []*taskqueuepb.PollerGroupInfo{
+		{Id: "duplicate", Weight: 1},
+	}))
+	groupInfos.updateGroups(nil)
+	require.Equal(t, map[string]float32{"current": 1}, groupInfos.snapshot().weights)
+	select {
+	case <-changed:
+		t.Fatal("stale or empty update notified store observers")
+	default:
+	}
+
+	groupInfos.updateGroups(testPollerGroupsInfo(11, []*taskqueuepb.PollerGroupInfo{
+		{Id: "new", Weight: 1},
+	}))
+	require.Equal(t, map[string]float32{"new": 1}, groupInfos.snapshot().weights)
+	select {
+	case <-changed:
+	default:
+		t.Fatal("newer update did not notify store observers")
+	}
+}
+
+func TestPollerGroupInfoStoreAppliesFirstZeroVersion(t *testing.T) {
+	groupInfos := newPollerGroupInfoStore()
+	groupInfos.updateGroups(testPollerGroupsInfo(0, []*taskqueuepb.PollerGroupInfo{
+		{Id: "group-a", Weight: 1},
+	}))
+
+	require.Equal(t, map[string]float32{"group-a": 1}, groupInfos.snapshot().weights)
+}
+
+func TestPollerGroupManagersShareWeightsAndKeepCoverageSeparate(t *testing.T) {
+	groupInfos := newPollerGroupInfoStore()
+	external := newPollerGroupManager(pollerGroupModeNonWorkflow, groupInfos)
+	internal := newPollerGroupManager(pollerGroupModeNonWorkflow, groupInfos)
+
+	external.updateGroups(testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{
+		{Id: "group-a", Weight: 100},
+		{Id: "group-b", Weight: 0},
+	}))
+
+	externalLease := external.reserve()
+	defer externalLease.release()
+	require.Equal(t, "group-a", externalLease.groupIDOrEmpty())
+
+	internalALease := internal.reserve()
+	defer internalALease.release()
+	require.Equal(t, "group-a", internalALease.groupIDOrEmpty(), "external coverage must not satisfy internal coverage")
+
+	internalBLease := internal.reserve()
+	defer internalBLease.release()
+	require.Equal(t, "group-b", internalBLease.groupIDOrEmpty())
+
+	external.updateGroups(testPollerGroupsInfo(2, []*taskqueuepb.PollerGroupInfo{
+		{Id: "group-a", Weight: 0},
+		{Id: "group-b", Weight: 100},
+	}))
+
+	floatingLease := internal.reserve()
+	defer floatingLease.release()
+	require.Equal(t, "group-b", floatingLease.groupIDOrEmpty(), "external weight update must affect the internal manager's next floating poll")
+	require.Equal(t, 1, external.tracker.groups["group-a"].pendingPollCount)
+	require.Equal(t, 1, internal.tracker.groups["group-a"].pendingPollCount)
+	require.Equal(t, 2, internal.tracker.groups["group-b"].pendingPollCount)
+}
+
+func TestPollerGroupManagerReserveWorkflowPollSatisfiesCoverageFirst(t *testing.T) {
+	manager := newPollerGroupManager(pollerGroupModeWorkflowWithSticky, nil)
+	manager.updateGroups(testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{{Id: "group-a", Weight: 1}}))
+
+	lease := requireWorkflowPollLease(t, manager, enumspb.TASK_QUEUE_KIND_NORMAL)
+	require.Equal(t, "group-a", lease.groupIDOrEmpty())
+	require.Equal(t, enumspb.TASK_QUEUE_KIND_NORMAL, lease.queueKind)
+
+	_, ok := manager.tryReserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_NORMAL)
+	require.False(t, ok, "additional normal polls must wait for sticky coverage")
+
+	lease = requireWorkflowPollLease(t, manager, enumspb.TASK_QUEUE_KIND_STICKY)
+	require.Equal(t, "group-a", lease.groupIDOrEmpty())
+	require.Equal(t, enumspb.TASK_QUEUE_KIND_STICKY, lease.queueKind)
+
+	lease = requireWorkflowPollLease(t, manager, enumspb.TASK_QUEUE_KIND_NORMAL)
+	require.Equal(t, "group-a", lease.groupIDOrEmpty())
+	require.Equal(t, enumspb.TASK_QUEUE_KIND_NORMAL, lease.queueKind)
+}
+
+func TestPollerGroupManagerStickyDisabledDoesNotRequireStickyCoverage(t *testing.T) {
+	manager := newPollerGroupManager(pollerGroupModeWorkflow, nil)
+	manager.updateGroups(testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{{Id: "group-a", Weight: 1}}))
+
+	coverageLease := requireWorkflowPollLease(t, manager, enumspb.TASK_QUEUE_KIND_NORMAL)
+	defer coverageLease.release()
+
+	floatingLease := requireWorkflowPollLease(t, manager, enumspb.TASK_QUEUE_KIND_NORMAL)
+	defer floatingLease.release()
+	require.Equal(t, "group-a", floatingLease.groupIDOrEmpty())
+}
+
+func TestPollerGroupManagerReserveWorkflowPollFillsCoverageBeforeWeights(t *testing.T) {
+	manager := newPollerGroupManager(pollerGroupModeWorkflowWithSticky, nil)
+	manager.updateGroups(testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{
+		{Id: "uncovered", Weight: 0},
+		{Id: "covered", Weight: 100},
+	}))
+
+	lease := requireWorkflowPollLease(t, manager, enumspb.TASK_QUEUE_KIND_NORMAL)
+	require.Equal(t, "covered", lease.groupIDOrEmpty())
+	require.Equal(t, enumspb.TASK_QUEUE_KIND_NORMAL, lease.queueKind)
+
+	lease = requireWorkflowPollLease(t, manager, enumspb.TASK_QUEUE_KIND_NORMAL)
+	require.Equal(t, "uncovered", lease.groupIDOrEmpty())
+	require.Equal(t, enumspb.TASK_QUEUE_KIND_NORMAL, lease.queueKind)
+
+	_, ok := manager.tryReserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_NORMAL)
+	require.False(t, ok, "weighted normal polls must wait for sticky coverage")
+
+	lease = requireWorkflowPollLease(t, manager, enumspb.TASK_QUEUE_KIND_STICKY)
+	require.Equal(t, "covered", lease.groupIDOrEmpty())
+	require.Equal(t, enumspb.TASK_QUEUE_KIND_STICKY, lease.queueKind)
+
+	lease = requireWorkflowPollLease(t, manager, enumspb.TASK_QUEUE_KIND_STICKY)
+	require.Equal(t, "uncovered", lease.groupIDOrEmpty())
+	require.Equal(t, enumspb.TASK_QUEUE_KIND_STICKY, lease.queueKind)
+
+	lease = requireWorkflowPollLease(t, manager, enumspb.TASK_QUEUE_KIND_NORMAL)
+	require.Equal(t, "covered", lease.groupIDOrEmpty())
+	require.Equal(t, enumspb.TASK_QUEUE_KIND_NORMAL, lease.queueKind)
+}
+
+func TestPollerGroupManagerReserveWorkflowPollKeepsRunnerQueueKind(t *testing.T) {
+	manager := newPollerGroupManager(pollerGroupModeWorkflowWithSticky, nil)
+	manager.updateGroups(testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{{Id: "group-a", Weight: 1}}))
+
+	stickyLease := requireWorkflowPollLease(t, manager, enumspb.TASK_QUEUE_KIND_STICKY)
+	require.Equal(t, enumspb.TASK_QUEUE_KIND_STICKY, stickyLease.queueKind)
+
+	normalLease := requireWorkflowPollLease(t, manager, enumspb.TASK_QUEUE_KIND_NORMAL)
+	require.Equal(t, enumspb.TASK_QUEUE_KIND_NORMAL, normalLease.queueKind)
+
+	extraStickyLease := requireWorkflowPollLease(t, manager, enumspb.TASK_QUEUE_KIND_STICKY)
+	require.Equal(t, enumspb.TASK_QUEUE_KIND_STICKY, extraStickyLease.queueKind)
+}
+
+func TestPollerGroupManagerBlocksExtraNormalUntilAllStickyGroupsCovered(t *testing.T) {
+	manager := newPollerGroupManager(pollerGroupModeWorkflowWithSticky, nil)
+	manager.updateGroups(testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{
+		{Id: "group-a", Weight: 1},
+		{Id: "group-b", Weight: 1},
+		{Id: "group-c", Weight: 1},
+	}))
+
+	for range 3 {
+		lease := requireWorkflowPollLease(t, manager, enumspb.TASK_QUEUE_KIND_NORMAL)
+		require.Equal(t, enumspb.TASK_QUEUE_KIND_NORMAL, lease.queueKind)
+	}
+	firstSticky := requireWorkflowPollLease(t, manager, enumspb.TASK_QUEUE_KIND_STICKY)
+	require.Equal(t, enumspb.TASK_QUEUE_KIND_STICKY, firstSticky.queueKind)
+
+	_, ok := manager.tryReserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_NORMAL)
+	require.False(t, ok, "a fourth normal poll must wait while two sticky groups are uncovered")
+
+	secondSticky := requireWorkflowPollLease(t, manager, enumspb.TASK_QUEUE_KIND_STICKY)
+	thirdSticky := requireWorkflowPollLease(t, manager, enumspb.TASK_QUEUE_KIND_STICKY)
+	require.NotEqual(t, firstSticky.groupIDOrEmpty(), secondSticky.groupIDOrEmpty())
+	require.NotEqual(t, firstSticky.groupIDOrEmpty(), thirdSticky.groupIDOrEmpty())
+	require.NotEqual(t, secondSticky.groupIDOrEmpty(), thirdSticky.groupIDOrEmpty())
+
+	extraNormal := requireWorkflowPollLease(t, manager, enumspb.TASK_QUEUE_KIND_NORMAL)
+	require.Equal(t, enumspb.TASK_QUEUE_KIND_NORMAL, extraNormal.queueKind)
+}
+
+func TestPollerGroupManagerReserveWorkflowPollStickyCoverageAfterNormalRelease(t *testing.T) {
+	manager := newPollerGroupManager(pollerGroupModeWorkflowWithSticky, nil)
+	manager.updateGroups(testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{{Id: "group-a", Weight: 1}}))
+
+	lease := requireWorkflowPollLease(t, manager, enumspb.TASK_QUEUE_KIND_NORMAL)
+	require.Equal(t, "group-a", lease.groupIDOrEmpty())
+	require.Equal(t, enumspb.TASK_QUEUE_KIND_NORMAL, lease.queueKind)
+	lease.release()
+
+	lease = requireWorkflowPollLease(t, manager, enumspb.TASK_QUEUE_KIND_STICKY)
+	require.Equal(t, "group-a", lease.groupIDOrEmpty())
+	require.Equal(t, enumspb.TASK_QUEUE_KIND_STICKY, lease.queueKind)
+
+	_, ok := manager.tryReserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_STICKY)
+	require.False(t, ok, "additional sticky polls must wait for normal coverage to be restored")
+}
+
+func TestPollerGroupLeaseReleaseUsesRequestGroupID(t *testing.T) {
+	manager := newPollerGroupManager(pollerGroupModeWorkflowWithSticky, nil)
+	manager.updateGroups(testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{
+		{Id: "request-group", Weight: 100},
+		{Id: "response-group", Weight: 0},
+	}))
+
+	lease := requireWorkflowPollLease(t, manager, enumspb.TASK_QUEUE_KIND_NORMAL)
+	require.Equal(t, "request-group", lease.groupIDOrEmpty())
+	require.Equal(t, enumspb.TASK_QUEUE_KIND_NORMAL, lease.queueKind)
+
+	manager.tracker.groups["response-group"].workflowPendingNormal = 1
+	lease.release()
+
+	require.Equal(t, 0, manager.tracker.groups["request-group"].workflowPendingNormal)
+	require.Equal(t, 1, manager.tracker.groups["response-group"].workflowPendingNormal)
+}
+
+func TestPollerGroupManagerReserveWorkflowPollFallsBackBeforeGroupsKnown(t *testing.T) {
+	manager := newPollerGroupManager(pollerGroupModeWorkflowWithSticky, nil)
+
+	lease := requireWorkflowPollLease(t, manager, enumspb.TASK_QUEUE_KIND_STICKY)
+	require.Empty(t, lease.groupIDOrEmpty())
+	require.Equal(t, enumspb.TASK_QUEUE_KIND_STICKY, lease.queueKind)
+}
+
+func TestPollerGroupManagerRemovedGroupLeaseReleaseIsSafe(t *testing.T) {
+	manager := newPollerGroupManager(pollerGroupModeNonWorkflow, nil)
+	manager.updateGroups(testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{{Id: "group-a", Weight: 1}}))
+	lease := manager.reserve()
+
+	manager.updateGroups(testPollerGroupsInfo(2, nil))
+	require.Empty(t, manager.reserve().groupIDOrEmpty())
+	require.NotPanics(t, lease.release)
+}
+
+func TestPollerGroupLeaseReleaseDoesNotAffectReaddedGroup(t *testing.T) {
+	manager := newPollerGroupManager(pollerGroupModeNonWorkflow, nil)
+	manager.updateGroups(testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{{Id: "group-a", Weight: 1}}))
+	oldLease := manager.reserve()
+
+	manager.updateGroups(testPollerGroupsInfo(2, nil))
+	require.Empty(t, manager.reserve().groupIDOrEmpty())
+
+	manager.updateGroups(testPollerGroupsInfo(3, []*taskqueuepb.PollerGroupInfo{{Id: "group-a", Weight: 1}}))
+	newLease := manager.reserve()
+	newGroup := manager.tracker.groups["group-a"]
+	require.Equal(t, 1, newGroup.pendingPollCount)
+
+	oldLease.release()
+	require.Equal(t, 1, newGroup.pendingPollCount)
+
+	newLease.release()
+	require.Equal(t, 0, newGroup.pendingPollCount)
+}
+
+func TestPollerGroupManagersConcurrentSharedUpdatesAndReservations(t *testing.T) {
+	groupInfos := newPollerGroupInfoStore()
+	activity := newPollerGroupManager(pollerGroupModeNonWorkflow, groupInfos)
+	workflow := newPollerGroupManager(pollerGroupModeWorkflow, groupInfos)
+	groupInfos.updateGroups(testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{{Id: "group-a", Weight: 1}}))
+
+	var wg sync.WaitGroup
+	for i := range 100 {
+		wg.Add(3)
+		go func() {
+			defer wg.Done()
+			activity.reserve().release()
+		}()
+		go func() {
+			defer wg.Done()
+			lease, ok := workflow.tryReserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_NORMAL)
+			if ok {
+				lease.release()
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			groupInfos.updateGroups(testPollerGroupsInfo(int64(i+2), []*taskqueuepb.PollerGroupInfo{
+				{Id: "group-a", Weight: 1},
+				{Id: "group-b", Weight: 2},
+			}))
+		}()
+	}
+	wg.Wait()
+
+	require.Equal(t, 2, activity.requiredMin())
+	require.Equal(t, 2, workflow.requiredMin())
+}

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -1854,8 +1854,9 @@ func (wth *workflowTaskHandlerImpl) completeWorkflow(
 	// for query task
 	if task.Query != nil {
 		queryCompletedRequest := &workflowservice.RespondQueryTaskCompletedRequest{
-			TaskToken: task.TaskToken,
-			Namespace: wth.namespace,
+			TaskToken:     task.TaskToken,
+			Namespace:     wth.namespace,
+			PollerGroupId: task.GetPollerGroupId(),
 		}
 		var panicErr *PanicError
 		if errors.As(workflowContext.err, &panicErr) {

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -1999,6 +1999,7 @@ func (wth *workflowTaskHandlerImpl) completeWorkflow(
 		BinaryChecksum:   wth.workerBuildID,
 		QueryResults:     queryResults,
 		Namespace:        wth.namespace,
+		ResourceId:       getWorkflowResourceId(task.WorkflowExecution.GetWorkflowId()),
 		MeteringMetadata: &commonpb.MeteringMetadata{NonfirstLocalActivityExecutionAttempts: nonfirstLAAttempts},
 		SdkMetadata: &sdk.WorkflowTaskCompletedMetadata{
 			LangUsedFlags: langUsedFlags,
@@ -2249,10 +2250,11 @@ func (i *temporalInvoker) internalHeartBeat(ctx context.Context, details *common
 	defer cancel()
 
 	request := &workflowservice.RecordActivityTaskHeartbeatRequest{
-		TaskToken: i.taskToken,
-		Details:   details,
-		Identity:  i.identity,
-		Namespace: i.namespace,
+		TaskToken:  i.taskToken,
+		Details:    details,
+		Identity:   i.identity,
+		Namespace:  i.namespace,
+		ResourceId: getActivityResourceIdFromCtx(ctx),
 	}
 	var err error
 	if visitErr := visitProtoPayloads(ctx, i.outboundPayloadVisitor, request, 0); visitErr != nil {
@@ -2260,10 +2262,11 @@ func (i *temporalInvoker) internalHeartBeat(ctx context.Context, details *common
 		// waiting for the heartbeat timeout. Errors are ignored — if the RPC fails the
 		// activity will still be timed out by the server.
 		failReq := &workflowservice.RespondActivityTaskFailedRequest{
-			TaskToken: i.taskToken,
-			Failure:   i.failureConverter.ErrorToFailure(visitErr),
-			Identity:  i.identity,
-			Namespace: i.namespace,
+			TaskToken:  i.taskToken,
+			Failure:    i.failureConverter.ErrorToFailure(visitErr),
+			Identity:   i.identity,
+			Namespace:  i.namespace,
+			ResourceId: getActivityResourceIdFromCtx(ctx),
 		}
 		failCtx, failCancel := context.WithTimeout(context.Background(), recordTimeout)
 		defer failCancel()
@@ -2433,7 +2436,8 @@ func (ath *activityTaskHandlerImpl) Execute(taskQueue string, t *workflowservice
 		metricsHandler.Counter(metrics.UnregisteredActivityInvocationCounter).Inc(1)
 		return activityTaskResult{response: convertActivityResultToRespondRequest(ath.identity, t.TaskToken, nil,
 			NewActivityNotRegisteredError(activityType, ath.getRegisteredActivityNames()),
-			dataConverter, failureConverter, ath.namespace, false, ath.versionStamp, ath.deployment, ath.workerDeploymentOptions)}, nil
+			dataConverter, failureConverter, ath.namespace, false, ath.versionStamp, ath.deployment, ath.workerDeploymentOptions,
+			t.WorkflowExecution.GetWorkflowId(), t.ActivityId)}, nil
 	}
 
 	// panic handler
@@ -2452,7 +2456,8 @@ func (ath *activityTaskHandlerImpl) Execute(taskQueue string, t *workflowservice
 			panicErr := newPanicError(p, st)
 			result = activityTaskResult{
 				response: convertActivityResultToRespondRequest(ath.identity, t.TaskToken, nil, panicErr,
-					dataConverter, failureConverter, ath.namespace, false, ath.versionStamp, ath.deployment, ath.workerDeploymentOptions),
+					dataConverter, failureConverter, ath.namespace, false, ath.versionStamp, ath.deployment, ath.workerDeploymentOptions,
+					t.WorkflowExecution.GetWorkflowId(), t.ActivityId),
 			}
 		}
 	}()
@@ -2506,9 +2511,9 @@ func (ath *activityTaskHandlerImpl) Execute(taskQueue string, t *workflowservice
 			tagError, err,
 		)
 	}
-
 	response := convertActivityResultToRespondRequest(ath.identity, t.TaskToken, output, err,
-		dataConverter, failureConverter, ath.namespace, isActivityCanceled, ath.versionStamp, ath.deployment, ath.workerDeploymentOptions)
+		dataConverter, failureConverter, ath.namespace, isActivityCanceled, ath.versionStamp, ath.deployment, ath.workerDeploymentOptions,
+		t.WorkflowExecution.GetWorkflowId(), t.ActivityId)
 
 	if msg, ok := response.(proto.Message); ok {
 		var storageTarget converter.StorageDriverTargetInfo
@@ -2572,6 +2577,7 @@ func (ath *activityTaskHandlerImpl) visitorErrorToActivityFailure(msgPrefix stri
 		//lint:ignore SA1019 support legacy worker deployment APIs
 		Deployment:        ath.deployment,
 		DeploymentOptions: ath.workerDeploymentOptions,
+		ResourceId:        getActivityResourceId(t.WorkflowExecution.GetWorkflowId(), t.ActivityId),
 	}
 }
 
@@ -2630,6 +2636,14 @@ func createNewCommandWithMetadata(commandType enumspb.CommandType, metadata *sdk
 		CommandType:  commandType,
 		UserMetadata: metadata,
 	}
+}
+
+func getActivityResourceIdFromCtx(ctx context.Context) string {
+	env := getActivityEnvironmentFromCtx(ctx)
+	if env == nil {
+		return ""
+	}
+	return getActivityResourceId(env.workflowExecution.ID, env.activityID)
 }
 
 func recordActivityHeartbeat(ctx context.Context, service workflowservice.WorkflowServiceClient, metricsHandler metrics.Handler,

--- a/internal/internal_task_handlers_test.go
+++ b/internal/internal_task_handlers_test.go
@@ -833,6 +833,32 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_QueryWorkflow_NonSticky() {
 	t.Contains(queryResp.ErrorMessage, "unknown queryType")
 }
 
+func (t *TaskHandlersTestSuite) TestWorkflowTask_QueryResponseForwardsPollerGroupID() {
+	testEvents := []*historypb.HistoryEvent{
+		createTestEventWorkflowExecutionStarted(1, &historypb.WorkflowExecutionStartedEventAttributes{
+			TaskQueue: &taskqueuepb.TaskQueue{Name: testWorkflowTaskTaskqueue},
+		}),
+		createTestEventWorkflowTaskScheduled(2, &historypb.WorkflowTaskScheduledEventAttributes{
+			TaskQueue: &taskqueuepb.TaskQueue{Name: testWorkflowTaskTaskqueue},
+		}),
+		createTestEventWorkflowTaskStarted(3),
+	}
+	task := createQueryTask(testEvents, 3, "HelloWorld_Workflow", queryType)
+	task.PollerGroupId = "test-poller-group-42"
+
+	taskHandler := newWorkflowTaskHandler(t.getTestWorkerExecutionParams(), nil, t.registry)
+	wftask := workflowTask{task: task}
+	wfctx := t.mustWorkflowContextImpl(&wftask, taskHandler)
+	response, err := taskHandler.ProcessWorkflowTask(&wftask, wfctx, nil)
+	wfctx.Unlock(err)
+	t.NoError(err)
+	t.NotNil(response)
+
+	queryResp, ok := response.rawRequest.(*workflowservice.RespondQueryTaskCompletedRequest)
+	t.True(ok)
+	t.Equal("test-poller-group-42", queryResp.PollerGroupId)
+}
+
 func (t *TaskHandlersTestSuite) verifyQueryResult(response *workflowTaskCompletion, expectedResult string) {
 	t.NotNil(response)
 	queryResp, ok := response.rawRequest.(*workflowservice.RespondQueryTaskCompletedRequest)

--- a/internal/internal_task_handlers_test.go
+++ b/internal/internal_task_handlers_test.go
@@ -836,6 +836,32 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_QueryWorkflow_NonSticky() {
 	t.Contains(queryResp.ErrorMessage, "unknown queryType")
 }
 
+func (t *TaskHandlersTestSuite) TestWorkflowTask_QueryResponseForwardsPollerGroupID() {
+	testEvents := []*historypb.HistoryEvent{
+		createTestEventWorkflowExecutionStarted(1, &historypb.WorkflowExecutionStartedEventAttributes{
+			TaskQueue: &taskqueuepb.TaskQueue{Name: testWorkflowTaskTaskqueue},
+		}),
+		createTestEventWorkflowTaskScheduled(2, &historypb.WorkflowTaskScheduledEventAttributes{
+			TaskQueue: &taskqueuepb.TaskQueue{Name: testWorkflowTaskTaskqueue},
+		}),
+		createTestEventWorkflowTaskStarted(3),
+	}
+	task := createQueryTask(testEvents, 3, "HelloWorld_Workflow", queryType)
+	task.PollerGroupId = "test-poller-group-42"
+
+	taskHandler := newWorkflowTaskHandler(t.getTestWorkerExecutionParams(), nil, t.registry)
+	wftask := workflowTask{task: task}
+	wfctx := t.mustWorkflowContextImpl(&wftask, taskHandler)
+	response, err := taskHandler.ProcessWorkflowTask(&wftask, wfctx, nil)
+	wfctx.Unlock(err)
+	t.NoError(err)
+	t.NotNil(response)
+
+	queryResp, ok := response.rawRequest.(*workflowservice.RespondQueryTaskCompletedRequest)
+	t.True(ok)
+	t.Equal("test-poller-group-42", queryResp.PollerGroupId)
+}
+
 func (t *TaskHandlersTestSuite) verifyQueryResult(response *workflowTaskCompletion, expectedResult string) {
 	t.NotNil(response)
 	queryResp, ok := response.rawRequest.(*workflowservice.RespondQueryTaskCompletedRequest)
@@ -1848,7 +1874,7 @@ func (t *TaskHandlersTestSuite) TestLocalActivityRetry_Workflow() {
 		laTaskPoller := newLocalActivityPoller(params, laTunnel, nil, nil, stopCh)
 		go func() {
 			for {
-				task, _ := laTaskPoller.PollTask()
+				task, _ := laTaskPoller.PollTask(pollerGroupLease{})
 				if task == nil {
 					return
 				}
@@ -1930,7 +1956,7 @@ func (t *TaskHandlersTestSuite) TestLocalActivityRetry_WorkflowTaskHeartbeatFail
 	doneCh := make(chan struct{})
 	go func() {
 		// laTaskPoller needs to poll the local activity and process it
-		task, err := laTaskPoller.PollTask()
+		task, err := laTaskPoller.PollTask(pollerGroupLease{})
 		t.NoError(err)
 		err = laTaskPoller.ProcessTask(task)
 		t.NoError(err)

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -809,6 +809,7 @@ func (wtp *workflowTaskProcessor) reportGrpcMessageTooLarge(
 			Namespace:     wtp.namespace,
 			Failure:       wtp.failureConverter.ErrorToFailure(sendErr),
 			Cause:         enumspb.WORKFLOW_TASK_FAILED_CAUSE_GRPC_MESSAGE_TOO_LARGE,
+			PollerGroupId: task.GetPollerGroupId(),
 		}
 		if err = visitProtoPayloads(ctx, wtp.outboundPayloadVisitor, request, wtp.payloadVisitorConcurrency); err != nil {
 			wtp.logger.Error("Failed to visit payloads for GRPC message too large query failure response.", tagError, err)

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -1466,7 +1466,7 @@ func (atp *activityTaskPoller) poll(ctx context.Context) (taskForWorker, error) 
 		WorkerControlTaskQueue: atp.workerControlTaskQueue,
 	}
 
-	lease := atp.pollerGroups.reserve(enumspb.TASK_QUEUE_KIND_NORMAL)
+	lease := atp.pollerGroups.reserve()
 	defer lease.release()
 	request.PollerGroupId = lease.groupIDOrEmpty()
 

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -91,6 +91,8 @@ type (
 		workerInstanceKey string
 		// Per-client queue used by the server to send worker commands.
 		workerControlTaskQueue string
+		// Per-client poller-group snapshots received from poll responses.
+		pollerGroupInfoStore *pollerGroupInfoStore
 		// Server cancels polls on shutdown
 		workerPollCompleteOnShutdown *atomic.Bool
 	}
@@ -352,6 +354,16 @@ func (bp *basePoller) getCapabilities() *workflowservice.GetSystemInfoResponse_C
 	return bp.capabilities
 }
 
+func (bp *basePoller) updatePollerGroups(manager *pollerGroupManager, info *taskqueuepb.PollerGroupsInfo) {
+	if manager != nil {
+		manager.updateGroups(info)
+		return
+	}
+	if bp != nil {
+		bp.pollerGroupInfoStore.updateGroups(info)
+	}
+}
+
 func (bp *basePoller) getDeploymentName() string {
 	return bp.workerDeploymentVersion.DeploymentName
 }
@@ -375,6 +387,7 @@ func newWorkflowTaskProcessor(
 			pollTimeTracker:              params.pollTimeTracker,
 			workerInstanceKey:            params.workerInstanceKey,
 			workerControlTaskQueue:       params.workerControlTaskQueue,
+			pollerGroupInfoStore:         params.pollerGroupInfoStore,
 			workerPollCompleteOnShutdown: params.workerPollCompleteOnShutdown,
 		},
 		service:                      service,
@@ -1221,7 +1234,7 @@ func (wtp *workflowTaskPoller) poll(ctx context.Context) (taskForWorker, error) 
 	}
 
 	if response != nil {
-		wtp.pollerGroups.updateGroups(response.GetPollerGroupInfos())
+		wtp.updatePollerGroups(wtp.pollerGroups, response.GetPollerGroupsInfo())
 		if queueKind == enumspb.TASK_QUEUE_KIND_STICKY {
 			wtp.pollerGroups.updateStickyBacklog(response.GetPollerGroupId(), response.GetBacklogCountHint())
 		}
@@ -1420,6 +1433,7 @@ func newActivityTaskPoller(
 			pollTimeTracker:              params.pollTimeTracker,
 			workerInstanceKey:            params.workerInstanceKey,
 			workerControlTaskQueue:       params.workerControlTaskQueue,
+			pollerGroupInfoStore:         params.pollerGroupInfoStore,
 			workerPollCompleteOnShutdown: params.workerPollCompleteOnShutdown,
 		},
 		taskHandler:         taskHandler,
@@ -1475,7 +1489,7 @@ func (atp *activityTaskPoller) poll(ctx context.Context) (taskForWorker, error) 
 		return nil, err
 	}
 	if response != nil {
-		atp.pollerGroups.updateGroups(response.GetPollerGroupInfos())
+		atp.updatePollerGroups(atp.pollerGroups, response.GetPollerGroupsInfo())
 	}
 	if response == nil || len(response.TaskToken) == 0 {
 		// No activity info is available on empty poll.  Emit using base scope.

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -130,6 +130,8 @@ type (
 
 		inboundPayloadVisitor     PayloadVisitor
 		payloadVisitorConcurrency int
+
+		pollerGroups *pollerGroupManager
 	}
 
 	// workflowTaskProcessor implements processing of a workflow task and can create
@@ -174,6 +176,7 @@ type (
 		logger              log.Logger
 		activitiesPerSecond float64
 		numPollerMetric     *numPollerMetric
+		pollerGroups        *pollerGroupManager
 	}
 
 	historyIteratorImpl struct {
@@ -406,7 +409,10 @@ func (wtp *workflowTaskPoller) PollTask() (taskForWorker, error) {
 	return workflowTask, nil
 }
 
-func (wtp *workflowTaskProcessor) createPoller(mode workflowTaskPollerMode) taskPoller {
+func (wtp *workflowTaskProcessor) createPoller(
+	mode workflowTaskPollerMode,
+	pollerGroups *pollerGroupManager,
+) taskPoller {
 	return &workflowTaskPoller{
 		basePoller:                   wtp.basePoller,
 		mode:                         mode,
@@ -430,6 +436,7 @@ func (wtp *workflowTaskProcessor) createPoller(mode workflowTaskPollerMode) task
 		numStickyPollerMetric:        wtp.numStickyPollerMetric,
 		inboundPayloadVisitor:        wtp.inboundPayloadVisitor,
 		payloadVisitorConcurrency:    wtp.payloadVisitorConcurrency,
+		pollerGroups:                 pollerGroups,
 	}
 }
 
@@ -1115,30 +1122,37 @@ func (wtp *workflowTaskPoller) updateBacklog(taskQueueKind enumspb.TaskQueueKind
 //     3.2.1) if sticky task queue has backlog, always prefer to process sticky task first
 //     3.2.2) poll from the task queue that has less pending requests (prefer sticky when they are the same).
 func (wtp *workflowTaskPoller) getNextPollRequest() (request *workflowservice.PollWorkflowTaskQueueRequest) {
-	taskQueue := &taskqueuepb.TaskQueue{
-		Name: wtp.taskQueueName,
-		Kind: enumspb.TASK_QUEUE_KIND_NORMAL,
-	}
+	queueKind := enumspb.TASK_QUEUE_KIND_NORMAL
 
 	if wtp.mode == NonSticky || wtp.stickyCacheSize <= 0 {
 		// Do nothing, taskQueue is already set to non-sticky
 	} else if wtp.mode == Sticky {
-		taskQueue.Name = getWorkerTaskQueue(wtp.stickyUUID)
-		taskQueue.Kind = enumspb.TASK_QUEUE_KIND_STICKY
-		taskQueue.NormalName = wtp.taskQueueName
+		queueKind = enumspb.TASK_QUEUE_KIND_STICKY
 	} else if wtp.mode == Mixed {
 		wtp.requestLock.Lock()
 		if wtp.stickyBacklog > 0 || wtp.pendingStickyPollCount <= wtp.pendingRegularPollCount {
 			wtp.pendingStickyPollCount++
-			taskQueue.Name = getWorkerTaskQueue(wtp.stickyUUID)
-			taskQueue.Kind = enumspb.TASK_QUEUE_KIND_STICKY
-			taskQueue.NormalName = wtp.taskQueueName
+			queueKind = enumspb.TASK_QUEUE_KIND_STICKY
 		} else {
 			wtp.pendingRegularPollCount++
 		}
 		wtp.requestLock.Unlock()
 	} else {
 		panic("unknown workflow task poller mode")
+	}
+
+	return wtp.getPollRequestForKind(queueKind)
+}
+
+func (wtp *workflowTaskPoller) getPollRequestForKind(queueKind enumspb.TaskQueueKind) (request *workflowservice.PollWorkflowTaskQueueRequest) {
+	taskQueue := &taskqueuepb.TaskQueue{
+		Name: wtp.taskQueueName,
+		Kind: enumspb.TASK_QUEUE_KIND_NORMAL,
+	}
+	if queueKind == enumspb.TASK_QUEUE_KIND_STICKY {
+		taskQueue.Name = getWorkerTaskQueue(wtp.stickyUUID)
+		taskQueue.Kind = enumspb.TASK_QUEUE_KIND_STICKY
+		taskQueue.NormalName = wtp.taskQueueName
 	}
 
 	builtRequest := &workflowservice.PollWorkflowTaskQueueRequest{
@@ -1184,29 +1198,49 @@ func (wtp *workflowTaskPoller) poll(ctx context.Context) (taskForWorker, error) 
 		wtp.logger.Debug("workflowTaskPoller::Poll")
 	})
 
-	request := wtp.getNextPollRequest()
-	defer wtp.release(request.TaskQueue.GetKind())
+	var lease pollerGroupLease
+	var request *workflowservice.PollWorkflowTaskQueueRequest
+	var queueKind enumspb.TaskQueueKind
+	if wtp.pollerGroups != nil {
+		preferredQueueKind := wtp.preferredQueueKind()
+		lease = wtp.pollerGroups.reserveWorkflowPoll(preferredQueueKind, wtp.stickyCacheSize > 0)
+		defer lease.release()
+		queueKind = lease.queueKindOr(preferredQueueKind)
+		request = wtp.getPollRequestForKind(queueKind)
+		request.PollerGroupId = lease.groupIDOrEmpty()
+	} else {
+		request = wtp.getNextPollRequest()
+		queueKind = request.TaskQueue.GetKind()
+		defer wtp.release(queueKind)
+	}
 
 	response, err := wtp.pollWorkflowTaskQueue(ctx, request)
 	if err != nil {
-		wtp.updateBacklog(request.TaskQueue.GetKind(), 0)
+		wtp.updateBacklog(queueKind, 0)
 		return nil, err
+	}
+
+	if response != nil {
+		wtp.pollerGroups.updateGroups(response.GetPollerGroupInfos())
+		if queueKind == enumspb.TASK_QUEUE_KIND_STICKY {
+			wtp.pollerGroups.updateStickyBacklog(response.GetPollerGroupId(), response.GetBacklogCountHint())
+		}
 	}
 
 	if response == nil || len(response.TaskToken) == 0 {
 		// Emit using base scope as no workflow type information is available in the case of empty poll
 		wtp.metricsHandler.Counter(metrics.WorkflowTaskQueuePollEmptyCounter).Inc(1)
-		wtp.updateBacklog(request.TaskQueue.GetKind(), 0)
+		wtp.updateBacklog(queueKind, 0)
 		return &workflowTask{}, nil
 	}
 
-	if request.TaskQueue.GetKind() == enumspb.TASK_QUEUE_KIND_STICKY {
+	if queueKind == enumspb.TASK_QUEUE_KIND_STICKY {
 		wtp.pollTimeTracker.recordPollSuccess(metrics.PollerTypeWorkflowStickyTask)
 	} else {
 		wtp.pollTimeTracker.recordPollSuccess(metrics.PollerTypeWorkflowTask)
 	}
 
-	wtp.updateBacklog(request.TaskQueue.GetKind(), response.GetBacklogCountHint())
+	wtp.updateBacklog(queueKind, response.GetBacklogCountHint())
 
 	task := wtp.toWorkflowTask(response)
 	traceLog(func() {
@@ -1227,6 +1261,13 @@ func (wtp *workflowTaskPoller) poll(ctx context.Context) (taskForWorker, error) 
 	scheduleToStartLatency := response.GetStartedTime().AsTime().Sub(response.GetScheduledTime().AsTime())
 	metricsHandler.Timer(metrics.WorkflowTaskScheduleToStartLatency).Record(scheduleToStartLatency)
 	return task, nil
+}
+
+func (wtp *workflowTaskPoller) preferredQueueKind() enumspb.TaskQueueKind {
+	if wtp.mode == Sticky && wtp.stickyCacheSize > 0 {
+		return enumspb.TASK_QUEUE_KIND_STICKY
+	}
+	return enumspb.TASK_QUEUE_KIND_NORMAL
 }
 
 func (wtp *workflowTaskPoller) toWorkflowTask(response *workflowservice.PollWorkflowTaskQueueResponse) *workflowTask {
@@ -1362,7 +1403,12 @@ func newGetHistoryPageFunc(
 	}
 }
 
-func newActivityTaskPoller(taskHandler ActivityTaskHandler, service workflowservice.WorkflowServiceClient, params workerExecutionParameters) *activityTaskPoller {
+func newActivityTaskPoller(
+	taskHandler ActivityTaskHandler,
+	service workflowservice.WorkflowServiceClient,
+	params workerExecutionParameters,
+	pollerGroups *pollerGroupManager,
+) *activityTaskPoller {
 	return &activityTaskPoller{
 		basePoller: basePoller{
 			metricsHandler:               params.MetricsHandler,
@@ -1384,6 +1430,7 @@ func newActivityTaskPoller(taskHandler ActivityTaskHandler, service workflowserv
 		logger:              params.Logger,
 		activitiesPerSecond: params.TaskQueueActivitiesPerSecond,
 		numPollerMetric:     newNumPollerMetric(params.MetricsHandler, metrics.PollerTypeActivityTask),
+		pollerGroups:        pollerGroups,
 	}
 }
 
@@ -1400,6 +1447,7 @@ func (atp *activityTaskPoller) poll(ctx context.Context) (taskForWorker, error) 
 	traceLog(func() {
 		atp.logger.Debug("activityTaskPoller::Poll")
 	})
+
 	request := &workflowservice.PollActivityTaskQueueRequest{
 		Namespace:         atp.namespace,
 		TaskQueue:         &taskqueuepb.TaskQueue{Name: atp.taskQueueName, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
@@ -1418,9 +1466,16 @@ func (atp *activityTaskPoller) poll(ctx context.Context) (taskForWorker, error) 
 		WorkerControlTaskQueue: atp.workerControlTaskQueue,
 	}
 
+	lease := atp.pollerGroups.reserve(enumspb.TASK_QUEUE_KIND_NORMAL)
+	defer lease.release()
+	request.PollerGroupId = lease.groupIDOrEmpty()
+
 	response, err := atp.pollActivityTaskQueue(ctx, request)
 	if err != nil {
 		return nil, err
+	}
+	if response != nil {
+		atp.pollerGroups.updateGroups(response.GetPollerGroupInfos())
 	}
 	if response == nil || len(response.TaskToken) == 0 {
 		// No activity info is available on empty poll.  Emit using base scope.

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -586,7 +586,7 @@ func (wtp *workflowTaskProcessor) RespondTaskCompletedWithMetrics(
 			tagAttempt, task.Attempt,
 			tagError, taskErr)
 		emitFailMetric = true
-		failWorkflowTask := wtp.errorToFailWorkflowTask(task.TaskToken, taskErr)
+		failWorkflowTask := wtp.errorToFailWorkflowTask(task.TaskToken, task.WorkflowExecution.GetWorkflowId(), taskErr)
 		failureReason = metrics.FailureReasonWorkflowError
 		if failWorkflowTask.Cause == enumspb.WORKFLOW_TASK_FAILED_CAUSE_NON_DETERMINISTIC_ERROR {
 			failureReason = metrics.FailureReasonNonDeterminismError
@@ -628,7 +628,7 @@ func (wtp *workflowTaskProcessor) RespondTaskCompletedWithMetrics(
 		if errors.As(taskErr, new(payloadSizeError)) {
 			failureReason = metrics.FailureReasonPayloadsTooLarge
 		}
-		taskCompletion = &workflowTaskCompletion{rawRequest: wtp.errorToFailWorkflowTask(task.TaskToken, taskErr)}
+		taskCompletion = &workflowTaskCompletion{rawRequest: wtp.errorToFailWorkflowTask(task.TaskToken, task.WorkflowExecution.GetWorkflowId(), taskErr)}
 	}
 
 	taskDuration := time.Since(startTime)
@@ -774,7 +774,7 @@ func (wtp *workflowTaskProcessor) reportGrpcMessageTooLarge(
 	switch taskCompletion.rawRequest.(type) {
 	case *workflowservice.RespondWorkflowTaskCompletedRequest, *workflowservice.RespondWorkflowTaskFailedRequest:
 		emitFailMetric = true
-		request := wtp.errorToFailWorkflowTask(task.TaskToken, sendErr)
+		request := wtp.errorToFailWorkflowTask(task.TaskToken, task.WorkflowExecution.GetWorkflowId(), sendErr)
 		request.Cause = enumspb.WORKFLOW_TASK_FAILED_CAUSE_GRPC_MESSAGE_TOO_LARGE
 		if err = visitProtoPayloads(ctx, wtp.outboundPayloadVisitor, request, wtp.payloadVisitorConcurrency); err != nil {
 			wtp.logger.Error("Failed to visit payloads for GRPC message too large failure response.", tagError, err)
@@ -818,13 +818,13 @@ func (wtp *workflowTaskProcessor) handleInboundVisitorError(task *workflowservic
 	wtp.logger.Warn("Workflow task preprocess error: "+visitErr.Error(), keyvals...)
 	// Submit an explicit WFT failure so the server records the error immediately
 	// rather than waiting for the task to time out.
-	failReq := wtp.errorToFailWorkflowTask(task.TaskToken, visitErr)
+	failReq := wtp.errorToFailWorkflowTask(task.TaskToken, task.WorkflowExecution.GetWorkflowId(), visitErr)
 	if _, submitErr := wtp.sendTaskCompletedRequest(&workflowTaskCompletion{rawRequest: failReq}, task); submitErr != nil {
 		wtp.logger.Warn("Failed to submit WFT failure after inbound visitor error.", tagError, submitErr)
 	}
 }
 
-func (wtp *workflowTaskProcessor) errorToFailWorkflowTask(taskToken []byte, err error) *workflowservice.RespondWorkflowTaskFailedRequest {
+func (wtp *workflowTaskProcessor) errorToFailWorkflowTask(taskToken []byte, workflowId string, err error) *workflowservice.RespondWorkflowTaskFailedRequest {
 	cause := enumspb.WORKFLOW_TASK_FAILED_CAUSE_WORKFLOW_WORKER_UNHANDLED_FAILURE
 	// If it was a panic due to a bad state machine or if it was a history
 	// mismatch error, mark as non-deterministic
@@ -840,10 +840,10 @@ func (wtp *workflowTaskProcessor) errorToFailWorkflowTask(taskToken []byte, err 
 		cause = enumspb.WORKFLOW_TASK_FAILED_CAUSE_PAYLOADS_TOO_LARGE
 	}
 
-	return wtp.errorToFailWorkflowTaskWithCause(taskToken, err, cause)
+	return wtp.errorToFailWorkflowTaskWithCause(taskToken, workflowId, err, cause)
 }
 
-func (wtp *workflowTaskProcessor) errorToFailWorkflowTaskWithCause(taskToken []byte, err error, cause enumspb.WorkflowTaskFailedCause) *workflowservice.RespondWorkflowTaskFailedRequest {
+func (wtp *workflowTaskProcessor) errorToFailWorkflowTaskWithCause(taskToken []byte, workflowId string, err error, cause enumspb.WorkflowTaskFailedCause) *workflowservice.RespondWorkflowTaskFailedRequest {
 	builtRequest := &workflowservice.RespondWorkflowTaskFailedRequest{
 		TaskToken: taskToken,
 		Cause:     cause,
@@ -852,6 +852,7 @@ func (wtp *workflowTaskProcessor) errorToFailWorkflowTaskWithCause(taskToken []b
 		//lint:ignore SA1019 retain the checksum used by servers without Build ID versioning support
 		BinaryChecksum: wtp.workerBuildID,
 		Namespace:      wtp.namespace,
+		ResourceId:     getWorkflowResourceId(workflowId),
 		//lint:ignore SA1019 retain legacy Build ID versioning metadata for older servers
 		WorkerVersion: &commonpb.WorkerVersionStamp{
 			BuildId:       wtp.workerBuildID,
@@ -1602,6 +1603,23 @@ func reportActivityCompleteByID(
 	return reportErr
 }
 
+func getActivityResourceId(workflowId, activityId string) string {
+	if workflowId != "" {
+		return getWorkflowResourceId(workflowId)
+	}
+	if activityId != "" {
+		return fmt.Sprintf("activity:%s", activityId)
+	}
+	return ""
+}
+
+func getWorkflowResourceId(workflowId string) string {
+	if workflowId == "" {
+		return ""
+	}
+	return fmt.Sprintf("workflow:%s", workflowId)
+}
+
 func convertActivityResultToRespondRequest(
 	identity string,
 	taskToken []byte,
@@ -1614,6 +1632,8 @@ func convertActivityResultToRespondRequest(
 	versionStamp *commonpb.WorkerVersionStamp,
 	deployment *deploymentpb.Deployment,
 	workerDeploymentOptions *deploymentpb.WorkerDeploymentOptions,
+	workflowId string,
+	activityId string,
 ) any {
 	if err == ErrActivityResultPending {
 		// activity result is pending and will be completed asynchronously.
@@ -1623,10 +1643,11 @@ func convertActivityResultToRespondRequest(
 
 	if err == nil {
 		return &workflowservice.RespondActivityTaskCompletedRequest{
-			TaskToken: taskToken,
-			Result:    result,
-			Identity:  identity,
-			Namespace: namespace,
+			TaskToken:  taskToken,
+			Result:     result,
+			Identity:   identity,
+			Namespace:  namespace,
+			ResourceId: getActivityResourceId(workflowId, activityId),
 			//lint:ignore SA1019 retain legacy Build ID versioning metadata for older servers
 			WorkerVersion: versionStamp,
 			//lint:ignore SA1019 retain legacy deployment metadata for servers predating deployment options
@@ -1640,10 +1661,11 @@ func convertActivityResultToRespondRequest(
 		var canceledErr *CanceledError
 		if errors.As(err, &canceledErr) {
 			return &workflowservice.RespondActivityTaskCanceledRequest{
-				TaskToken: taskToken,
-				Details:   convertErrDetailsToPayloads(canceledErr.details, dataConverter),
-				Identity:  identity,
-				Namespace: namespace,
+				TaskToken:  taskToken,
+				Details:    convertErrDetailsToPayloads(canceledErr.details, dataConverter),
+				Identity:   identity,
+				Namespace:  namespace,
+				ResourceId: getActivityResourceId(workflowId, activityId),
 				//lint:ignore SA1019 retain legacy Build ID versioning metadata for older servers
 				WorkerVersion: versionStamp,
 				//lint:ignore SA1019 retain legacy deployment metadata for servers predating deployment options
@@ -1653,9 +1675,10 @@ func convertActivityResultToRespondRequest(
 		}
 		if errors.Is(err, context.Canceled) {
 			return &workflowservice.RespondActivityTaskCanceledRequest{
-				TaskToken: taskToken,
-				Identity:  identity,
-				Namespace: namespace,
+				TaskToken:  taskToken,
+				Identity:   identity,
+				Namespace:  namespace,
+				ResourceId: getActivityResourceId(workflowId, activityId),
 				//lint:ignore SA1019 retain legacy Build ID versioning metadata for older servers
 				WorkerVersion: versionStamp,
 				//lint:ignore SA1019 retain legacy deployment metadata for servers predating deployment options
@@ -1672,10 +1695,11 @@ func convertActivityResultToRespondRequest(
 	}
 
 	return &workflowservice.RespondActivityTaskFailedRequest{
-		TaskToken: taskToken,
-		Failure:   failureConverter.ErrorToFailure(err),
-		Identity:  identity,
-		Namespace: namespace,
+		TaskToken:  taskToken,
+		Failure:    failureConverter.ErrorToFailure(err),
+		Identity:   identity,
+		Namespace:  namespace,
+		ResourceId: getActivityResourceId(workflowId, activityId),
 		//lint:ignore SA1019 retain legacy Build ID versioning metadata for older servers
 		WorkerVersion: versionStamp,
 		//lint:ignore SA1019 retain legacy deployment metadata for servers predating deployment options
@@ -1710,6 +1734,7 @@ func convertActivityResultToRespondRequestByID(
 			ActivityId: activityID,
 			Result:     result,
 			Identity:   identity,
+			ResourceId: getActivityResourceId(workflowID, activityID),
 		}
 	}
 
@@ -1724,6 +1749,7 @@ func convertActivityResultToRespondRequestByID(
 				ActivityId: activityID,
 				Details:    convertErrDetailsToPayloads(canceledErr.details, dataConverter),
 				Identity:   identity,
+				ResourceId: getActivityResourceId(workflowID, activityID),
 			}
 		}
 		if errors.Is(err, context.Canceled) {
@@ -1733,6 +1759,7 @@ func convertActivityResultToRespondRequestByID(
 				RunId:      runID,
 				ActivityId: activityID,
 				Identity:   identity,
+				ResourceId: getActivityResourceId(workflowID, activityID),
 			}
 		}
 	}
@@ -1750,6 +1777,7 @@ func convertActivityResultToRespondRequestByID(
 		ActivityId: activityID,
 		Failure:    failureConverter.ErrorToFailure(err),
 		Identity:   identity,
+		ResourceId: getActivityResourceId(workflowID, activityID),
 	}
 }
 

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -52,13 +52,19 @@ const (
 )
 
 type (
-	// taskPoller interface to poll for tasks
+	// taskPoller polls for one task at a time. A single implementation instance
+	// may be called concurrently by multiple poll loops, so implementations must
+	// be safe for concurrent use. The caller owns any supplied poller-group lease.
+	// Workflow leases are acquired before slot reservation because admission must
+	// select normal or sticky. Activity and Nexus reserve internally before their
+	// RPCs to avoid holding group coverage while waiting for a slot.
 	taskPoller interface {
 		// PollTask polls for one new task
-		PollTask() (taskForWorker, error)
+		PollTask(pollerGroupLease) (taskForWorker, error)
 	}
 
-	// taskProcessor interface to process tasks
+	// taskProcessor processes tasks after polling and dispatch. ProcessTask may be
+	// invoked concurrently for different slot permits.
 	taskProcessor interface {
 		// ProcessTask processes a task
 		ProcessTask(any) error
@@ -91,6 +97,8 @@ type (
 		workerInstanceKey string
 		// Per-client queue used by the server to send worker commands.
 		workerControlTaskQueue string
+		// Per-client poller-group snapshots received from poll responses.
+		pollerGroupInfoStore *pollerGroupInfoStore
 		// Server cancels polls on shutdown
 		workerPollCompleteOnShutdown *atomic.Bool
 	}
@@ -130,6 +138,8 @@ type (
 
 		inboundPayloadVisitor     PayloadVisitor
 		payloadVisitorConcurrency int
+
+		pollerGroups *pollerGroupManager
 	}
 
 	// workflowTaskProcessor implements processing of a workflow task and can create
@@ -174,6 +184,7 @@ type (
 		logger              log.Logger
 		activitiesPerSecond float64
 		numPollerMetric     *numPollerMetric
+		pollerGroups        *pollerGroupManager
 	}
 
 	historyIteratorImpl struct {
@@ -349,6 +360,23 @@ func (bp *basePoller) getCapabilities() *workflowservice.GetSystemInfoResponse_C
 	return bp.capabilities
 }
 
+func (bp *basePoller) updatePollerGroups(manager *pollerGroupManager, info *taskqueuepb.PollerGroupsInfo) {
+	if manager != nil {
+		// Group-aware pollers publish through their manager to the client-shared
+		// store, whose change notification wakes all interested runners.
+		manager.updateGroups(info)
+		return
+	}
+	if bp != nil {
+		// Fixed pollers have no manager, but their responses may still discover
+		// poller groups. Publishing directly to the shared store wakes any
+		// autoscaling runners on this client that can use the new snapshot.
+		// TODO: Use this update to transition the fixed poller itself from
+		// SimpleMaximum to autoscaling when runtime transition support is added.
+		bp.pollerGroupInfoStore.updateGroups(info)
+	}
+}
+
 func (bp *basePoller) getDeploymentName() string {
 	return bp.workerDeploymentVersion.DeploymentName
 }
@@ -372,6 +400,7 @@ func newWorkflowTaskProcessor(
 			pollTimeTracker:              params.pollTimeTracker,
 			workerInstanceKey:            params.workerInstanceKey,
 			workerControlTaskQueue:       params.workerControlTaskQueue,
+			pollerGroupInfoStore:         params.pollerGroupInfoStore,
 			workerPollCompleteOnShutdown: params.workerPollCompleteOnShutdown,
 		},
 		service:                      service,
@@ -396,9 +425,15 @@ func newWorkflowTaskProcessor(
 }
 
 // PollTask polls a new task
-func (wtp *workflowTaskPoller) PollTask() (taskForWorker, error) {
+func (wtp *workflowTaskPoller) PollTask(lease pollerGroupLease) (taskForWorker, error) {
 	// Get the task.
-	workflowTask, err := wtp.doPoll(wtp.poll)
+	poll := wtp.poll
+	if lease.manager != nil {
+		poll = func(ctx context.Context) (taskForWorker, error) {
+			return wtp.pollWithLease(ctx, lease)
+		}
+	}
+	workflowTask, err := wtp.doPoll(poll)
 	if err != nil {
 		return nil, err
 	}
@@ -406,7 +441,10 @@ func (wtp *workflowTaskPoller) PollTask() (taskForWorker, error) {
 	return workflowTask, nil
 }
 
-func (wtp *workflowTaskProcessor) createPoller(mode workflowTaskPollerMode) taskPoller {
+func (wtp *workflowTaskProcessor) createPoller(
+	mode workflowTaskPollerMode,
+	pollerGroups *pollerGroupManager,
+) taskPoller {
 	return &workflowTaskPoller{
 		basePoller:                   wtp.basePoller,
 		mode:                         mode,
@@ -430,6 +468,7 @@ func (wtp *workflowTaskProcessor) createPoller(mode workflowTaskPollerMode) task
 		numStickyPollerMetric:        wtp.numStickyPollerMetric,
 		inboundPayloadVisitor:        wtp.inboundPayloadVisitor,
 		payloadVisitorConcurrency:    wtp.payloadVisitorConcurrency,
+		pollerGroups:                 pollerGroups,
 	}
 }
 
@@ -789,6 +828,7 @@ func (wtp *workflowTaskProcessor) reportGrpcMessageTooLarge(
 			Namespace:     wtp.namespace,
 			Failure:       wtp.failureConverter.ErrorToFailure(sendErr),
 			Cause:         enumspb.WORKFLOW_TASK_FAILED_CAUSE_GRPC_MESSAGE_TOO_LARGE,
+			PollerGroupId: task.GetPollerGroupId(),
 		}
 		if err = visitProtoPayloads(ctx, wtp.outboundPayloadVisitor, request, wtp.payloadVisitorConcurrency); err != nil {
 			wtp.logger.Error("Failed to visit payloads for GRPC message too large query failure response.", tagError, err)
@@ -934,7 +974,7 @@ func newLocalActivityPoller(
 	}
 }
 
-func (latp *localActivityTaskPoller) PollTask() (taskForWorker, error) {
+func (latp *localActivityTaskPoller) PollTask(pollerGroupLease) (taskForWorker, error) {
 	task := latp.laTunnel.getTask()
 	if task == nil {
 		return nil, nil
@@ -1127,31 +1167,38 @@ func (wtp *workflowTaskPoller) updateBacklog(taskQueueKind enumspb.TaskQueueKind
 //     3.2. otherwise:
 //     3.2.1) if sticky task queue has backlog, always prefer to process sticky task first
 //     3.2.2) poll from the task queue that has less pending requests (prefer sticky when they are the same).
-func (wtp *workflowTaskPoller) getNextPollRequest() (request *workflowservice.PollWorkflowTaskQueueRequest) {
-	taskQueue := &taskqueuepb.TaskQueue{
-		Name: wtp.taskQueueName,
-		Kind: enumspb.TASK_QUEUE_KIND_NORMAL,
-	}
+func (wtp *workflowTaskPoller) getNextPollRequest() *workflowservice.PollWorkflowTaskQueueRequest {
+	queueKind := enumspb.TASK_QUEUE_KIND_NORMAL
 
 	if wtp.mode == NonSticky || wtp.stickyCacheSize <= 0 {
 		// Do nothing, taskQueue is already set to non-sticky
 	} else if wtp.mode == Sticky {
-		taskQueue.Name = getWorkerTaskQueue(wtp.stickyUUID)
-		taskQueue.Kind = enumspb.TASK_QUEUE_KIND_STICKY
-		taskQueue.NormalName = wtp.taskQueueName
+		queueKind = enumspb.TASK_QUEUE_KIND_STICKY
 	} else if wtp.mode == Mixed {
 		wtp.requestLock.Lock()
 		if wtp.stickyBacklog > 0 || wtp.pendingStickyPollCount <= wtp.pendingRegularPollCount {
 			wtp.pendingStickyPollCount++
-			taskQueue.Name = getWorkerTaskQueue(wtp.stickyUUID)
-			taskQueue.Kind = enumspb.TASK_QUEUE_KIND_STICKY
-			taskQueue.NormalName = wtp.taskQueueName
+			queueKind = enumspb.TASK_QUEUE_KIND_STICKY
 		} else {
 			wtp.pendingRegularPollCount++
 		}
 		wtp.requestLock.Unlock()
 	} else {
 		panic("unknown workflow task poller mode")
+	}
+
+	return wtp.getPollRequestForKind(queueKind)
+}
+
+func (wtp *workflowTaskPoller) getPollRequestForKind(queueKind enumspb.TaskQueueKind) *workflowservice.PollWorkflowTaskQueueRequest {
+	taskQueue := &taskqueuepb.TaskQueue{
+		Name: wtp.taskQueueName,
+		Kind: enumspb.TASK_QUEUE_KIND_NORMAL,
+	}
+	if queueKind == enumspb.TASK_QUEUE_KIND_STICKY {
+		taskQueue.Name = getWorkerTaskQueue(wtp.stickyUUID)
+		taskQueue.Kind = enumspb.TASK_QUEUE_KIND_STICKY
+		taskQueue.NormalName = wtp.taskQueueName
 	}
 
 	builtRequest := &workflowservice.PollWorkflowTaskQueueRequest{
@@ -1195,33 +1242,69 @@ func (wtp *workflowTaskPoller) pollWorkflowTaskQueue(ctx context.Context, reques
 
 // Poll for a single workflow task from the service
 func (wtp *workflowTaskPoller) poll(ctx context.Context) (taskForWorker, error) {
+	if wtp.pollerGroups == nil {
+		// SimpleMaximum uses one Mixed poller with no poller-group manager;
+		return wtp.pollWithLease(ctx, pollerGroupLease{})
+	}
+	queueKind := wtp.preferredQueueKind()
+	lease, ok := wtp.pollerGroups.tryReserveWorkflowPoll(queueKind)
+	if !ok {
+		return nil, fmt.Errorf("workflow poll for %s queue attempted before required poller-group coverage", queueKind)
+	}
+	defer lease.release()
+	return wtp.pollWithLease(ctx, lease)
+}
+
+func (wtp *workflowTaskPoller) pollWithLease(
+	ctx context.Context,
+	lease pollerGroupLease,
+) (taskForWorker, error) {
 	traceLog(func() {
 		wtp.logger.Debug("workflowTaskPoller::Poll")
 	})
 
-	request := wtp.getNextPollRequest()
-	defer wtp.release(request.TaskQueue.GetKind())
+	var request *workflowservice.PollWorkflowTaskQueueRequest
+	var queueKind enumspb.TaskQueueKind
+	if wtp.pollerGroups != nil {
+		queueKind = wtp.preferredQueueKind()
+		if lease.manager != wtp.pollerGroups {
+			return nil, errors.New("workflow poller-group lease belongs to a different manager")
+		}
+		if lease.queueKind != queueKind {
+			return nil, fmt.Errorf("workflow poller-group lease has queue kind %s, expected %s", lease.queueKind, queueKind)
+		}
+		request = wtp.getPollRequestForKind(queueKind)
+		request.PollerGroupId = lease.groupIDOrEmpty()
+	} else {
+		request = wtp.getNextPollRequest()
+		queueKind = request.TaskQueue.GetKind()
+		defer wtp.release(queueKind)
+	}
 
 	response, err := wtp.pollWorkflowTaskQueue(ctx, request)
 	if err != nil {
-		wtp.updateBacklog(request.TaskQueue.GetKind(), 0)
+		wtp.updateBacklog(queueKind, 0)
 		return nil, err
+	}
+
+	if response != nil {
+		wtp.updatePollerGroups(wtp.pollerGroups, response.GetPollerGroupsInfo())
 	}
 
 	if response == nil || len(response.TaskToken) == 0 {
 		// Emit using base scope as no workflow type information is available in the case of empty poll
 		wtp.metricsHandler.Counter(metrics.WorkflowTaskQueuePollEmptyCounter).Inc(1)
-		wtp.updateBacklog(request.TaskQueue.GetKind(), 0)
+		wtp.updateBacklog(queueKind, 0)
 		return &workflowTask{}, nil
 	}
 
-	if request.TaskQueue.GetKind() == enumspb.TASK_QUEUE_KIND_STICKY {
+	if queueKind == enumspb.TASK_QUEUE_KIND_STICKY {
 		wtp.pollTimeTracker.recordPollSuccess(metrics.PollerTypeWorkflowStickyTask)
 	} else {
 		wtp.pollTimeTracker.recordPollSuccess(metrics.PollerTypeWorkflowTask)
 	}
 
-	wtp.updateBacklog(request.TaskQueue.GetKind(), response.GetBacklogCountHint())
+	wtp.updateBacklog(queueKind, response.GetBacklogCountHint())
 
 	task := wtp.toWorkflowTask(response)
 	traceLog(func() {
@@ -1242,6 +1325,13 @@ func (wtp *workflowTaskPoller) poll(ctx context.Context) (taskForWorker, error) 
 	scheduleToStartLatency := response.GetStartedTime().AsTime().Sub(response.GetScheduledTime().AsTime())
 	metricsHandler.Timer(metrics.WorkflowTaskScheduleToStartLatency).Record(scheduleToStartLatency)
 	return task, nil
+}
+
+func (wtp *workflowTaskPoller) preferredQueueKind() enumspb.TaskQueueKind {
+	if wtp.mode == Sticky && wtp.stickyCacheSize > 0 {
+		return enumspb.TASK_QUEUE_KIND_STICKY
+	}
+	return enumspb.TASK_QUEUE_KIND_NORMAL
 }
 
 func (wtp *workflowTaskPoller) toWorkflowTask(response *workflowservice.PollWorkflowTaskQueueResponse) *workflowTask {
@@ -1377,7 +1467,12 @@ func newGetHistoryPageFunc(
 	}
 }
 
-func newActivityTaskPoller(taskHandler ActivityTaskHandler, service workflowservice.WorkflowServiceClient, params workerExecutionParameters) *activityTaskPoller {
+func newActivityTaskPoller(
+	taskHandler ActivityTaskHandler,
+	service workflowservice.WorkflowServiceClient,
+	params workerExecutionParameters,
+	pollerGroups *pollerGroupManager,
+) *activityTaskPoller {
 	return &activityTaskPoller{
 		basePoller: basePoller{
 			metricsHandler:               params.MetricsHandler,
@@ -1389,6 +1484,7 @@ func newActivityTaskPoller(taskHandler ActivityTaskHandler, service workflowserv
 			pollTimeTracker:              params.pollTimeTracker,
 			workerInstanceKey:            params.workerInstanceKey,
 			workerControlTaskQueue:       params.workerControlTaskQueue,
+			pollerGroupInfoStore:         params.pollerGroupInfoStore,
 			workerPollCompleteOnShutdown: params.workerPollCompleteOnShutdown,
 		},
 		taskHandler:         taskHandler,
@@ -1399,6 +1495,7 @@ func newActivityTaskPoller(taskHandler ActivityTaskHandler, service workflowserv
 		logger:              params.Logger,
 		activitiesPerSecond: params.TaskQueueActivitiesPerSecond,
 		numPollerMetric:     newNumPollerMetric(params.MetricsHandler, metrics.PollerTypeActivityTask),
+		pollerGroups:        pollerGroups,
 	}
 }
 
@@ -1412,9 +1509,19 @@ func (atp *activityTaskPoller) pollActivityTaskQueue(ctx context.Context, reques
 
 // Poll for a single activity task from the service
 func (atp *activityTaskPoller) poll(ctx context.Context) (taskForWorker, error) {
+	lease := atp.pollerGroups.reserve()
+	defer lease.release()
+	return atp.pollWithLease(ctx, lease)
+}
+
+func (atp *activityTaskPoller) pollWithLease(
+	ctx context.Context,
+	lease pollerGroupLease,
+) (taskForWorker, error) {
 	traceLog(func() {
 		atp.logger.Debug("activityTaskPoller::Poll")
 	})
+
 	request := &workflowservice.PollActivityTaskQueueRequest{
 		Namespace:         atp.namespace,
 		TaskQueue:         &taskqueuepb.TaskQueue{Name: atp.taskQueueName, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
@@ -1434,9 +1541,14 @@ func (atp *activityTaskPoller) poll(ctx context.Context) (taskForWorker, error) 
 		WorkerControlTaskQueue: atp.workerControlTaskQueue,
 	}
 
+	request.PollerGroupId = lease.groupIDOrEmpty()
+
 	response, err := atp.pollActivityTaskQueue(ctx, request)
 	if err != nil {
 		return nil, err
+	}
+	if response != nil {
+		atp.updatePollerGroups(atp.pollerGroups, response.GetPollerGroupsInfo())
 	}
 	if response == nil || len(response.TaskToken) == 0 {
 		// No activity info is available on empty poll.  Emit using base scope.
@@ -1457,9 +1569,18 @@ func (atp *activityTaskPoller) poll(ctx context.Context) (taskForWorker, error) 
 }
 
 // PollTask polls a new task
-func (atp *activityTaskPoller) PollTask() (taskForWorker, error) {
+func (atp *activityTaskPoller) PollTask(lease pollerGroupLease) (taskForWorker, error) {
 	// Get the task.
-	activityTask, err := atp.doPoll(atp.poll)
+	poll := atp.poll
+	if lease.manager != nil {
+		if lease.manager != atp.pollerGroups {
+			return nil, errors.New("activity poller-group lease belongs to a different manager")
+		}
+		poll = func(ctx context.Context) (taskForWorker, error) {
+			return atp.pollWithLease(ctx, lease)
+		}
+	}
+	activityTask, err := atp.doPoll(poll)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/internal_task_pollers_test.go
+++ b/internal/internal_task_pollers_test.go
@@ -97,6 +97,39 @@ func TestPollRequestsIncludeWorkerControlTaskQueue(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestFixedActivityPollerPublishesPollerGroupsToSharedStore(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	service := workflowservicemock.NewMockWorkflowServiceClient(ctrl)
+	const groupID = "poller-group"
+	groupInfos := newPollerGroupInfoStore()
+
+	service.EXPECT().PollActivityTaskQueue(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, req *workflowservice.PollActivityTaskQueueRequest, _ ...grpc.CallOption) (*workflowservice.PollActivityTaskQueueResponse, error) {
+			require.Empty(t, req.GetPollerGroupId(), "fixed poller should remain ungrouped")
+			return &workflowservice.PollActivityTaskQueueResponse{
+				PollerGroupsInfo: testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{{Id: groupID, Weight: 1}}),
+			}, nil
+		})
+
+	poller := &activityTaskPoller{
+		basePoller: basePoller{
+			metricsHandler:       metrics.NopHandler,
+			pollerGroupInfoStore: groupInfos,
+		},
+		service:         service,
+		numPollerMetric: newNumPollerMetric(metrics.NopHandler, metrics.PollerTypeActivityTask),
+	}
+	_, err := poller.poll(context.Background())
+	require.NoError(t, err)
+
+	internalManager := newPollerGroupManager(false, groupInfos)
+	lease := internalManager.reserve()
+	defer lease.release()
+	require.Equal(t, groupID, lease.groupIDOrEmpty())
+}
+
 // This test simulates a namespace going from non-MCN to MCN
 func TestWorkflowPollResponseSeedsPollerGroupsAfterUngroupedTaskPoll(t *testing.T) {
 	t.Parallel()
@@ -122,9 +155,9 @@ func TestWorkflowPollResponseSeedsPollerGroupsAfterUngroupedTaskPoll(t *testing.
 				ScheduledTime:     now,
 				StartedTime:       now,
 				PollerGroupId:     groupID,
-				PollerGroupInfos: []*taskqueuepb.PollerGroupInfo{
+				PollerGroupsInfo: testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{
 					{Id: groupID, Weight: 1},
-				},
+				}),
 			}, nil
 		})
 	service.EXPECT().PollWorkflowTaskQueue(gomock.Any(), gomock.Any(), gomock.Any()).
@@ -146,7 +179,7 @@ func TestWorkflowPollResponseSeedsPollerGroupsAfterUngroupedTaskPoll(t *testing.
 		identity:              identity,
 		service:               service,
 		logger:                ilog.NewDefaultLogger(),
-		pollerGroups:          newPollerGroupManager(true),
+		pollerGroups:          newPollerGroupManager(true, nil),
 		numNormalPollerMetric: newNumPollerMetric(metrics.NopHandler, metrics.PollerTypeWorkflowTask),
 		numStickyPollerMetric: newNumPollerMetric(metrics.NopHandler, metrics.PollerTypeWorkflowStickyTask),
 	}
@@ -191,7 +224,7 @@ func TestWorkflowPollWithoutPollerGroupsRemainsUngrouped(t *testing.T) {
 		identity:              identity,
 		service:               service,
 		logger:                ilog.NewDefaultLogger(),
-		pollerGroups:          newPollerGroupManager(true),
+		pollerGroups:          newPollerGroupManager(true, nil),
 		numNormalPollerMetric: newNumPollerMetric(metrics.NopHandler, metrics.PollerTypeWorkflowTask),
 		numStickyPollerMetric: newNumPollerMetric(metrics.NopHandler, metrics.PollerTypeWorkflowStickyTask),
 	}
@@ -217,16 +250,18 @@ func TestWorkflowPollEmptyPollerGroupsClearsKnownPollerGroups(t *testing.T) {
 		groupID   = "poller-group"
 	)
 
-	pollerGroups := newPollerGroupManager(true)
-	pollerGroups.updateGroups([]*taskqueuepb.PollerGroupInfo{
+	pollerGroups := newPollerGroupManager(true, nil)
+	pollerGroups.updateGroups(testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{
 		{Id: groupID, Weight: 1},
-	})
+	}))
 
 	service.EXPECT().PollWorkflowTaskQueue(gomock.Any(), gomock.Any(), gomock.Any()).
 		DoAndReturn(func(_ context.Context, req *workflowservice.PollWorkflowTaskQueueRequest, _ ...grpc.CallOption) (*workflowservice.PollWorkflowTaskQueueResponse, error) {
 			require.Equal(t, groupID, req.GetPollerGroupId())
 			require.Equal(t, enumspb.TASK_QUEUE_KIND_NORMAL, req.GetTaskQueue().GetKind())
-			return &workflowservice.PollWorkflowTaskQueueResponse{}, nil
+			return &workflowservice.PollWorkflowTaskQueueResponse{
+				PollerGroupsInfo: testPollerGroupsInfo(2, nil),
+			}, nil
 		})
 	service.EXPECT().PollWorkflowTaskQueue(gomock.Any(), gomock.Any(), gomock.Any()).
 		DoAndReturn(func(_ context.Context, req *workflowservice.PollWorkflowTaskQueueRequest, _ ...grpc.CallOption) (*workflowservice.PollWorkflowTaskQueueResponse, error) {
@@ -276,19 +311,19 @@ func TestWorkflowEmptyPollResponseReplacesInvalidPollerGroup(t *testing.T) {
 		newGroupID = "new-poller-group"
 	)
 
-	pollerGroups := newPollerGroupManager(true)
-	pollerGroups.updateGroups([]*taskqueuepb.PollerGroupInfo{
+	pollerGroups := newPollerGroupManager(true, nil)
+	pollerGroups.updateGroups(testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{
 		{Id: oldGroupID, Weight: 1},
-	})
+	}))
 
 	service.EXPECT().PollWorkflowTaskQueue(gomock.Any(), gomock.Any(), gomock.Any()).
 		DoAndReturn(func(_ context.Context, req *workflowservice.PollWorkflowTaskQueueRequest, _ ...grpc.CallOption) (*workflowservice.PollWorkflowTaskQueueResponse, error) {
 			require.Equal(t, oldGroupID, req.GetPollerGroupId())
 			require.Equal(t, enumspb.TASK_QUEUE_KIND_NORMAL, req.GetTaskQueue().GetKind())
 			return &workflowservice.PollWorkflowTaskQueueResponse{
-				PollerGroupInfos: []*taskqueuepb.PollerGroupInfo{
+				PollerGroupsInfo: testPollerGroupsInfo(2, []*taskqueuepb.PollerGroupInfo{
 					{Id: newGroupID, Weight: 1},
-				},
+				}),
 			}, nil
 		})
 	service.EXPECT().PollWorkflowTaskQueue(gomock.Any(), gomock.Any(), gomock.Any()).
@@ -336,21 +371,21 @@ func TestWorkflowPollerGroupUpdateFromOnePollerAffectsAnotherPoller(t *testing.T
 		secondGroupID = "second-poller-group"
 	)
 
-	pollerGroups := newPollerGroupManager(true)
-	pollerGroups.updateGroups([]*taskqueuepb.PollerGroupInfo{
+	pollerGroups := newPollerGroupManager(true, nil)
+	pollerGroups.updateGroups(testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{
 		{Id: firstGroupID, Weight: 100},
 		{Id: secondGroupID, Weight: 0},
-	})
+	}))
 
 	gomock.InOrder(
 		service.EXPECT().PollWorkflowTaskQueue(gomock.Any(), gomock.Any(), gomock.Any()).
 			DoAndReturn(func(_ context.Context, req *workflowservice.PollWorkflowTaskQueueRequest, _ ...grpc.CallOption) (*workflowservice.PollWorkflowTaskQueueResponse, error) {
 				require.Equal(t, firstGroupID, req.GetPollerGroupId())
 				return &workflowservice.PollWorkflowTaskQueueResponse{
-					PollerGroupInfos: []*taskqueuepb.PollerGroupInfo{
+					PollerGroupsInfo: testPollerGroupsInfo(2, []*taskqueuepb.PollerGroupInfo{
 						{Id: firstGroupID, Weight: 0},
 						{Id: secondGroupID, Weight: 100},
-					},
+					}),
 				}, nil
 			}),
 		service.EXPECT().PollWorkflowTaskQueue(gomock.Any(), gomock.Any(), gomock.Any()).

--- a/internal/internal_task_pollers_test.go
+++ b/internal/internal_task_pollers_test.go
@@ -97,6 +97,296 @@ func TestPollRequestsIncludeWorkerControlTaskQueue(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// This test simulates a namespace going from non-MCN to MCN
+func TestWorkflowPollResponseSeedsPollerGroupsAfterUngroupedTaskPoll(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	service := workflowservicemock.NewMockWorkflowServiceClient(ctrl)
+	const (
+		namespace = "test-ns"
+		taskQueue = "test-task-queue"
+		identity  = "test-worker"
+		groupID   = "poller-group-1"
+	)
+
+	now := timestamppb.Now()
+	service.EXPECT().PollWorkflowTaskQueue(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, req *workflowservice.PollWorkflowTaskQueueRequest, _ ...grpc.CallOption) (*workflowservice.PollWorkflowTaskQueueResponse, error) {
+			require.Empty(t, req.GetPollerGroupId())
+			require.Equal(t, enumspb.TASK_QUEUE_KIND_NORMAL, req.GetTaskQueue().GetKind())
+			return &workflowservice.PollWorkflowTaskQueueResponse{
+				TaskToken:         []byte("task-token"),
+				WorkflowExecution: &commonpb.WorkflowExecution{WorkflowId: "workflow-id", RunId: "run-id"},
+				WorkflowType:      &commonpb.WorkflowType{Name: "workflow-type"},
+				ScheduledTime:     now,
+				StartedTime:       now,
+				PollerGroupId:     groupID,
+				PollerGroupInfos: []*taskqueuepb.PollerGroupInfo{
+					{Id: groupID, Weight: 1},
+				},
+			}, nil
+		})
+	service.EXPECT().PollWorkflowTaskQueue(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, req *workflowservice.PollWorkflowTaskQueueRequest, _ ...grpc.CallOption) (*workflowservice.PollWorkflowTaskQueueResponse, error) {
+			require.Equal(t, groupID, req.GetPollerGroupId())
+			require.Equal(t, enumspb.TASK_QUEUE_KIND_NORMAL, req.GetTaskQueue().GetKind())
+			return &workflowservice.PollWorkflowTaskQueueResponse{}, nil
+		})
+
+	wtp := &workflowTaskPoller{
+		basePoller: basePoller{
+			metricsHandler:  metrics.NopHandler,
+			workerBuildID:   "test-build-id",
+			pollTimeTracker: &pollTimeTracker{},
+		},
+		mode:                  NonSticky,
+		namespace:             namespace,
+		taskQueueName:         taskQueue,
+		identity:              identity,
+		service:               service,
+		logger:                ilog.NewDefaultLogger(),
+		pollerGroups:          newPollerGroupManager(true),
+		numNormalPollerMetric: newNumPollerMetric(metrics.NopHandler, metrics.PollerTypeWorkflowTask),
+		numStickyPollerMetric: newNumPollerMetric(metrics.NopHandler, metrics.PollerTypeWorkflowStickyTask),
+	}
+
+	task, err := wtp.poll(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, task)
+	require.Equal(t, []byte("task-token"), task.(*workflowTask).task.GetTaskToken())
+
+	_, err = wtp.poll(context.Background())
+	require.NoError(t, err)
+}
+
+func TestWorkflowPollWithoutPollerGroupsRemainsUngrouped(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	service := workflowservicemock.NewMockWorkflowServiceClient(ctrl)
+	const (
+		namespace = "test-ns"
+		taskQueue = "test-task-queue"
+		identity  = "test-worker"
+	)
+
+	service.EXPECT().PollWorkflowTaskQueue(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, req *workflowservice.PollWorkflowTaskQueueRequest, _ ...grpc.CallOption) (*workflowservice.PollWorkflowTaskQueueResponse, error) {
+			require.Empty(t, req.GetPollerGroupId())
+			require.Equal(t, enumspb.TASK_QUEUE_KIND_NORMAL, req.GetTaskQueue().GetKind())
+			return &workflowservice.PollWorkflowTaskQueueResponse{}, nil
+		}).
+		Times(2)
+
+	wtp := &workflowTaskPoller{
+		basePoller: basePoller{
+			metricsHandler:  metrics.NopHandler,
+			workerBuildID:   "test-build-id",
+			pollTimeTracker: &pollTimeTracker{},
+		},
+		mode:                  NonSticky,
+		namespace:             namespace,
+		taskQueueName:         taskQueue,
+		identity:              identity,
+		service:               service,
+		logger:                ilog.NewDefaultLogger(),
+		pollerGroups:          newPollerGroupManager(true),
+		numNormalPollerMetric: newNumPollerMetric(metrics.NopHandler, metrics.PollerTypeWorkflowTask),
+		numStickyPollerMetric: newNumPollerMetric(metrics.NopHandler, metrics.PollerTypeWorkflowStickyTask),
+	}
+
+	task, err := wtp.poll(context.Background())
+	require.NoError(t, err)
+	require.True(t, task.isEmpty())
+
+	task, err = wtp.poll(context.Background())
+	require.NoError(t, err)
+	require.True(t, task.isEmpty())
+}
+
+func TestWorkflowPollEmptyPollerGroupsClearsKnownPollerGroups(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	service := workflowservicemock.NewMockWorkflowServiceClient(ctrl)
+	const (
+		namespace = "test-ns"
+		taskQueue = "test-task-queue"
+		identity  = "test-worker"
+		groupID   = "poller-group"
+	)
+
+	pollerGroups := newPollerGroupManager(true)
+	pollerGroups.updateGroups([]*taskqueuepb.PollerGroupInfo{
+		{Id: groupID, Weight: 1},
+	})
+
+	service.EXPECT().PollWorkflowTaskQueue(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, req *workflowservice.PollWorkflowTaskQueueRequest, _ ...grpc.CallOption) (*workflowservice.PollWorkflowTaskQueueResponse, error) {
+			require.Equal(t, groupID, req.GetPollerGroupId())
+			require.Equal(t, enumspb.TASK_QUEUE_KIND_NORMAL, req.GetTaskQueue().GetKind())
+			return &workflowservice.PollWorkflowTaskQueueResponse{}, nil
+		})
+	service.EXPECT().PollWorkflowTaskQueue(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, req *workflowservice.PollWorkflowTaskQueueRequest, _ ...grpc.CallOption) (*workflowservice.PollWorkflowTaskQueueResponse, error) {
+			require.Empty(t, req.GetPollerGroupId())
+			require.Equal(t, enumspb.TASK_QUEUE_KIND_NORMAL, req.GetTaskQueue().GetKind())
+			return &workflowservice.PollWorkflowTaskQueueResponse{}, nil
+		})
+
+	wtp := &workflowTaskPoller{
+		basePoller: basePoller{
+			metricsHandler:  metrics.NopHandler,
+			workerBuildID:   "test-build-id",
+			pollTimeTracker: &pollTimeTracker{},
+		},
+		mode:                  NonSticky,
+		namespace:             namespace,
+		taskQueueName:         taskQueue,
+		identity:              identity,
+		service:               service,
+		logger:                ilog.NewDefaultLogger(),
+		pollerGroups:          pollerGroups,
+		numNormalPollerMetric: newNumPollerMetric(metrics.NopHandler, metrics.PollerTypeWorkflowTask),
+		numStickyPollerMetric: newNumPollerMetric(metrics.NopHandler, metrics.PollerTypeWorkflowStickyTask),
+	}
+
+	task, err := wtp.poll(context.Background())
+	require.NoError(t, err)
+	require.True(t, task.isEmpty())
+
+	task, err = wtp.poll(context.Background())
+	require.NoError(t, err)
+	require.True(t, task.isEmpty())
+}
+
+// This test validates the SDK sending invalid PollerGroupInfo and server returning
+// an updated, separate valid PollerGroupInfo successfully updates SDKs PollerGroupInfo tracking
+func TestWorkflowEmptyPollResponseReplacesInvalidPollerGroup(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	service := workflowservicemock.NewMockWorkflowServiceClient(ctrl)
+	const (
+		namespace  = "test-ns"
+		taskQueue  = "test-task-queue"
+		identity   = "test-worker"
+		oldGroupID = "old-poller-group"
+		newGroupID = "new-poller-group"
+	)
+
+	pollerGroups := newPollerGroupManager(true)
+	pollerGroups.updateGroups([]*taskqueuepb.PollerGroupInfo{
+		{Id: oldGroupID, Weight: 1},
+	})
+
+	service.EXPECT().PollWorkflowTaskQueue(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, req *workflowservice.PollWorkflowTaskQueueRequest, _ ...grpc.CallOption) (*workflowservice.PollWorkflowTaskQueueResponse, error) {
+			require.Equal(t, oldGroupID, req.GetPollerGroupId())
+			require.Equal(t, enumspb.TASK_QUEUE_KIND_NORMAL, req.GetTaskQueue().GetKind())
+			return &workflowservice.PollWorkflowTaskQueueResponse{
+				PollerGroupInfos: []*taskqueuepb.PollerGroupInfo{
+					{Id: newGroupID, Weight: 1},
+				},
+			}, nil
+		})
+	service.EXPECT().PollWorkflowTaskQueue(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, req *workflowservice.PollWorkflowTaskQueueRequest, _ ...grpc.CallOption) (*workflowservice.PollWorkflowTaskQueueResponse, error) {
+			require.Equal(t, newGroupID, req.GetPollerGroupId())
+			require.Equal(t, enumspb.TASK_QUEUE_KIND_NORMAL, req.GetTaskQueue().GetKind())
+			return &workflowservice.PollWorkflowTaskQueueResponse{}, nil
+		})
+
+	wtp := &workflowTaskPoller{
+		basePoller: basePoller{
+			metricsHandler:  metrics.NopHandler,
+			workerBuildID:   "test-build-id",
+			pollTimeTracker: &pollTimeTracker{},
+		},
+		mode:                  NonSticky,
+		namespace:             namespace,
+		taskQueueName:         taskQueue,
+		identity:              identity,
+		service:               service,
+		logger:                ilog.NewDefaultLogger(),
+		pollerGroups:          pollerGroups,
+		numNormalPollerMetric: newNumPollerMetric(metrics.NopHandler, metrics.PollerTypeWorkflowTask),
+		numStickyPollerMetric: newNumPollerMetric(metrics.NopHandler, metrics.PollerTypeWorkflowStickyTask),
+	}
+
+	task, err := wtp.poll(context.Background())
+	require.NoError(t, err)
+	require.True(t, task.isEmpty())
+
+	_, err = wtp.poll(context.Background())
+	require.NoError(t, err)
+}
+
+func TestWorkflowPollerGroupUpdateFromOnePollerAffectsAnotherPoller(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	service := workflowservicemock.NewMockWorkflowServiceClient(ctrl)
+	const (
+		namespace     = "test-ns"
+		taskQueue     = "test-task-queue"
+		identity      = "test-worker"
+		firstGroupID  = "first-poller-group"
+		secondGroupID = "second-poller-group"
+	)
+
+	pollerGroups := newPollerGroupManager(true)
+	pollerGroups.updateGroups([]*taskqueuepb.PollerGroupInfo{
+		{Id: firstGroupID, Weight: 100},
+		{Id: secondGroupID, Weight: 0},
+	})
+
+	gomock.InOrder(
+		service.EXPECT().PollWorkflowTaskQueue(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, req *workflowservice.PollWorkflowTaskQueueRequest, _ ...grpc.CallOption) (*workflowservice.PollWorkflowTaskQueueResponse, error) {
+				require.Equal(t, firstGroupID, req.GetPollerGroupId())
+				return &workflowservice.PollWorkflowTaskQueueResponse{
+					PollerGroupInfos: []*taskqueuepb.PollerGroupInfo{
+						{Id: firstGroupID, Weight: 0},
+						{Id: secondGroupID, Weight: 100},
+					},
+				}, nil
+			}),
+		service.EXPECT().PollWorkflowTaskQueue(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, req *workflowservice.PollWorkflowTaskQueueRequest, _ ...grpc.CallOption) (*workflowservice.PollWorkflowTaskQueueResponse, error) {
+				require.Equal(t, secondGroupID, req.GetPollerGroupId())
+				return &workflowservice.PollWorkflowTaskQueueResponse{}, nil
+			}),
+	)
+
+	newPoller := func() *workflowTaskPoller {
+		return &workflowTaskPoller{
+			basePoller: basePoller{
+				metricsHandler:  metrics.NopHandler,
+				workerBuildID:   "test-build-id",
+				pollTimeTracker: &pollTimeTracker{},
+			},
+			mode:                  NonSticky,
+			namespace:             namespace,
+			taskQueueName:         taskQueue,
+			identity:              identity,
+			service:               service,
+			logger:                ilog.NewDefaultLogger(),
+			pollerGroups:          pollerGroups,
+			numNormalPollerMetric: newNumPollerMetric(metrics.NopHandler, metrics.PollerTypeWorkflowTask),
+			numStickyPollerMetric: newNumPollerMetric(metrics.NopHandler, metrics.PollerTypeWorkflowStickyTask),
+		}
+	}
+
+	task, err := newPoller().poll(context.Background())
+	require.NoError(t, err)
+	require.True(t, task.isEmpty())
+
+	_, err = newPoller().poll(context.Background())
+	require.NoError(t, err)
+}
+
 func TestWFTRacePrevention(t *testing.T) {
 	params := workerExecutionParameters{cache: NewWorkerCache()}
 	ensureRequiredParams(&params)

--- a/internal/internal_task_pollers_test.go
+++ b/internal/internal_task_pollers_test.go
@@ -97,6 +97,46 @@ func TestPollRequestsIncludeWorkerControlTaskQueue(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestReportGrpcMessageTooLargeQueryForwardsPollerGroupID(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	service := workflowservicemock.NewMockWorkflowServiceClient(ctrl)
+	const pollerGroupID = "poller-group"
+
+	service.EXPECT().RespondQueryTaskCompleted(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, req *workflowservice.RespondQueryTaskCompletedRequest, _ ...grpc.CallOption) (*workflowservice.RespondQueryTaskCompletedResponse, error) {
+			require.Equal(t, pollerGroupID, req.GetPollerGroupId())
+			require.Equal(t, enumspb.QUERY_RESULT_TYPE_FAILED, req.GetCompletedType())
+			require.Equal(t, enumspb.WORKFLOW_TASK_FAILED_CAUSE_GRPC_MESSAGE_TOO_LARGE, req.GetCause())
+			return &workflowservice.RespondQueryTaskCompletedResponse{}, nil
+		})
+
+	processor := &workflowTaskProcessor{
+		basePoller:       basePoller{metricsHandler: metrics.NopHandler},
+		namespace:        "test-namespace",
+		service:          service,
+		logger:           ilog.NewDefaultLogger(),
+		failureConverter: GetDefaultFailureConverter(),
+	}
+	task := &workflowservice.PollWorkflowTaskQueueResponse{
+		TaskToken:     []byte("task-token"),
+		PollerGroupId: pollerGroupID,
+	}
+	taskCompletion := &workflowTaskCompletion{
+		rawRequest: &workflowservice.RespondQueryTaskCompletedRequest{},
+	}
+
+	emitFailMetric, err := processor.reportGrpcMessageTooLarge(
+		context.Background(),
+		taskCompletion,
+		task,
+		errors.New("message too large"),
+	)
+	require.NoError(t, err)
+	require.False(t, emitFailMetric)
+}
+
 func TestFixedActivityPollerPublishesPollerGroupsToSharedStore(t *testing.T) {
 	t.Parallel()
 

--- a/internal/internal_task_pollers_test.go
+++ b/internal/internal_task_pollers_test.go
@@ -521,7 +521,7 @@ func TestErrorToFailWorkflowTaskCause(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			resp := poller.errorToFailWorkflowTask([]byte("token"), tc.err)
+			resp := poller.errorToFailWorkflowTask([]byte("token"), "test-workflow-id", tc.err)
 			require.Equal(t, tc.cause, resp.Cause)
 		})
 	}

--- a/internal/internal_task_pollers_test.go
+++ b/internal/internal_task_pollers_test.go
@@ -38,7 +38,7 @@ func TestLocalActivityTaskPollerReturnsNilWhenTunnelStops(t *testing.T) {
 		laTunnel: newLocalActivityTunnel(stopCh),
 	}
 
-	task, err := poller.PollTask()
+	task, err := poller.PollTask(pollerGroupLease{})
 	require.NoError(t, err)
 	if task != nil {
 		t.Fatalf("PollTask() returned a non-nil task of type %T", task)
@@ -108,6 +108,485 @@ func TestPollRequestsIncludeWorkerControlTaskQueue(t *testing.T) {
 		numPollerMetric: newNumPollerMetric(metrics.NopHandler, metrics.PollerTypeActivityTask),
 	}
 	_, err = atp.poll(t.Context())
+	require.NoError(t, err)
+}
+
+func TestReportGrpcMessageTooLargeQueryForwardsPollerGroupID(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	service := workflowservicemock.NewMockWorkflowServiceClient(ctrl)
+	const pollerGroupID = "poller-group"
+
+	service.EXPECT().RespondQueryTaskCompleted(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, req *workflowservice.RespondQueryTaskCompletedRequest, _ ...grpc.CallOption) (*workflowservice.RespondQueryTaskCompletedResponse, error) {
+			require.Equal(t, pollerGroupID, req.GetPollerGroupId())
+			require.Equal(t, enumspb.QUERY_RESULT_TYPE_FAILED, req.GetCompletedType())
+			require.Equal(t, enumspb.WORKFLOW_TASK_FAILED_CAUSE_GRPC_MESSAGE_TOO_LARGE, req.GetCause())
+			return &workflowservice.RespondQueryTaskCompletedResponse{}, nil
+		})
+
+	processor := &workflowTaskProcessor{
+		basePoller:       basePoller{metricsHandler: metrics.NopHandler},
+		namespace:        "test-namespace",
+		service:          service,
+		logger:           ilog.NewDefaultLogger(),
+		failureConverter: GetDefaultFailureConverter(),
+	}
+	task := &workflowservice.PollWorkflowTaskQueueResponse{
+		TaskToken:     []byte("task-token"),
+		PollerGroupId: pollerGroupID,
+	}
+	taskCompletion := &workflowTaskCompletion{
+		rawRequest: &workflowservice.RespondQueryTaskCompletedRequest{},
+	}
+
+	emitFailMetric, err := processor.reportGrpcMessageTooLarge(
+		t.Context(),
+		taskCompletion,
+		task,
+		errors.New("message too large"),
+	)
+	require.NoError(t, err)
+	require.False(t, emitFailMetric)
+}
+
+func TestFixedActivityPollerPublishesPollerGroupsToSharedStore(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	service := workflowservicemock.NewMockWorkflowServiceClient(ctrl)
+	const groupID = "poller-group"
+	groupInfos := newPollerGroupInfoStore()
+
+	service.EXPECT().PollActivityTaskQueue(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, req *workflowservice.PollActivityTaskQueueRequest, _ ...grpc.CallOption) (*workflowservice.PollActivityTaskQueueResponse, error) {
+			require.Empty(t, req.GetPollerGroupId(), "fixed poller should remain ungrouped")
+			return &workflowservice.PollActivityTaskQueueResponse{
+				PollerGroupsInfo: testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{{Id: groupID, Weight: 1}}),
+			}, nil
+		})
+
+	poller := &activityTaskPoller{
+		basePoller: basePoller{
+			metricsHandler:       metrics.NopHandler,
+			pollerGroupInfoStore: groupInfos,
+		},
+		service:         service,
+		numPollerMetric: newNumPollerMetric(metrics.NopHandler, metrics.PollerTypeActivityTask),
+	}
+	_, err := poller.poll(t.Context())
+	require.NoError(t, err)
+
+	internalManager := newPollerGroupManager(pollerGroupModeNonWorkflow, groupInfos)
+	lease := internalManager.reserve()
+	defer lease.release()
+	require.Equal(t, groupID, lease.groupIDOrEmpty())
+}
+
+func TestActivityPollUsesPreReservedPollerGroup(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	service := workflowservicemock.NewMockWorkflowServiceClient(ctrl)
+	pollerGroups := newPollerGroupManager(pollerGroupModeNonWorkflow, nil)
+	pollerGroups.updateGroups(testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{
+		{Id: "old-group", Weight: 1},
+	}))
+	lease := pollerGroups.reserve()
+	defer lease.release()
+	pollerGroups.updateGroups(testPollerGroupsInfo(2, []*taskqueuepb.PollerGroupInfo{
+		{Id: "new-group", Weight: 1},
+	}))
+
+	service.EXPECT().PollActivityTaskQueue(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, req *workflowservice.PollActivityTaskQueueRequest, _ ...grpc.CallOption) (*workflowservice.PollActivityTaskQueueResponse, error) {
+			require.Equal(t, "old-group", req.GetPollerGroupId())
+			return &workflowservice.PollActivityTaskQueueResponse{}, nil
+		})
+
+	poller := &activityTaskPoller{
+		basePoller: basePoller{
+			metricsHandler: metrics.NopHandler,
+			workerBuildID:  "test-build-id",
+		},
+		service:         service,
+		numPollerMetric: newNumPollerMetric(metrics.NopHandler, metrics.PollerTypeActivityTask),
+		pollerGroups:    pollerGroups,
+	}
+	_, err := poller.PollTask(lease)
+	require.NoError(t, err)
+}
+
+func TestWorkflowPollUsesPreReservedRunnerQueueKind(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	service := workflowservicemock.NewMockWorkflowServiceClient(ctrl)
+	const (
+		namespace = "test-ns"
+		taskQueue = "test-task-queue"
+		groupID   = "poller-group"
+	)
+	pollerGroups := newPollerGroupManager(pollerGroupModeWorkflowWithSticky, nil)
+	pollerGroups.updateGroups(testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{
+		{Id: groupID, Weight: 1},
+	}))
+	lease := requireWorkflowPollLease(t, pollerGroups, enumspb.TASK_QUEUE_KIND_STICKY)
+	defer lease.release()
+
+	service.EXPECT().PollWorkflowTaskQueue(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, req *workflowservice.PollWorkflowTaskQueueRequest, _ ...grpc.CallOption) (*workflowservice.PollWorkflowTaskQueueResponse, error) {
+			require.Equal(t, groupID, req.GetPollerGroupId())
+			require.Equal(t, enumspb.TASK_QUEUE_KIND_STICKY, req.GetTaskQueue().GetKind())
+			return &workflowservice.PollWorkflowTaskQueueResponse{}, nil
+		})
+
+	poller := &workflowTaskPoller{
+		basePoller: basePoller{
+			metricsHandler:  metrics.NopHandler,
+			workerBuildID:   "test-build-id",
+			pollTimeTracker: &pollTimeTracker{},
+		},
+		mode:                  Sticky,
+		namespace:             namespace,
+		taskQueueName:         taskQueue,
+		service:               service,
+		logger:                ilog.NewDefaultLogger(),
+		stickyUUID:            "sticky-worker",
+		stickyCacheSize:       1,
+		pollerGroups:          pollerGroups,
+		numNormalPollerMetric: newNumPollerMetric(metrics.NopHandler, metrics.PollerTypeWorkflowTask),
+		numStickyPollerMetric: newNumPollerMetric(metrics.NopHandler, metrics.PollerTypeWorkflowStickyTask),
+	}
+
+	task, err := poller.PollTask(lease)
+	require.NoError(t, err)
+	require.True(t, task.isEmpty())
+}
+
+func TestWorkflowPollRejectsLeaseFromDifferentManager(t *testing.T) {
+	t.Parallel()
+
+	pollerGroups := newPollerGroupManager(pollerGroupModeWorkflow, nil)
+	poller := &workflowTaskPoller{
+		mode:         NonSticky,
+		pollerGroups: pollerGroups,
+	}
+
+	_, err := poller.pollWithLease(t.Context(), pollerGroupLease{
+		manager:   newPollerGroupManager(pollerGroupModeWorkflow, nil),
+		queueKind: enumspb.TASK_QUEUE_KIND_NORMAL,
+	})
+	require.EqualError(t, err, "workflow poller-group lease belongs to a different manager")
+}
+
+func TestWorkflowPollRejectsLeaseForDifferentQueueKind(t *testing.T) {
+	t.Parallel()
+
+	pollerGroups := newPollerGroupManager(pollerGroupModeWorkflowWithSticky, nil)
+	poller := &workflowTaskPoller{
+		mode:            Sticky,
+		stickyCacheSize: 1,
+		pollerGroups:    pollerGroups,
+	}
+
+	_, err := poller.pollWithLease(t.Context(), pollerGroupLease{
+		manager:   pollerGroups,
+		queueKind: enumspb.TASK_QUEUE_KIND_NORMAL,
+	})
+	require.EqualError(t, err, "workflow poller-group lease has queue kind Normal, expected Sticky")
+}
+
+// This test simulates a namespace going from non-MCN to MCN
+func TestWorkflowPollResponseSeedsPollerGroupsAfterUngroupedTaskPoll(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	service := workflowservicemock.NewMockWorkflowServiceClient(ctrl)
+	const (
+		namespace = "test-ns"
+		taskQueue = "test-task-queue"
+		identity  = "test-worker"
+		groupID   = "poller-group-1"
+	)
+
+	now := timestamppb.Now()
+	service.EXPECT().PollWorkflowTaskQueue(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, req *workflowservice.PollWorkflowTaskQueueRequest, _ ...grpc.CallOption) (*workflowservice.PollWorkflowTaskQueueResponse, error) {
+			require.Empty(t, req.GetPollerGroupId())
+			require.Equal(t, enumspb.TASK_QUEUE_KIND_NORMAL, req.GetTaskQueue().GetKind())
+			return &workflowservice.PollWorkflowTaskQueueResponse{
+				TaskToken:         []byte("task-token"),
+				WorkflowExecution: &commonpb.WorkflowExecution{WorkflowId: "workflow-id", RunId: "run-id"},
+				WorkflowType:      &commonpb.WorkflowType{Name: "workflow-type"},
+				ScheduledTime:     now,
+				StartedTime:       now,
+				PollerGroupId:     groupID,
+				PollerGroupsInfo: testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{
+					{Id: groupID, Weight: 1},
+				}),
+			}, nil
+		})
+	service.EXPECT().PollWorkflowTaskQueue(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, req *workflowservice.PollWorkflowTaskQueueRequest, _ ...grpc.CallOption) (*workflowservice.PollWorkflowTaskQueueResponse, error) {
+			require.Equal(t, groupID, req.GetPollerGroupId())
+			require.Equal(t, enumspb.TASK_QUEUE_KIND_NORMAL, req.GetTaskQueue().GetKind())
+			return &workflowservice.PollWorkflowTaskQueueResponse{}, nil
+		})
+
+	wtp := &workflowTaskPoller{
+		basePoller: basePoller{
+			metricsHandler:  metrics.NopHandler,
+			workerBuildID:   "test-build-id",
+			pollTimeTracker: &pollTimeTracker{},
+		},
+		mode:                  NonSticky,
+		namespace:             namespace,
+		taskQueueName:         taskQueue,
+		identity:              identity,
+		service:               service,
+		logger:                ilog.NewDefaultLogger(),
+		pollerGroups:          newPollerGroupManager(pollerGroupModeWorkflow, nil),
+		numNormalPollerMetric: newNumPollerMetric(metrics.NopHandler, metrics.PollerTypeWorkflowTask),
+		numStickyPollerMetric: newNumPollerMetric(metrics.NopHandler, metrics.PollerTypeWorkflowStickyTask),
+	}
+
+	task, err := wtp.poll(t.Context())
+	require.NoError(t, err)
+	require.NotNil(t, task)
+	require.Equal(t, []byte("task-token"), task.(*workflowTask).task.GetTaskToken())
+
+	_, err = wtp.poll(t.Context())
+	require.NoError(t, err)
+}
+
+func TestWorkflowPollWithoutPollerGroupsRemainsUngrouped(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	service := workflowservicemock.NewMockWorkflowServiceClient(ctrl)
+	const (
+		namespace = "test-ns"
+		taskQueue = "test-task-queue"
+		identity  = "test-worker"
+	)
+
+	service.EXPECT().PollWorkflowTaskQueue(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, req *workflowservice.PollWorkflowTaskQueueRequest, _ ...grpc.CallOption) (*workflowservice.PollWorkflowTaskQueueResponse, error) {
+			require.Empty(t, req.GetPollerGroupId())
+			require.Equal(t, enumspb.TASK_QUEUE_KIND_NORMAL, req.GetTaskQueue().GetKind())
+			return &workflowservice.PollWorkflowTaskQueueResponse{}, nil
+		}).
+		Times(2)
+
+	wtp := &workflowTaskPoller{
+		basePoller: basePoller{
+			metricsHandler:  metrics.NopHandler,
+			workerBuildID:   "test-build-id",
+			pollTimeTracker: &pollTimeTracker{},
+		},
+		mode:                  NonSticky,
+		namespace:             namespace,
+		taskQueueName:         taskQueue,
+		identity:              identity,
+		service:               service,
+		logger:                ilog.NewDefaultLogger(),
+		pollerGroups:          newPollerGroupManager(pollerGroupModeWorkflow, nil),
+		numNormalPollerMetric: newNumPollerMetric(metrics.NopHandler, metrics.PollerTypeWorkflowTask),
+		numStickyPollerMetric: newNumPollerMetric(metrics.NopHandler, metrics.PollerTypeWorkflowStickyTask),
+	}
+
+	task, err := wtp.poll(t.Context())
+	require.NoError(t, err)
+	require.True(t, task.isEmpty())
+
+	task, err = wtp.poll(t.Context())
+	require.NoError(t, err)
+	require.True(t, task.isEmpty())
+}
+
+func TestWorkflowPollEmptyPollerGroupsClearsKnownPollerGroups(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	service := workflowservicemock.NewMockWorkflowServiceClient(ctrl)
+	const (
+		namespace = "test-ns"
+		taskQueue = "test-task-queue"
+		identity  = "test-worker"
+		groupID   = "poller-group"
+	)
+
+	pollerGroups := newPollerGroupManager(pollerGroupModeWorkflow, nil)
+	pollerGroups.updateGroups(testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{
+		{Id: groupID, Weight: 1},
+	}))
+
+	service.EXPECT().PollWorkflowTaskQueue(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, req *workflowservice.PollWorkflowTaskQueueRequest, _ ...grpc.CallOption) (*workflowservice.PollWorkflowTaskQueueResponse, error) {
+			require.Equal(t, groupID, req.GetPollerGroupId())
+			require.Equal(t, enumspb.TASK_QUEUE_KIND_NORMAL, req.GetTaskQueue().GetKind())
+			return &workflowservice.PollWorkflowTaskQueueResponse{
+				PollerGroupsInfo: testPollerGroupsInfo(2, nil),
+			}, nil
+		})
+	service.EXPECT().PollWorkflowTaskQueue(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, req *workflowservice.PollWorkflowTaskQueueRequest, _ ...grpc.CallOption) (*workflowservice.PollWorkflowTaskQueueResponse, error) {
+			require.Empty(t, req.GetPollerGroupId())
+			require.Equal(t, enumspb.TASK_QUEUE_KIND_NORMAL, req.GetTaskQueue().GetKind())
+			return &workflowservice.PollWorkflowTaskQueueResponse{}, nil
+		})
+
+	wtp := &workflowTaskPoller{
+		basePoller: basePoller{
+			metricsHandler:  metrics.NopHandler,
+			workerBuildID:   "test-build-id",
+			pollTimeTracker: &pollTimeTracker{},
+		},
+		mode:                  NonSticky,
+		namespace:             namespace,
+		taskQueueName:         taskQueue,
+		identity:              identity,
+		service:               service,
+		logger:                ilog.NewDefaultLogger(),
+		pollerGroups:          pollerGroups,
+		numNormalPollerMetric: newNumPollerMetric(metrics.NopHandler, metrics.PollerTypeWorkflowTask),
+		numStickyPollerMetric: newNumPollerMetric(metrics.NopHandler, metrics.PollerTypeWorkflowStickyTask),
+	}
+
+	task, err := wtp.poll(t.Context())
+	require.NoError(t, err)
+	require.True(t, task.isEmpty())
+
+	task, err = wtp.poll(t.Context())
+	require.NoError(t, err)
+	require.True(t, task.isEmpty())
+}
+
+// This test validates the SDK sending invalid PollerGroupInfo and server returning
+// an updated, separate valid PollerGroupInfo successfully updates SDKs PollerGroupInfo tracking
+func TestWorkflowEmptyPollResponseReplacesInvalidPollerGroup(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	service := workflowservicemock.NewMockWorkflowServiceClient(ctrl)
+	const (
+		namespace  = "test-ns"
+		taskQueue  = "test-task-queue"
+		identity   = "test-worker"
+		oldGroupID = "old-poller-group"
+		newGroupID = "new-poller-group"
+	)
+
+	pollerGroups := newPollerGroupManager(pollerGroupModeWorkflow, nil)
+	pollerGroups.updateGroups(testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{
+		{Id: oldGroupID, Weight: 1},
+	}))
+
+	service.EXPECT().PollWorkflowTaskQueue(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, req *workflowservice.PollWorkflowTaskQueueRequest, _ ...grpc.CallOption) (*workflowservice.PollWorkflowTaskQueueResponse, error) {
+			require.Equal(t, oldGroupID, req.GetPollerGroupId())
+			require.Equal(t, enumspb.TASK_QUEUE_KIND_NORMAL, req.GetTaskQueue().GetKind())
+			return &workflowservice.PollWorkflowTaskQueueResponse{
+				PollerGroupsInfo: testPollerGroupsInfo(2, []*taskqueuepb.PollerGroupInfo{
+					{Id: newGroupID, Weight: 1},
+				}),
+			}, nil
+		})
+	service.EXPECT().PollWorkflowTaskQueue(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, req *workflowservice.PollWorkflowTaskQueueRequest, _ ...grpc.CallOption) (*workflowservice.PollWorkflowTaskQueueResponse, error) {
+			require.Equal(t, newGroupID, req.GetPollerGroupId())
+			require.Equal(t, enumspb.TASK_QUEUE_KIND_NORMAL, req.GetTaskQueue().GetKind())
+			return &workflowservice.PollWorkflowTaskQueueResponse{}, nil
+		})
+
+	wtp := &workflowTaskPoller{
+		basePoller: basePoller{
+			metricsHandler:  metrics.NopHandler,
+			workerBuildID:   "test-build-id",
+			pollTimeTracker: &pollTimeTracker{},
+		},
+		mode:                  NonSticky,
+		namespace:             namespace,
+		taskQueueName:         taskQueue,
+		identity:              identity,
+		service:               service,
+		logger:                ilog.NewDefaultLogger(),
+		pollerGroups:          pollerGroups,
+		numNormalPollerMetric: newNumPollerMetric(metrics.NopHandler, metrics.PollerTypeWorkflowTask),
+		numStickyPollerMetric: newNumPollerMetric(metrics.NopHandler, metrics.PollerTypeWorkflowStickyTask),
+	}
+
+	task, err := wtp.poll(t.Context())
+	require.NoError(t, err)
+	require.True(t, task.isEmpty())
+
+	_, err = wtp.poll(t.Context())
+	require.NoError(t, err)
+}
+
+func TestWorkflowPollerGroupUpdateFromOnePollerAffectsAnotherPoller(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	service := workflowservicemock.NewMockWorkflowServiceClient(ctrl)
+	const (
+		namespace     = "test-ns"
+		taskQueue     = "test-task-queue"
+		identity      = "test-worker"
+		firstGroupID  = "first-poller-group"
+		secondGroupID = "second-poller-group"
+	)
+
+	pollerGroups := newPollerGroupManager(pollerGroupModeWorkflow, nil)
+	pollerGroups.updateGroups(testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{
+		{Id: firstGroupID, Weight: 100},
+		{Id: secondGroupID, Weight: 0},
+	}))
+
+	gomock.InOrder(
+		service.EXPECT().PollWorkflowTaskQueue(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, req *workflowservice.PollWorkflowTaskQueueRequest, _ ...grpc.CallOption) (*workflowservice.PollWorkflowTaskQueueResponse, error) {
+				require.Equal(t, firstGroupID, req.GetPollerGroupId())
+				return &workflowservice.PollWorkflowTaskQueueResponse{
+					PollerGroupsInfo: testPollerGroupsInfo(2, []*taskqueuepb.PollerGroupInfo{
+						{Id: firstGroupID, Weight: 0},
+						{Id: secondGroupID, Weight: 100},
+					}),
+				}, nil
+			}),
+		service.EXPECT().PollWorkflowTaskQueue(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, req *workflowservice.PollWorkflowTaskQueueRequest, _ ...grpc.CallOption) (*workflowservice.PollWorkflowTaskQueueResponse, error) {
+				require.Equal(t, secondGroupID, req.GetPollerGroupId())
+				return &workflowservice.PollWorkflowTaskQueueResponse{}, nil
+			}),
+	)
+
+	newPoller := func() *workflowTaskPoller {
+		return &workflowTaskPoller{
+			basePoller: basePoller{
+				metricsHandler:  metrics.NopHandler,
+				workerBuildID:   "test-build-id",
+				pollTimeTracker: &pollTimeTracker{},
+			},
+			mode:                  NonSticky,
+			namespace:             namespace,
+			taskQueueName:         taskQueue,
+			identity:              identity,
+			service:               service,
+			logger:                ilog.NewDefaultLogger(),
+			pollerGroups:          pollerGroups,
+			numNormalPollerMetric: newNumPollerMetric(metrics.NopHandler, metrics.PollerTypeWorkflowTask),
+			numStickyPollerMetric: newNumPollerMetric(metrics.NopHandler, metrics.PollerTypeWorkflowStickyTask),
+		}
+	}
+
+	task, err := newPoller().poll(t.Context())
+	require.NoError(t, err)
+	require.True(t, task.isEmpty())
+
+	_, err = newPoller().poll(t.Context())
 	require.NoError(t, err)
 }
 

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -26,7 +26,6 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	historypb "go.temporal.io/api/history/v1"
 	"go.temporal.io/api/serviceerror"
-	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	"go.temporal.io/api/temporalproto"
 	workerpb "go.temporal.io/api/worker/v1"
 	"go.temporal.io/api/workflowservice/v1"
@@ -243,6 +242,7 @@ type (
 		workerInstanceKey string
 
 		workerControlTaskQueue string
+		pollerGroupInfoStore   *pollerGroupInfoStore
 
 		activityCancellationCallbacks *activityCancellationCallbacks
 
@@ -454,13 +454,6 @@ func newWorkflowTaskWorkerInternal(
 	}
 }
 
-func (ww *workflowWorker) seedPollerGroupInfos(groups []*taskqueuepb.PollerGroupInfo) {
-	if ww == nil || ww.pollerGroups == nil || len(groups) == 0 {
-		return
-	}
-	ww.pollerGroups.updateGroups(groups)
-}
-
 // Start the worker.
 func (ww *workflowWorker) Start() error {
 	// AggregatedWorker initializes pollers after resolving namespace capabilities.
@@ -493,7 +486,7 @@ func buildWorkflowScalableTaskPollers(
 ) ([]scalableTaskPoller, *pollerGroupManager) {
 	switch behavior.(type) {
 	case *pollerBehaviorAutoscaling:
-		pollerGroups := newPollerGroupManager(true)
+		pollerGroups := newPollerGroupManager(true, params.pollerGroupInfoStore)
 		scalableTaskPollers := []scalableTaskPoller{
 			newScalableTaskPoller(
 				taskProcessor.createPoller(NonSticky, pollerGroups),
@@ -679,13 +672,6 @@ func newActivityWorker(
 	}
 }
 
-func (aw *activityWorker) seedPollerGroupInfos(groups []*taskqueuepb.PollerGroupInfo) {
-	if aw == nil || aw.pollerGroups == nil || len(groups) == 0 {
-		return
-	}
-	aw.pollerGroups.updateGroups(groups)
-}
-
 // Start the worker.
 func (aw *activityWorker) Start() error {
 	// AggregatedWorker initializes pollers after resolving namespace capabilities.
@@ -707,7 +693,7 @@ func (aw *activityWorker) initializeTaskPollers(behavior PollerBehavior) {
 	aw.executionParameters.ActivityTaskPollerBehavior = behavior
 	var pollerGroups *pollerGroupManager
 	if _, ok := behavior.(*pollerBehaviorAutoscaling); ok {
-		pollerGroups = newPollerGroupManager(false)
+		pollerGroups = newPollerGroupManager(false, aw.executionParameters.pollerGroupInfoStore)
 	}
 	if poller, ok := aw.poller.(*activityTaskPoller); ok {
 		poller.pollerGroups = pollerGroups
@@ -1492,7 +1478,6 @@ func (aw *AggregatedWorker) start() error {
 	if !util.IsInterfaceNil(aw.activityWorker) {
 		aw.activityWorker.initializeTaskPollers(aw.executionParams.ActivityTaskPollerBehavior)
 	}
-	aw.seedPollerGroupInfos(nsData.pollerGroupInfos)
 
 	if !util.IsInterfaceNil(aw.workflowWorker) {
 		if err := aw.workflowWorker.Start(); err != nil {
@@ -1563,7 +1548,6 @@ func (aw *AggregatedWorker) start() error {
 		if err != nil {
 			return fmt.Errorf("failed to create a nexus worker: %w", err)
 		}
-		aw.nexusWorker.seedPollerGroupInfos(nsData.pollerGroupInfos)
 		if err := aw.nexusWorker.Start(); err != nil {
 			return fmt.Errorf("failed to start a nexus worker: %w", err)
 		}
@@ -1576,18 +1560,6 @@ func (aw *AggregatedWorker) start() error {
 	}
 	aw.logger.Info("Started Worker")
 	return nil
-}
-
-func (aw *AggregatedWorker) seedPollerGroupInfos(groups []*taskqueuepb.PollerGroupInfo) {
-	if len(groups) == 0 {
-		return
-	}
-	if !util.IsInterfaceNil(aw.workflowWorker) {
-		aw.workflowWorker.seedPollerGroupInfos(groups)
-	}
-	if !util.IsInterfaceNil(aw.activityWorker) {
-		aw.activityWorker.seedPollerGroupInfos(groups)
-	}
 }
 
 func (aw *AggregatedWorker) assertNotStopped() {
@@ -2490,6 +2462,7 @@ func NewAggregatedWorker(client *WorkflowClient, taskQueue string, options Worke
 		pollTimeTracker:               &pollTimeTracker{},
 		workerInstanceKey:             workerInstanceKey,
 		workerControlTaskQueue:        workerControlTaskQueue(client.namespace, client.workerGroupingKey),
+		pollerGroupInfoStore:          client.pollerGroupInfoStore,
 		activityCancellationCallbacks: activityCancellationCallbacks,
 		workerPollCompleteOnShutdown:  workerPollCompleteOnShutdown,
 		serverSupportsAutoscaling:     &atomic.Bool{},

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -1472,11 +1472,11 @@ func (aw *AggregatedWorker) start() error {
 		}
 	}
 
+	// Poller behavior can depend on namespace capabilities, so workflow and
+	// activity scalable task pollers are initialized only after those capabilities
+	// have been resolved.
 	if !util.IsInterfaceNil(aw.workflowWorker) {
 		aw.workflowWorker.initializeTaskPollers(aw.executionParams.WorkflowTaskPollerBehavior)
-	}
-	if !util.IsInterfaceNil(aw.activityWorker) {
-		aw.activityWorker.initializeTaskPollers(aw.executionParams.ActivityTaskPollerBehavior)
 	}
 
 	if !util.IsInterfaceNil(aw.workflowWorker) {
@@ -1488,6 +1488,7 @@ func (aw *AggregatedWorker) start() error {
 		}
 	}
 	if !util.IsInterfaceNil(aw.activityWorker) {
+		aw.activityWorker.initializeTaskPollers(aw.executionParams.ActivityTaskPollerBehavior)
 		if err := aw.activityWorker.Start(); err != nil {
 			// stop workflow worker.
 			if !util.IsInterfaceNil(aw.workflowWorker) {

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -26,6 +26,7 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	historypb "go.temporal.io/api/history/v1"
 	"go.temporal.io/api/serviceerror"
+	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	"go.temporal.io/api/temporalproto"
 	workerpb "go.temporal.io/api/worker/v1"
 	"go.temporal.io/api/workflowservice/v1"
@@ -88,6 +89,7 @@ type (
 		worker              *baseWorker
 		localActivityWorker *baseWorker
 		identity            string
+		pollerGroups        *pollerGroupManager
 		// stopC is created by newWorkflowWorkerInternal, exposed through
 		// WorkerStopChannel to workflow task handling, passed to local activity
 		// contexts as the worker stop channel, and closed by workflowWorker.Stop().
@@ -107,6 +109,7 @@ type (
 		poller              taskPoller
 		worker              *baseWorker
 		identity            string
+		pollerGroups        *pollerGroupManager
 		// stopC is created by newActivityWorker, exposed through WorkerStopChannel
 		// to activity task polling/handling, and closed by activityWorker.Stop().
 		stopC chan struct{}
@@ -417,6 +420,7 @@ func newWorkflowTaskWorkerInternal(
 				),
 				"",
 				nil,
+				nil,
 			),
 		},
 		taskProcessor:  localActivityTaskPoller,
@@ -450,6 +454,13 @@ func newWorkflowTaskWorkerInternal(
 	}
 }
 
+func (ww *workflowWorker) seedPollerGroupInfos(groups []*taskqueuepb.PollerGroupInfo) {
+	if ww == nil || ww.pollerGroups == nil || len(groups) == 0 {
+		return
+	}
+	ww.pollerGroups.updateGroups(groups)
+}
+
 // Start the worker.
 func (ww *workflowWorker) Start() error {
 	// AggregatedWorker initializes pollers after resolving namespace capabilities.
@@ -475,47 +486,58 @@ func (ww *workflowWorker) Stop() {
 // the given behavior. A simple-maximum behavior uses a single Mixed poller,
 // while an autoscaling behavior uses a NonSticky poller plus a Sticky poller
 // when the sticky cache is enabled.
-func buildWorkflowScalableTaskPollers(taskProcessor *workflowTaskProcessor, behavior PollerBehavior, params workerExecutionParameters) []scalableTaskPoller {
+func buildWorkflowScalableTaskPollers(
+	taskProcessor *workflowTaskProcessor,
+	behavior PollerBehavior,
+	params workerExecutionParameters,
+) ([]scalableTaskPoller, *pollerGroupManager) {
 	switch behavior.(type) {
 	case *pollerBehaviorAutoscaling:
+		pollerGroups := newPollerGroupManager(true)
 		scalableTaskPollers := []scalableTaskPoller{
 			newScalableTaskPoller(
-				taskProcessor.createPoller(NonSticky),
+				taskProcessor.createPoller(NonSticky, pollerGroups),
 				params.Logger,
 				behavior,
 				metrics.PollerTypeWorkflowTask,
 				params.serverSupportsAutoscaling,
+				pollerGroups,
 			),
 		}
 		if taskProcessor.stickyCacheSize > 0 {
 			scalableTaskPollers = append(
 				scalableTaskPollers,
 				newScalableTaskPoller(
-					taskProcessor.createPoller(Sticky),
+					taskProcessor.createPoller(Sticky, pollerGroups),
 					params.Logger,
 					behavior,
 					metrics.PollerTypeWorkflowStickyTask,
 					params.serverSupportsAutoscaling,
+					pollerGroups,
 				),
 			)
 		}
-		return scalableTaskPollers
+		return scalableTaskPollers, pollerGroups
 	default: // *pollerBehaviorSimpleMaximum
 		return []scalableTaskPoller{
 			newScalableTaskPoller(
-				taskProcessor.createPoller(Mixed),
+				taskProcessor.createPoller(Mixed, nil),
 				params.Logger,
 				behavior,
 				metrics.PollerTypeWorkflowTask,
 				params.serverSupportsAutoscaling,
+				nil,
 			),
-		}
+		}, nil
 	}
 }
 
 func (ww *workflowWorker) initializeTaskPollers(behavior PollerBehavior) {
+	taskProcessor := ww.worker.options.taskProcessor.(*workflowTaskProcessor)
 	ww.executionParameters.WorkflowTaskPollerBehavior = behavior
-	ww.worker.initializeTaskPollers(buildWorkflowScalableTaskPollers(ww.taskProcessor, behavior, ww.executionParameters))
+	taskPollers, pollerGroups := buildWorkflowScalableTaskPollers(taskProcessor, behavior, ww.executionParameters)
+	ww.pollerGroups = pollerGroups
+	ww.worker.initializeTaskPollers(taskPollers)
 }
 
 func newSessionWorker(client *WorkflowClient, params workerExecutionParameters, env *registry, maxConcurrentSessionExecutionSize int) *sessionWorker {
@@ -618,7 +640,7 @@ func newActivityWorker(
 		taskHandler = newActivityTaskHandler(client, params, env)
 	}
 
-	poller := newActivityTaskPoller(taskHandler, service, params)
+	poller := newActivityTaskPoller(taskHandler, service, params, nil)
 	var slotSupplier SlotSupplier
 	if overrides != nil && overrides.slotSupplier != nil {
 		slotSupplier = overrides.slotSupplier
@@ -657,6 +679,13 @@ func newActivityWorker(
 	}
 }
 
+func (aw *activityWorker) seedPollerGroupInfos(groups []*taskqueuepb.PollerGroupInfo) {
+	if aw == nil || aw.pollerGroups == nil || len(groups) == 0 {
+		return
+	}
+	aw.pollerGroups.updateGroups(groups)
+}
+
 // Start the worker.
 func (aw *activityWorker) Start() error {
 	// AggregatedWorker initializes pollers after resolving namespace capabilities.
@@ -676,6 +705,14 @@ func (aw *activityWorker) Stop() {
 
 func (aw *activityWorker) initializeTaskPollers(behavior PollerBehavior) {
 	aw.executionParameters.ActivityTaskPollerBehavior = behavior
+	var pollerGroups *pollerGroupManager
+	if _, ok := behavior.(*pollerBehaviorAutoscaling); ok {
+		pollerGroups = newPollerGroupManager(false)
+	}
+	if poller, ok := aw.poller.(*activityTaskPoller); ok {
+		poller.pollerGroups = pollerGroups
+	}
+	aw.pollerGroups = pollerGroups
 	aw.worker.initializeTaskPollers([]scalableTaskPoller{
 		newScalableTaskPoller(
 			aw.poller,
@@ -683,6 +720,7 @@ func (aw *activityWorker) initializeTaskPollers(behavior PollerBehavior) {
 			behavior,
 			metrics.PollerTypeActivityTask,
 			aw.executionParameters.serverSupportsAutoscaling,
+			pollerGroups,
 		),
 	})
 }
@@ -1448,11 +1486,15 @@ func (aw *AggregatedWorker) start() error {
 		}
 	}
 
-	// Poller behavior can depend on namespace capabilities, so workflow and
-	// activity scalable task pollers are initialized only after those capabilities
-	// have been resolved.
 	if !util.IsInterfaceNil(aw.workflowWorker) {
 		aw.workflowWorker.initializeTaskPollers(aw.executionParams.WorkflowTaskPollerBehavior)
+	}
+	if !util.IsInterfaceNil(aw.activityWorker) {
+		aw.activityWorker.initializeTaskPollers(aw.executionParams.ActivityTaskPollerBehavior)
+	}
+	aw.seedPollerGroupInfos(nsData.pollerGroupInfos)
+
+	if !util.IsInterfaceNil(aw.workflowWorker) {
 		if err := aw.workflowWorker.Start(); err != nil {
 			return err
 		}
@@ -1461,7 +1503,6 @@ func (aw *AggregatedWorker) start() error {
 		}
 	}
 	if !util.IsInterfaceNil(aw.activityWorker) {
-		aw.activityWorker.initializeTaskPollers(aw.executionParams.ActivityTaskPollerBehavior)
 		if err := aw.activityWorker.Start(); err != nil {
 			// stop workflow worker.
 			if !util.IsInterfaceNil(aw.workflowWorker) {
@@ -1522,6 +1563,7 @@ func (aw *AggregatedWorker) start() error {
 		if err != nil {
 			return fmt.Errorf("failed to create a nexus worker: %w", err)
 		}
+		aw.nexusWorker.seedPollerGroupInfos(nsData.pollerGroupInfos)
 		if err := aw.nexusWorker.Start(); err != nil {
 			return fmt.Errorf("failed to start a nexus worker: %w", err)
 		}
@@ -1534,6 +1576,18 @@ func (aw *AggregatedWorker) start() error {
 	}
 	aw.logger.Info("Started Worker")
 	return nil
+}
+
+func (aw *AggregatedWorker) seedPollerGroupInfos(groups []*taskqueuepb.PollerGroupInfo) {
+	if len(groups) == 0 {
+		return
+	}
+	if !util.IsInterfaceNil(aw.workflowWorker) {
+		aw.workflowWorker.seedPollerGroupInfos(groups)
+	}
+	if !util.IsInterfaceNil(aw.activityWorker) {
+		aw.activityWorker.seedPollerGroupInfos(groups)
+	}
 }
 
 func (aw *AggregatedWorker) assertNotStopped() {

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -240,6 +240,7 @@ type (
 		workerInstanceKey string
 
 		workerControlTaskQueue string
+		pollerGroupInfoStore   *pollerGroupInfoStore
 
 		activityCancellationCallbacks *activityCancellationCallbacks
 
@@ -417,6 +418,7 @@ func newWorkflowTaskWorkerInternal(
 				),
 				"",
 				nil,
+				nil,
 			),
 		},
 		taskProcessor:  localActivityTaskPoller,
@@ -474,28 +476,40 @@ func (ww *workflowWorker) Stop() {
 // buildWorkflowScalableTaskPollers builds the set of workflow task pollers for
 // the given behavior. A simple-maximum behavior uses a single Mixed poller,
 // while an autoscaling behavior uses a NonSticky poller plus a Sticky poller
-// when the sticky cache is enabled.
-func buildWorkflowScalableTaskPollers(taskProcessor *workflowTaskProcessor, behavior PollerBehavior, params workerExecutionParameters) []scalableTaskPoller {
+// when the sticky cache is enabled. Each returned poller is a reusable object
+// with independent concurrency control, not one object per poll attempt.
+func buildWorkflowScalableTaskPollers(
+	taskProcessor *workflowTaskProcessor,
+	behavior PollerBehavior,
+	params workerExecutionParameters,
+) []scalableTaskPoller {
 	switch behavior.(type) {
 	case *pollerBehaviorAutoscaling:
+		mode := pollerGroupModeWorkflow
+		if taskProcessor.stickyCacheSize > 0 {
+			mode = pollerGroupModeWorkflowWithSticky
+		}
+		pollerGroups := newPollerGroupManager(mode, params.pollerGroupInfoStore)
 		scalableTaskPollers := []scalableTaskPoller{
 			newScalableTaskPoller(
-				taskProcessor.createPoller(NonSticky),
+				taskProcessor.createPoller(NonSticky, pollerGroups),
 				params.Logger,
 				behavior,
 				metrics.PollerTypeWorkflowTask,
 				params.serverSupportsAutoscaling,
+				pollerGroups,
 			),
 		}
 		if taskProcessor.stickyCacheSize > 0 {
 			scalableTaskPollers = append(
 				scalableTaskPollers,
 				newScalableTaskPoller(
-					taskProcessor.createPoller(Sticky),
+					taskProcessor.createPoller(Sticky, pollerGroups),
 					params.Logger,
 					behavior,
 					metrics.PollerTypeWorkflowStickyTask,
 					params.serverSupportsAutoscaling,
+					pollerGroups,
 				),
 			)
 		}
@@ -503,19 +517,22 @@ func buildWorkflowScalableTaskPollers(taskProcessor *workflowTaskProcessor, beha
 	default: // *pollerBehaviorSimpleMaximum
 		return []scalableTaskPoller{
 			newScalableTaskPoller(
-				taskProcessor.createPoller(Mixed),
+				taskProcessor.createPoller(Mixed, nil),
 				params.Logger,
 				behavior,
 				metrics.PollerTypeWorkflowTask,
 				params.serverSupportsAutoscaling,
+				nil,
 			),
 		}
 	}
 }
 
 func (ww *workflowWorker) initializeTaskPollers(behavior PollerBehavior) {
+	taskProcessor := ww.worker.options.taskProcessor.(*workflowTaskProcessor)
 	ww.executionParameters.WorkflowTaskPollerBehavior = behavior
-	ww.worker.initializeTaskPollers(buildWorkflowScalableTaskPollers(ww.taskProcessor, behavior, ww.executionParameters))
+	taskPollers := buildWorkflowScalableTaskPollers(taskProcessor, behavior, ww.executionParameters)
+	ww.worker.initializeTaskPollers(taskPollers)
 }
 
 func newSessionWorker(client *WorkflowClient, params workerExecutionParameters, env *registry, maxConcurrentSessionExecutionSize int) *sessionWorker {
@@ -618,7 +635,7 @@ func newActivityWorker(
 		taskHandler = newActivityTaskHandler(client, params, env)
 	}
 
-	poller := newActivityTaskPoller(taskHandler, service, params)
+	poller := newActivityTaskPoller(taskHandler, service, params, nil)
 	var slotSupplier SlotSupplier
 	if overrides != nil && overrides.slotSupplier != nil {
 		slotSupplier = overrides.slotSupplier
@@ -676,6 +693,13 @@ func (aw *activityWorker) Stop() {
 
 func (aw *activityWorker) initializeTaskPollers(behavior PollerBehavior) {
 	aw.executionParameters.ActivityTaskPollerBehavior = behavior
+	var pollerGroups *pollerGroupManager
+	if _, ok := behavior.(*pollerBehaviorAutoscaling); ok {
+		pollerGroups = newPollerGroupManager(pollerGroupModeNonWorkflow, aw.executionParameters.pollerGroupInfoStore)
+	}
+	if poller, ok := aw.poller.(*activityTaskPoller); ok {
+		poller.pollerGroups = pollerGroups
+	}
 	aw.worker.initializeTaskPollers([]scalableTaskPoller{
 		newScalableTaskPoller(
 			aw.poller,
@@ -683,6 +707,7 @@ func (aw *activityWorker) initializeTaskPollers(behavior PollerBehavior) {
 			behavior,
 			metrics.PollerTypeActivityTask,
 			aw.executionParameters.serverSupportsAutoscaling,
+			pollerGroups,
 		),
 	})
 }
@@ -1453,6 +1478,9 @@ func (aw *AggregatedWorker) start() error {
 	// have been resolved.
 	if !util.IsInterfaceNil(aw.workflowWorker) {
 		aw.workflowWorker.initializeTaskPollers(aw.executionParams.WorkflowTaskPollerBehavior)
+	}
+
+	if !util.IsInterfaceNil(aw.workflowWorker) {
 		if err := aw.workflowWorker.Start(); err != nil {
 			return err
 		}
@@ -2436,6 +2464,7 @@ func NewAggregatedWorker(client *WorkflowClient, taskQueue string, options Worke
 		pollTimeTracker:               &pollTimeTracker{},
 		workerInstanceKey:             workerInstanceKey,
 		workerControlTaskQueue:        workerControlTaskQueue(client.namespace, client.workerGroupingKey),
+		pollerGroupInfoStore:          client.pollerGroupInfoStore,
 		activityCancellationCallbacks: activityCancellationCallbacks,
 		workerPollCompleteOnShutdown:  workerPollCompleteOnShutdown,
 		serverSupportsAutoscaling:     &atomic.Bool{},

--- a/internal/internal_worker_base.go
+++ b/internal/internal_worker_base.go
@@ -294,10 +294,12 @@ type (
 	barrier chan struct{}
 
 	autoscalingTaskPollerRunner struct {
-		autoscaler *pollerAutoscaler
-		wakeCh     chan struct{}
-		activeMu   sync.Mutex
-		active     int
+		autoscaler   *pollerAutoscaler
+		pollerGroups *pollerGroupManager
+		queueKind    enumspb.TaskQueueKind
+		wakeCh       chan struct{}
+		activeMu     sync.Mutex
+		active       int
 	}
 
 	// pollerBalancer is used to balance the number of poll requests from different poller types
@@ -981,19 +983,21 @@ func (prh *pollerAutoscaler) handleTask(task taskForWorker) {
 func (prh *pollerAutoscaler) updateTarget(f func(int64) int64) {
 	target := prh.target.Load()
 	newTarget := f(target)
-	if newTarget < int64(prh.minPollerCount) {
-		newTarget = int64(prh.minPollerCount)
-	} else if newTarget > int64(prh.maxPollerCount) {
-		newTarget = int64(prh.maxPollerCount)
-	}
+	newTarget = int64(effectivePollerTarget(
+		int(newTarget),
+		prh.minPollerCount,
+		prh.maxPollerCount,
+		0,
+	))
 	for !prh.target.CompareAndSwap(target, newTarget) {
 		target = prh.target.Load()
 		newTarget = f(target)
-		if newTarget < int64(prh.minPollerCount) {
-			newTarget = int64(prh.minPollerCount)
-		} else if newTarget > int64(prh.maxPollerCount) {
-			newTarget = int64(prh.maxPollerCount)
-		}
+		newTarget = int64(effectivePollerTarget(
+			int(newTarget),
+			prh.minPollerCount,
+			prh.maxPollerCount,
+			0,
+		))
 	}
 	if prh.targetChangedCallback != nil {
 		traceLog(func() {
@@ -1045,17 +1049,23 @@ func (prh *pollerAutoscaler) newPeriod() {
 	prh.scaleUpAllowed.Store(float64(ingestedThisPeriod) >= float64(ingestedLastPeriod)*1.1)
 }
 
-func newAutoscalingTaskPollerRunner(autoscaler *pollerAutoscaler) *autoscalingTaskPollerRunner {
+func newAutoscalingTaskPollerRunner(
+	autoscaler *pollerAutoscaler,
+	pollerGroups *pollerGroupManager,
+	queueKind enumspb.TaskQueueKind,
+) *autoscalingTaskPollerRunner {
 	return &autoscalingTaskPollerRunner{
-		autoscaler: autoscaler,
-		wakeCh:     make(chan struct{}, 1),
+		autoscaler:   autoscaler,
+		pollerGroups: pollerGroups,
+		queueKind:    queueKind,
+		wakeCh:       make(chan struct{}, 1),
 	}
 }
 
 func (r *autoscalingTaskPollerRunner) acquire(ctx context.Context) (func(), error) {
 	for {
 		r.activeMu.Lock()
-		target := int(r.autoscaler.target.Load())
+		target := r.effectiveTarget()
 		if r.active < target {
 			r.active++
 			r.activeMu.Unlock()
@@ -1069,6 +1079,30 @@ func (r *autoscalingTaskPollerRunner) acquire(ctx context.Context) (func(), erro
 		case <-r.wakeCh:
 		}
 	}
+}
+
+// effectiveTarget expects the r.activeMu lock to already be held
+func (r *autoscalingTaskPollerRunner) effectiveTarget() int {
+	target := int(r.autoscaler.target.Load())
+	return effectivePollerTarget(
+		target,
+		r.autoscaler.minPollerCount,
+		r.autoscaler.maxPollerCount,
+		r.pollerGroups.requiredMin(r.queueKind),
+	)
+}
+
+func effectivePollerTarget(current, configuredMin, configuredMax, requiredMin int) int {
+	effectiveMin := max(configuredMin, requiredMin)
+	effectiveMax := max(configuredMax, effectiveMin)
+
+	if current < effectiveMin {
+		return effectiveMin
+	}
+	if current > effectiveMax {
+		return effectiveMax
+	}
+	return current
 }
 
 func (r *autoscalingTaskPollerRunner) release() {
@@ -1097,6 +1131,7 @@ func newScalableTaskPoller(
 	pollerBehavior PollerBehavior,
 	taskPollerType string,
 	serverSupportsAutoscaling *atomic.Bool,
+	pollerGroups *pollerGroupManager,
 ) scalableTaskPoller {
 	tw := scalableTaskPoller{
 		taskPoller:     poller,
@@ -1111,7 +1146,9 @@ func newScalableTaskPoller(
 			logger:                    logger,
 			serverSupportsAutoscaling: serverSupportsAutoscaling,
 		})
-		tw.autoscalingRunner = newAutoscalingTaskPollerRunner(tw.pollerAutoscaler)
+		queueKind, _ := taskQueueKindForPoller(tw)
+		tw.autoscalingRunner = newAutoscalingTaskPollerRunner(tw.pollerAutoscaler, pollerGroups, queueKind)
+		pollerGroups.addListener(tw.autoscalingRunner.signal)
 		tw.pollerAutoscaler.targetChangedCallback = func() {
 			tw.autoscalingRunner.signal()
 		}

--- a/internal/internal_worker_base.go
+++ b/internal/internal_worker_base.go
@@ -658,19 +658,21 @@ func (bw *baseWorker) slotReservationData(taskWorker scalableTaskPoller) slotRes
 }
 
 func taskQueueKindForPoller(taskWorker scalableTaskPoller) (enumspb.TaskQueueKind, bool) {
-	switch taskWorker.taskPollerType {
+	if taskWorker.autoscalingRunner == nil {
+		return enumspb.TASK_QUEUE_KIND_UNSPECIFIED, false
+	}
+	return taskQueueKindForAutoscalingPollerType(taskWorker.taskPollerType)
+}
+
+func taskQueueKindForAutoscalingPollerType(taskPollerType string) (enumspb.TaskQueueKind, bool) {
+	switch taskPollerType {
 	case metrics.PollerTypeWorkflowStickyTask:
 		return enumspb.TASK_QUEUE_KIND_STICKY, true
-	case metrics.PollerTypeWorkflowTask:
-		// Autoscaling workflow pollers are split by queue kind. SimpleMaximum
-		// workflow pollers are mixed, so their kind is not known at reservation time.
-		if taskWorker.autoscalingRunner != nil {
-			return enumspb.TASK_QUEUE_KIND_NORMAL, true
-		}
-	case metrics.PollerTypeActivityTask, metrics.PollerTypeNexusTask:
+	case metrics.PollerTypeWorkflowTask, metrics.PollerTypeActivityTask, metrics.PollerTypeNexusTask:
 		return enumspb.TASK_QUEUE_KIND_NORMAL, true
+	default:
+		return enumspb.TASK_QUEUE_KIND_UNSPECIFIED, false
 	}
-	return enumspb.TASK_QUEUE_KIND_UNSPECIFIED, false
 }
 
 func (bw *baseWorker) tryReserveSlot() *SlotPermit {
@@ -1146,7 +1148,7 @@ func newScalableTaskPoller(
 			logger:                    logger,
 			serverSupportsAutoscaling: serverSupportsAutoscaling,
 		})
-		queueKind, _ := taskQueueKindForPoller(tw)
+		queueKind, _ := taskQueueKindForAutoscalingPollerType(taskPollerType)
 		tw.autoscalingRunner = newAutoscalingTaskPollerRunner(tw.pollerAutoscaler, pollerGroups, queueKind)
 		pollerGroups.addListener(tw.autoscalingRunner.signal)
 		tw.pollerAutoscaler.targetChangedCallback = func() {

--- a/internal/internal_worker_base.go
+++ b/internal/internal_worker_base.go
@@ -1150,7 +1150,6 @@ func newScalableTaskPoller(
 		})
 		queueKind, _ := taskQueueKindForAutoscalingPollerType(taskPollerType)
 		tw.autoscalingRunner = newAutoscalingTaskPollerRunner(tw.pollerAutoscaler, pollerGroups, queueKind)
-		pollerGroups.addListener(tw.autoscalingRunner.signal)
 		tw.pollerAutoscaler.targetChangedCallback = func() {
 			tw.autoscalingRunner.signal()
 		}

--- a/internal/internal_worker_base.go
+++ b/internal/internal_worker_base.go
@@ -187,10 +187,13 @@ type (
 		Close()
 	}
 
+	// scalableTaskPoller is the reusable poller plus its concurrency-control
+	// configuration. It does not represent a goroutine or a single poll attempt;
+	// baseWorker may invoke taskPoller concurrently from multiple poll loops.
 	scalableTaskPoller struct {
 		taskPollerType string
-		// pollerCount is the number of pollers tasks to start. There may be less than this
-		// due to limited slots, rate limiting, or poller autoscaling.
+		// pollerCount is the number of fixed poll loops to start. There may be fewer
+		// active polls due to limited slots or rate limiting.
 		pollerCount       int
 		taskPoller        taskPoller
 		pollerAutoscaler  *pollerAutoscaler
@@ -297,10 +300,13 @@ type (
 	barrier chan struct{}
 
 	autoscalingTaskPollerRunner struct {
-		autoscaler *pollerAutoscaler
-		wakeCh     chan struct{}
-		activeMu   sync.Mutex
-		active     int
+		autoscaler   *pollerAutoscaler
+		pollerGroups *pollerGroupManager
+		queueKind    enumspb.TaskQueueKind
+		wakeCh       chan struct{}
+		activeMu     sync.Mutex
+		// active counts admitted logical poll attempts, not supporting goroutines.
+		active int
 	}
 
 	// pollerBalancer is used to balance the number of poll requests from different poller types
@@ -430,7 +436,9 @@ func (bw *baseWorker) initializeTaskPollers(taskPollers []scalableTaskPoller) {
 	}
 }
 
-// Start starts a fixed set of routines to do the work.
+// Start creates the fixed control goroutines for polling, autoscaling, and
+// dispatch. Autoscaling poll-attempt and task-processing goroutines are created
+// dynamically while the worker is running.
 func (bw *baseWorker) Start() {
 	if bw.isWorkerStarted {
 		return
@@ -446,21 +454,24 @@ func (bw *baseWorker) Start() {
 
 	for _, taskWorker := range bw.options.taskPollers {
 		if taskWorker.autoscalingRunner != nil {
+			// Autoscaling pollers are created with both a runner and an autoscaler.
+			// The runner's manager opens polls under the current target.
 			bw.stopWG.Add(1)
 			bw.pollerWG.Add(1)
 			go bw.runAutoscalingPoller(taskWorker)
+
+			// The autoscaler's separate loop periodically refreshes scaling signals.
+			bw.stopWG.Add(1)
+			go func() {
+				defer bw.stopWG.Done()
+				taskWorker.pollerAutoscaler.run(bw.stopCh)
+			}()
 		} else {
 			for i := 0; i < taskWorker.pollerCount; i++ {
 				bw.stopWG.Add(1)
 				bw.pollerWG.Add(1)
 				go bw.runPoller(taskWorker)
 			}
-		}
-
-		if taskWorker.pollerAutoscaler != nil {
-			bw.stopWG.Go(func() {
-				taskWorker.pollerAutoscaler.run(bw.stopCh)
-			})
 		}
 	}
 
@@ -538,7 +549,7 @@ func (bw *baseWorker) runPoller(taskWorker scalableTaskPoller) {
 			if bw.pollerBalancer != nil {
 				bw.pollerBalancer.incrementPoller(taskWorker.taskPollerType)
 			}
-			bw.pollTask(taskWorker, permit)
+			bw.pollTask(taskWorker, permit, pollerGroupLease{})
 			if bw.pollerBalancer != nil {
 				bw.pollerBalancer.decrementPoller(taskWorker.taskPollerType)
 			}
@@ -549,8 +560,9 @@ func (bw *baseWorker) runPoller(taskWorker scalableTaskPoller) {
 // runAutoscalingPoller is the autoscaling counterpart to runPoller. runPoller is
 // itself the long-lived poller: it reserves a slot, opens one poll RPC
 // synchronously, and loops. The autoscaling path instead uses this goroutine as
-// a manager: it reserves a slot, waits for active polls to be below the current
-// autoscaler target, then spawns a short-lived goroutine for that poll RPC.
+// a manager: it waits for runner admission, reserves a slot, then spawns one
+// short-lived goroutine per logical poll. The configured poller limit bounds
+// logical active polls, not the supporting goroutine count.
 func (bw *baseWorker) runAutoscalingPoller(taskWorker scalableTaskPoller) {
 	defer bw.stopWG.Done()
 	defer bw.pollerWG.Done()
@@ -574,7 +586,7 @@ func (bw *baseWorker) runAutoscalingPoller(taskWorker scalableTaskPoller) {
 			}
 		}
 
-		releaseActive, err := taskWorker.autoscalingRunner.acquire(bw.limiterContext)
+		lease, releaseActive, err := taskWorker.autoscalingRunner.acquire(bw.limiterContext)
 		if err != nil {
 			return
 		}
@@ -584,11 +596,13 @@ func (bw *baseWorker) runAutoscalingPoller(taskWorker scalableTaskPoller) {
 		var permit *SlotPermit
 		select {
 		case <-bw.stopCh:
+			lease.release()
 			releaseActive()
 			return
 		case permit = <-reserveChan:
 		}
 		if permit == nil { // There was an error reserving a slot
+			lease.release()
 			releaseActive()
 			// Avoid spamming reserve hard in the event it's constantly failing
 			if ctx.Err() == nil {
@@ -599,6 +613,7 @@ func (bw *baseWorker) runAutoscalingPoller(taskWorker scalableTaskPoller) {
 
 		if bw.sessionTokenBucket != nil && !bw.sessionTokenBucket.waitForAvailableToken() {
 			bw.releaseSlot(permit, SlotReleaseReasonUnused)
+			lease.release()
 			releaseActive()
 			return
 		}
@@ -612,10 +627,11 @@ func (bw *baseWorker) runAutoscalingPoller(taskWorker scalableTaskPoller) {
 			defer bw.stopWG.Done()
 			defer pollWG.Done()
 			defer releaseActive()
+			defer lease.release()
 			if bw.pollerBalancer != nil {
 				defer bw.pollerBalancer.decrementPoller(taskWorker.taskPollerType)
 			}
-			bw.pollTask(taskWorker, slotPermit)
+			bw.pollTask(taskWorker, slotPermit, lease)
 		}(permit)
 	}
 }
@@ -656,19 +672,21 @@ func (bw *baseWorker) slotReservationData(taskWorker scalableTaskPoller) slotRes
 }
 
 func taskQueueKindForPoller(taskWorker scalableTaskPoller) (enumspb.TaskQueueKind, bool) {
-	switch taskWorker.taskPollerType {
+	if taskWorker.autoscalingRunner == nil {
+		return enumspb.TASK_QUEUE_KIND_UNSPECIFIED, false
+	}
+	return taskQueueKindForAutoscalingPollerType(taskWorker.taskPollerType)
+}
+
+func taskQueueKindForAutoscalingPollerType(taskPollerType string) (enumspb.TaskQueueKind, bool) {
+	switch taskPollerType {
 	case metrics.PollerTypeWorkflowStickyTask:
 		return enumspb.TASK_QUEUE_KIND_STICKY, true
-	case metrics.PollerTypeWorkflowTask:
-		// Autoscaling workflow pollers are split by queue kind. SimpleMaximum
-		// workflow pollers are mixed, so their kind is not known at reservation time.
-		if taskWorker.autoscalingRunner != nil {
-			return enumspb.TASK_QUEUE_KIND_NORMAL, true
-		}
-	case metrics.PollerTypeActivityTask, metrics.PollerTypeNexusTask:
+	case metrics.PollerTypeWorkflowTask, metrics.PollerTypeActivityTask, metrics.PollerTypeNexusTask:
 		return enumspb.TASK_QUEUE_KIND_NORMAL, true
+	default:
+		return enumspb.TASK_QUEUE_KIND_UNSPECIFIED, false
 	}
-	return enumspb.TASK_QUEUE_KIND_UNSPECIFIED, false
 }
 
 func (bw *baseWorker) tryReserveSlot() *SlotPermit {
@@ -792,7 +810,11 @@ func (bw *baseWorker) runEagerTaskDispatcher() {
 	}
 }
 
-func (bw *baseWorker) pollTask(taskWorker scalableTaskPoller, slotPermit *SlotPermit) {
+func (bw *baseWorker) pollTask(
+	taskWorker scalableTaskPoller,
+	slotPermit *SlotPermit,
+	lease pollerGroupLease,
+) {
 	var err error
 	var task taskForWorker
 	didSendTask := false
@@ -804,7 +826,7 @@ func (bw *baseWorker) pollTask(taskWorker scalableTaskPoller, slotPermit *SlotPe
 
 	bw.retrier.Throttle(bw.stopCh)
 	if bw.pollLimiter == nil || bw.pollLimiter.Wait(bw.limiterContext) == nil {
-		task, err = taskWorker.taskPoller.PollTask()
+		task, err = taskWorker.taskPoller.PollTask(lease)
 		bw.logPollTaskError(err)
 		if err != nil {
 			// We retry "non retriable" errors while long polling for a while, because some proxies return
@@ -982,19 +1004,21 @@ func (prh *pollerAutoscaler) handleTask(task taskForWorker) {
 func (prh *pollerAutoscaler) updateTarget(f func(int64) int64) {
 	target := prh.target.Load()
 	newTarget := f(target)
-	if newTarget < int64(prh.minPollerCount) {
-		newTarget = int64(prh.minPollerCount)
-	} else if newTarget > int64(prh.maxPollerCount) {
-		newTarget = int64(prh.maxPollerCount)
-	}
+	newTarget = int64(effectivePollerTarget(
+		int(newTarget),
+		prh.minPollerCount,
+		prh.maxPollerCount,
+		0,
+	))
 	for !prh.target.CompareAndSwap(target, newTarget) {
 		target = prh.target.Load()
 		newTarget = f(target)
-		if newTarget < int64(prh.minPollerCount) {
-			newTarget = int64(prh.minPollerCount)
-		} else if newTarget > int64(prh.maxPollerCount) {
-			newTarget = int64(prh.maxPollerCount)
-		}
+		newTarget = int64(effectivePollerTarget(
+			int(newTarget),
+			prh.minPollerCount,
+			prh.maxPollerCount,
+			0,
+		))
 	}
 	if prh.targetChangedCallback != nil {
 		traceLog(func() {
@@ -1046,30 +1070,90 @@ func (prh *pollerAutoscaler) newPeriod() {
 	prh.scaleUpAllowed.Store(float64(ingestedThisPeriod) >= float64(ingestedLastPeriod)*1.1)
 }
 
-func newAutoscalingTaskPollerRunner(autoscaler *pollerAutoscaler) *autoscalingTaskPollerRunner {
-	return &autoscalingTaskPollerRunner{
-		autoscaler: autoscaler,
-		wakeCh:     make(chan struct{}, 1),
+func newAutoscalingTaskPollerRunner(
+	autoscaler *pollerAutoscaler,
+	pollerGroups *pollerGroupManager,
+	queueKind enumspb.TaskQueueKind,
+) *autoscalingTaskPollerRunner {
+	runner := &autoscalingTaskPollerRunner{
+		autoscaler:   autoscaler,
+		pollerGroups: pollerGroups,
+		queueKind:    queueKind,
+		wakeCh:       make(chan struct{}, 1),
 	}
+	pollerGroups.registerWaiter(runner.signal)
+	return runner
 }
 
-func (r *autoscalingTaskPollerRunner) acquire(ctx context.Context) (func(), error) {
+func (r *autoscalingTaskPollerRunner) acquire(ctx context.Context) (pollerGroupLease, func(), error) {
 	for {
+		// Capture the store notification before evaluating admission. If the
+		// snapshot changes during the evaluation, this channel is closed and the
+		// runner immediately tries again instead of missing the update.
+		var pollerGroupsChanged <-chan struct{}
+		if r.pollerGroups != nil {
+			pollerGroupsChanged = r.pollerGroups.groupInfos.changed()
+		}
 		r.activeMu.Lock()
-		target := int(r.autoscaler.target.Load())
+		target := r.effectiveTarget()
+		var lease pollerGroupLease
+		var ok bool
 		if r.active < target {
+			lease, ok = r.tryReservePollerGroup()
+		} else {
+			// Polls for removed groups, and ungrouped polls issued before groups
+			// became known, still count as active. Let mandatory current coverage
+			// temporarily exceed the autoscaling target while those polls drain.
+			lease, ok = r.pollerGroups.tryReserveRequired(r.queueKind)
+		}
+		if ok {
 			r.active++
 			r.activeMu.Unlock()
-			return r.release, nil
+			return lease, r.release, nil
 		}
 		r.activeMu.Unlock()
 
 		select {
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			return pollerGroupLease{}, nil, ctx.Err()
 		case <-r.wakeCh:
+		case <-pollerGroupsChanged:
 		}
 	}
+}
+
+func (r *autoscalingTaskPollerRunner) tryReservePollerGroup() (pollerGroupLease, bool) {
+	if r.pollerGroups == nil || r.pollerGroups.tracker == nil {
+		return pollerGroupLease{}, true
+	}
+	if r.pollerGroups.tracker.mode == pollerGroupModeNonWorkflow {
+		return r.pollerGroups.reserve(), true
+	}
+	return r.pollerGroups.tryReserveWorkflowPoll(r.queueKind)
+}
+
+// effectiveTarget expects the r.activeMu lock to already be held
+func (r *autoscalingTaskPollerRunner) effectiveTarget() int {
+	target := int(r.autoscaler.target.Load())
+	return effectivePollerTarget(
+		target,
+		r.autoscaler.minPollerCount,
+		r.autoscaler.maxPollerCount,
+		r.pollerGroups.requiredMin(),
+	)
+}
+
+func effectivePollerTarget(current, configuredMin, configuredMax, requiredMin int) int {
+	effectiveMin := max(configuredMin, requiredMin)
+	effectiveMax := max(configuredMax, effectiveMin)
+
+	if current < effectiveMin {
+		return effectiveMin
+	}
+	if current > effectiveMax {
+		return effectiveMax
+	}
+	return current
 }
 
 func (r *autoscalingTaskPollerRunner) release() {
@@ -1098,6 +1182,7 @@ func newScalableTaskPoller(
 	pollerBehavior PollerBehavior,
 	taskPollerType string,
 	serverSupportsAutoscaling *atomic.Bool,
+	pollerGroups *pollerGroupManager,
 ) scalableTaskPoller {
 	tw := scalableTaskPoller{
 		taskPoller:     poller,
@@ -1112,7 +1197,8 @@ func newScalableTaskPoller(
 			logger:                    logger,
 			serverSupportsAutoscaling: serverSupportsAutoscaling,
 		})
-		tw.autoscalingRunner = newAutoscalingTaskPollerRunner(tw.pollerAutoscaler)
+		queueKind, _ := taskQueueKindForAutoscalingPollerType(taskPollerType)
+		tw.autoscalingRunner = newAutoscalingTaskPollerRunner(tw.pollerAutoscaler, pollerGroups, queueKind)
 		tw.pollerAutoscaler.targetChangedCallback = func() {
 			tw.autoscalingRunner.signal()
 		}

--- a/internal/internal_worker_base_test.go
+++ b/internal/internal_worker_base_test.go
@@ -46,6 +46,7 @@ func (s *ScalableTaskPollerSuite) TestNewScalableTaskPollerSetsTaskPollerType() 
 		behavior,
 		metrics.PollerTypeWorkflowStickyTask,
 		&atomic.Bool{},
+		nil,
 	)
 
 	s.Equal(metrics.PollerTypeWorkflowStickyTask, poller.taskPollerType)
@@ -62,6 +63,7 @@ func (s *ScalableTaskPollerSuite) TestNewScalableTaskPollerUsesDynamicRunnerOnly
 		},
 		metrics.PollerTypeWorkflowTask,
 		&atomic.Bool{},
+		nil,
 	)
 	s.NotNil(autoscalingPoller.autoscalingRunner)
 	s.Equal(0, autoscalingPoller.pollerCount)
@@ -72,6 +74,7 @@ func (s *ScalableTaskPollerSuite) TestNewScalableTaskPollerUsesDynamicRunnerOnly
 		&pollerBehaviorSimpleMaximum{maximumNumberOfPollers: 2},
 		metrics.PollerTypeWorkflowTask,
 		&atomic.Bool{},
+		nil,
 	)
 	s.Nil(simpleMaximumPoller.autoscalingRunner)
 	s.Equal(2, simpleMaximumPoller.pollerCount)
@@ -98,6 +101,7 @@ func (s *ScalableTaskPollerSuite) TestSlotReservationDataUsesKnownTaskQueueKind(
 		autoscalingBehavior,
 		metrics.PollerTypeWorkflowTask,
 		&atomic.Bool{},
+		nil,
 	)
 	s.Equal(enumspb.TASK_QUEUE_KIND_NORMAL, bw.slotReservationData(nonStickyPoller).taskQueueKind)
 
@@ -107,6 +111,7 @@ func (s *ScalableTaskPollerSuite) TestSlotReservationDataUsesKnownTaskQueueKind(
 		autoscalingBehavior,
 		metrics.PollerTypeWorkflowStickyTask,
 		&atomic.Bool{},
+		nil,
 	)
 	s.Equal(enumspb.TASK_QUEUE_KIND_STICKY, bw.slotReservationData(stickyPoller).taskQueueKind)
 
@@ -116,6 +121,7 @@ func (s *ScalableTaskPollerSuite) TestSlotReservationDataUsesKnownTaskQueueKind(
 		&pollerBehaviorSimpleMaximum{maximumNumberOfPollers: 1},
 		metrics.PollerTypeWorkflowTask,
 		&atomic.Bool{},
+		nil,
 	)
 	s.Equal(enumspb.TASK_QUEUE_KIND_UNSPECIFIED, bw.slotReservationData(mixedPoller).taskQueueKind)
 }
@@ -146,6 +152,7 @@ func (s *ScalableTaskPollerSuite) TestInitializeTaskPollersCreatesBalancerForMul
 			&pollerBehaviorAutoscaling{initialNumberOfPollers: 1, maximumNumberOfPollers: 2, minimumNumberOfPollers: 1},
 			pollerType,
 			&atomic.Bool{},
+			nil,
 		)
 	}
 
@@ -264,7 +271,7 @@ func (s *ScalableTaskPollerSuite) TestAutoscalingConcurrencyScalesUpToMaximum() 
 	}
 
 	blockingPoller := newBlockingProbeTaskPoller()
-	poller := newScalableTaskPoller(blockingPoller, ilog.NewNopLogger(), behavior, "", nil)
+	poller := newScalableTaskPoller(blockingPoller, ilog.NewNopLogger(), behavior, "", nil, nil)
 	bw := newBaseWorker(baseWorkerOptions{
 		slotSupplier:     &testSlotSupplier{},
 		maxTaskPerSecond: 1000,
@@ -308,7 +315,7 @@ func (s *ScalableTaskPollerSuite) TestAutoscalingScalesDownToMinimum() {
 	}
 
 	blockingPoller := newBlockingProbeTaskPoller()
-	poller := newScalableTaskPoller(blockingPoller, ilog.NewNopLogger(), behavior, "", nil)
+	poller := newScalableTaskPoller(blockingPoller, ilog.NewNopLogger(), behavior, "", nil, nil)
 
 	bw := newBaseWorker(baseWorkerOptions{
 		slotSupplier:     &testSlotSupplier{},
@@ -350,7 +357,7 @@ func (s *ScalableTaskPollerSuite) TestAutoscalingDoesNotHoldSlotWhileWaitingForP
 	}
 
 	blockingPoller := newBlockingProbeTaskPoller()
-	poller := newScalableTaskPoller(blockingPoller, ilog.NewNopLogger(), behavior, "", nil)
+	poller := newScalableTaskPoller(blockingPoller, ilog.NewNopLogger(), behavior, "", nil, nil)
 	slotSupplier := newLimitedSlotSupplier(2)
 
 	bw := newBaseWorker(baseWorkerOptions{
@@ -391,7 +398,7 @@ func (s *ScalableTaskPollerSuite) TestAutoscalingBalancerDoesNotHoldSlotsWhileBl
 	}
 
 	blockingPoller := newBlockingProbeTaskPoller()
-	poller := newScalableTaskPoller(blockingPoller, ilog.NewNopLogger(), behavior, "a", nil)
+	poller := newScalableTaskPoller(blockingPoller, ilog.NewNopLogger(), behavior, "a", nil, nil)
 	slotSupplier := newLimitedSlotSupplier(2)
 
 	bw := newBaseWorker(baseWorkerOptions{
@@ -670,6 +677,7 @@ func TestAutoscalingTaskNotDroppedDuringShutdown(t *testing.T) {
 		},
 		"test",
 		&atomic.Bool{},
+		nil,
 	)
 
 	bw := newBaseWorker(baseWorkerOptions{
@@ -1223,6 +1231,7 @@ func (s *ScalableTaskPollerSuite) TestNewScalableTaskPollerAllTypes() {
 				behavior,
 				tc.ptype,
 				&atomic.Bool{},
+				nil,
 			)
 			s.Equal(tc.ptype, poller.taskPollerType)
 		})

--- a/internal/internal_worker_base_test.go
+++ b/internal/internal_worker_base_test.go
@@ -350,11 +350,11 @@ func (s *ScalableTaskPollerSuite) TestAutoscalingScalesDownToMinimum() {
 	}
 }
 
-func (s *ScalableTaskPollerSuite) TestAutoscalingPollerGroupAddRaisesRequiredMinimum() {
-	pollerGroups := newPollerGroupManager(true)
-	pollerGroups.updateGroups([]*taskqueuepb.PollerGroupInfo{
+func (s *ScalableTaskPollerSuite) TestAutoscalingPollerGroupAddRaisesRequiredMinimumAfterPollCompletion() {
+	pollerGroups := newPollerGroupManager(true, nil)
+	pollerGroups.updateGroups(testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{
 		{Id: "group-a", Weight: 1},
-	})
+	}))
 	autoscaler := newPollerAutoscaler(pollerAutoscalerOptions{
 		initialPollerCount: 1,
 		maxPollerCount:     1,
@@ -365,56 +365,39 @@ func (s *ScalableTaskPollerSuite) TestAutoscalingPollerGroupAddRaisesRequiredMin
 		pollerGroups,
 		enumspb.TASK_QUEUE_KIND_NORMAL,
 	)
-	pollerGroups.addListener(runner.signal)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	release, err := runner.acquire(ctx)
 	require.NoError(s.T(), err)
-	defer release()
 	assert.Equal(s.T(), 1, runner.activePolls(), "expected one active poll for one group")
 
-	type acquireResult struct {
-		release func()
-		err     error
-	}
-	acquired := make(chan acquireResult, 1)
-	go func() {
-		acquiredRelease, err := runner.acquire(ctx)
-		acquired <- acquireResult{release: acquiredRelease, err: err}
-	}()
-	require.Never(s.T(), func() bool {
-		return len(acquired) > 0
-	}, 100*time.Millisecond, 10*time.Millisecond, "second acquire should wait before group add")
-
 	assert.Equal(s.T(), 1, runner.effectiveTarget(), "expected one effective poller before group add")
-	pollerGroups.updateGroups([]*taskqueuepb.PollerGroupInfo{
+	pollerGroups.updateGroups(testPollerGroupsInfo(2, []*taskqueuepb.PollerGroupInfo{
 		{Id: "group-a", Weight: 1},
 		{Id: "group-b", Weight: 1},
-	})
+	}))
 
-	var result acquireResult
-	require.Eventually(s.T(), func() bool {
-		select {
-		case result = <-acquired:
-			return true
-		default:
-			return false
-		}
-	}, time.Second, 10*time.Millisecond, "expected group add to signal runner")
-	require.NoError(s.T(), result.err)
-	defer result.release()
+	assert.Equal(s.T(), 2, runner.effectiveTarget(), "expected group add to raise required minimum")
+	release()
+
+	firstRelease, err := runner.acquire(ctx)
+	require.NoError(s.T(), err)
+	defer firstRelease()
+	secondRelease, err := runner.acquire(ctx)
+	require.NoError(s.T(), err)
+	defer secondRelease()
 	assert.Equal(s.T(), 2, runner.activePolls(), "expected group add to raise required minimum")
 	assert.Equal(s.T(), int64(1), autoscaler.target.Load(), "group add should not mutate autoscaler target")
 }
 
 func (s *ScalableTaskPollerSuite) TestAutoscalingPollerGroupRemovalLowersRequiredMinimum() {
-	pollerGroups := newPollerGroupManager(true)
-	pollerGroups.updateGroups([]*taskqueuepb.PollerGroupInfo{
+	pollerGroups := newPollerGroupManager(true, nil)
+	pollerGroups.updateGroups(testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{
 		{Id: "group-a", Weight: 1},
 		{Id: "group-b", Weight: 100},
-	})
+	}))
 	autoscaler := newPollerAutoscaler(pollerAutoscalerOptions{
 		initialPollerCount: 1,
 		maxPollerCount:     1,
@@ -427,9 +410,9 @@ func (s *ScalableTaskPollerSuite) TestAutoscalingPollerGroupRemovalLowersRequire
 	)
 
 	assert.Equal(s.T(), 2, runner.effectiveTarget(), "expected two effective pollers for two groups")
-	pollerGroups.updateGroups([]*taskqueuepb.PollerGroupInfo{
+	pollerGroups.updateGroups(testPollerGroupsInfo(2, []*taskqueuepb.PollerGroupInfo{
 		{Id: "group-a", Weight: 1},
-	})
+	}))
 
 	assert.Equal(s.T(), 1, runner.effectiveTarget(), "expected group removal to lower required minimum")
 	lease := pollerGroups.reserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_NORMAL, false)
@@ -499,11 +482,11 @@ func (s *ScalableTaskPollerSuite) TestAutoscalingMCNRequiredFloorStillGatedBySlo
 		maximumNumberOfPollers: 1,
 		minimumNumberOfPollers: 1,
 	}
-	pollerGroups := newPollerGroupManager(true)
-	pollerGroups.updateGroups([]*taskqueuepb.PollerGroupInfo{
+	pollerGroups := newPollerGroupManager(true, nil)
+	pollerGroups.updateGroups(testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{
 		{Id: "group-a", Weight: 1},
 		{Id: "group-b", Weight: 1},
-	})
+	}))
 
 	blockingPoller := newBlockingProbeTaskPoller()
 	poller := newScalableTaskPoller(

--- a/internal/internal_worker_base_test.go
+++ b/internal/internal_worker_base_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
+	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	"go.temporal.io/sdk/internal/common/metrics"
 	ilog "go.temporal.io/sdk/internal/log"
 )
@@ -349,6 +350,209 @@ func (s *ScalableTaskPollerSuite) TestAutoscalingScalesDownToMinimum() {
 	}
 }
 
+func (s *ScalableTaskPollerSuite) TestAutoscalingPollerGroupAddRaisesRequiredMinimum() {
+	pollerGroups := newPollerGroupManager(true)
+	pollerGroups.updateGroups([]*taskqueuepb.PollerGroupInfo{
+		{Id: "group-a", Weight: 1},
+	})
+	autoscaler := newPollerAutoscaler(pollerAutoscalerOptions{
+		initialPollerCount: 1,
+		maxPollerCount:     1,
+		minPollerCount:     1,
+	})
+	runner := newAutoscalingTaskPollerRunner(
+		autoscaler,
+		pollerGroups,
+		enumspb.TASK_QUEUE_KIND_NORMAL,
+	)
+	pollerGroups.addListener(runner.signal)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	release, err := runner.acquire(ctx)
+	require.NoError(s.T(), err)
+	defer release()
+	assert.Equal(s.T(), 1, runner.activePolls(), "expected one active poll for one group")
+
+	type acquireResult struct {
+		release func()
+		err     error
+	}
+	acquired := make(chan acquireResult, 1)
+	go func() {
+		acquiredRelease, err := runner.acquire(ctx)
+		acquired <- acquireResult{release: acquiredRelease, err: err}
+	}()
+	require.Never(s.T(), func() bool {
+		return len(acquired) > 0
+	}, 100*time.Millisecond, 10*time.Millisecond, "second acquire should wait before group add")
+
+	assert.Equal(s.T(), 1, runner.effectiveTarget(), "expected one effective poller before group add")
+	pollerGroups.updateGroups([]*taskqueuepb.PollerGroupInfo{
+		{Id: "group-a", Weight: 1},
+		{Id: "group-b", Weight: 1},
+	})
+
+	var result acquireResult
+	require.Eventually(s.T(), func() bool {
+		select {
+		case result = <-acquired:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond, "expected group add to signal runner")
+	require.NoError(s.T(), result.err)
+	defer result.release()
+	assert.Equal(s.T(), 2, runner.activePolls(), "expected group add to raise required minimum")
+	assert.Equal(s.T(), int64(1), autoscaler.target.Load(), "group add should not mutate autoscaler target")
+}
+
+func (s *ScalableTaskPollerSuite) TestAutoscalingPollerGroupRemovalLowersRequiredMinimum() {
+	pollerGroups := newPollerGroupManager(true)
+	pollerGroups.updateGroups([]*taskqueuepb.PollerGroupInfo{
+		{Id: "group-a", Weight: 1},
+		{Id: "group-b", Weight: 100},
+	})
+	autoscaler := newPollerAutoscaler(pollerAutoscalerOptions{
+		initialPollerCount: 1,
+		maxPollerCount:     1,
+		minPollerCount:     1,
+	})
+	runner := newAutoscalingTaskPollerRunner(
+		autoscaler,
+		pollerGroups,
+		enumspb.TASK_QUEUE_KIND_NORMAL,
+	)
+
+	assert.Equal(s.T(), 2, runner.effectiveTarget(), "expected two effective pollers for two groups")
+	pollerGroups.updateGroups([]*taskqueuepb.PollerGroupInfo{
+		{Id: "group-a", Weight: 1},
+	})
+
+	assert.Equal(s.T(), 1, runner.effectiveTarget(), "expected group removal to lower required minimum")
+	lease := pollerGroups.reserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_NORMAL, false)
+	defer lease.release()
+	assert.Equal(s.T(), "group-a", lease.groupIDOrEmpty(), "future reservations should not use removed groups")
+	assert.Equal(s.T(), int64(1), autoscaler.target.Load(), "group removal should not mutate autoscaler target")
+}
+
+func (s *ScalableTaskPollerSuite) TestAutoscalingEffectiveTargetUsesMCNRequiredMinimumAsFloor() {
+	tests := []struct {
+		name          string
+		current       int
+		configuredMin int
+		configuredMax int
+		requiredMin   int
+		expected      int
+	}{
+		{
+			name:          "configured min below required minimum",
+			current:       1,
+			configuredMin: 1,
+			configuredMax: 10,
+			requiredMin:   3,
+			expected:      3,
+		},
+		{
+			name:          "configured max below required minimum",
+			current:       1,
+			configuredMin: 1,
+			configuredMax: 2,
+			requiredMin:   4,
+			expected:      4,
+		},
+		{
+			name:          "current target respected within effective bounds",
+			current:       3,
+			configuredMin: 1,
+			configuredMax: 5,
+			requiredMin:   2,
+			expected:      3,
+		},
+		{
+			name:          "current target capped at configured max when above effective bounds",
+			current:       6,
+			configuredMin: 1,
+			configuredMax: 5,
+			requiredMin:   2,
+			expected:      5,
+		},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			s.Equal(tt.expected, effectivePollerTarget(
+				tt.current,
+				tt.configuredMin,
+				tt.configuredMax,
+				tt.requiredMin,
+			))
+		})
+	}
+}
+
+func (s *ScalableTaskPollerSuite) TestAutoscalingMCNRequiredFloorStillGatedBySlots() {
+	behavior := &pollerBehaviorAutoscaling{
+		initialNumberOfPollers: 1,
+		maximumNumberOfPollers: 1,
+		minimumNumberOfPollers: 1,
+	}
+	pollerGroups := newPollerGroupManager(true)
+	pollerGroups.updateGroups([]*taskqueuepb.PollerGroupInfo{
+		{Id: "group-a", Weight: 1},
+		{Id: "group-b", Weight: 1},
+	})
+
+	blockingPoller := newBlockingProbeTaskPoller()
+	poller := newScalableTaskPoller(
+		blockingPoller,
+		ilog.NewNopLogger(),
+		behavior,
+		metrics.PollerTypeWorkflowTask,
+		&atomic.Bool{},
+		pollerGroups,
+	)
+	slotSupplier := newLimitedSlotSupplier(1)
+
+	bw := newBaseWorker(baseWorkerOptions{
+		slotSupplier:     slotSupplier,
+		maxTaskPerSecond: 1000,
+		taskPollers:      []scalableTaskPoller{poller},
+		taskProcessor:    noopTaskProcessor{},
+		workerType:       "AutoscalingMCNSlotCapacityTest",
+		logger:           ilog.NewNopLogger(),
+		stopTimeout:      time.Second,
+		metricsHandler:   metrics.NopHandler,
+	})
+
+	bw.Start()
+	defer func() {
+		blockingPoller.Allow(readAutoscalingPollerState(poller.autoscalingRunner))
+		blockingPoller.Close()
+		bw.Stop()
+	}()
+
+	assert.Equal(s.T(), 2, poller.autoscalingRunner.effectiveTarget(),
+		"expected MCN required floor to raise the effective target")
+	require.Eventually(s.T(), func() bool {
+		return blockingPoller.startedPolls() == 1
+	}, time.Second, 10*time.Millisecond, "expected first poll to start")
+	require.Equal(s.T(), int32(1), slotSupplier.reserves.Load(), "expected only one slot to be reserved")
+	require.Nil(s.T(), slotSupplier.TryReserveSlot(nil), "expected no spare slot while first poll is running")
+
+	require.Never(s.T(), func() bool {
+		return blockingPoller.startedPolls() > 1
+	}, 200*time.Millisecond, 10*time.Millisecond, "MCN required floor should not bypass slot capacity")
+
+	blockingPoller.Allow(1)
+
+	require.Eventually(s.T(), func() bool {
+		return blockingPoller.startedPolls() == 2
+	}, time.Second, 10*time.Millisecond, "expected second poll to start after a slot is released")
+}
+
 func (s *ScalableTaskPollerSuite) TestAutoscalingDoesNotHoldSlotWhileWaitingForPollCapacity() {
 	behavior := &pollerBehaviorAutoscaling{
 		initialNumberOfPollers: 1,
@@ -434,6 +638,7 @@ type blockingProbeTaskPoller struct {
 	signals chan struct{}
 	done    chan struct{}
 	closed  atomic.Bool
+	started atomic.Int32
 }
 
 func newBlockingProbeTaskPoller() *blockingProbeTaskPoller {
@@ -445,6 +650,7 @@ func newBlockingProbeTaskPoller() *blockingProbeTaskPoller {
 
 // PollTask implements taskPoller and blocks until a signal is provided so active polls stay acquired.
 func (p *blockingProbeTaskPoller) PollTask() (taskForWorker, error) {
+	p.started.Add(1)
 	select {
 	case <-p.signals:
 		return nil, nil
@@ -461,6 +667,10 @@ func (p *blockingProbeTaskPoller) Allow(n int) {
 			return
 		}
 	}
+}
+
+func (p *blockingProbeTaskPoller) startedPolls() int32 {
+	return p.started.Load()
 }
 
 func (p *blockingProbeTaskPoller) Close() {

--- a/internal/internal_worker_base_test.go
+++ b/internal/internal_worker_base_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
+	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	"go.temporal.io/sdk/internal/common/metrics"
 	ilog "go.temporal.io/sdk/internal/log"
 )
@@ -47,6 +48,7 @@ func (s *ScalableTaskPollerSuite) TestNewScalableTaskPollerSetsTaskPollerType() 
 		behavior,
 		metrics.PollerTypeWorkflowStickyTask,
 		&atomic.Bool{},
+		nil,
 	)
 
 	s.Equal(metrics.PollerTypeWorkflowStickyTask, poller.taskPollerType)
@@ -63,6 +65,7 @@ func (s *ScalableTaskPollerSuite) TestNewScalableTaskPollerUsesDynamicRunnerOnly
 		},
 		metrics.PollerTypeWorkflowTask,
 		&atomic.Bool{},
+		nil,
 	)
 	s.NotNil(autoscalingPoller.autoscalingRunner)
 	s.Equal(0, autoscalingPoller.pollerCount)
@@ -73,6 +76,7 @@ func (s *ScalableTaskPollerSuite) TestNewScalableTaskPollerUsesDynamicRunnerOnly
 		&pollerBehaviorSimpleMaximum{maximumNumberOfPollers: 2},
 		metrics.PollerTypeWorkflowTask,
 		&atomic.Bool{},
+		nil,
 	)
 	s.Nil(simpleMaximumPoller.autoscalingRunner)
 	s.Equal(2, simpleMaximumPoller.pollerCount)
@@ -99,6 +103,7 @@ func (s *ScalableTaskPollerSuite) TestSlotReservationDataUsesKnownTaskQueueKind(
 		autoscalingBehavior,
 		metrics.PollerTypeWorkflowTask,
 		&atomic.Bool{},
+		nil,
 	)
 	s.Equal(enumspb.TASK_QUEUE_KIND_NORMAL, bw.slotReservationData(nonStickyPoller).taskQueueKind)
 
@@ -108,6 +113,7 @@ func (s *ScalableTaskPollerSuite) TestSlotReservationDataUsesKnownTaskQueueKind(
 		autoscalingBehavior,
 		metrics.PollerTypeWorkflowStickyTask,
 		&atomic.Bool{},
+		nil,
 	)
 	s.Equal(enumspb.TASK_QUEUE_KIND_STICKY, bw.slotReservationData(stickyPoller).taskQueueKind)
 
@@ -117,6 +123,7 @@ func (s *ScalableTaskPollerSuite) TestSlotReservationDataUsesKnownTaskQueueKind(
 		&pollerBehaviorSimpleMaximum{maximumNumberOfPollers: 1},
 		metrics.PollerTypeWorkflowTask,
 		&atomic.Bool{},
+		nil,
 	)
 	s.Equal(enumspb.TASK_QUEUE_KIND_UNSPECIFIED, bw.slotReservationData(mixedPoller).taskQueueKind)
 }
@@ -147,6 +154,7 @@ func (s *ScalableTaskPollerSuite) TestInitializeTaskPollersCreatesBalancerForMul
 			&pollerBehaviorAutoscaling{initialNumberOfPollers: 1, maximumNumberOfPollers: 2, minimumNumberOfPollers: 1},
 			pollerType,
 			&atomic.Bool{},
+			nil,
 		)
 	}
 
@@ -344,7 +352,7 @@ func (s *ScalableTaskPollerSuite) TestAutoscalingConcurrencyScalesUpToMaximum() 
 	}
 
 	blockingPoller := newBlockingProbeTaskPoller()
-	poller := newScalableTaskPoller(blockingPoller, ilog.NewNopLogger(), behavior, "", nil)
+	poller := newScalableTaskPoller(blockingPoller, ilog.NewNopLogger(), behavior, "", nil, nil)
 	bw := newBaseWorker(baseWorkerOptions{
 		slotSupplier:     &testSlotSupplier{},
 		maxTaskPerSecond: 1000,
@@ -389,7 +397,7 @@ func (s *ScalableTaskPollerSuite) TestAutoscalingScalesDownToMinimum() {
 		}
 
 		blockingPoller := newBlockingProbeTaskPoller()
-		poller := newScalableTaskPoller(blockingPoller, ilog.NewNopLogger(), behavior, "", nil)
+		poller := newScalableTaskPoller(blockingPoller, ilog.NewNopLogger(), behavior, "", nil, nil)
 
 		bw := newBaseWorker(baseWorkerOptions{
 			slotSupplier:     &testSlotSupplier{},
@@ -424,6 +432,403 @@ func (s *ScalableTaskPollerSuite) TestAutoscalingScalesDownToMinimum() {
 	})
 }
 
+func (s *ScalableTaskPollerSuite) TestAutoscalingPollerGroupAddRaisesRequiredMinimumAfterPollCompletion() {
+	pollerGroups := newPollerGroupManager(pollerGroupModeWorkflow, nil)
+	pollerGroups.updateGroups(testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{
+		{Id: "group-a", Weight: 1},
+	}))
+	autoscaler := newPollerAutoscaler(pollerAutoscalerOptions{
+		initialPollerCount: 1,
+		maxPollerCount:     1,
+		minPollerCount:     1,
+	})
+	runner := newAutoscalingTaskPollerRunner(
+		autoscaler,
+		pollerGroups,
+		enumspb.TASK_QUEUE_KIND_NORMAL,
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	_, release, err := runner.acquire(ctx)
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), 1, runner.activePolls(), "expected one active poll for one group")
+
+	assert.Equal(s.T(), 1, runner.effectiveTarget(), "expected one effective poller before group add")
+	pollerGroups.updateGroups(testPollerGroupsInfo(2, []*taskqueuepb.PollerGroupInfo{
+		{Id: "group-a", Weight: 1},
+		{Id: "group-b", Weight: 1},
+	}))
+
+	assert.Equal(s.T(), 2, runner.effectiveTarget(), "expected group add to raise required minimum")
+	release()
+
+	_, firstRelease, err := runner.acquire(ctx)
+	require.NoError(s.T(), err)
+	defer firstRelease()
+	_, secondRelease, err := runner.acquire(ctx)
+	require.NoError(s.T(), err)
+	defer secondRelease()
+	assert.Equal(s.T(), 2, runner.activePolls(), "expected group add to raise required minimum")
+	assert.Equal(s.T(), int64(1), autoscaler.target.Load(), "group add should not mutate autoscaler target")
+}
+
+func (s *ScalableTaskPollerSuite) TestAutoscalingPollerGroupUpdateWakesRunnerSharingStore() {
+	groupInfos := newPollerGroupInfoStore()
+	publisher := newPollerGroupManager(pollerGroupModeNonWorkflow, groupInfos)
+	subscriber := newPollerGroupManager(pollerGroupModeWorkflow, groupInfos)
+	publisher.updateGroups(testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{
+		{Id: "group-a", Weight: 1},
+	}))
+	runner := newAutoscalingTaskPollerRunner(
+		newPollerAutoscaler(pollerAutoscalerOptions{
+			initialPollerCount: 1,
+			maxPollerCount:     1,
+			minPollerCount:     1,
+		}),
+		subscriber,
+		enumspb.TASK_QUEUE_KIND_NORMAL,
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	firstLease, firstRelease, err := runner.acquire(ctx)
+	require.NoError(s.T(), err)
+	defer firstRelease()
+	defer firstLease.release()
+
+	type acquireResult struct {
+		lease   pollerGroupLease
+		release func()
+		err     error
+	}
+	resultCh := make(chan acquireResult, 1)
+	go func() {
+		lease, release, err := runner.acquire(ctx)
+		resultCh <- acquireResult{lease: lease, release: release, err: err}
+	}()
+
+	select {
+	case result := <-resultCh:
+		if result.release != nil {
+			result.release()
+		}
+		result.lease.release()
+		s.T().Fatal("second poll acquired before another group was added")
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	publisher.updateGroups(testPollerGroupsInfo(2, []*taskqueuepb.PollerGroupInfo{
+		{Id: "group-a", Weight: 1},
+		{Id: "group-b", Weight: 1},
+	}))
+
+	select {
+	case result := <-resultCh:
+		require.NoError(s.T(), result.err)
+		defer result.release()
+		defer result.lease.release()
+		require.Equal(s.T(), "group-b", result.lease.groupIDOrEmpty())
+	case <-time.After(time.Second):
+		s.T().Fatal("shared store update did not wake runner")
+	}
+}
+
+func (s *ScalableTaskPollerSuite) TestAutoscalingCurrentGroupCoverageDoesNotWaitForStalePolls() {
+	for _, test := range []struct {
+		name          string
+		mode          pollerGroupMode
+		initialGroups []*taskqueuepb.PollerGroupInfo
+	}{
+		{
+			name: "workflow replaced groups",
+			mode: pollerGroupModeWorkflow,
+			initialGroups: []*taskqueuepb.PollerGroupInfo{
+				{Id: "old-a", Weight: 1},
+				{Id: "old-b", Weight: 1},
+			},
+		},
+		{
+			name: "non-workflow replaced groups",
+			mode: pollerGroupModeNonWorkflow,
+			initialGroups: []*taskqueuepb.PollerGroupInfo{
+				{Id: "old-a", Weight: 1},
+				{Id: "old-b", Weight: 1},
+			},
+		},
+		{name: "non-workflow ungrouped polls", mode: pollerGroupModeNonWorkflow},
+	} {
+		s.Run(test.name, func() {
+			pollerGroups := newPollerGroupManager(test.mode, nil)
+			pollerGroups.updateGroups(testPollerGroupsInfo(1, test.initialGroups))
+			runner := newAutoscalingTaskPollerRunner(
+				newPollerAutoscaler(pollerAutoscalerOptions{
+					initialPollerCount: 2,
+					maxPollerCount:     2,
+					minPollerCount:     2,
+				}),
+				pollerGroups,
+				enumspb.TASK_QUEUE_KIND_NORMAL,
+			)
+
+			type admission struct {
+				lease   pollerGroupLease
+				release func()
+			}
+			acquire := func() []admission {
+				admissions := make([]admission, 0, 2)
+				for range 2 {
+					lease, release, err := runner.acquire(s.T().Context())
+					require.NoError(s.T(), err)
+					admissions = append(admissions, admission{lease: lease, release: release})
+				}
+				return admissions
+			}
+			release := func(admissions []admission) {
+				for _, admission := range admissions {
+					admission.lease.release()
+					admission.release()
+				}
+			}
+
+			oldAdmissions := acquire()
+
+			pollerGroups.updateGroups(testPollerGroupsInfo(2, []*taskqueuepb.PollerGroupInfo{
+				{Id: "new-a", Weight: 1},
+				{Id: "new-b", Weight: 1},
+			}))
+
+			newAdmissions := acquire()
+			newGroups := make(map[string]struct{}, len(newAdmissions))
+			for _, admission := range newAdmissions {
+				newGroups[admission.lease.groupIDOrEmpty()] = struct{}{}
+			}
+			require.Equal(s.T(), map[string]struct{}{"new-a": {}, "new-b": {}}, newGroups)
+			require.Equal(s.T(), 4, runner.activePolls(), "current coverage may temporarily exceed the target while stale polls drain")
+
+			release(oldAdmissions)
+			require.Equal(s.T(), 2, runner.activePolls())
+			_, ok := pollerGroups.tryReserveRequired(enumspb.TASK_QUEUE_KIND_NORMAL)
+			require.False(s.T(), ok, "releasing stale polls must not remove current coverage")
+			release(newAdmissions)
+		})
+	}
+}
+
+func (s *ScalableTaskPollerSuite) TestAutoscalingPollerGroupRemovalLowersRequiredMinimum() {
+	pollerGroups := newPollerGroupManager(pollerGroupModeWorkflow, nil)
+	pollerGroups.updateGroups(testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{
+		{Id: "group-a", Weight: 1},
+		{Id: "group-b", Weight: 100},
+	}))
+	autoscaler := newPollerAutoscaler(pollerAutoscalerOptions{
+		initialPollerCount: 1,
+		maxPollerCount:     1,
+		minPollerCount:     1,
+	})
+	runner := newAutoscalingTaskPollerRunner(
+		autoscaler,
+		pollerGroups,
+		enumspb.TASK_QUEUE_KIND_NORMAL,
+	)
+
+	assert.Equal(s.T(), 2, runner.effectiveTarget(), "expected two effective pollers for two groups")
+	pollerGroups.updateGroups(testPollerGroupsInfo(2, []*taskqueuepb.PollerGroupInfo{
+		{Id: "group-a", Weight: 1},
+	}))
+
+	assert.Equal(s.T(), 1, runner.effectiveTarget(), "expected group removal to lower required minimum")
+	lease, ok := pollerGroups.tryReserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_NORMAL)
+	require.True(s.T(), ok)
+	defer lease.release()
+	assert.Equal(s.T(), "group-a", lease.groupIDOrEmpty(), "future reservations should not use removed groups")
+	assert.Equal(s.T(), int64(1), autoscaler.target.Load(), "group removal should not mutate autoscaler target")
+}
+
+func (s *ScalableTaskPollerSuite) TestAutoscalingWorkflowRunnerBlocksExtraNormalUntilStickyCoverage() {
+	pollerGroups := newPollerGroupManager(pollerGroupModeWorkflowWithSticky, nil)
+	pollerGroups.updateGroups(testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{
+		{Id: "group-a", Weight: 1},
+	}))
+	normalRunner := newAutoscalingTaskPollerRunner(
+		newPollerAutoscaler(pollerAutoscalerOptions{
+			initialPollerCount: 2,
+			maxPollerCount:     2,
+			minPollerCount:     1,
+		}),
+		pollerGroups,
+		enumspb.TASK_QUEUE_KIND_NORMAL,
+	)
+	stickyRunner := newAutoscalingTaskPollerRunner(
+		newPollerAutoscaler(pollerAutoscalerOptions{
+			initialPollerCount: 1,
+			maxPollerCount:     1,
+			minPollerCount:     1,
+		}),
+		pollerGroups,
+		enumspb.TASK_QUEUE_KIND_STICKY,
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	firstNormalLease, firstNormalRelease, err := normalRunner.acquire(ctx)
+	require.NoError(s.T(), err)
+	defer firstNormalRelease()
+	defer firstNormalLease.release()
+
+	type acquisition struct {
+		lease   pollerGroupLease
+		release func()
+		err     error
+	}
+	secondNormal := make(chan acquisition, 1)
+	go func() {
+		lease, release, err := normalRunner.acquire(ctx)
+		secondNormal <- acquisition{lease: lease, release: release, err: err}
+	}()
+
+	select {
+	case result := <-secondNormal:
+		if result.release != nil {
+			result.release()
+		}
+		result.lease.release()
+		s.T().Fatal("extra normal poll acquired before sticky coverage", result.err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	stickyLease, stickyRelease, err := stickyRunner.acquire(ctx)
+	require.NoError(s.T(), err)
+	defer stickyRelease()
+	defer stickyLease.release()
+
+	select {
+	case result := <-secondNormal:
+		require.NoError(s.T(), result.err)
+		require.Equal(s.T(), enumspb.TASK_QUEUE_KIND_NORMAL, result.lease.queueKind)
+		result.lease.release()
+		result.release()
+	case <-time.After(time.Second):
+		s.T().Fatal("extra normal poll did not acquire after sticky coverage completed")
+	}
+}
+
+func (s *ScalableTaskPollerSuite) TestAutoscalingEffectiveTargetUsesMCNRequiredMinimumAsFloor() {
+	tests := []struct {
+		name          string
+		current       int
+		configuredMin int
+		configuredMax int
+		requiredMin   int
+		expected      int
+	}{
+		{
+			name:          "configured min below required minimum",
+			current:       1,
+			configuredMin: 1,
+			configuredMax: 10,
+			requiredMin:   3,
+			expected:      3,
+		},
+		{
+			name:          "configured max below required minimum",
+			current:       1,
+			configuredMin: 1,
+			configuredMax: 2,
+			requiredMin:   4,
+			expected:      4,
+		},
+		{
+			name:          "current target respected within effective bounds",
+			current:       3,
+			configuredMin: 1,
+			configuredMax: 5,
+			requiredMin:   2,
+			expected:      3,
+		},
+		{
+			name:          "current target capped at configured max when above effective bounds",
+			current:       6,
+			configuredMin: 1,
+			configuredMax: 5,
+			requiredMin:   2,
+			expected:      5,
+		},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			s.Equal(tt.expected, effectivePollerTarget(
+				tt.current,
+				tt.configuredMin,
+				tt.configuredMax,
+				tt.requiredMin,
+			))
+		})
+	}
+}
+
+func (s *ScalableTaskPollerSuite) TestAutoscalingMCNRequiredFloorStillGatedBySlots() {
+	behavior := &pollerBehaviorAutoscaling{
+		initialNumberOfPollers: 1,
+		maximumNumberOfPollers: 1,
+		minimumNumberOfPollers: 1,
+	}
+	pollerGroups := newPollerGroupManager(pollerGroupModeWorkflow, nil)
+	pollerGroups.updateGroups(testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{
+		{Id: "group-a", Weight: 1},
+		{Id: "group-b", Weight: 1},
+	}))
+
+	blockingPoller := newBlockingProbeTaskPoller()
+	poller := newScalableTaskPoller(
+		blockingPoller,
+		ilog.NewNopLogger(),
+		behavior,
+		metrics.PollerTypeWorkflowTask,
+		&atomic.Bool{},
+		pollerGroups,
+	)
+	slotSupplier := newLimitedSlotSupplier(1)
+
+	bw := newBaseWorker(baseWorkerOptions{
+		slotSupplier:     slotSupplier,
+		maxTaskPerSecond: 1000,
+		taskPollers:      []scalableTaskPoller{poller},
+		taskProcessor:    noopTaskProcessor{},
+		workerType:       "AutoscalingMCNSlotCapacityTest",
+		logger:           ilog.NewNopLogger(),
+		stopTimeout:      time.Second,
+		metricsHandler:   metrics.NopHandler,
+	})
+
+	bw.Start()
+	defer func() {
+		blockingPoller.Allow(readAutoscalingPollerState(poller.autoscalingRunner))
+		blockingPoller.Close()
+		bw.Stop()
+	}()
+
+	assert.Equal(s.T(), 2, poller.autoscalingRunner.effectiveTarget(),
+		"expected MCN required floor to raise the effective target")
+	require.Eventually(s.T(), func() bool {
+		return blockingPoller.startedPolls() == 1
+	}, time.Second, 10*time.Millisecond, "expected first poll to start")
+	require.Equal(s.T(), int32(1), slotSupplier.reserves.Load(), "expected only one slot to be reserved")
+	require.Nil(s.T(), slotSupplier.TryReserveSlot(nil), "expected no spare slot while first poll is running")
+
+	require.Never(s.T(), func() bool {
+		return blockingPoller.startedPolls() > 1
+	}, 200*time.Millisecond, 10*time.Millisecond, "MCN required floor should not bypass slot capacity")
+
+	blockingPoller.Allow(1)
+
+	require.Eventually(s.T(), func() bool {
+		return blockingPoller.startedPolls() == 2
+	}, time.Second, 10*time.Millisecond, "expected second poll to start after a slot is released")
+}
+
 func (s *ScalableTaskPollerSuite) TestAutoscalingDoesNotHoldSlotWhileWaitingForPollCapacity() {
 	synctest.Test(s.T(), func(t *testing.T) {
 		behavior := &pollerBehaviorAutoscaling{
@@ -433,7 +838,7 @@ func (s *ScalableTaskPollerSuite) TestAutoscalingDoesNotHoldSlotWhileWaitingForP
 		}
 
 		blockingPoller := newBlockingProbeTaskPoller()
-		poller := newScalableTaskPoller(blockingPoller, ilog.NewNopLogger(), behavior, "", nil)
+		poller := newScalableTaskPoller(blockingPoller, ilog.NewNopLogger(), behavior, "", nil, nil)
 		slotSupplier := newLimitedSlotSupplier(2)
 
 		bw := newBaseWorker(baseWorkerOptions{
@@ -473,7 +878,7 @@ func (s *ScalableTaskPollerSuite) TestAutoscalingBalancerDoesNotHoldSlotsWhileBl
 		}
 
 		blockingPoller := newBlockingProbeTaskPoller()
-		poller := newScalableTaskPoller(blockingPoller, ilog.NewNopLogger(), behavior, "a", nil)
+		poller := newScalableTaskPoller(blockingPoller, ilog.NewNopLogger(), behavior, "a", nil, nil)
 		slotSupplier := newLimitedSlotSupplier(2)
 
 		bw := newBaseWorker(baseWorkerOptions{
@@ -507,6 +912,7 @@ type blockingProbeTaskPoller struct {
 	signals chan struct{}
 	done    chan struct{}
 	closed  atomic.Bool
+	started atomic.Int32
 }
 
 func newBlockingProbeTaskPoller() *blockingProbeTaskPoller {
@@ -517,7 +923,8 @@ func newBlockingProbeTaskPoller() *blockingProbeTaskPoller {
 }
 
 // PollTask implements taskPoller and blocks until a signal is provided so active polls stay acquired.
-func (p *blockingProbeTaskPoller) PollTask() (taskForWorker, error) {
+func (p *blockingProbeTaskPoller) PollTask(pollerGroupLease) (taskForWorker, error) {
+	p.started.Add(1)
 	select {
 	case <-p.signals:
 		return nil, nil
@@ -534,6 +941,10 @@ func (p *blockingProbeTaskPoller) Allow(n int) {
 			return
 		}
 	}
+}
+
+func (p *blockingProbeTaskPoller) startedPolls() int32 {
+	return p.started.Load()
 }
 
 func (p *blockingProbeTaskPoller) Close() {
@@ -759,6 +1170,7 @@ func TestAutoscalingTaskNotDroppedDuringShutdown(t *testing.T) {
 			},
 			"test",
 			&atomic.Bool{},
+			nil,
 		)
 
 		bw := newBaseWorker(baseWorkerOptions{
@@ -1022,7 +1434,7 @@ type shutdownTaskPoller struct {
 	returned    atomic.Bool
 }
 
-func (p *shutdownTaskPoller) PollTask() (taskForWorker, error) {
+func (p *shutdownTaskPoller) PollTask(pollerGroupLease) (taskForWorker, error) {
 	select {
 	case p.pollStarted <- struct{}{}:
 	default:
@@ -1132,7 +1544,7 @@ type blockingShutdownPoller struct {
 	started     atomic.Bool
 }
 
-func (p *blockingShutdownPoller) PollTask() (taskForWorker, error) {
+func (p *blockingShutdownPoller) PollTask(pollerGroupLease) (taskForWorker, error) {
 	if p.started.CompareAndSwap(false, true) {
 		close(p.pollStarted)
 	}
@@ -1147,7 +1559,7 @@ type stopAwareShutdownPoller struct {
 	stopped     atomic.Bool
 }
 
-func (p *stopAwareShutdownPoller) PollTask() (taskForWorker, error) {
+func (p *stopAwareShutdownPoller) PollTask(pollerGroupLease) (taskForWorker, error) {
 	if p.started.CompareAndSwap(false, true) {
 		close(p.pollStarted)
 	}
@@ -1316,6 +1728,7 @@ func (s *ScalableTaskPollerSuite) TestNewScalableTaskPollerAllTypes() {
 				behavior,
 				tc.ptype,
 				&atomic.Bool{},
+				nil,
 			)
 			s.Equal(tc.ptype, poller.taskPollerType)
 		})

--- a/internal/internal_worker_heartbeat.go
+++ b/internal/internal_worker_heartbeat.go
@@ -79,6 +79,7 @@ func (m *heartbeatManager) sharedNamespaceWorkerForLocked(namespace string) *sha
 		stopC:                         make(chan struct{}),
 		stoppedC:                      make(chan struct{}),
 		logger:                        m.logger,
+		pollerGroups:                  newPollerGroupManager(false, m.client.pollerGroupInfoStore),
 	}
 	m.workers[namespace] = hw
 	return hw
@@ -104,7 +105,6 @@ func (m *heartbeatManager) registerWorker(
 	defer m.workersMutex.Unlock()
 
 	hw := m.sharedNamespaceWorkerForLocked(namespace)
-
 	if hw.started.CompareAndSwap(false, true) {
 		hw.workerCommandsSupported = nsData.capabilities.GetWorkerCommands()
 		go hw.run()
@@ -159,6 +159,7 @@ type sharedNamespaceWorker struct {
 	workerControlTaskQueue        string
 	workerInstanceKey             string
 	metricsHandler                metrics.Handler
+	pollerGroups                  *pollerGroupManager
 
 	// stopC is created when the namespace heartbeat worker starts and closed by
 	// sharedNamespaceWorker.stop() to tell run() to exit.
@@ -225,7 +226,6 @@ func (hw *sharedNamespaceWorker) sendHeartbeats() error {
 		WorkerHeartbeat: heartbeats,
 		ResourceId:      fmt.Sprintf("worker:%s", hw.client.workerGroupingKey),
 	})
-
 	if err != nil {
 		if status.Code(err) == codes.Unimplemented {
 			// Server doesn't support heartbeats; return error to stop the worker.
@@ -238,41 +238,87 @@ func (hw *sharedNamespaceWorker) sendHeartbeats() error {
 }
 
 func (hw *sharedNamespaceWorker) runWorkerCommands() {
+	pollerRunner := newAutoscalingTaskPollerRunner(
+		newPollerAutoscaler(pollerAutoscalerOptions{
+			initialPollerCount: 1,
+			maxPollerCount:     1,
+			minPollerCount:     1,
+		}),
+		hw.pollerGroups,
+		enumspb.TASK_QUEUE_KIND_WORKER_COMMANDS,
+	)
+	var pollWG sync.WaitGroup
+	defer pollWG.Wait()
+
 	for {
-		select {
-		case <-hw.workerCtx.Done():
-			return
-		default:
-		}
-
-		task, err := hw.pollWorkerCommandTask()
+		releaseActive, err := pollerRunner.acquire(hw.workerCtx)
 		if err != nil {
-			if hw.workerCtx.Err() != nil {
-				return
-			}
-			hw.logger.Warn("Failed polling worker command task", "Error", err)
-			select {
-			case <-time.After(time.Second):
-			case <-hw.workerCtx.Done():
-				return
-			}
-			continue
-		}
-		if task == nil || len(task.TaskToken) == 0 {
-			continue
-		}
-		if task.GetRequest() == nil {
-			hw.logger.Warn("Received worker command task with nil request")
-			continue
+			return
 		}
 
-		if err := hw.handleWorkerCommandTask(task); err != nil {
-			hw.logger.Warn("Failed handling worker command task", "Error", err)
-		}
+		pollWG.Add(1)
+		go func() {
+			defer pollWG.Done()
+
+			task := hw.pollWorkerCommandOnce()
+			releaseActive()
+			if task == nil {
+				return
+			}
+
+			if err := hw.handleWorkerCommandTask(task); err != nil {
+				hw.logger.Warn("Failed handling worker command task", "Error", err)
+			}
+		}()
 	}
 }
 
-func (hw *sharedNamespaceWorker) pollWorkerCommandTask() (*workflowservice.PollNexusTaskQueueResponse, error) {
+func (hw *sharedNamespaceWorker) pollWorkerCommandOnce() *workflowservice.PollNexusTaskQueueResponse {
+	task, err := hw.pollWorkerCommand()
+	if err == nil {
+		return task
+	}
+	if hw.workerCtx.Err() != nil {
+		return nil
+	}
+
+	hw.logger.Warn("Failed polling worker command task", "Error", err)
+	timer := time.NewTimer(time.Second)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+	case <-hw.workerCtx.Done():
+	}
+	return nil
+}
+
+func (hw *sharedNamespaceWorker) pollWorkerCommand() (
+	*workflowservice.PollNexusTaskQueueResponse,
+	error,
+) {
+	lease := hw.pollerGroups.reserve()
+	defer lease.release()
+
+	task, err := hw.pollWorkerCommandTask(lease.groupIDOrEmpty())
+	if err != nil {
+		return nil, err
+	}
+	if task != nil {
+		hw.pollerGroups.updateGroups(task.GetPollerGroupsInfo())
+	}
+	if task == nil || len(task.TaskToken) == 0 {
+		return nil, nil
+	}
+	if task.GetRequest() == nil {
+		hw.logger.Warn("Received worker command task with nil request")
+		return nil, nil
+	}
+	return task, nil
+}
+
+func (hw *sharedNamespaceWorker) pollWorkerCommandTask(
+	pollerGroupID string,
+) (*workflowservice.PollNexusTaskQueueResponse, error) {
 	rpcMetricsHandler := hw.metricsHandler.WithTags(metrics.TaskQueueTags(hw.workerControlTaskQueue))
 	grpcCtx, cancel := newGRPCContext(
 		hw.workerCtx,
@@ -294,6 +340,7 @@ func (hw *sharedNamespaceWorker) pollWorkerCommandTask() (*workflowservice.PollN
 		WorkerVersionCapabilities: &commonpb.WorkerVersionCapabilities{
 			BuildId: "1.0",
 		},
+		PollerGroupId: pollerGroupID,
 	})
 }
 

--- a/internal/internal_worker_heartbeat.go
+++ b/internal/internal_worker_heartbeat.go
@@ -230,6 +230,7 @@ func (hw *sharedNamespaceWorker) sendHeartbeats() error {
 		Namespace:       hw.namespace,
 		Identity:        hw.client.identity,
 		WorkerHeartbeat: heartbeats,
+		ResourceId:      fmt.Sprintf("worker:%s", hw.client.workerGroupingKey),
 	})
 
 	if err != nil {

--- a/internal/internal_worker_heartbeat.go
+++ b/internal/internal_worker_heartbeat.go
@@ -80,6 +80,7 @@ func (m *heartbeatManager) sharedNamespaceWorkerForLocked(namespace string) *sha
 		stopC:                         make(chan struct{}),
 		stoppedC:                      make(chan struct{}),
 		logger:                        m.logger,
+		pollerGroups:                  newPollerGroupManager(pollerGroupModeNonWorkflow, m.client.pollerGroupInfoStore),
 	}
 	m.workers[namespace] = hw
 	return hw
@@ -160,6 +161,7 @@ type sharedNamespaceWorker struct {
 	workerControlTaskQueue        string
 	workerInstanceKey             string
 	metricsHandler                metrics.Handler
+	pollerGroups                  *pollerGroupManager
 
 	// stopC is created when the namespace heartbeat worker starts and closed by
 	// sharedNamespaceWorker.stop() to tell run() to exit.
@@ -232,7 +234,6 @@ func (hw *sharedNamespaceWorker) sendHeartbeats() error {
 		WorkerHeartbeat: heartbeats,
 		ResourceId:      fmt.Sprintf("worker:%s", hw.client.workerGroupingKey),
 	})
-
 	if err != nil {
 		if status.Code(err) == codes.Unimplemented {
 			// Server doesn't support heartbeats; return error to stop the worker.
@@ -245,41 +246,87 @@ func (hw *sharedNamespaceWorker) sendHeartbeats() error {
 }
 
 func (hw *sharedNamespaceWorker) runWorkerCommands() {
+	pollerRunner := newAutoscalingTaskPollerRunner(
+		newPollerAutoscaler(pollerAutoscalerOptions{
+			initialPollerCount: 1,
+			maxPollerCount:     1,
+			minPollerCount:     1,
+		}),
+		hw.pollerGroups,
+		enumspb.TASK_QUEUE_KIND_WORKER_COMMANDS,
+	)
+	var pollWG sync.WaitGroup
+	defer pollWG.Wait()
+
 	for {
-		select {
-		case <-hw.workerCtx.Done():
-			return
-		default:
-		}
-
-		task, err := hw.pollWorkerCommandTask()
+		_, releaseActive, err := pollerRunner.acquire(hw.workerCtx)
 		if err != nil {
-			if hw.workerCtx.Err() != nil {
-				return
-			}
-			hw.logger.Warn("Failed polling worker command task", "Error", err)
-			select {
-			case <-time.After(time.Second):
-			case <-hw.workerCtx.Done():
-				return
-			}
-			continue
-		}
-		if task == nil || len(task.TaskToken) == 0 {
-			continue
-		}
-		if task.GetRequest() == nil {
-			hw.logger.Warn("Received worker command task with nil request")
-			continue
+			return
 		}
 
-		if err := hw.handleWorkerCommandTask(task); err != nil {
-			hw.logger.Warn("Failed handling worker command task", "Error", err)
-		}
+		pollWG.Add(1)
+		go func() {
+			defer pollWG.Done()
+
+			task := hw.pollWorkerCommandOnce()
+			releaseActive()
+			if task == nil {
+				return
+			}
+
+			if err := hw.handleWorkerCommandTask(task); err != nil {
+				hw.logger.Warn("Failed handling worker command task", "Error", err)
+			}
+		}()
 	}
 }
 
-func (hw *sharedNamespaceWorker) pollWorkerCommandTask() (*workflowservice.PollNexusTaskQueueResponse, error) {
+func (hw *sharedNamespaceWorker) pollWorkerCommandOnce() *workflowservice.PollNexusTaskQueueResponse {
+	task, err := hw.pollWorkerCommand()
+	if err == nil {
+		return task
+	}
+	if hw.workerCtx.Err() != nil {
+		return nil
+	}
+
+	hw.logger.Warn("Failed polling worker command task", "Error", err)
+	timer := time.NewTimer(time.Second)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+	case <-hw.workerCtx.Done():
+	}
+	return nil
+}
+
+func (hw *sharedNamespaceWorker) pollWorkerCommand() (
+	*workflowservice.PollNexusTaskQueueResponse,
+	error,
+) {
+	lease := hw.pollerGroups.reserve()
+	defer lease.release()
+
+	task, err := hw.pollWorkerCommandTask(lease.groupIDOrEmpty())
+	if err != nil {
+		return nil, err
+	}
+	if task != nil {
+		hw.pollerGroups.updateGroups(task.GetPollerGroupsInfo())
+	}
+	if task == nil || len(task.TaskToken) == 0 {
+		return nil, nil
+	}
+	if task.GetRequest() == nil {
+		hw.logger.Warn("Received worker command task with nil request")
+		return nil, nil
+	}
+	return task, nil
+}
+
+func (hw *sharedNamespaceWorker) pollWorkerCommandTask(
+	pollerGroupID string,
+) (*workflowservice.PollNexusTaskQueueResponse, error) {
 	rpcMetricsHandler := hw.metricsHandler.WithTags(metrics.TaskQueueTags(hw.workerControlTaskQueue))
 	grpcCtx, cancel := newGRPCContext(
 		hw.workerCtx,
@@ -302,6 +349,7 @@ func (hw *sharedNamespaceWorker) pollWorkerCommandTask() (*workflowservice.PollN
 			BuildId:              "1.0",
 			WorkerVersioningMode: enumspb.WORKER_VERSIONING_MODE_UNVERSIONED,
 		},
+		PollerGroupId: pollerGroupID,
 	})
 }
 

--- a/internal/internal_worker_heartbeat_test.go
+++ b/internal/internal_worker_heartbeat_test.go
@@ -3,14 +3,18 @@ package internal
 import (
 	"bytes"
 	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
+	namespacepb "go.temporal.io/api/namespace/v1"
 	nexuspb "go.temporal.io/api/nexus/v1"
 	workerservicepb "go.temporal.io/api/nexusservices/workerservice/v1"
+	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	workerpb "go.temporal.io/api/worker/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/api/workflowservicemock/v1"
@@ -91,22 +95,23 @@ func TestWorkerCommandPollUsesWorkerCommandsQueue(t *testing.T) {
 	mockService := workflowservicemock.NewMockWorkflowServiceClient(ctrl)
 
 	const (
-		namespace    = "test-ns"
-		controlQueue = "temporal-sys/worker-commands/test-ns/grouping-key"
-		workerKey    = "worker-command-worker"
-		workerIdent  = "worker-identity"
+		namespace      = "test-ns"
+		groupingKey    = "grouping-key"
+		controlQueue   = "temporal-sys/worker-commands/test-ns/grouping-key"
+		workerIdentity = "worker-identity"
 	)
+	var workerInstanceKey string
 
 	mockService.EXPECT().PollNexusTaskQueue(gomock.Any(), gomock.Any(), gomock.Any()).
 		DoAndReturn(func(_ context.Context, req *workflowservice.PollNexusTaskQueueRequest, _ ...grpc.CallOption) (*workflowservice.PollNexusTaskQueueResponse, error) {
 			if req.Namespace != namespace {
 				t.Fatalf("namespace = %q, want %q", req.Namespace, namespace)
 			}
-			if req.Identity != workerIdent {
-				t.Fatalf("identity = %q, want %q", req.Identity, workerIdent)
+			if req.Identity != workerIdentity {
+				t.Fatalf("identity = %q, want %q", req.Identity, workerIdentity)
 			}
-			if req.WorkerInstanceKey != workerKey {
-				t.Fatalf("worker instance key = %q, want %q", req.WorkerInstanceKey, workerKey)
+			if req.WorkerInstanceKey != workerInstanceKey {
+				t.Fatalf("worker instance key = %q, want %q", req.WorkerInstanceKey, workerInstanceKey)
 			}
 			if req.TaskQueue.GetName() != controlQueue {
 				t.Fatalf("task queue = %q, want %q", req.TaskQueue.GetName(), controlQueue)
@@ -117,22 +122,198 @@ func TestWorkerCommandPollUsesWorkerCommandsQueue(t *testing.T) {
 			return &workflowservice.PollNexusTaskQueueResponse{}, nil
 		})
 
+	client := NewServiceClient(mockService, nil, ClientOptions{Namespace: namespace, Identity: workerIdentity})
+	client.workerGroupingKey = groupingKey
+	hw := client.heartbeatManager.sharedNamespaceWorkerFor(namespace)
+	defer hw.heartbeatCancel()
+	workerInstanceKey = hw.workerInstanceKey
+	require.NotEmpty(t, workerInstanceKey)
+
+	if _, err := hw.pollWorkerCommandTask(""); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestWorkerCommandFirstPollUsesDescribeNamespacePollerGroups(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	mockService := workflowservicemock.NewMockWorkflowServiceClient(ctrl)
+	const (
+		namespace = "test-ns"
+		groupID   = "described-poller-group"
+	)
+
+	mockService.EXPECT().DescribeNamespace(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(&workflowservice.DescribeNamespaceResponse{
+			NamespaceInfo:    &namespacepb.NamespaceInfo{},
+			PollerGroupsInfo: testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{{Id: groupID, Weight: 1}}),
+		}, nil)
+	mockService.EXPECT().PollNexusTaskQueue(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, req *workflowservice.PollNexusTaskQueueRequest, _ ...grpc.CallOption) (*workflowservice.PollNexusTaskQueueResponse, error) {
+			require.Equal(t, groupID, req.GetPollerGroupId())
+			return &workflowservice.PollNexusTaskQueueResponse{}, nil
+		})
+
+	client := NewServiceClient(mockService, nil, ClientOptions{Namespace: namespace})
+	_, err := client.loadNamespaceData(metrics.NopHandler)
+	require.NoError(t, err)
+
+	hw := client.heartbeatManager.sharedNamespaceWorkerFor(namespace)
+	defer hw.heartbeatCancel()
+	_, err = hw.pollWorkerCommand()
+	require.NoError(t, err)
+}
+
+func TestWorkerCommandPollUsesPollerGroups(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	mockService := workflowservicemock.NewMockWorkflowServiceClient(ctrl)
+	const groupID = "poller-group"
+
+	gomock.InOrder(
+		mockService.EXPECT().PollNexusTaskQueue(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, req *workflowservice.PollNexusTaskQueueRequest, _ ...grpc.CallOption) (*workflowservice.PollNexusTaskQueueResponse, error) {
+				if req.GetPollerGroupId() != "" {
+					t.Fatalf("first poller group = %q, want empty", req.GetPollerGroupId())
+				}
+				return &workflowservice.PollNexusTaskQueueResponse{
+					PollerGroupsInfo: testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{{Id: groupID, Weight: 1}}),
+				}, nil
+			}),
+		mockService.EXPECT().PollNexusTaskQueue(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, req *workflowservice.PollNexusTaskQueueRequest, _ ...grpc.CallOption) (*workflowservice.PollNexusTaskQueueResponse, error) {
+				if req.GetPollerGroupId() != groupID {
+					t.Fatalf("second poller group = %q, want %q", req.GetPollerGroupId(), groupID)
+				}
+				return &workflowservice.PollNexusTaskQueueResponse{}, nil
+			}),
+	)
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	hw := &sharedNamespaceWorker{
 		client: &WorkflowClient{
 			workflowService: mockService,
-			identity:        workerIdent,
 		},
-		namespace:              namespace,
 		workerCtx:              ctx,
-		workerControlTaskQueue: controlQueue,
-		workerInstanceKey:      workerKey,
+		workerControlTaskQueue: "worker-commands",
 		metricsHandler:         metrics.NopHandler,
+		pollerGroups:           newPollerGroupManager(false, nil),
 	}
 
-	if _, err := hw.pollWorkerCommandTask(); err != nil {
+	if _, err := hw.pollWorkerCommand(); err != nil {
 		t.Fatal(err)
+	}
+	if _, err := hw.pollWorkerCommand(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestWorkerCommandPollUsesExternalPollerGroupUpdate(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	mockService := workflowservicemock.NewMockWorkflowServiceClient(ctrl)
+	const groupID = "external-poller-group"
+
+	mockService.EXPECT().PollNexusTaskQueue(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, req *workflowservice.PollNexusTaskQueueRequest, _ ...grpc.CallOption) (*workflowservice.PollNexusTaskQueueResponse, error) {
+			if req.GetPollerGroupId() != groupID {
+				t.Fatalf("worker command poller group = %q, want %q", req.GetPollerGroupId(), groupID)
+			}
+			return &workflowservice.PollNexusTaskQueueResponse{
+				PollerGroupsInfo: testPollerGroupsInfo(2, []*taskqueuepb.PollerGroupInfo{{Id: groupID, Weight: 1}}),
+			}, nil
+		})
+
+	client := NewServiceClient(mockService, nil, ClientOptions{Namespace: "test-ns"})
+	hw := client.heartbeatManager.sharedNamespaceWorkerFor(client.namespace)
+	defer hw.heartbeatCancel()
+
+	externalPollerGroups := newPollerGroupManager(false, client.pollerGroupInfoStore)
+	externalPollerGroups.updateGroups(testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{{Id: groupID, Weight: 1}}))
+	require.Same(t, externalPollerGroups.groupInfos, hw.pollerGroups.groupInfos)
+
+	if _, err := hw.pollWorkerCommand(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestWorkerCommandsMaintainPollerGroupCoverage(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	mockService := workflowservicemock.NewMockWorkflowServiceClient(ctrl)
+	groups := []*taskqueuepb.PollerGroupInfo{
+		{Id: "group-a", Weight: 1},
+		{Id: "group-b", Weight: 1},
+	}
+	started := make(chan string, len(groups))
+	var pollCount atomic.Int32
+
+	mockService.EXPECT().PollNexusTaskQueue(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, req *workflowservice.PollNexusTaskQueueRequest, _ ...grpc.CallOption) (*workflowservice.PollNexusTaskQueueResponse, error) {
+			if pollCount.Add(1) == 1 {
+				if req.GetPollerGroupId() != groups[0].GetId() {
+					t.Errorf("initial poller group = %q, want %q", req.GetPollerGroupId(), groups[0].GetId())
+				}
+				return &workflowservice.PollNexusTaskQueueResponse{
+					PollerGroupsInfo: testPollerGroupsInfo(2, groups),
+				}, nil
+			}
+			select {
+			case started <- req.GetPollerGroupId():
+			default:
+			}
+			<-ctx.Done()
+			return nil, ctx.Err()
+		}).AnyTimes()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	pollerGroups := newPollerGroupManager(false, nil)
+	pollerGroups.updateGroups(testPollerGroupsInfo(1, groups[:1]))
+	hw := &sharedNamespaceWorker{
+		client: &WorkflowClient{
+			workflowService: mockService,
+		},
+		workerCtx:              ctx,
+		workerControlTaskQueue: "worker-commands",
+		metricsHandler:         metrics.NopHandler,
+		logger:                 ilog.NewNopLogger(),
+		pollerGroups:           pollerGroups,
+	}
+	done := make(chan struct{})
+	go func() {
+		hw.runWorkerCommands()
+		close(done)
+	}()
+
+	seen := make(map[string]struct{}, len(groups))
+	for len(seen) < len(groups) {
+		select {
+		case groupID := <-started:
+			seen[groupID] = struct{}{}
+		case <-time.After(5 * time.Second):
+			cancel()
+			<-done
+			t.Fatalf("timed out waiting for group coverage; saw %v", seen)
+		}
+	}
+	for _, group := range groups {
+		if _, ok := seen[group.GetId()]; !ok {
+			cancel()
+			<-done
+			t.Fatalf("missing pending poll for group %q; saw %v", group.GetId(), seen)
+		}
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out stopping worker command pollers")
 	}
 }
 

--- a/internal/internal_worker_heartbeat_test.go
+++ b/internal/internal_worker_heartbeat_test.go
@@ -3,16 +3,19 @@ package internal
 import (
 	"bytes"
 	"context"
+	"sync/atomic"
 	"testing"
 	"testing/synctest"
 	"time"
 
 	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	namespacepb "go.temporal.io/api/namespace/v1"
 	nexuspb "go.temporal.io/api/nexus/v1"
 	workerservicepb "go.temporal.io/api/nexusservices/workerservice/v1"
+	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	workerpb "go.temporal.io/api/worker/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/api/workflowservicemock/v1"
@@ -127,8 +130,191 @@ func TestWorkerCommandPollUsesWorkerCommandsQueue(t *testing.T) {
 		metricsHandler:         metrics.NopHandler,
 	}
 
-	if _, err := hw.pollWorkerCommandTask(); err != nil {
+	if _, err := hw.pollWorkerCommandTask(""); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestWorkerCommandFirstPollUsesDescribeNamespacePollerGroups(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	mockService := workflowservicemock.NewMockWorkflowServiceClient(ctrl)
+	const (
+		namespace = "test-ns"
+		groupID   = "described-poller-group"
+	)
+
+	mockService.EXPECT().DescribeNamespace(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(&workflowservice.DescribeNamespaceResponse{
+			NamespaceInfo:    &namespacepb.NamespaceInfo{},
+			PollerGroupsInfo: testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{{Id: groupID, Weight: 1}}),
+		}, nil)
+	mockService.EXPECT().PollNexusTaskQueue(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, req *workflowservice.PollNexusTaskQueueRequest, _ ...grpc.CallOption) (*workflowservice.PollNexusTaskQueueResponse, error) {
+			require.Equal(t, groupID, req.GetPollerGroupId())
+			return &workflowservice.PollNexusTaskQueueResponse{}, nil
+		})
+
+	client := NewServiceClient(mockService, nil, ClientOptions{Namespace: namespace})
+	_, err := client.loadNamespaceData(metrics.NopHandler)
+	require.NoError(t, err)
+
+	hw := client.heartbeatManager.sharedNamespaceWorkerFor(namespace)
+	defer hw.heartbeatCancel()
+	_, err = hw.pollWorkerCommand()
+	require.NoError(t, err)
+}
+
+func TestWorkerCommandPollUsesPollerGroups(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	mockService := workflowservicemock.NewMockWorkflowServiceClient(ctrl)
+	const groupID = "poller-group"
+
+	gomock.InOrder(
+		mockService.EXPECT().PollNexusTaskQueue(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, req *workflowservice.PollNexusTaskQueueRequest, _ ...grpc.CallOption) (*workflowservice.PollNexusTaskQueueResponse, error) {
+				if req.GetPollerGroupId() != "" {
+					t.Fatalf("first poller group = %q, want empty", req.GetPollerGroupId())
+				}
+				return &workflowservice.PollNexusTaskQueueResponse{
+					PollerGroupsInfo: testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{{Id: groupID, Weight: 1}}),
+				}, nil
+			}),
+		mockService.EXPECT().PollNexusTaskQueue(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, req *workflowservice.PollNexusTaskQueueRequest, _ ...grpc.CallOption) (*workflowservice.PollNexusTaskQueueResponse, error) {
+				if req.GetPollerGroupId() != groupID {
+					t.Fatalf("second poller group = %q, want %q", req.GetPollerGroupId(), groupID)
+				}
+				return &workflowservice.PollNexusTaskQueueResponse{}, nil
+			}),
+	)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	hw := &sharedNamespaceWorker{
+		client: &WorkflowClient{
+			workflowService: mockService,
+		},
+		workerCtx:              ctx,
+		workerControlTaskQueue: "worker-commands",
+		metricsHandler:         metrics.NopHandler,
+		pollerGroups:           newPollerGroupManager(pollerGroupModeNonWorkflow, nil),
+	}
+
+	if _, err := hw.pollWorkerCommand(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := hw.pollWorkerCommand(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestWorkerCommandPollUsesExternalPollerGroupUpdate(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	mockService := workflowservicemock.NewMockWorkflowServiceClient(ctrl)
+	const groupID = "external-poller-group"
+
+	mockService.EXPECT().PollNexusTaskQueue(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, req *workflowservice.PollNexusTaskQueueRequest, _ ...grpc.CallOption) (*workflowservice.PollNexusTaskQueueResponse, error) {
+			if req.GetPollerGroupId() != groupID {
+				t.Fatalf("worker command poller group = %q, want %q", req.GetPollerGroupId(), groupID)
+			}
+			return &workflowservice.PollNexusTaskQueueResponse{
+				PollerGroupsInfo: testPollerGroupsInfo(2, []*taskqueuepb.PollerGroupInfo{{Id: groupID, Weight: 1}}),
+			}, nil
+		})
+
+	client := NewServiceClient(mockService, nil, ClientOptions{Namespace: "test-ns"})
+	hw := client.heartbeatManager.sharedNamespaceWorkerFor(client.namespace)
+	defer hw.heartbeatCancel()
+
+	externalPollerGroups := newPollerGroupManager(pollerGroupModeNonWorkflow, client.pollerGroupInfoStore)
+	externalPollerGroups.updateGroups(testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{{Id: groupID, Weight: 1}}))
+	require.Same(t, externalPollerGroups.groupInfos, hw.pollerGroups.groupInfos)
+
+	if _, err := hw.pollWorkerCommand(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestWorkerCommandsMaintainPollerGroupCoverage(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	mockService := workflowservicemock.NewMockWorkflowServiceClient(ctrl)
+	groups := []*taskqueuepb.PollerGroupInfo{
+		{Id: "group-a", Weight: 1},
+		{Id: "group-b", Weight: 1},
+	}
+	started := make(chan string, len(groups))
+	var pollCount atomic.Int32
+
+	mockService.EXPECT().PollNexusTaskQueue(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, req *workflowservice.PollNexusTaskQueueRequest, _ ...grpc.CallOption) (*workflowservice.PollNexusTaskQueueResponse, error) {
+			if pollCount.Add(1) == 1 {
+				if req.GetPollerGroupId() != groups[0].GetId() {
+					t.Errorf("initial poller group = %q, want %q", req.GetPollerGroupId(), groups[0].GetId())
+				}
+				return &workflowservice.PollNexusTaskQueueResponse{
+					PollerGroupsInfo: testPollerGroupsInfo(2, groups),
+				}, nil
+			}
+			select {
+			case started <- req.GetPollerGroupId():
+			default:
+			}
+			<-ctx.Done()
+			return nil, ctx.Err()
+		}).AnyTimes()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	pollerGroups := newPollerGroupManager(pollerGroupModeNonWorkflow, nil)
+	pollerGroups.updateGroups(testPollerGroupsInfo(1, groups[:1]))
+	hw := &sharedNamespaceWorker{
+		client: &WorkflowClient{
+			workflowService: mockService,
+		},
+		workerCtx:              ctx,
+		workerControlTaskQueue: "worker-commands",
+		metricsHandler:         metrics.NopHandler,
+		logger:                 ilog.NewNopLogger(),
+		pollerGroups:           pollerGroups,
+	}
+	done := make(chan struct{})
+	go func() {
+		hw.runWorkerCommands()
+		close(done)
+	}()
+
+	seen := make(map[string]struct{}, len(groups))
+	for len(seen) < len(groups) {
+		select {
+		case groupID := <-started:
+			seen[groupID] = struct{}{}
+		case <-time.After(5 * time.Second):
+			cancel()
+			<-done
+			t.Fatalf("timed out waiting for group coverage; saw %v", seen)
+		}
+	}
+	for _, group := range groups {
+		if _, ok := seen[group.GetId()]; !ok {
+			cancel()
+			<-done
+			t.Fatalf("missing pending poll for group %q; saw %v", group.GetId(), seen)
+		}
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out stopping worker command pollers")
 	}
 }
 

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -1856,18 +1856,36 @@ func (s *internalWorkerTestSuite) TestPollerAutoscalingAutoEnrollWithDefaults() 
 	s.IsType(&pollerBehaviorAutoscaling{}, worker.executionParams.NexusTaskPollerBehavior)
 
 	// The actual running pollers reflect the autoscaling structure.
-	require.NotEmpty(s.T(), worker.workflowWorker.worker.options.taskPollers)
-	for _, p := range worker.workflowWorker.worker.options.taskPollers {
-		s.NotNil(p.autoscalingRunner)
+	workflowPollers := worker.workflowWorker.worker.options.taskPollers
+	require.NotEmpty(s.T(), workflowPollers)
+	require.NotNil(s.T(), workflowPollers[0].autoscalingRunner)
+	workflowGroups := workflowPollers[0].autoscalingRunner.pollerGroups
+	require.NotNil(s.T(), workflowGroups)
+	require.Same(s.T(), worker.client.pollerGroupInfoStore, workflowGroups.groupInfos)
+	for _, p := range workflowPollers {
+		require.NotNil(s.T(), p.autoscalingRunner)
+		require.Same(s.T(), workflowGroups, p.autoscalingRunner.pollerGroups)
 	}
-	require.NotEmpty(s.T(), worker.activityWorker.worker.options.taskPollers)
-	for _, p := range worker.activityWorker.worker.options.taskPollers {
-		s.NotNil(p.autoscalingRunner)
+	activityPollers := worker.activityWorker.worker.options.taskPollers
+	require.NotEmpty(s.T(), activityPollers)
+	require.NotNil(s.T(), activityPollers[0].autoscalingRunner)
+	activityGroups := activityPollers[0].autoscalingRunner.pollerGroups
+	require.NotNil(s.T(), activityGroups)
+	require.Same(s.T(), worker.client.pollerGroupInfoStore, activityGroups.groupInfos)
+	for _, p := range activityPollers {
+		require.NotNil(s.T(), p.autoscalingRunner)
+		require.Same(s.T(), activityGroups, p.autoscalingRunner.pollerGroups)
 	}
 	require.NotNil(s.T(), worker.nexusWorker)
-	require.NotEmpty(s.T(), worker.nexusWorker.worker.options.taskPollers)
-	for _, p := range worker.nexusWorker.worker.options.taskPollers {
-		s.NotNil(p.autoscalingRunner)
+	nexusPollers := worker.nexusWorker.worker.options.taskPollers
+	require.NotEmpty(s.T(), nexusPollers)
+	require.NotNil(s.T(), nexusPollers[0].autoscalingRunner)
+	nexusGroups := nexusPollers[0].autoscalingRunner.pollerGroups
+	require.NotNil(s.T(), nexusGroups)
+	require.Same(s.T(), worker.client.pollerGroupInfoStore, nexusGroups.groupInfos)
+	for _, p := range nexusPollers {
+		require.NotNil(s.T(), p.autoscalingRunner)
+		require.Same(s.T(), nexusGroups, p.autoscalingRunner.pollerGroups)
 	}
 
 	// Auto-enroll implies full autoscaling support, including scale-down.
@@ -1979,9 +1997,15 @@ func (s *internalWorkerTestSuite) TestPollerAutoscalingAutoEnrollSessionWorker()
 
 	require.NotNil(s.T(), worker.sessionWorker)
 
-	require.NotEmpty(s.T(), worker.sessionWorker.activityWorker.worker.options.taskPollers)
-	for _, p := range worker.sessionWorker.activityWorker.worker.options.taskPollers {
-		s.NotNil(p.autoscalingRunner)
+	activityPollers := worker.sessionWorker.activityWorker.worker.options.taskPollers
+	require.NotEmpty(s.T(), activityPollers)
+	require.NotNil(s.T(), activityPollers[0].autoscalingRunner)
+	activityGroups := activityPollers[0].autoscalingRunner.pollerGroups
+	require.NotNil(s.T(), activityGroups)
+	require.Same(s.T(), worker.client.pollerGroupInfoStore, activityGroups.groupInfos)
+	for _, p := range activityPollers {
+		require.NotNil(s.T(), p.autoscalingRunner)
+		require.Same(s.T(), activityGroups, p.autoscalingRunner.pollerGroups)
 	}
 
 	require.Len(s.T(), worker.sessionWorker.creationWorker.worker.options.taskPollers, 1)
@@ -2206,6 +2230,188 @@ func setupPollingMocks(namespace string, service *workflowservicemock.MockWorkfl
 	workflowTask := &workflowservice.PollWorkflowTaskQueueResponse{}
 	service.EXPECT().PollWorkflowTaskQueue(gomock.Any(), gomock.Any(), gomock.Any()).Return(workflowTask, nil).AnyTimes()
 	service.EXPECT().RespondWorkflowTaskCompleted(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+}
+
+func (s *internalWorkerTestSuite) TestDescribeNamespacePollerGroupsSeedWorkflowNormalAndStickyPolls() {
+	namespace := "testNamespace"
+	taskQueue := "seeded-workflow-tq"
+	groupID := "seeded-group"
+	service := workflowservicemock.NewMockWorkflowServiceClient(s.mockCtrl)
+	service.EXPECT().GetSystemInfo(gomock.Any(), gomock.Any(), gomock.Any()).Return(&workflowservice.GetSystemInfoResponse{}, nil).AnyTimes()
+	expectDescribeNamespaceWithPollerGroup(service, namespace, groupID)
+	service.EXPECT().ShutdownWorker(gomock.Any(), gomock.Any(), gomock.Any()).Return(&workflowservice.ShutdownWorkerResponse{}, nil).AnyTimes()
+	service.EXPECT().PollActivityTaskQueue(gomock.Any(), gomock.Any(), gomock.Any()).Return(&workflowservice.PollActivityTaskQueueResponse{}, nil).AnyTimes()
+
+	polls := make(chan *workflowservice.PollWorkflowTaskQueueRequest, 20)
+	releaseNormalPoll := make(chan struct{})
+	var releaseNormalPollOnce sync.Once
+	defer releaseNormalPollOnce.Do(func() { close(releaseNormalPoll) })
+	var blockNormalPollOnce sync.Once
+	service.EXPECT().PollWorkflowTaskQueue(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, req *workflowservice.PollWorkflowTaskQueueRequest, opts ...grpc.CallOption) (*workflowservice.PollWorkflowTaskQueueResponse, error) {
+			select {
+			case polls <- proto.Clone(req).(*workflowservice.PollWorkflowTaskQueueRequest):
+			default:
+			}
+			if req.GetPollerGroupId() == groupID && req.GetTaskQueue().GetKind() == enumspb.TASK_QUEUE_KIND_NORMAL {
+				blockNormalPollOnce.Do(func() {
+					select {
+					case <-releaseNormalPoll:
+					case <-ctx.Done():
+					}
+				})
+			}
+			return &workflowservice.PollWorkflowTaskQueueResponse{}, nil
+		},
+	).AnyTimes()
+
+	client := NewServiceClient(service, nil, ClientOptions{Namespace: namespace})
+	worker := NewAggregatedWorker(client, taskQueue, WorkerOptions{
+		WorkflowTaskPollerBehavior: seededTestAutoscalingPollerBehavior(),
+		ActivityTaskPollerBehavior: NewPollerBehaviorSimpleMaximum(PollerBehaviorSimpleMaximumOptions{MaximumNumberOfPollers: 1}),
+		NexusTaskPollerBehavior:    NewPollerBehaviorSimpleMaximum(PollerBehaviorSimpleMaximumOptions{MaximumNumberOfPollers: 1}),
+	})
+	require.NoError(s.T(), worker.Start())
+	defer worker.Stop()
+
+	var sawNormal, sawSticky bool
+	require.Eventually(s.T(), func() bool {
+		for {
+			select {
+			case req := <-polls:
+				if req.GetPollerGroupId() != groupID {
+					continue
+				}
+				switch req.GetTaskQueue().GetKind() {
+				case enumspb.TASK_QUEUE_KIND_NORMAL:
+					sawNormal = true
+				case enumspb.TASK_QUEUE_KIND_STICKY:
+					sawSticky = true
+				}
+			default:
+				return sawNormal && sawSticky
+			}
+		}
+	}, 2*time.Second, 10*time.Millisecond)
+	releaseNormalPollOnce.Do(func() { close(releaseNormalPoll) })
+}
+
+func (s *internalWorkerTestSuite) TestDescribeNamespacePollerGroupsSeedActivityPolls() {
+	namespace := "testNamespace"
+	taskQueue := "seeded-activity-tq"
+	groupID := "seeded-group"
+	service := workflowservicemock.NewMockWorkflowServiceClient(s.mockCtrl)
+	service.EXPECT().GetSystemInfo(gomock.Any(), gomock.Any(), gomock.Any()).Return(&workflowservice.GetSystemInfoResponse{}, nil).AnyTimes()
+	expectDescribeNamespaceWithPollerGroup(service, namespace, groupID)
+	service.EXPECT().ShutdownWorker(gomock.Any(), gomock.Any(), gomock.Any()).Return(&workflowservice.ShutdownWorkerResponse{}, nil).AnyTimes()
+
+	polls := make(chan string, 5)
+	service.EXPECT().PollActivityTaskQueue(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, req *workflowservice.PollActivityTaskQueueRequest, opts ...grpc.CallOption) (*workflowservice.PollActivityTaskQueueResponse, error) {
+			select {
+			case polls <- req.GetPollerGroupId():
+			default:
+			}
+			return &workflowservice.PollActivityTaskQueueResponse{}, nil
+		},
+	).AnyTimes()
+
+	client := NewServiceClient(service, nil, ClientOptions{Namespace: namespace})
+	worker := NewAggregatedWorker(client, taskQueue, WorkerOptions{
+		DisableWorkflowWorker:      true,
+		WorkflowTaskPollerBehavior: NewPollerBehaviorSimpleMaximum(PollerBehaviorSimpleMaximumOptions{MaximumNumberOfPollers: 2}),
+		ActivityTaskPollerBehavior: seededTestAutoscalingPollerBehavior(),
+		NexusTaskPollerBehavior:    NewPollerBehaviorSimpleMaximum(PollerBehaviorSimpleMaximumOptions{MaximumNumberOfPollers: 1}),
+	})
+	require.NoError(s.T(), worker.Start())
+	defer worker.Stop()
+
+	require.Eventually(s.T(), func() bool {
+		for {
+			select {
+			case id := <-polls:
+				if id == groupID {
+					return true
+				}
+			default:
+				return false
+			}
+		}
+	}, 2*time.Second, 10*time.Millisecond)
+}
+
+func (s *internalWorkerTestSuite) TestDescribeNamespacePollerGroupsSeedNexusPolls() {
+	namespace := "testNamespace"
+	taskQueue := "seeded-nexus-tq"
+	groupID := "seeded-group"
+	service := workflowservicemock.NewMockWorkflowServiceClient(s.mockCtrl)
+	service.EXPECT().GetSystemInfo(gomock.Any(), gomock.Any(), gomock.Any()).Return(&workflowservice.GetSystemInfoResponse{}, nil).AnyTimes()
+	expectDescribeNamespaceWithPollerGroup(service, namespace, groupID)
+	service.EXPECT().ShutdownWorker(gomock.Any(), gomock.Any(), gomock.Any()).Return(&workflowservice.ShutdownWorkerResponse{}, nil).AnyTimes()
+
+	polls := make(chan string, 5)
+	service.EXPECT().PollNexusTaskQueue(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, req *workflowservice.PollNexusTaskQueueRequest, opts ...grpc.CallOption) (*workflowservice.PollNexusTaskQueueResponse, error) {
+			select {
+			case polls <- req.GetPollerGroupId():
+			default:
+			}
+			return &workflowservice.PollNexusTaskQueueResponse{}, nil
+		},
+	).AnyTimes()
+
+	client := NewServiceClient(service, nil, ClientOptions{Namespace: namespace})
+	worker := NewAggregatedWorker(client, taskQueue, WorkerOptions{
+		DisableWorkflowWorker:      true,
+		LocalActivityWorkerOnly:    true,
+		WorkflowTaskPollerBehavior: NewPollerBehaviorSimpleMaximum(PollerBehaviorSimpleMaximumOptions{MaximumNumberOfPollers: 2}),
+		ActivityTaskPollerBehavior: NewPollerBehaviorSimpleMaximum(PollerBehaviorSimpleMaximumOptions{MaximumNumberOfPollers: 1}),
+		NexusTaskPollerBehavior:    seededTestAutoscalingPollerBehavior(),
+	})
+	nexusService := nexus.NewService("seeded-service")
+	require.NoError(s.T(), nexusService.Register(nexus.NewSyncOperation("op", func(ctx context.Context, input string, opts nexus.StartOperationOptions) (string, error) {
+		return "", nil
+	})))
+	worker.RegisterNexusService(nexusService)
+
+	require.NoError(s.T(), worker.Start())
+	defer worker.Stop()
+
+	require.Eventually(s.T(), func() bool {
+		for {
+			select {
+			case id := <-polls:
+				if id == groupID {
+					return true
+				}
+			default:
+				return false
+			}
+		}
+	}, 2*time.Second, 10*time.Millisecond)
+}
+
+func expectDescribeNamespaceWithPollerGroup(service *workflowservicemock.MockWorkflowServiceClient, namespace string, groupID string) {
+	service.EXPECT().DescribeNamespace(gomock.Any(), gomock.Any(), gomock.Any()).Return(&workflowservice.DescribeNamespaceResponse{
+		NamespaceInfo: &namespacepb.NamespaceInfo{
+			Name:  namespace,
+			State: enumspb.NAMESPACE_STATE_REGISTERED,
+			Capabilities: &namespacepb.NamespaceInfo_Capabilities{
+				PollerAutoscaling: true,
+			},
+		},
+		PollerGroupsInfo: testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{
+			{Id: groupID, Weight: 1},
+		}),
+	}, nil).AnyTimes()
+}
+
+func seededTestAutoscalingPollerBehavior() PollerBehavior {
+	return NewPollerBehaviorAutoscaling(PollerBehaviorAutoscalingOptions{
+		InitialNumberOfPollers: 2,
+		MinimumNumberOfPollers: 1,
+		MaximumNumberOfPollers: 2,
+	})
 }
 
 func createWorkerWithDataConverter(service *workflowservicemock.MockWorkflowServiceClient) *AggregatedWorker {

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -2371,7 +2371,10 @@ func (s *internalWorkerTestSuite) TestRecordActivityHeartbeatByIDWithOptions_Ser
 	client := NewServiceClient(s.service, nil, ClientOptions{DataConverter: dc})
 
 	heartbeatResponse := workflowservice.RecordActivityTaskHeartbeatByIdResponse{CancelRequested: false}
-	s.service.EXPECT().RecordActivityTaskHeartbeatById(gomock.Any(), gomock.Any(), gomock.Any()).Return(&heartbeatResponse, nil)
+	s.service.EXPECT().RecordActivityTaskHeartbeatById(gomock.Any(), gomock.Any(), gomock.Any()).Return(&heartbeatResponse, nil).
+		Do(func(_ interface{}, req *workflowservice.RecordActivityTaskHeartbeatByIdRequest, _ ...interface{}) {
+			s.Equal("workflow:wid", req.ResourceId)
+		})
 
 	err := client.RecordActivityHeartbeatByIDWithOptions(context.Background(), RecordActivityHeartbeatByIDOptions{
 		Namespace:    DefaultNamespace,
@@ -2401,7 +2404,10 @@ func (s *internalWorkerTestSuite) TestCompleteActivityWithOptions_SerializationC
 	client := NewServiceClient(s.service, nil, ClientOptions{DataConverter: dc})
 
 	response := &workflowservice.RespondActivityTaskCompletedResponse{}
-	s.service.EXPECT().RespondActivityTaskCompleted(gomock.Any(), gomock.Any(), gomock.Any()).Return(response, nil)
+	s.service.EXPECT().RespondActivityTaskCompleted(gomock.Any(), gomock.Any(), gomock.Any()).Return(response, nil).
+		Do(func(_ interface{}, req *workflowservice.RespondActivityTaskCompletedRequest, _ ...interface{}) {
+			s.Equal("workflow:wid", req.ResourceId)
+		})
 
 	err := client.CompleteActivityWithOptions(context.Background(), CompleteActivityOptions{
 		TaskToken:    []byte("token"),
@@ -2432,6 +2438,7 @@ func (s *internalWorkerTestSuite) TestCompleteActivity_DelegatesToWithOptions() 
 	s.service.EXPECT().RespondActivityTaskCompleted(gomock.Any(), gomock.Any(), gomock.Any()).Return(response, nil).
 		Do(func(_ any, req *workflowservice.RespondActivityTaskCompletedRequest, _ ...any) {
 			s.Equal([]byte("token"), req.TaskToken)
+			s.Empty(req.ResourceId)
 		})
 
 	err := client.CompleteActivity(context.Background(), []byte("token"), "result", nil)
@@ -2485,7 +2492,10 @@ func (s *internalWorkerTestSuite) TestRecordActivityHeartbeatWithOptions_Seriali
 	client := NewServiceClient(s.service, nil, ClientOptions{DataConverter: dc})
 
 	heartbeatResponse := workflowservice.RecordActivityTaskHeartbeatResponse{CancelRequested: false}
-	s.service.EXPECT().RecordActivityTaskHeartbeat(gomock.Any(), gomock.Any(), gomock.Any()).Return(&heartbeatResponse, nil)
+	s.service.EXPECT().RecordActivityTaskHeartbeat(gomock.Any(), gomock.Any(), gomock.Any()).Return(&heartbeatResponse, nil).
+		Do(func(_ interface{}, req *workflowservice.RecordActivityTaskHeartbeatRequest, _ ...interface{}) {
+			s.Equal("workflow:wid", req.ResourceId)
+		})
 
 	err := client.RecordActivityHeartbeatWithOptions(context.Background(), RecordActivityHeartbeatOptions{
 		TaskToken:    []byte("token"),
@@ -2516,6 +2526,7 @@ func (s *internalWorkerTestSuite) TestRecordActivityHeartbeat_DelegatesToWithOpt
 	s.service.EXPECT().RecordActivityTaskHeartbeat(gomock.Any(), gomock.Any(), gomock.Any()).Return(&heartbeatResponse, nil).
 		Do(func(_ any, req *workflowservice.RecordActivityTaskHeartbeatRequest, _ ...any) {
 			s.Equal([]byte("token"), req.TaskToken)
+			s.Empty(req.ResourceId)
 		})
 
 	err := client.RecordActivityHeartbeat(context.Background(), []byte("token"), "progress")

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -1851,17 +1851,26 @@ func (s *internalWorkerTestSuite) TestPollerAutoscalingAutoEnrollWithDefaults() 
 
 	// The actual running pollers reflect the autoscaling structure.
 	require.NotEmpty(s.T(), worker.workflowWorker.worker.options.taskPollers)
+	require.NotNil(s.T(), worker.workflowWorker.pollerGroups)
+	require.Same(s.T(), worker.client.pollerGroupInfoStore, worker.workflowWorker.pollerGroups.groupInfos)
 	for _, p := range worker.workflowWorker.worker.options.taskPollers {
 		s.NotNil(p.autoscalingRunner)
+		require.Same(s.T(), worker.workflowWorker.pollerGroups, p.autoscalingRunner.pollerGroups)
 	}
 	require.NotEmpty(s.T(), worker.activityWorker.worker.options.taskPollers)
+	require.NotNil(s.T(), worker.activityWorker.pollerGroups)
+	require.Same(s.T(), worker.client.pollerGroupInfoStore, worker.activityWorker.pollerGroups.groupInfos)
 	for _, p := range worker.activityWorker.worker.options.taskPollers {
 		s.NotNil(p.autoscalingRunner)
+		require.Same(s.T(), worker.activityWorker.pollerGroups, p.autoscalingRunner.pollerGroups)
 	}
 	require.NotNil(s.T(), worker.nexusWorker)
 	require.NotEmpty(s.T(), worker.nexusWorker.worker.options.taskPollers)
+	require.NotNil(s.T(), worker.nexusWorker.pollerGroups)
+	require.Same(s.T(), worker.client.pollerGroupInfoStore, worker.nexusWorker.pollerGroups.groupInfos)
 	for _, p := range worker.nexusWorker.worker.options.taskPollers {
 		s.NotNil(p.autoscalingRunner)
+		require.Same(s.T(), worker.nexusWorker.pollerGroups, p.autoscalingRunner.pollerGroups)
 	}
 
 	// Auto-enroll implies full autoscaling support, including scale-down.
@@ -1974,8 +1983,11 @@ func (s *internalWorkerTestSuite) TestPollerAutoscalingAutoEnrollSessionWorker()
 	require.NotNil(s.T(), worker.sessionWorker)
 
 	require.NotEmpty(s.T(), worker.sessionWorker.activityWorker.worker.options.taskPollers)
+	require.NotNil(s.T(), worker.sessionWorker.activityWorker.pollerGroups)
+	require.Same(s.T(), worker.client.pollerGroupInfoStore, worker.sessionWorker.activityWorker.pollerGroups.groupInfos)
 	for _, p := range worker.sessionWorker.activityWorker.worker.options.taskPollers {
 		s.NotNil(p.autoscalingRunner)
+		require.Same(s.T(), worker.sessionWorker.activityWorker.pollerGroups, p.autoscalingRunner.pollerGroups)
 	}
 
 	require.Len(s.T(), worker.sessionWorker.creationWorker.worker.options.taskPollers, 1)
@@ -2372,9 +2384,9 @@ func expectDescribeNamespaceWithPollerGroup(service *workflowservicemock.MockWor
 				PollerAutoscaling: true,
 			},
 		},
-		PollerGroupInfos: []*taskqueuepb.PollerGroupInfo{
+		PollerGroupsInfo: testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{
 			{Id: groupID, Weight: 1},
-		},
+		}),
 	}, nil).AnyTimes()
 }
 

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -2204,6 +2204,188 @@ func setupPollingMocks(namespace string, service *workflowservicemock.MockWorkfl
 	service.EXPECT().RespondWorkflowTaskCompleted(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 }
 
+func (s *internalWorkerTestSuite) TestDescribeNamespacePollerGroupsSeedWorkflowNormalAndStickyPolls() {
+	namespace := "testNamespace"
+	taskQueue := "seeded-workflow-tq"
+	groupID := "seeded-group"
+	service := workflowservicemock.NewMockWorkflowServiceClient(s.mockCtrl)
+	service.EXPECT().GetSystemInfo(gomock.Any(), gomock.Any(), gomock.Any()).Return(&workflowservice.GetSystemInfoResponse{}, nil).AnyTimes()
+	expectDescribeNamespaceWithPollerGroup(service, namespace, groupID)
+	service.EXPECT().ShutdownWorker(gomock.Any(), gomock.Any(), gomock.Any()).Return(&workflowservice.ShutdownWorkerResponse{}, nil).AnyTimes()
+	service.EXPECT().PollActivityTaskQueue(gomock.Any(), gomock.Any(), gomock.Any()).Return(&workflowservice.PollActivityTaskQueueResponse{}, nil).AnyTimes()
+
+	polls := make(chan *workflowservice.PollWorkflowTaskQueueRequest, 20)
+	releaseNormalPoll := make(chan struct{})
+	var releaseNormalPollOnce sync.Once
+	defer releaseNormalPollOnce.Do(func() { close(releaseNormalPoll) })
+	var blockNormalPollOnce sync.Once
+	service.EXPECT().PollWorkflowTaskQueue(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, req *workflowservice.PollWorkflowTaskQueueRequest, opts ...grpc.CallOption) (*workflowservice.PollWorkflowTaskQueueResponse, error) {
+			select {
+			case polls <- proto.Clone(req).(*workflowservice.PollWorkflowTaskQueueRequest):
+			default:
+			}
+			if req.GetPollerGroupId() == groupID && req.GetTaskQueue().GetKind() == enumspb.TASK_QUEUE_KIND_NORMAL {
+				blockNormalPollOnce.Do(func() {
+					select {
+					case <-releaseNormalPoll:
+					case <-ctx.Done():
+					}
+				})
+			}
+			return &workflowservice.PollWorkflowTaskQueueResponse{}, nil
+		},
+	).AnyTimes()
+
+	client := NewServiceClient(service, nil, ClientOptions{Namespace: namespace})
+	worker := NewAggregatedWorker(client, taskQueue, WorkerOptions{
+		WorkflowTaskPollerBehavior: seededTestAutoscalingPollerBehavior(),
+		ActivityTaskPollerBehavior: NewPollerBehaviorSimpleMaximum(PollerBehaviorSimpleMaximumOptions{MaximumNumberOfPollers: 1}),
+		NexusTaskPollerBehavior:    NewPollerBehaviorSimpleMaximum(PollerBehaviorSimpleMaximumOptions{MaximumNumberOfPollers: 1}),
+	})
+	require.NoError(s.T(), worker.Start())
+	defer worker.Stop()
+
+	var sawNormal, sawSticky bool
+	require.Eventually(s.T(), func() bool {
+		for {
+			select {
+			case req := <-polls:
+				if req.GetPollerGroupId() != groupID {
+					continue
+				}
+				switch req.GetTaskQueue().GetKind() {
+				case enumspb.TASK_QUEUE_KIND_NORMAL:
+					sawNormal = true
+				case enumspb.TASK_QUEUE_KIND_STICKY:
+					sawSticky = true
+				}
+			default:
+				return sawNormal && sawSticky
+			}
+		}
+	}, 2*time.Second, 10*time.Millisecond)
+	releaseNormalPollOnce.Do(func() { close(releaseNormalPoll) })
+}
+
+func (s *internalWorkerTestSuite) TestDescribeNamespacePollerGroupsSeedActivityPolls() {
+	namespace := "testNamespace"
+	taskQueue := "seeded-activity-tq"
+	groupID := "seeded-group"
+	service := workflowservicemock.NewMockWorkflowServiceClient(s.mockCtrl)
+	service.EXPECT().GetSystemInfo(gomock.Any(), gomock.Any(), gomock.Any()).Return(&workflowservice.GetSystemInfoResponse{}, nil).AnyTimes()
+	expectDescribeNamespaceWithPollerGroup(service, namespace, groupID)
+	service.EXPECT().ShutdownWorker(gomock.Any(), gomock.Any(), gomock.Any()).Return(&workflowservice.ShutdownWorkerResponse{}, nil).AnyTimes()
+
+	polls := make(chan string, 5)
+	service.EXPECT().PollActivityTaskQueue(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, req *workflowservice.PollActivityTaskQueueRequest, opts ...grpc.CallOption) (*workflowservice.PollActivityTaskQueueResponse, error) {
+			select {
+			case polls <- req.GetPollerGroupId():
+			default:
+			}
+			return &workflowservice.PollActivityTaskQueueResponse{}, nil
+		},
+	).AnyTimes()
+
+	client := NewServiceClient(service, nil, ClientOptions{Namespace: namespace})
+	worker := NewAggregatedWorker(client, taskQueue, WorkerOptions{
+		DisableWorkflowWorker:      true,
+		WorkflowTaskPollerBehavior: NewPollerBehaviorSimpleMaximum(PollerBehaviorSimpleMaximumOptions{MaximumNumberOfPollers: 2}),
+		ActivityTaskPollerBehavior: seededTestAutoscalingPollerBehavior(),
+		NexusTaskPollerBehavior:    NewPollerBehaviorSimpleMaximum(PollerBehaviorSimpleMaximumOptions{MaximumNumberOfPollers: 1}),
+	})
+	require.NoError(s.T(), worker.Start())
+	defer worker.Stop()
+
+	require.Eventually(s.T(), func() bool {
+		for {
+			select {
+			case id := <-polls:
+				if id == groupID {
+					return true
+				}
+			default:
+				return false
+			}
+		}
+	}, 2*time.Second, 10*time.Millisecond)
+}
+
+func (s *internalWorkerTestSuite) TestDescribeNamespacePollerGroupsSeedNexusPolls() {
+	namespace := "testNamespace"
+	taskQueue := "seeded-nexus-tq"
+	groupID := "seeded-group"
+	service := workflowservicemock.NewMockWorkflowServiceClient(s.mockCtrl)
+	service.EXPECT().GetSystemInfo(gomock.Any(), gomock.Any(), gomock.Any()).Return(&workflowservice.GetSystemInfoResponse{}, nil).AnyTimes()
+	expectDescribeNamespaceWithPollerGroup(service, namespace, groupID)
+	service.EXPECT().ShutdownWorker(gomock.Any(), gomock.Any(), gomock.Any()).Return(&workflowservice.ShutdownWorkerResponse{}, nil).AnyTimes()
+
+	polls := make(chan string, 5)
+	service.EXPECT().PollNexusTaskQueue(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, req *workflowservice.PollNexusTaskQueueRequest, opts ...grpc.CallOption) (*workflowservice.PollNexusTaskQueueResponse, error) {
+			select {
+			case polls <- req.GetPollerGroupId():
+			default:
+			}
+			return &workflowservice.PollNexusTaskQueueResponse{}, nil
+		},
+	).AnyTimes()
+
+	client := NewServiceClient(service, nil, ClientOptions{Namespace: namespace})
+	worker := NewAggregatedWorker(client, taskQueue, WorkerOptions{
+		DisableWorkflowWorker:      true,
+		LocalActivityWorkerOnly:    true,
+		WorkflowTaskPollerBehavior: NewPollerBehaviorSimpleMaximum(PollerBehaviorSimpleMaximumOptions{MaximumNumberOfPollers: 2}),
+		ActivityTaskPollerBehavior: NewPollerBehaviorSimpleMaximum(PollerBehaviorSimpleMaximumOptions{MaximumNumberOfPollers: 1}),
+		NexusTaskPollerBehavior:    seededTestAutoscalingPollerBehavior(),
+	})
+	nexusService := nexus.NewService("seeded-service")
+	require.NoError(s.T(), nexusService.Register(nexus.NewSyncOperation("op", func(ctx context.Context, input string, opts nexus.StartOperationOptions) (string, error) {
+		return "", nil
+	})))
+	worker.RegisterNexusService(nexusService)
+
+	require.NoError(s.T(), worker.Start())
+	defer worker.Stop()
+
+	require.Eventually(s.T(), func() bool {
+		for {
+			select {
+			case id := <-polls:
+				if id == groupID {
+					return true
+				}
+			default:
+				return false
+			}
+		}
+	}, 2*time.Second, 10*time.Millisecond)
+}
+
+func expectDescribeNamespaceWithPollerGroup(service *workflowservicemock.MockWorkflowServiceClient, namespace string, groupID string) {
+	service.EXPECT().DescribeNamespace(gomock.Any(), gomock.Any(), gomock.Any()).Return(&workflowservice.DescribeNamespaceResponse{
+		NamespaceInfo: &namespacepb.NamespaceInfo{
+			Name:  namespace,
+			State: enumspb.NAMESPACE_STATE_REGISTERED,
+			Capabilities: &namespacepb.NamespaceInfo_Capabilities{
+				PollerAutoscaling: true,
+			},
+		},
+		PollerGroupInfos: []*taskqueuepb.PollerGroupInfo{
+			{Id: groupID, Weight: 1},
+		},
+	}, nil).AnyTimes()
+}
+
+func seededTestAutoscalingPollerBehavior() PollerBehavior {
+	return NewPollerBehaviorAutoscaling(PollerBehaviorAutoscalingOptions{
+		InitialNumberOfPollers: 2,
+		MinimumNumberOfPollers: 1,
+		MaximumNumberOfPollers: 2,
+	})
+}
+
 func createWorkerWithDataConverter(service *workflowservicemock.MockWorkflowServiceClient) *AggregatedWorker {
 	return createWorkerWithThrottle(service, 0.0, iconverter.NewTestDataConverter())
 }

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -88,6 +88,7 @@ type (
 		getSystemInfoTimeout     time.Duration
 		workerHeartbeatInterval  time.Duration
 		workerGroupingKey        string
+		pollerGroupInfoStore     *pollerGroupInfoStore
 		heartbeatManager         *heartbeatManager
 
 		// The pointer value is shared across multiple clients. If non-nil, only
@@ -100,9 +101,8 @@ type (
 
 	// namespaceData holds cached namespace capabilities and limits.
 	namespaceData struct {
-		capabilities     *namespacepb.NamespaceInfo_Capabilities
-		limits           *namespacepb.NamespaceInfo_Limits
-		pollerGroupInfos []*taskqueuepb.PollerGroupInfo
+		capabilities *namespacepb.NamespaceInfo_Capabilities
+		limits       *namespacepb.NamespaceInfo_Limits
 	}
 
 	// namespaceClient is the client for managing namespaces.
@@ -1690,7 +1690,7 @@ func (wc *WorkflowClient) loadNamespaceData(metricsHandler metrics.Handler) (nam
 	if resp != nil {
 		data.capabilities = resp.GetNamespaceInfo().GetCapabilities()
 		data.limits = resp.GetNamespaceInfo().GetLimits()
-		data.pollerGroupInfos = resp.GetPollerGroupInfos()
+		wc.pollerGroupInfoStore.updateGroups(resp.GetPollerGroupsInfo())
 	}
 	if data.capabilities == nil {
 		data.capabilities = &namespacepb.NamespaceInfo_Capabilities{}

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -100,8 +100,9 @@ type (
 
 	// namespaceData holds cached namespace capabilities and limits.
 	namespaceData struct {
-		capabilities *namespacepb.NamespaceInfo_Capabilities
-		limits       *namespacepb.NamespaceInfo_Limits
+		capabilities     *namespacepb.NamespaceInfo_Capabilities
+		limits           *namespacepb.NamespaceInfo_Limits
+		pollerGroupInfos []*taskqueuepb.PollerGroupInfo
 	}
 
 	// namespaceClient is the client for managing namespaces.
@@ -1689,6 +1690,7 @@ func (wc *WorkflowClient) loadNamespaceData(metricsHandler metrics.Handler) (nam
 	if resp != nil {
 		data.capabilities = resp.GetNamespaceInfo().GetCapabilities()
 		data.limits = resp.GetNamespaceInfo().GetLimits()
+		data.pollerGroupInfos = resp.GetPollerGroupInfos()
 	}
 	if data.capabilities == nil {
 		data.capabilities = &namespacepb.NamespaceInfo_Capabilities{}

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -87,6 +87,7 @@ type (
 		getSystemInfoTimeout     time.Duration
 		workerHeartbeatInterval  time.Duration
 		workerGroupingKey        string
+		pollerGroupInfoStore     *pollerGroupInfoStore
 		sdkName                  string
 		sdkVersion               string
 		heartbeatManager         *heartbeatManager
@@ -1718,6 +1719,7 @@ func (wc *WorkflowClient) loadNamespaceData(metricsHandler metrics.Handler) (nam
 	if resp != nil {
 		data.capabilities = resp.GetNamespaceInfo().GetCapabilities()
 		data.limits = resp.GetNamespaceInfo().GetLimits()
+		wc.pollerGroupInfoStore.updateGroups(resp.GetPollerGroupsInfo())
 	}
 	if data.capabilities == nil {
 		data.capabilities = &namespacepb.NamespaceInfo_Capabilities{}

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -551,7 +551,8 @@ func (wc *WorkflowClient) CompleteActivityWithOptions(ctx context.Context, opts 
 	// We do allow canceled error to be passed here
 	cancelAllowed := true
 	request := convertActivityResultToRespondRequest(wc.identity, opts.TaskToken,
-		data, opts.Err, dataConverter, failureConverter, wc.namespace, cancelAllowed, nil, nil, nil)
+		data, opts.Err, dataConverter, failureConverter, wc.namespace, cancelAllowed, nil, nil, nil,
+		opts.WorkflowID, "")
 	if msg, ok := request.(proto.Message); ok {
 		storeCtx := extstore.WithStorageTarget(ctx, extstore.StorageDriverWorkflowInfo{
 			Namespace:    cmp.Or(opts.Namespace, wc.namespace),
@@ -711,10 +712,11 @@ func (wc *WorkflowClient) RecordActivityHeartbeatWithOptions(ctx context.Context
 		return err
 	}
 	request := &workflowservice.RecordActivityTaskHeartbeatRequest{
-		TaskToken: opts.TaskToken,
-		Details:   data,
-		Identity:  wc.identity,
-		Namespace: cmp.Or(opts.Namespace, wc.namespace),
+		TaskToken:  opts.TaskToken,
+		Details:    data,
+		Identity:   wc.identity,
+		Namespace:  cmp.Or(opts.Namespace, wc.namespace),
+		ResourceId: getWorkflowResourceId(opts.WorkflowID),
 	}
 	if err := visitProtoPayloads(ctx, wc.newOutboundPayloadVisitor(), request, 0); err != nil {
 		return err
@@ -761,6 +763,7 @@ func (wc *WorkflowClient) RecordActivityHeartbeatByIDWithOptions(ctx context.Con
 		ActivityId: opts.ActivityID,
 		Details:    data,
 		Identity:   wc.identity,
+		ResourceId: getActivityResourceId(opts.WorkflowID, opts.ActivityID),
 	}
 	if err := visitProtoPayloads(ctx, wc.newOutboundPayloadVisitor(), byIDRequest, 0); err != nil {
 		return err
@@ -2369,6 +2372,7 @@ func (w *workflowClientInterceptor) updateWithStartWorkflow(
 			startOp,
 			updateOp,
 		},
+		ResourceId: getWorkflowResourceId(startRequest.WorkflowId),
 	}
 
 	storeCtx := extstore.WithStorageTarget(ctx, extstore.StorageDriverWorkflowInfo{

--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -1334,7 +1334,8 @@ func (env *testWorkflowEnvironmentImpl) CompleteActivity(taskToken []byte, resul
 		// We do allow canceled error to be passed here
 		cancelAllowed := true
 		request := convertActivityResultToRespondRequest("test-identity", taskToken, data, err,
-			activityHandle.dataConverter, activityHandle.failureConverter, defaultTestNamespace, cancelAllowed, nil, nil, nil)
+			activityHandle.dataConverter, activityHandle.failureConverter, defaultTestNamespace, cancelAllowed, nil, nil, nil,
+			activityHandle.task.WorkflowExecution.GetWorkflowId(), activityHandle.task.ActivityId)
 		env.handleActivityResult(activityHandle, request, activityHandle.dataConverter)
 	}, false /* do not auto schedule workflow task, because activity might be still pending */)
 

--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -2813,7 +2813,7 @@ func (env *testWorkflowEnvironmentImpl) ExecuteNexusOperation(
 		response, failure, err := taskHandler.Execute(task)
 		if err != nil {
 			// No retries for operations, fail the operation immediately.
-			failure, err = taskHandler.fillInFailure(task.TaskToken, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeInternal, "%s", err.Error()), false)
+			failure, err = taskHandler.fillInFailure(task.TaskToken, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeInternal, "%s", err.Error()), false, task.GetPollerGroupId())
 		}
 		if failure != nil {
 			// Convert to a nexus HandlerError first to simulate the flow in the server.

--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -2873,7 +2873,7 @@ func (env *testWorkflowEnvironmentImpl) ExecuteNexusOperation(
 		if err != nil {
 			// No retries for operations, fail the operation immediately.
 			//lint:ignore SA4006 fillInFailure cannot fail for a handler error without a cause.
-			failure, err = taskHandler.fillInFailure(task.TaskToken, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeInternal, "%s", err.Error()), false)
+			failure, err = taskHandler.fillInFailure(task.TaskToken, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeInternal, "%s", err.Error()), false, task.GetPollerGroupId())
 		}
 		if failure != nil {
 			// Convert to a nexus HandlerError first to simulate the flow in the server.

--- a/internal/resource_id_test.go
+++ b/internal/resource_id_test.go
@@ -1,0 +1,790 @@
+package internal
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	historypb "go.temporal.io/api/history/v1"
+	taskqueuepb "go.temporal.io/api/taskqueue/v1"
+	workerpb "go.temporal.io/api/worker/v1"
+	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/api/workflowservicemock/v1"
+	"go.temporal.io/sdk/converter"
+	"go.temporal.io/sdk/internal/common/metrics"
+)
+
+// TestResourceIDImplementation tests that our actual implementation code
+// correctly populates resource_id fields in various request types
+func TestResourceIDImplementation(t *testing.T) {
+	t.Run("ActivityHeartbeat", func(t *testing.T) {
+		testActivityHeartbeatResourceID(t)
+	})
+	t.Run("WorkflowTaskRequests", func(t *testing.T) {
+		testWorkflowTaskResourceID(t)
+	})
+	t.Run("ActivityTaskRequests", func(t *testing.T) {
+		testActivityTaskRequestsResourceID(t)
+	})
+	t.Run("BatchOperationRequest", func(t *testing.T) {
+		testExecuteMultiOperationResourceID(t)
+	})
+	t.Run("WorkerHeartbeatRequest", func(t *testing.T) {
+		testRecordWorkerHeartbeatResourceID(t)
+	})
+}
+
+func TestGetActivityResourceId_BothEmpty(t *testing.T) {
+	result := getActivityResourceId("", "")
+	assert.Empty(t, result, "Expected empty resource ID when both workflowId and activityId are empty")
+}
+
+func TestGetWorkflowResourceId_Empty(t *testing.T) {
+	result := getWorkflowResourceId("")
+	assert.Empty(t, result, "Expected empty resource ID when workflowId is empty")
+}
+
+func TestGetActivityResourceIdFromCtx_NoActivityEnv(t *testing.T) {
+	result := getActivityResourceIdFromCtx(t.Context())
+	assert.Empty(t, result, "Expected empty resource ID when context has no activity environment")
+}
+
+// Test activity heartbeat resource_id population using actual SDK code path
+func testActivityHeartbeatResourceID(t *testing.T) {
+	testCases := []struct {
+		name               string
+		createActivityEnv  func(ServiceInvoker) *activityEnvironment
+		expectedResourceID string
+	}{
+		{
+			name: "WithWorkflowExecution",
+			createActivityEnv: func(invoker ServiceInvoker) *activityEnvironment {
+				return &activityEnvironment{
+					serviceInvoker: invoker,
+					workflowExecution: WorkflowExecution{
+						ID:    "test-workflow-123",
+						RunID: "test-run-456",
+					},
+					logger: getLogger(),
+				}
+			},
+			expectedResourceID: "workflow:test-workflow-123",
+		},
+		{
+			name: "StandaloneActivity",
+			createActivityEnv: func(invoker ServiceInvoker) *activityEnvironment {
+				return &activityEnvironment{
+					serviceInvoker: invoker,
+					activityID:     "standalone-activity-999",
+					logger:         getLogger(),
+				}
+			},
+			expectedResourceID: "activity:standalone-activity-999",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Test setup inside the loop for clean isolation
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
+			service := workflowservicemock.NewMockWorkflowServiceClient(mockCtrl)
+
+			var capturedRequest *workflowservice.RecordActivityTaskHeartbeatRequest
+			service.EXPECT().
+				RecordActivityTaskHeartbeat(gomock.Any(), gomock.Any(), gomock.Any()).
+				Do(func(ctx context.Context, req *workflowservice.RecordActivityTaskHeartbeatRequest, opts ...interface{}) {
+					capturedRequest = req
+				}).
+				Return(&workflowservice.RecordActivityTaskHeartbeatResponse{}, nil).
+				Times(1)
+
+			ctx, cancel := context.WithCancelCause(t.Context())
+			defer cancel(nil)
+			invoker := newServiceInvoker([]byte("test-token"), "test-identity", service, metrics.NopHandler, cancel,
+				1*time.Second, make(chan struct{}), "test-namespace", &atomic.Bool{}, nil, GetDefaultFailureConverter())
+
+			// Only the activity environment creation varies
+			activityCtx, _ := newActivityContext(ctx, nil, tc.createActivityEnv(invoker))
+
+			// Call the actual SDK function
+			RecordActivityHeartbeat(activityCtx, "test-heartbeat-details")
+
+			// Validate the captured request
+			require.NotNil(t, capturedRequest)
+			assert.Equal(t, tc.expectedResourceID, capturedRequest.ResourceId)
+		})
+	}
+}
+
+// Test workflow task request resource_id population using actual SDK code paths
+func testWorkflowTaskResourceID(t *testing.T) {
+	t.Run("WorkflowTaskCompleted", func(t *testing.T) {
+		testWorkflowTaskCompletedResourceID(t)
+	})
+	t.Run("WorkflowTaskFailed", func(t *testing.T) {
+		testWorkflowTaskFailedResourceID(t)
+	})
+}
+
+// Test RespondWorkflowTaskCompletedRequest resource_id field (resource_id = 18)
+// Expected: Workflow ID from original task
+func testWorkflowTaskCompletedResourceID(t *testing.T) {
+	testCases := []struct {
+		name               string
+		workflowID         string
+		runID              string
+		expectedResourceID string
+	}{
+		{
+			name:               "StandardWorkflowTask",
+			workflowID:         "test-workflow-completed-123",
+			runID:              "test-run-completed-456",
+			expectedResourceID: "workflow:test-workflow-completed-123",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
+			service := workflowservicemock.NewMockWorkflowServiceClient(mockCtrl)
+
+			var capturedRequest *workflowservice.RespondWorkflowTaskCompletedRequest
+			service.EXPECT().
+				RespondWorkflowTaskCompleted(gomock.Any(), gomock.Any(), gomock.Any()).
+				Do(func(ctx context.Context, req *workflowservice.RespondWorkflowTaskCompletedRequest, opts ...interface{}) {
+					capturedRequest = req
+				}).
+				Return(&workflowservice.RespondWorkflowTaskCompletedResponse{}, nil).
+				Times(1)
+
+			// Create a simple workflow task with basic history
+			task := createTestWorkflowTask(tc.workflowID, tc.runID)
+
+			// Create workflow task handler
+			params := workerExecutionParameters{
+				Namespace: "test-namespace",
+				Identity:  "test-identity",
+				cache:     NewWorkerCache(),
+			}
+			ensureRequiredParams(&params)
+			registry := newRegistry()
+			registry.RegisterWorkflowWithOptions(
+				helloWorldWorkflowFunc,
+				RegisterWorkflowOptions{Name: "HelloWorld_Workflow"},
+			)
+
+			handler := newWorkflowTaskHandler(params, nil, registry)
+
+			// Process the workflow task through the poller to trigger the completion
+			poller := newWorkflowTaskProcessor(handler, handler, service, params, uuid.NewString())
+
+			wt := &workflowTask{task: task}
+			err := poller.processWorkflowTask(wt)
+
+			// We expect the task to complete successfully since workflow is registered
+			require.NoError(t, err)
+
+			// Validate the captured request
+			require.NotNil(t, capturedRequest)
+			assert.Equal(t, tc.expectedResourceID, capturedRequest.ResourceId)
+		})
+	}
+}
+
+// Test RespondWorkflowTaskFailedRequest resource_id field (resource_id = 11)
+// Expected: Workflow ID from original task
+func testWorkflowTaskFailedResourceID(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	service := workflowservicemock.NewMockWorkflowServiceClient(mockCtrl)
+
+	var capturedRequest *workflowservice.RespondWorkflowTaskFailedRequest
+	service.EXPECT().
+		RespondWorkflowTaskFailed(gomock.Any(), gomock.Any(), gomock.Any()).
+		Do(func(ctx context.Context, req *workflowservice.RespondWorkflowTaskFailedRequest, opts ...interface{}) {
+			capturedRequest = req
+		}).
+		Return(&workflowservice.RespondWorkflowTaskFailedResponse{}, nil).
+		Times(1)
+
+	// Create a workflow task that will fail (unregistered workflow type)
+	task := createTestWorkflowTaskWithType("test-workflow-failed-123", "test-run-failed-456", "UnregisteredWorkflow")
+
+	// Create workflow task handler without registering the workflow
+	params := workerExecutionParameters{
+		Namespace: "test-namespace",
+		Identity:  "test-identity",
+		cache:     NewWorkerCache(),
+	}
+	ensureRequiredParams(&params)
+	registry := newRegistry() // Empty registry to cause failure
+
+	handler := newWorkflowTaskHandler(params, nil, registry)
+
+	// Process the workflow task through the poller to trigger the failure
+	poller := newWorkflowTaskProcessor(handler, handler, service, params, uuid.NewString())
+
+	wt := &workflowTask{task: task}
+	err := poller.processWorkflowTask(wt)
+
+	// Task processing succeeds but should trigger failure request due to unregistered workflow
+	require.NoError(t, err)
+
+	// Validate the captured request
+	require.NotNil(t, capturedRequest)
+	assert.Equal(t, "workflow:test-workflow-failed-123", capturedRequest.ResourceId)
+}
+
+// Test activity task request resource_id population using actual SDK code paths
+func testActivityTaskRequestsResourceID(t *testing.T) {
+	t.Run("ActivityTaskHeartbeatById", func(t *testing.T) {
+		testActivityTaskHeartbeatByIdResourceID(t)
+	})
+	t.Run("ConvertActivityResultValidation", func(t *testing.T) {
+		testConvertActivityResultValidation(t)
+	})
+	t.Run("ConvertActivityResultByIDValidation", func(t *testing.T) {
+		testConvertActivityResultByIDValidation(t)
+	})
+}
+
+// Test convertActivityResultToRespondRequest validation
+// This tests all 4 activity task requests that use this function:
+// - RespondActivityTaskCompletedRequest (resource_id = 8)
+// - RespondActivityTaskFailedRequest (resource_id = 9)
+// - RespondActivityTaskCanceledRequest (resource_id = 8)
+// - RecordActivityTaskHeartbeatRequest (resource_id = 5)
+func testConvertActivityResultValidation(t *testing.T) {
+	testCases := []struct {
+		name               string
+		workflowID         string
+		activityID         string
+		expectedResourceID string
+		testType           string
+		simulateError      error
+		description        string
+	}{
+		{
+			name:               "CompletedWithWorkflow",
+			workflowID:         "test-workflow-completed-123",
+			activityID:         "test-activity-456",
+			expectedResourceID: "workflow:test-workflow-completed-123",
+			testType:           "completed",
+			simulateError:      nil,
+			description:        "RespondActivityTaskCompletedRequest should use workflow ID when present",
+		},
+		{
+			name:               "CompletedStandalone",
+			workflowID:         "",
+			activityID:         "standalone-activity-completed-789",
+			expectedResourceID: "activity:standalone-activity-completed-789",
+			testType:           "completed",
+			simulateError:      nil,
+			description:        "RespondActivityTaskCompletedRequest should use activity ID for standalone activities",
+		},
+		{
+			name:               "FailedWithWorkflow",
+			workflowID:         "test-workflow-failed-123",
+			activityID:         "test-activity-failed-456",
+			expectedResourceID: "workflow:test-workflow-failed-123",
+			testType:           "failed",
+			simulateError:      errors.New("activity failed"),
+			description:        "RespondActivityTaskFailedRequest should use workflow ID when present",
+		},
+		{
+			name:               "FailedStandalone",
+			workflowID:         "",
+			activityID:         "standalone-activity-failed-789",
+			expectedResourceID: "activity:standalone-activity-failed-789",
+			testType:           "failed",
+			simulateError:      errors.New("standalone activity failed"),
+			description:        "RespondActivityTaskFailedRequest should use activity ID for standalone activities",
+		},
+		{
+			name:               "CanceledWithWorkflow",
+			workflowID:         "test-workflow-canceled-123",
+			activityID:         "test-activity-canceled-456",
+			expectedResourceID: "workflow:test-workflow-canceled-123",
+			testType:           "canceled",
+			simulateError:      NewCanceledError(),
+			description:        "RespondActivityTaskCanceledRequest should use workflow ID when present",
+		},
+		{
+			name:               "CanceledStandalone",
+			workflowID:         "",
+			activityID:         "standalone-activity-canceled-789",
+			expectedResourceID: "activity:standalone-activity-canceled-789",
+			testType:           "canceled",
+			simulateError:      NewCanceledError(),
+			description:        "RespondActivityTaskCanceledRequest should use activity ID for standalone activities",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Call the conversion function directly to test resource ID population
+			result := convertActivityResultToRespondRequest(
+				"test-identity",
+				[]byte("test-task-token"),
+				nil, // result payloads
+				tc.simulateError,
+				converter.GetDefaultDataConverter(), // data converter
+				GetDefaultFailureConverter(),        // failure converter
+				"test-namespace",
+				true, // cancel allowed
+				nil,  // version stamp
+				nil,  // deployment
+				nil,  // worker deployment options
+				tc.workflowID,
+				tc.activityID,
+			)
+
+			// Validate the result based on the test type
+			switch tc.testType {
+			case "completed":
+				if tc.simulateError == nil {
+					completedRequest, ok := result.(*workflowservice.RespondActivityTaskCompletedRequest)
+					require.True(t, ok, "Result should be a RespondActivityTaskCompletedRequest")
+					assert.Equal(t, tc.expectedResourceID, completedRequest.ResourceId, tc.description)
+				}
+			case "failed":
+				if tc.simulateError != nil && !errors.Is(tc.simulateError, context.Canceled) {
+					var canceledErr *CanceledError
+					if !errors.As(tc.simulateError, &canceledErr) {
+						failedRequest, ok := result.(*workflowservice.RespondActivityTaskFailedRequest)
+						require.True(t, ok, "Result should be a RespondActivityTaskFailedRequest")
+						assert.Equal(t, tc.expectedResourceID, failedRequest.ResourceId, tc.description)
+					}
+				}
+			case "canceled":
+				var canceledErr *CanceledError
+				if errors.As(tc.simulateError, &canceledErr) {
+					canceledRequest, ok := result.(*workflowservice.RespondActivityTaskCanceledRequest)
+					require.True(t, ok, "Result should be a RespondActivityTaskCanceledRequest")
+					assert.Equal(t, tc.expectedResourceID, canceledRequest.ResourceId, tc.description)
+				}
+			default:
+				t.Fatalf("unknown test type %q", tc.testType)
+			}
+		})
+	}
+}
+
+// Test convertActivityResultToRespondRequestByID validation
+// This tests all 4 ByID activity task requests that use this function:
+// - RespondActivityTaskCompletedByIdRequest (resource_id = 7)
+// - RespondActivityTaskFailedByIdRequest (resource_id = 8)
+// - RespondActivityTaskCanceledByIdRequest (resource_id = 8)
+// - RecordActivityTaskHeartbeatByIdRequest (resource_id = 7)
+func testConvertActivityResultByIDValidation(t *testing.T) {
+	testCases := []struct {
+		name               string
+		workflowID         string
+		activityID         string
+		expectedResourceID string
+		testType           string
+		simulateError      error
+		description        string
+	}{
+		{
+			name:               "CompletedByIDWithWorkflow",
+			workflowID:         "test-workflow-completed-by-id-123",
+			activityID:         "test-activity-by-id-456",
+			expectedResourceID: "workflow:test-workflow-completed-by-id-123",
+			testType:           "completed",
+			simulateError:      nil,
+			description:        "RespondActivityTaskCompletedByIdRequest should use workflow ID when present",
+		},
+		{
+			name:               "CompletedByIDStandalone",
+			workflowID:         "",
+			activityID:         "standalone-activity-completed-by-id-789",
+			expectedResourceID: "activity:standalone-activity-completed-by-id-789",
+			testType:           "completed",
+			simulateError:      nil,
+			description:        "RespondActivityTaskCompletedByIdRequest should use activity ID for standalone activities",
+		},
+		{
+			name:               "FailedByIDWithWorkflow",
+			workflowID:         "test-workflow-failed-by-id-123",
+			activityID:         "test-activity-failed-by-id-456",
+			expectedResourceID: "workflow:test-workflow-failed-by-id-123",
+			testType:           "failed",
+			simulateError:      errors.New("activity failed by ID"),
+			description:        "RespondActivityTaskFailedByIdRequest should use workflow ID when present",
+		},
+		{
+			name:               "FailedByIDStandalone",
+			workflowID:         "",
+			activityID:         "standalone-activity-failed-by-id-789",
+			expectedResourceID: "activity:standalone-activity-failed-by-id-789",
+			testType:           "failed",
+			simulateError:      errors.New("standalone activity failed by ID"),
+			description:        "RespondActivityTaskFailedByIdRequest should use activity ID for standalone activities",
+		},
+		{
+			name:               "CanceledByIDWithWorkflow",
+			workflowID:         "test-workflow-canceled-by-id-123",
+			activityID:         "test-activity-canceled-by-id-456",
+			expectedResourceID: "workflow:test-workflow-canceled-by-id-123",
+			testType:           "canceled",
+			simulateError:      NewCanceledError(),
+			description:        "RespondActivityTaskCanceledByIdRequest should use workflow ID when present",
+		},
+		{
+			name:               "CanceledByIDStandalone",
+			workflowID:         "",
+			activityID:         "standalone-activity-canceled-by-id-789",
+			expectedResourceID: "activity:standalone-activity-canceled-by-id-789",
+			testType:           "canceled",
+			simulateError:      NewCanceledError(),
+			description:        "RespondActivityTaskCanceledByIdRequest should use activity ID for standalone activities",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Call the conversion function directly to test resource ID population
+			result := convertActivityResultToRespondRequestByID(
+				"test-identity",
+				"test-namespace",
+				tc.workflowID,
+				"test-run-id",
+				tc.activityID,
+				nil, // result payloads
+				tc.simulateError,
+				converter.GetDefaultDataConverter(), // data converter
+				GetDefaultFailureConverter(),        // failure converter
+				true,                                // cancel allowed
+			)
+
+			// Validate the result based on the test type
+			switch tc.testType {
+			case "completed":
+				if tc.simulateError == nil {
+					completedRequest, ok := result.(*workflowservice.RespondActivityTaskCompletedByIdRequest)
+					require.True(t, ok, "Result should be a RespondActivityTaskCompletedByIdRequest")
+					assert.Equal(t, tc.expectedResourceID, completedRequest.ResourceId, tc.description)
+				}
+			case "failed":
+				if tc.simulateError != nil && !errors.Is(tc.simulateError, context.Canceled) {
+					var canceledErr *CanceledError
+					if !errors.As(tc.simulateError, &canceledErr) {
+						failedRequest, ok := result.(*workflowservice.RespondActivityTaskFailedByIdRequest)
+						require.True(t, ok, "Result should be a RespondActivityTaskFailedByIdRequest")
+						assert.Equal(t, tc.expectedResourceID, failedRequest.ResourceId, tc.description)
+					}
+				}
+			case "canceled":
+				var canceledErr *CanceledError
+				if errors.As(tc.simulateError, &canceledErr) {
+					canceledRequest, ok := result.(*workflowservice.RespondActivityTaskCanceledByIdRequest)
+					require.True(t, ok, "Result should be a RespondActivityTaskCanceledByIdRequest")
+					assert.Equal(t, tc.expectedResourceID, canceledRequest.ResourceId, tc.description)
+				}
+			default:
+				t.Fatalf("unknown test type %q", tc.testType)
+			}
+		})
+	}
+}
+
+// Helper functions for creating test workflow tasks
+
+func createTestWorkflowTask(workflowID, runID string) *workflowservice.PollWorkflowTaskQueueResponse {
+	return createTestWorkflowTaskWithType(workflowID, runID, "HelloWorld_Workflow")
+}
+
+func createTestWorkflowTaskWithType(workflowID, runID, workflowType string) *workflowservice.PollWorkflowTaskQueueResponse {
+	events := []*historypb.HistoryEvent{
+		{
+			EventId:   1,
+			EventTime: nil,
+			EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED,
+			Attributes: &historypb.HistoryEvent_WorkflowExecutionStartedEventAttributes{
+				WorkflowExecutionStartedEventAttributes: &historypb.WorkflowExecutionStartedEventAttributes{
+					WorkflowType: &commonpb.WorkflowType{Name: workflowType},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: "test-task-queue"},
+				},
+			},
+		},
+		{
+			EventId:   2,
+			EventTime: nil,
+			EventType: enumspb.EVENT_TYPE_WORKFLOW_TASK_SCHEDULED,
+			Attributes: &historypb.HistoryEvent_WorkflowTaskScheduledEventAttributes{
+				WorkflowTaskScheduledEventAttributes: &historypb.WorkflowTaskScheduledEventAttributes{
+					TaskQueue: &taskqueuepb.TaskQueue{Name: "test-task-queue"},
+				},
+			},
+		},
+		{
+			EventId:   3,
+			EventTime: nil,
+			EventType: enumspb.EVENT_TYPE_WORKFLOW_TASK_STARTED,
+			Attributes: &historypb.HistoryEvent_WorkflowTaskStartedEventAttributes{
+				WorkflowTaskStartedEventAttributes: &historypb.WorkflowTaskStartedEventAttributes{
+					Identity: "test-identity",
+				},
+			},
+		},
+	}
+
+	return &workflowservice.PollWorkflowTaskQueueResponse{
+		TaskToken: []byte("test-task-token"),
+		WorkflowExecution: &commonpb.WorkflowExecution{
+			WorkflowId: workflowID,
+			RunId:      runID,
+		},
+		WorkflowType: &commonpb.WorkflowType{Name: workflowType},
+		History:      &historypb.History{Events: events},
+		Attempt:      1,
+	}
+}
+
+// Test RecordActivityTaskHeartbeatByIdRequest resource_id field (resource_id = 7)
+// Expected: Workflow ID or activity ID for standalone activities
+func testActivityTaskHeartbeatByIdResourceID(t *testing.T) {
+	testCases := []struct {
+		name               string
+		workflowID         string
+		activityID         string
+		expectedResourceID string
+		description        string
+	}{
+		{
+			name:               "WithWorkflowExecution",
+			workflowID:         "test-workflow-heartbeat-by-id-123",
+			activityID:         "test-activity-heartbeat-by-id-456",
+			expectedResourceID: "workflow:test-workflow-heartbeat-by-id-123",
+			description:        "Should use workflow ID when present",
+		},
+		{
+			name:               "StandaloneActivity",
+			workflowID:         "",
+			activityID:         "standalone-activity-heartbeat-by-id-789",
+			expectedResourceID: "activity:standalone-activity-heartbeat-by-id-789",
+			description:        "Should use activity ID for standalone activities",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
+			service := workflowservicemock.NewMockWorkflowServiceClient(mockCtrl)
+
+			// Mock GetSystemInfo which is called during client initialization
+			service.EXPECT().
+				GetSystemInfo(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(&workflowservice.GetSystemInfoResponse{}, nil).
+				AnyTimes()
+
+			var capturedRequest *workflowservice.RecordActivityTaskHeartbeatByIdRequest
+			service.EXPECT().
+				RecordActivityTaskHeartbeatById(gomock.Any(), gomock.Any(), gomock.Any()).
+				Do(func(ctx context.Context, req *workflowservice.RecordActivityTaskHeartbeatByIdRequest, opts ...interface{}) {
+					capturedRequest = req
+				}).
+				Return(&workflowservice.RecordActivityTaskHeartbeatByIdResponse{}, nil).
+				Times(1)
+
+			// Create workflow client and call heartbeat by ID
+			client := NewServiceClient(service, nil, ClientOptions{Namespace: "test-namespace"})
+
+			ctx := t.Context()
+			err := client.RecordActivityHeartbeatByID(ctx, "test-namespace", tc.workflowID, "", tc.activityID, "heartbeat-details")
+
+			// Validate call succeeded
+			require.NoError(t, err)
+
+			// Validate the captured request
+			require.NotNil(t, capturedRequest, "Request should have been captured")
+			assert.Equal(t, tc.expectedResourceID, capturedRequest.ResourceId, tc.description)
+		})
+	}
+}
+
+// Test ExecuteMultiOperationRequest resource_id field (resource_id = 3)
+// Expected: Should match operations[0].start_workflow.workflow_id
+func testExecuteMultiOperationResourceID(t *testing.T) {
+	testCases := []struct {
+		name               string
+		workflowID         string
+		expectedResourceID string
+	}{
+		{
+			name:               "StartUpdateWorkflow",
+			workflowID:         "test-workflow-batch-123",
+			expectedResourceID: "workflow:test-workflow-batch-123",
+		},
+		{
+			name:               "MultiOpWithDifferentID",
+			workflowID:         "batch-operation-workflow-456",
+			expectedResourceID: "workflow:batch-operation-workflow-456",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
+			service := workflowservicemock.NewMockWorkflowServiceClient(mockCtrl)
+
+			// Mock GetSystemInfo which gets called during client operations
+			service.EXPECT().GetSystemInfo(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(&workflowservice.GetSystemInfoResponse{}, nil).AnyTimes()
+
+			var capturedRequest *workflowservice.ExecuteMultiOperationRequest
+			service.EXPECT().
+				ExecuteMultiOperation(gomock.Any(), gomock.Any(), gomock.Any()).
+				Do(func(ctx context.Context, req *workflowservice.ExecuteMultiOperationRequest, opts ...interface{}) {
+					capturedRequest = req
+				}).
+				Return(&workflowservice.ExecuteMultiOperationResponse{
+					Responses: []*workflowservice.ExecuteMultiOperationResponse_Response{
+						{
+							Response: &workflowservice.ExecuteMultiOperationResponse_Response_StartWorkflow{
+								StartWorkflow: &workflowservice.StartWorkflowExecutionResponse{
+									RunId: "test-run-id",
+								},
+							},
+						},
+						{
+							Response: &workflowservice.ExecuteMultiOperationResponse_Response_UpdateWorkflow{
+								UpdateWorkflow: &workflowservice.UpdateWorkflowExecutionResponse{
+									Stage: enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED,
+								},
+							},
+						},
+					},
+				}, nil).
+				Times(1)
+
+			// Create a client to trigger ExecuteMultiOperation via UpdateWithStartWorkflow
+			client := NewServiceClient(service, nil, ClientOptions{
+				Namespace: "test-namespace",
+			})
+
+			// Create start operation with workflow options
+			startOp := client.NewWithStartWorkflowOperation(
+				StartWorkflowOptions{
+					ID:                       tc.workflowID,
+					TaskQueue:                "test-task-queue",
+					WorkflowIDConflictPolicy: enumspb.WORKFLOW_ID_CONFLICT_POLICY_FAIL,
+				},
+				"TestWorkflow",
+			)
+
+			// Execute the update with start workflow operation
+			ctx := t.Context()
+			_, err := client.UpdateWithStartWorkflow(ctx, UpdateWithStartWorkflowOptions{
+				StartWorkflowOperation: startOp,
+				UpdateOptions: UpdateWorkflowOptions{
+					UpdateName:   "TestUpdate",
+					Args:         []any{},
+					WaitForStage: WorkflowUpdateStageAccepted,
+				},
+			})
+
+			// The operation should succeed
+			require.NoError(t, err)
+
+			// Validate the captured request
+			require.NotNil(t, capturedRequest, "ExecuteMultiOperationRequest should have been captured")
+			assert.Equal(t, tc.expectedResourceID, capturedRequest.ResourceId,
+				"ResourceId should match the workflow ID from the start operation")
+
+			// Additional validation: ensure we have the expected operations
+			require.Len(t, capturedRequest.Operations, 2, "Should have start and update operations")
+
+			// Verify the first operation is a start workflow operation with the expected workflow ID
+			startWorkflowOp := capturedRequest.Operations[0].GetStartWorkflow()
+			require.NotNil(t, startWorkflowOp, "First operation should be StartWorkflow")
+			assert.Equal(t, tc.workflowID, startWorkflowOp.WorkflowId,
+				"Start workflow operation should have the expected workflow ID")
+		})
+	}
+}
+
+// Test RecordWorkerHeartbeatRequest resource_id field (resource_id = 4)
+// Expected: Contains the worker grouping key
+func testRecordWorkerHeartbeatResourceID(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	service := workflowservicemock.NewMockWorkflowServiceClient(mockCtrl)
+
+	// Mock GetSystemInfo which gets called during client operations
+	service.EXPECT().GetSystemInfo(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(&workflowservice.GetSystemInfoResponse{}, nil).AnyTimes()
+
+	var capturedRequest *workflowservice.RecordWorkerHeartbeatRequest
+	service.EXPECT().
+		RecordWorkerHeartbeat(gomock.Any(), gomock.Any(), gomock.Any()).
+		Do(func(ctx context.Context, req *workflowservice.RecordWorkerHeartbeatRequest, opts ...interface{}) {
+			capturedRequest = req
+		}).
+		Return(&workflowservice.RecordWorkerHeartbeatResponse{}, nil).
+		Times(1)
+
+	// Create a client with a specific workerGroupingKey
+	wfClient := NewServiceClient(service, nil, ClientOptions{
+		Namespace: "test-namespace",
+	})
+
+	// Set the workerGroupingKey to our test value
+	wfClient.workerGroupingKey = "test-worker-grouping-key-123"
+
+	// Create a sharedNamespaceWorker and call sendHeartbeats
+	heartbeatCtx, heartbeatCancel := context.WithCancel(t.Context())
+	defer heartbeatCancel()
+
+	hw := &sharedNamespaceWorker{
+		client:          wfClient,
+		namespace:       "test-namespace",
+		workerCtx:       heartbeatCtx,
+		heartbeatCancel: heartbeatCancel,
+		callbacks: map[string]func() *workerpb.WorkerHeartbeat{
+			"test-worker": func() *workerpb.WorkerHeartbeat {
+				return &workerpb.WorkerHeartbeat{
+					WorkerIdentity: "test-worker-identity",
+				}
+			},
+		},
+	}
+
+	// Call sendHeartbeats which should construct and send the request
+	err := hw.sendHeartbeats()
+
+	// The operation should succeed
+	require.NoError(t, err)
+
+	// Validate the captured request
+	require.NotNil(t, capturedRequest, "RecordWorkerHeartbeatRequest should have been captured")
+	assert.Equal(t, "worker:test-worker-grouping-key-123", capturedRequest.ResourceId,
+		"ResourceId should match the worker grouping key")
+
+	// Additional validation
+	assert.Equal(t, "test-namespace", capturedRequest.Namespace,
+		"Namespace should be set correctly")
+	require.Len(t, capturedRequest.WorkerHeartbeat, 1,
+		"Should have one worker heartbeat")
+	assert.Equal(t, "test-worker-identity", capturedRequest.WorkerHeartbeat[0].WorkerIdentity,
+		"Worker identity should be set correctly")
+}

--- a/internal/worker.go
+++ b/internal/worker.go
@@ -49,7 +49,10 @@ type (
 		// Default: 1
 		MinimumNumberOfPollers int
 
-		// MaximumNumberOfPollers is the maximum number of pollers the worker is allowed scale up to.
+		// MaximumNumberOfPollers is the maximum number of pollers the worker is allowed to scale up to.
+		// Poller-group coverage takes precedence: the worker may exceed this value to
+		// maintain at least one poll per server-provided group. For workflow tasks,
+		// this coverage minimum applies independently to normal and sticky pollers.
 		//
 		// Default: 100
 		MaximumNumberOfPollers int


### PR DESCRIPTION
## Summary

Adds initial poller-group support for autoscaling workers in multi-cell namespaces.

- Stores a versioned, client-scoped snapshot of poller-group membership and weights. The snapshot is seeded by `DescribeNamespace` and updated from poll responses.
- Wakes autoscaling runners sharing the client whenever a newer group snapshot is accepted, regardless of which poller received the update.
- Adds group-aware polling for autoscaling Workflow, Activity, Nexus, and worker-command pollers.
- Maintains at least one Activity, Nexus, and worker-command poll per group.
- Maintains separate normal and sticky Workflow poll coverage for each group when sticky polling is enabled.
- Raises the autoscaling effective minimum when additional polls are required for group coverage. This may exceed the user-configured maximum, although actual polls remain limited by available task slots.
- Uses request-scoped leases so pending-poll accounting is released on success, empty responses, errors, cancellation, and shutdown.
- Distinguishes the group selected for the poll request from the group returned by the server.
- Forwards the response group ID through query, Nexus, and worker-command follow-up requests where routing requires it.
- Fixed pollers remain ungrouped, but their poll responses can publish newer group information to autoscaling pollers sharing the client.

## Current limitations

- Poller behavior cannot change dynamically after the worker starts. A running `SimpleMaximum` poller will not switch to autoscaling when poller-group information appears, and an autoscaling poller will not switch to `SimpleMaximum` when it disappears. Startup auto-enrollment only applies when poller behavior was left at its default; explicitly configured `SimpleMaximum` pollers remain fixed and ungrouped. Runtime transitions will be handled in a follow-up PR.
- Workflow `backlog_count_hint` is cell-specific, but this PR does not track it per poller group or use it to allocate floating capacity between normal and sticky polling. Normal and sticky currently have independent autoscaling runners with fixed queue kinds. Per-cell backlog-aware scheduling will be handled in a follow-up PR.

## Testing

Key tests cover:

- Workflow normal/sticky coordination:
  - `TestPollerGroupManagerReserveWorkflowPollStickyCoverageAfterNormalRelease` verifies that an additional sticky poll is blocked when normal coverage has been lost.
  - `TestAutoscalingWorkflowRunnerBlocksExtraNormalUntilStickyCoverage` verifies the inverse: excess normal polling waits until sticky coverage is established.
  - `TestPollerGroupManagerReserveWorkflowPollSatisfiesCoverageFirst` verifies that missing group coverage is filled before excess polls are allowed.
  - `TestPollerGroupManagerReserveWorkflowPollFillsCoverageBeforeWeights` verifies that coverage takes priority over weighted selection.
- Dynamic group membership and notification:
  - `TestAutoscalingPollerGroupAddRaisesRequiredMinimumAfterPollCompletion` verifies that adding a group raises the effective polling floor.
  - `TestAutoscalingPollerGroupRemovalLowersRequiredMinimum` verifies that removing a group lowers the floor and prevents future reservations for that group.
  - `TestAutoscalingPollerGroupUpdateWakesRunnerSharingStore` verifies that an update published through one manager wakes a runner attached to another manager sharing the client store.
- Snapshot consistency:
  - `TestPollerGroupInfoStoreOnlyAppliesNewerVersions`
  - `TestPollerGroupManagerEmptyUpdateClearsGroups`
- Lease correctness:
  - `TestPollerGroupLeaseReleaseUsesRequestGroupID`
  - `TestPollerGroupLeaseReleaseDoesNotAffectReaddedGroup`
- Poll and routing integration:
  - `TestDescribeNamespacePollerGroupsSeedWorkflowNormalAndStickyPolls`
  - `TestWorkflowEmptyPollResponseReplacesInvalidPollerGroup`
  - `TestWorkerCommandsMaintainPollerGroupCoverage`
  - `TestNexusCompletionForwardsPollerGroupID`
  - `TestNexusPollerCompletionUsesResponsePollerGroupID`
  - `TestNexusFailureForwardsPollerGroupID`
  - `TaskHandlersTestSuite.TestWorkflowTask_QueryResponseForwardsPollerGroupID`
  - `TestReportGrpcMessageTooLargeQueryForwardsPollerGroupID`

Focused race-enabled unit tests and `go run . check` pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core worker polling, autoscaling admission, and RPC metadata across workflow, activity, Nexus, and heartbeat paths; mis-routing or coverage bugs could affect multi-cell task delivery, though behavior is gated on autoscaling and extensive tests cover coordination edge cases.
> 
> **Overview**
> Adds **poller-group-aware autoscaling** so workers in multi-cell namespaces keep poll coverage aligned with server-provided groups and weights.
> 
> Each Temporal client now owns a **versioned `pollerGroupInfoStore`** (seeded from `DescribeNamespace`, updated from poll responses). Autoscaling **workflow** (normal and sticky, tracked separately), **activity**, **Nexus**, and **worker-command** pollers reserve a group lease before polling, set `PollerGroupId` on poll requests, and apply newer `PollerGroupsInfo` from responses. The autoscaling runner’s **effective minimum** rises to at least one poll per group (workflow normal/sticky independently), which can exceed the configured max poller count while **task slots** still cap how many polls actually run; extra capacity is spread by group weights after coverage is satisfied.
> 
> **Task completion paths** echo the poll response’s `PollerGroupId` on query, Nexus complete/fail, and related follow-ups so routing stays consistent when request and response groups differ. Fixed (`SimpleMaximum`) pollers stay ungrouped but can still publish group snapshots into the shared store for autoscaling peers on the same client.
> 
> Worker-option docs note that **maximum poller count may be overridden** for mandatory group coverage. Runtime flip from fixed to autoscaling when groups appear is explicitly deferred.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c145c604e6b725abe80299263956c9d44f3878f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->