### PR TITLE
Fix inaccurate deadlock detection error message

### DIFF
--- a/internal/internal_coroutines_test.go
+++ b/internal/internal_coroutines_test.go
@@ -1225,7 +1225,7 @@ func TestDeadlockDetectorAndAwaitRace(t *testing.T) {
 	defer d.Close()
 	// Expecting deadlock detection timeout instead of a data race.
 	err := d.ExecuteUntilAllBlocked(defaultDeadlockDetectionTimeout)
-	require.EqualError(t, err, "[TMPRL1101] Potential deadlock detected: workflow goroutine \"root\" didn't yield for over a second")
+	require.EqualError(t, err, "[TMPRL1101] Potential deadlock detected: workflow goroutine \"root\" didn't yield for over 1s")
 }
 
 func TestAwaitCancellation(t *testing.T) {
@@ -1936,7 +1936,7 @@ func TestDeadlockDetectorStackTrace(t *testing.T) {
 
 	var wfPanic *workflowPanicError
 	require.ErrorAs(t, err, &wfPanic)
-	require.Equal(t, `[TMPRL1101] Potential deadlock detected: workflow goroutine "sleeper" didn't yield for over a second`, wfPanic.Error())
+	require.Equal(t, `[TMPRL1101] Potential deadlock detected: workflow goroutine "sleeper" didn't yield for over 1s`, wfPanic.Error())
 	require.Regexp(t, `^coroutine sleeper \[running\]:\ntime\.Sleep\(0x[\da-f]+\)\n`, wfPanic.StackTrace())
 	require.Equal(t, 4, strings.Count(wfPanic.StackTrace(), "\n"), "2 stack frames expected")
 }

--- a/internal/internal_workflow.go
+++ b/internal/internal_workflow.go
@@ -1162,7 +1162,7 @@ func (s *coroutineState) call(timeout time.Duration) {
 			st = fmt.Sprintf("<%s>", err)
 		}
 		msg := fmt.Sprintf("[TMPRL1101] Potential deadlock detected: "+
-			"workflow goroutine %q didn't yield for over a second", s.name)
+			"workflow goroutine %q didn't yield for over %s", s.name, timeout)
 		s.closed.Store(true)
 		s.panicError = newWorkflowPanicError(msg, st)
 	}


### PR DESCRIPTION
## What was changed
Fix deadlock detection error message to match the user-configured timeout

## Why?
Error message was misleading

## Checklist
<!--- add/delete as needed --->

1. Closes #2418 

2. How was this tested: Modified the timeout test

3. Any docs updates needed? No
