### PR TITLE
Always respect SDK flags regardless of if GetSystemInfo works & enable per-RPC compression downgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ to docs, or any other relevant information.
 
 ## [Unreleased]
 
+### Fixed
+
+- Respect SDK flags already recorded in workflow history even when `GetSystemInfo` does not report
+  SDK metadata support.
+
 ### Added
 
 - Exposed `BackoffStartInterval` when continuing as new, which will delay the first task of the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ to docs, or any other relevant information.
 
 - Respect SDK flags already recorded in workflow history even when `GetSystemInfo` does not report
   SDK metadata support.
+- Only treat `GetSystemInfo` `UNIMPLEMENTED` responses as missing server capability support when
+  the error indicates an unknown method.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ to docs, or any other relevant information.
   SDK metadata support.
 - Only treat `GetSystemInfo` `UNIMPLEMENTED` responses as missing server capability support when
   the error indicates an unknown method.
+- Retry server RPCs without gzip compression when a method reports that gzip decompression is
+  unsupported, while continuing to use gzip for other methods.
 
 ### Added
 

--- a/client/client.go
+++ b/client/client.go
@@ -223,7 +223,9 @@ type (
 	GrpcCompression = internal.GrpcCompression
 
 	// GrpcCompressionGzip compresses outbound gRPC request bodies with gzip and
-	// accepts gzip-compressed responses. This is the default.
+	// accepts gzip-compressed responses. This is the default. If a specific
+	// server RPC does not support gzip, the client may retry that RPC without
+	// compression and continue using gzip for other RPCs.
 	GrpcCompressionGzip = internal.GrpcCompressionGzip
 
 	// GrpcCompressionNone disables gRPC request compression.

--- a/internal/client.go
+++ b/internal/client.go
@@ -55,7 +55,9 @@ type GrpcCompression interface {
 
 type (
 	// GrpcCompressionGzip compresses outbound gRPC request bodies with gzip and
-	// accepts gzip-compressed responses. This is the default.
+	// accepts gzip-compressed responses. This is the default. If a specific
+	// server RPC does not support gzip, the client may retry that RPC without
+	// compression and continue using gzip for other RPCs.
 	//
 	// Exposed as: [go.temporal.io/sdk/client.GrpcCompressionGzip]
 	GrpcCompressionGzip struct{}
@@ -1044,7 +1046,9 @@ type (
 		MaxPayloadSize int
 
 		// GrpcCompression controls transport-level gRPC compression for requests
-		// sent to the Temporal server.
+		// sent to the Temporal server. If gzip is enabled and a specific server
+		// RPC does not support gzip, the client may retry that RPC without
+		// compression and continue using gzip for other RPCs.
 		//
 		// default: &GrpcCompressionGzip{}
 		GrpcCompression GrpcCompression

--- a/internal/grpc_dialer.go
+++ b/internal/grpc_dialer.go
@@ -156,7 +156,8 @@ func requiredInterceptors(
 	case nil, *GrpcCompressionGzip:
 		interceptors = append(interceptors, newGzipDowngradeInterceptor())
 	}
-	interceptors = append(interceptors,
+	interceptors = append(
+		interceptors,
 		// Performs retries *IF* retry options are set for the call.
 		grpc_retry.UnaryClientInterceptor(),
 		// Prevents retrying grpc message too large errors, while allowing retries of other resource exhausted errors.

--- a/internal/grpc_dialer.go
+++ b/internal/grpc_dialer.go
@@ -195,7 +195,6 @@ func newGzipDowngradeInterceptor() grpc.UnaryClientInterceptor {
 		}
 		msg := strings.ToLower(err.Error())
 		if status.Code(err) != codes.Unimplemented ||
-			!strings.Contains(msg, grpcgzip.Name) ||
 			(!strings.Contains(msg, "decompress") &&
 				!strings.Contains(msg, "grpc-encoding") &&
 				!strings.Contains(msg, "compressor")) {

--- a/internal/grpc_dialer.go
+++ b/internal/grpc_dialer.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -13,8 +15,10 @@ import (
 	"go.temporal.io/sdk/internal/common/retry"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/backoff"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/encoding"
 	grpcgzip "google.golang.org/grpc/encoding/gzip"
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/metadata"
@@ -147,13 +151,19 @@ func requiredInterceptors(
 		// By default the grpc retry interceptor *is disabled*, preventing accidental use of retries.
 		// We add call options for retry configuration based on the values present in the context.
 		retry.NewRetryOptionsInterceptor(excludeInternalFromRetry),
+	}
+	switch clientOptions.ConnectionOptions.GrpcCompression.(type) {
+	case nil, *GrpcCompressionGzip:
+		interceptors = append(interceptors, newGzipDowngradeInterceptor())
+	}
+	interceptors = append(interceptors,
 		// Performs retries *IF* retry options are set for the call.
 		grpc_retry.UnaryClientInterceptor(),
 		// Prevents retrying grpc message too large errors, while allowing retries of other resource exhausted errors.
 		retry.GrpcMessageTooLargeErrorInterceptor,
 		// Report metrics for every call made to the server.
 		metrics.NewGRPCInterceptor(clientOptions.MetricsHandler, attemptSuffix, clientOptions.DisableErrorCodeMetricTags),
-	}
+	)
 	if clientOptions.HeadersProvider != nil {
 		interceptors = append(interceptors, headersProviderInterceptor(clientOptions.HeadersProvider))
 	}
@@ -170,6 +180,37 @@ func requiredInterceptors(
 	// Add namespace provider interceptor
 	interceptors = append(interceptors, namespaceProviderInterceptor())
 	return interceptors
+}
+
+func newGzipDowngradeInterceptor() grpc.UnaryClientInterceptor {
+	var gzipUnsupportedMethods sync.Map
+	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		if _, ok := gzipUnsupportedMethods.Load(method); ok {
+			return invoker(ctx, method, req, reply, cc, appendIdentityCompressor(opts)...)
+		}
+
+		err := invoker(ctx, method, req, reply, cc, opts...)
+		if err == nil {
+			return nil
+		}
+		msg := strings.ToLower(err.Error())
+		if status.Code(err) != codes.Unimplemented ||
+			!strings.Contains(msg, grpcgzip.Name) ||
+			(!strings.Contains(msg, "decompress") &&
+				!strings.Contains(msg, "grpc-encoding") &&
+				!strings.Contains(msg, "compressor")) {
+			return err
+		}
+
+		gzipUnsupportedMethods.Store(method, struct{}{})
+		return invoker(ctx, method, req, reply, cc, appendIdentityCompressor(opts)...)
+	}
+}
+
+func appendIdentityCompressor(opts []grpc.CallOption) []grpc.CallOption {
+	identityOpts := make([]grpc.CallOption, len(opts), len(opts)+1)
+	copy(identityOpts, opts)
+	return append(identityOpts, grpc.UseCompressor(encoding.Identity))
 }
 
 func namespaceProviderInterceptor() grpc.UnaryClientInterceptor {

--- a/internal/grpc_dialer_test.go
+++ b/internal/grpc_dialer_test.go
@@ -117,12 +117,15 @@ func TestHeadersProvider_IncludedWithHeadersProvider(t *testing.T) {
 }
 
 func TestMissingGetServerInfo(t *testing.T) {
-	// Make a gRPC server that has everything unimplemented
+	// Make a gRPC server that responds like an older server missing GetSystemInfo.
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
-	srv := grpc.NewServer()
+	srv := grpc.NewServer(grpc.UnknownServiceHandler(func(_ interface{}, _ grpc.ServerStream) error {
+		return status.Error(codes.Unimplemented, "unknown method GetSystemInfo")
+	}))
+	defer srv.Stop()
 	go func() {
-		if err := srv.Serve(l); err != nil {
+		if err := srv.Serve(l); err != nil && !errors.Is(err, grpc.ErrServerStopped) {
 			log.Fatal(err)
 		}
 	}()

--- a/internal/grpc_dialer_test.go
+++ b/internal/grpc_dialer_test.go
@@ -26,6 +26,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	grpcgzip "google.golang.org/grpc/encoding/gzip"
 	"google.golang.org/grpc/health"
 	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/metadata"
@@ -107,13 +108,13 @@ func TestHeadersProvider_Error(t *testing.T) {
 
 func TestHeadersProvider_NotIncludedWhenNil(t *testing.T) {
 	interceptors := requiredInterceptors(&ClientOptions{}, nil)
-	require.Equal(t, 7, len(interceptors))
+	require.Equal(t, 8, len(interceptors))
 }
 
 func TestHeadersProvider_IncludedWithHeadersProvider(t *testing.T) {
 	opts := &ClientOptions{HeadersProvider: authHeadersProvider{token: "test-auth-token"}}
 	interceptors := requiredInterceptors(opts, nil)
-	require.Equal(t, 8, len(interceptors))
+	require.Equal(t, 9, len(interceptors))
 }
 
 func TestMissingGetServerInfo(t *testing.T) {
@@ -394,6 +395,83 @@ func TestGrpcCompression(t *testing.T) {
 	}
 }
 
+func TestGrpcCompressionDowngradesUnsupportedMethod(t *testing.T) {
+	srv, err := startTestGRPCServer()
+	require.NoError(t, err)
+	defer srv.Stop()
+	srv.rejectGzipGetSystemInfo = true
+	srv.statsHandler.reset()
+
+	client, err := DialClient(context.Background(), ClientOptions{HostPort: srv.addr})
+	require.NoError(t, err)
+	defer client.Close()
+
+	getSystemInfoMethod := workflowServiceMethod("GetSystemInfo")
+	getSystemInfoHistory := srv.statsHandler.compressionHistoryForMethod(getSystemInfoMethod)
+	require.Len(t, getSystemInfoHistory, 2)
+	require.Equal(t, grpcgzip.Name, getSystemInfoHistory[0])
+	require.NotEqual(t, grpcgzip.Name, getSystemInfoHistory[1])
+
+	_, err = client.WorkflowService().GetSystemInfo(context.Background(), &workflowservice.GetSystemInfoRequest{})
+	require.NoError(t, err)
+	getSystemInfoHistory = srv.statsHandler.compressionHistoryForMethod(getSystemInfoMethod)
+	require.Len(t, getSystemInfoHistory, 3)
+	require.Equal(t, 1, countCompression(getSystemInfoHistory, grpcgzip.Name))
+	require.NotEqual(t, grpcgzip.Name, getSystemInfoHistory[2])
+
+	_, err = client.WorkflowService().SignalWorkflowExecution(context.Background(),
+		&workflowservice.SignalWorkflowExecutionRequest{
+			Namespace:  "test-namespace",
+			SignalName: strings.Repeat("test-signal", 100),
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t,
+		grpcgzip.Name,
+		srv.statsHandler.compressionForMethod(workflowServiceMethod("SignalWorkflowExecution")),
+	)
+}
+
+func TestGrpcCompressionNoneDoesNotInstallDowngrade(t *testing.T) {
+	srv, err := startTestGRPCServer()
+	require.NoError(t, err)
+	defer srv.Stop()
+	srv.rejectGzipGetSystemInfo = true
+	srv.statsHandler.reset()
+
+	client, err := DialClient(context.Background(), ClientOptions{
+		HostPort: srv.addr,
+		ConnectionOptions: ConnectionOptions{
+			GrpcCompression: &GrpcCompressionNone{},
+		},
+	})
+	require.NoError(t, err)
+	defer client.Close()
+
+	getSystemInfoHistory := srv.statsHandler.compressionHistoryForMethod(workflowServiceMethod("GetSystemInfo"))
+	require.Len(t, getSystemInfoHistory, 1)
+	require.NotEqual(t, grpcgzip.Name, getSystemInfoHistory[0])
+}
+
+func TestGrpcCompressionDoesNotDowngradeGenericUnimplemented(t *testing.T) {
+	srv, err := startTestGRPCServer()
+	require.NoError(t, err)
+	defer srv.Stop()
+	srv.getSystemInfoResponseError = status.Error(codes.Unimplemented, "gzip feature is not implemented")
+	srv.statsHandler.reset()
+
+	client, err := NewLazyClient(ClientOptions{HostPort: srv.addr})
+	require.NoError(t, err)
+	defer client.Close()
+
+	_, err = client.WorkflowService().GetSystemInfo(context.Background(), &workflowservice.GetSystemInfoRequest{})
+	require.Error(t, err)
+
+	getSystemInfoHistory := srv.statsHandler.compressionHistoryForMethod(workflowServiceMethod("GetSystemInfo"))
+	require.Len(t, getSystemInfoHistory, 1)
+	require.Equal(t, grpcgzip.Name, getSystemInfoHistory[0])
+}
+
 func TestCustomResolver(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -666,6 +744,7 @@ type testGRPCServer struct {
 	healthServer                         *health.Server
 	statsHandler                         *compressionStatsHandler
 	sigWfCount                           int32
+	rejectGzipGetSystemInfo              bool
 	getSystemInfoRequestContext          context.Context
 	getSystemInfoResponse                workflowservice.GetSystemInfoResponse
 	getSystemInfoResponseError           error
@@ -727,6 +806,10 @@ func (t *testGRPCServer) GetSystemInfo(
 	req *workflowservice.GetSystemInfoRequest,
 ) (*workflowservice.GetSystemInfoResponse, error) {
 	t.getSystemInfoRequestContext = ctx
+	if t.rejectGzipGetSystemInfo &&
+		t.statsHandler.compressionForMethod(workflowServiceMethod("GetSystemInfo")) == grpcgzip.Name {
+		return nil, status.Error(codes.Unimplemented, `grpc: Decompressor is not installed for grpc-encoding "gzip"`)
+	}
 	return &t.getSystemInfoResponse, t.getSystemInfoResponseError
 }
 
@@ -748,8 +831,9 @@ func (t *testGRPCServer) resetSignalWorkflowInvokeCount() {
 }
 
 type compressionStatsHandler struct {
-	mu                  sync.Mutex
-	compressionByMethod map[string]string
+	mu                         sync.Mutex
+	compressionByMethod        map[string]string
+	compressionHistoryByMethod map[string][]string
 }
 
 func (h *compressionStatsHandler) TagRPC(ctx context.Context, _ *stats.RPCTagInfo) context.Context {
@@ -766,7 +850,14 @@ func (h *compressionStatsHandler) HandleRPC(_ context.Context, s stats.RPCStats)
 	if h.compressionByMethod == nil {
 		h.compressionByMethod = make(map[string]string)
 	}
+	if h.compressionHistoryByMethod == nil {
+		h.compressionHistoryByMethod = make(map[string][]string)
+	}
 	h.compressionByMethod[inHeader.FullMethod] = inHeader.Compression
+	h.compressionHistoryByMethod[inHeader.FullMethod] = append(
+		h.compressionHistoryByMethod[inHeader.FullMethod],
+		inHeader.Compression,
+	)
 }
 
 func (h *compressionStatsHandler) TagConn(ctx context.Context, _ *stats.ConnTagInfo) context.Context {
@@ -779,4 +870,31 @@ func (h *compressionStatsHandler) compressionForMethod(method string) string {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	return h.compressionByMethod[method]
+}
+
+func (h *compressionStatsHandler) compressionHistoryForMethod(method string) []string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return append([]string(nil), h.compressionHistoryByMethod[method]...)
+}
+
+func (h *compressionStatsHandler) reset() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.compressionByMethod = nil
+	h.compressionHistoryByMethod = nil
+}
+
+func workflowServiceMethod(method string) string {
+	return "/" + workflowservice.WorkflowService_ServiceDesc.ServiceName + "/" + method
+}
+
+func countCompression(history []string, compression string) int {
+	var count int
+	for _, c := range history {
+		if c == compression {
+			count++
+		}
+	}
+	return count
 }

--- a/internal/internal_flags.go
+++ b/internal/internal_flags.go
@@ -113,15 +113,14 @@ func newSDKFlagSet(capabilities *workflowservice.GetSystemInfoResponse_Capabilit
 	}
 }
 
-// tryUse returns true if this flag may currently be used. If record is true, always returns
-// true and records the flag as being used.
+// tryUse returns true if this flag may currently be used.
 func (sf *sdkFlags) tryUse(flag sdkFlag, record bool) bool {
-	if !sf.capabilities.GetSdkMetadata() {
-		return false
-	}
-
 	if sf.currentFlags[flag] || sf.newFlags[flag] {
 		return true
+	}
+
+	if !sf.capabilities.GetSdkMetadata() {
+		return false
 	}
 
 	if !record {
@@ -138,9 +137,6 @@ func (sf *sdkFlags) tryUse(flag sdkFlag, record bool) bool {
 
 // set marks a flag as in current use regardless of replay status.
 func (sf *sdkFlags) set(flags ...sdkFlag) {
-	if !sf.capabilities.GetSdkMetadata() {
-		return
-	}
 	for _, flag := range flags {
 		sf.currentFlags[flag] = true
 	}

--- a/internal/internal_flags_test.go
+++ b/internal/internal_flags_test.go
@@ -41,10 +41,11 @@ func TestLoadFlagOverridesFromEnv(t *testing.T) {
 }
 
 func TestSet(t *testing.T) {
-	t.Run("metadata disabled drops flags", func(t *testing.T) {
+	t.Run("metadata disabled keeps flags from history", func(t *testing.T) {
 		flags := newSDKFlagSet(&metadataDisabled)
 		flags.set(SDKFlagChildWorkflowErrorExecution)
-		require.False(t, flags.currentFlags[SDKFlagChildWorkflowErrorExecution])
+		require.True(t, flags.currentFlags[SDKFlagChildWorkflowErrorExecution])
+		require.Empty(t, flags.gatherNewSDKFlags(), "set() flags are not 'new'")
 	})
 
 	t.Run("metadata enabled keeps flags", func(t *testing.T) {
@@ -58,6 +59,7 @@ func TestSet(t *testing.T) {
 func TestTryUse(t *testing.T) {
 	tests := []struct {
 		name        string
+		capability  *workflowservice.GetSystemInfoResponse_Capabilities
 		inHistory   bool
 		record      bool
 		flagDefault bool
@@ -66,6 +68,7 @@ func TestTryUse(t *testing.T) {
 	}{
 		{
 			name:        "in history returns true regardless of default or record",
+			capability:  &metadataEnabled,
 			inHistory:   true,
 			record:      false,
 			flagDefault: false,
@@ -74,6 +77,7 @@ func TestTryUse(t *testing.T) {
 		},
 		{
 			name:        "default=true record=true enables and records flag",
+			capability:  &metadataEnabled,
 			inHistory:   false,
 			record:      true,
 			flagDefault: true,
@@ -82,6 +86,7 @@ func TestTryUse(t *testing.T) {
 		},
 		{
 			name:        "default=true record=false returns false",
+			capability:  &metadataEnabled,
 			inHistory:   false,
 			record:      false,
 			flagDefault: true,
@@ -90,9 +95,28 @@ func TestTryUse(t *testing.T) {
 		},
 		{
 			name:        "default=false record=true returns false",
+			capability:  &metadataEnabled,
 			inHistory:   false,
 			record:      true,
 			flagDefault: false,
+			wantResult:  false,
+			wantNewFlag: false,
+		},
+		{
+			name:        "metadata disabled in history returns true",
+			capability:  &metadataDisabled,
+			inHistory:   true,
+			record:      false,
+			flagDefault: false,
+			wantResult:  true,
+			wantNewFlag: false,
+		},
+		{
+			name:        "metadata disabled record=true returns false",
+			capability:  &metadataDisabled,
+			inHistory:   false,
+			record:      true,
+			flagDefault: true,
 			wantResult:  false,
 			wantNewFlag: false,
 		},
@@ -105,7 +129,7 @@ func TestTryUse(t *testing.T) {
 
 			sdkFlagsAllowed[SDKFlagBlockedSelectorSignalReceive] = tt.flagDefault
 
-			flags := newSDKFlagSet(&metadataEnabled)
+			flags := newSDKFlagSet(tt.capability)
 			if tt.inHistory {
 				flags.set(SDKFlagBlockedSelectorSignalReceive)
 			}

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"math"
 	"reflect"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -34,6 +35,7 @@ import (
 	"go.temporal.io/api/workflowservice/v1"
 
 	"go.temporal.io/sdk/converter"
+	"go.temporal.io/sdk/internal/common/backoff"
 	"go.temporal.io/sdk/internal/common/metrics"
 	"go.temporal.io/sdk/internal/common/retry"
 	"go.temporal.io/sdk/internal/common/serializer"
@@ -1585,12 +1587,20 @@ func (wc *WorkflowClient) loadCapabilities(ctx context.Context) (*workflowservic
 		return capabilities, nil
 	}
 
-	// Fetch the capabilities
-	grpcCtx, cancel := newGRPCContext(ctx, grpcTimeout(wc.getSystemInfoTimeout))
-	defer cancel()
-	resp, err := wc.workflowService.GetSystemInfo(grpcCtx, &workflowservice.GetSystemInfoRequest{})
-	// We ignore unimplemented
-	if _, isUnimplemented := err.(*serviceerror.Unimplemented); err != nil && !isUnimplemented {
+	var resp *workflowservice.GetSystemInfoResponse
+	err := backoff.Retry(ctx, func() error {
+		grpcCtx, cancel := newGRPCContext(ctx, grpcTimeout(wc.getSystemInfoTimeout))
+		defer cancel()
+		var err error
+		resp, err = wc.workflowService.GetSystemInfo(grpcCtx, &workflowservice.GetSystemInfoRequest{})
+		if isUnknownMethodUnimplemented(err) {
+			return nil
+		}
+		return err
+	}, createDynamicServiceRetryPolicy(ctx), func(err error) bool {
+		return isUnimplemented(err)
+	})
+	if err != nil {
 		return nil, fmt.Errorf("failed reaching server: %w", err)
 	}
 	if resp != nil && resp.Capabilities != nil {
@@ -1607,6 +1617,16 @@ func (wc *WorkflowClient) loadCapabilities(ctx context.Context) (*workflowservic
 	wc.excludeInternalFromRetry.Store(capabilities.InternalErrorDifferentiation)
 	wc.capabilitiesLock.Unlock()
 	return capabilities, nil
+}
+
+func isUnknownMethodUnimplemented(err error) bool {
+	return isUnimplemented(err) &&
+		strings.Contains(strings.ToLower(err.Error()), "unknown method")
+}
+
+func isUnimplemented(err error) bool {
+	var unimplemented *serviceerror.Unimplemented
+	return errors.As(err, &unimplemented) || status.Code(err) == codes.Unimplemented
 }
 
 // Get namespace capabilities, lazily fetching from server if not already obtained.

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -1611,8 +1611,11 @@ func (wc *WorkflowClient) loadCapabilities(ctx context.Context) (*workflowservic
 
 func isUnknownMethodUnimplemented(err error) bool {
 	var unimplemented *serviceerror.Unimplemented
-	return (errors.As(err, &unimplemented) || status.Code(err) == codes.Unimplemented) &&
-		strings.Contains(strings.ToLower(err.Error()), "unknown method")
+	if !errors.As(err, &unimplemented) && status.Code(err) != codes.Unimplemented {
+		return false
+	}
+	errMsg := strings.ToLower(err.Error())
+	return strings.Contains(errMsg, "unknown method") || strings.Contains(errMsg, "not implemented")
 }
 
 // Get namespace capabilities, lazily fetching from server if not already obtained.

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -35,7 +35,6 @@ import (
 	"go.temporal.io/api/workflowservice/v1"
 
 	"go.temporal.io/sdk/converter"
-	"go.temporal.io/sdk/internal/common/backoff"
 	"go.temporal.io/sdk/internal/common/metrics"
 	"go.temporal.io/sdk/internal/common/retry"
 	"go.temporal.io/sdk/internal/common/serializer"
@@ -1587,20 +1586,11 @@ func (wc *WorkflowClient) loadCapabilities(ctx context.Context) (*workflowservic
 		return capabilities, nil
 	}
 
-	var resp *workflowservice.GetSystemInfoResponse
-	err := backoff.Retry(ctx, func() error {
-		grpcCtx, cancel := newGRPCContext(ctx, grpcTimeout(wc.getSystemInfoTimeout))
-		defer cancel()
-		var err error
-		resp, err = wc.workflowService.GetSystemInfo(grpcCtx, &workflowservice.GetSystemInfoRequest{})
-		if isUnknownMethodUnimplemented(err) {
-			return nil
-		}
-		return err
-	}, createDynamicServiceRetryPolicy(ctx), func(err error) bool {
-		return isUnimplemented(err)
-	})
-	if err != nil {
+	// Fetch the capabilities
+	grpcCtx, cancel := newGRPCContext(ctx, grpcTimeout(wc.getSystemInfoTimeout))
+	defer cancel()
+	resp, err := wc.workflowService.GetSystemInfo(grpcCtx, &workflowservice.GetSystemInfoRequest{})
+	if err != nil && !isUnknownMethodUnimplemented(err) {
 		return nil, fmt.Errorf("failed reaching server: %w", err)
 	}
 	if resp != nil && resp.Capabilities != nil {
@@ -1620,13 +1610,9 @@ func (wc *WorkflowClient) loadCapabilities(ctx context.Context) (*workflowservic
 }
 
 func isUnknownMethodUnimplemented(err error) bool {
-	return isUnimplemented(err) &&
-		strings.Contains(strings.ToLower(err.Error()), "unknown method")
-}
-
-func isUnimplemented(err error) bool {
 	var unimplemented *serviceerror.Unimplemented
-	return errors.As(err, &unimplemented) || status.Code(err) == codes.Unimplemented
+	return (errors.As(err, &unimplemented) || status.Code(err) == codes.Unimplemented) &&
+		strings.Contains(strings.ToLower(err.Error()), "unknown method")
 }
 
 // Get namespace capabilities, lazily fetching from server if not already obtained.

--- a/internal/internal_workflow_client_test.go
+++ b/internal/internal_workflow_client_test.go
@@ -1409,6 +1409,77 @@ func (s *workflowClientTestSuite) TearDownTest() {
 	s.mockCtrl.Finish() // assert mock’s expectations
 }
 
+func TestLoadCapabilitiesUnknownMethodUnimplementedUsesEmptyCapabilities(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	service := workflowservicemock.NewMockWorkflowServiceClient(mockCtrl)
+	service.EXPECT().
+		GetSystemInfo(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil, serviceerror.NewUnimplemented("unknown method GetSystemInfo")).
+		Times(1)
+
+	client := &WorkflowClient{
+		workflowService:          service,
+		excludeInternalFromRetry: &atomic.Bool{},
+		getSystemInfoTimeout:     defaultGetSystemInfoTimeout,
+	}
+
+	capabilities, err := client.loadCapabilities(context.Background())
+	require.NoError(t, err)
+	require.True(t, proto.Equal(&workflowservice.GetSystemInfoResponse_Capabilities{}, capabilities))
+}
+
+func TestLoadCapabilitiesNonUnknownMethodUnimplementedRetries(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	wantCapabilities := &workflowservice.GetSystemInfoResponse_Capabilities{SdkMetadata: true}
+	service := workflowservicemock.NewMockWorkflowServiceClient(mockCtrl)
+	gomock.InOrder(
+		service.EXPECT().
+			GetSystemInfo(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(nil, serviceerror.NewUnimplemented("frontend has not loaded GetSystemInfo")),
+		service.EXPECT().
+			GetSystemInfo(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(&workflowservice.GetSystemInfoResponse{Capabilities: wantCapabilities}, nil),
+	)
+
+	client := &WorkflowClient{
+		workflowService:          service,
+		excludeInternalFromRetry: &atomic.Bool{},
+		getSystemInfoTimeout:     defaultGetSystemInfoTimeout,
+	}
+
+	capabilities, err := client.loadCapabilities(context.Background())
+	require.NoError(t, err)
+	require.True(t, proto.Equal(wantCapabilities, capabilities))
+}
+
+func TestLoadCapabilitiesNonUnknownMethodUnimplementedFails(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	service := workflowservicemock.NewMockWorkflowServiceClient(mockCtrl)
+	service.EXPECT().
+		GetSystemInfo(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil, serviceerror.NewUnimplemented("frontend has not loaded GetSystemInfo")).
+		Times(1)
+
+	client := &WorkflowClient{
+		workflowService:          service,
+		excludeInternalFromRetry: &atomic.Bool{},
+		getSystemInfoTimeout:     defaultGetSystemInfoTimeout,
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancel()
+
+	_, err := client.loadCapabilities(ctx)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "failed reaching server")
+	require.ErrorContains(t, err, "frontend has not loaded GetSystemInfo")
+}
+
 func (s *workflowClientTestSuite) TestSignalWithStartWorkflow() {
 	signalName := "my signal"
 	signalInput := []byte("my signal input")

--- a/internal/internal_workflow_client_test.go
+++ b/internal/internal_workflow_client_test.go
@@ -1430,32 +1430,6 @@ func TestLoadCapabilitiesUnknownMethodUnimplementedUsesEmptyCapabilities(t *test
 	require.True(t, proto.Equal(&workflowservice.GetSystemInfoResponse_Capabilities{}, capabilities))
 }
 
-func TestLoadCapabilitiesNonUnknownMethodUnimplementedRetries(t *testing.T) {
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-
-	wantCapabilities := &workflowservice.GetSystemInfoResponse_Capabilities{SdkMetadata: true}
-	service := workflowservicemock.NewMockWorkflowServiceClient(mockCtrl)
-	gomock.InOrder(
-		service.EXPECT().
-			GetSystemInfo(gomock.Any(), gomock.Any(), gomock.Any()).
-			Return(nil, serviceerror.NewUnimplemented("frontend has not loaded GetSystemInfo")),
-		service.EXPECT().
-			GetSystemInfo(gomock.Any(), gomock.Any(), gomock.Any()).
-			Return(&workflowservice.GetSystemInfoResponse{Capabilities: wantCapabilities}, nil),
-	)
-
-	client := &WorkflowClient{
-		workflowService:          service,
-		excludeInternalFromRetry: &atomic.Bool{},
-		getSystemInfoTimeout:     defaultGetSystemInfoTimeout,
-	}
-
-	capabilities, err := client.loadCapabilities(context.Background())
-	require.NoError(t, err)
-	require.True(t, proto.Equal(wantCapabilities, capabilities))
-}
-
 func TestLoadCapabilitiesNonUnknownMethodUnimplementedFails(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
@@ -1471,10 +1445,8 @@ func TestLoadCapabilitiesNonUnknownMethodUnimplementedFails(t *testing.T) {
 		excludeInternalFromRetry: &atomic.Bool{},
 		getSystemInfoTimeout:     defaultGetSystemInfoTimeout,
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
-	defer cancel()
 
-	_, err := client.loadCapabilities(ctx)
+	_, err := client.loadCapabilities(context.Background())
 	require.Error(t, err)
 	require.ErrorContains(t, err, "failed reaching server")
 	require.ErrorContains(t, err, "frontend has not loaded GetSystemInfo")
@@ -2811,7 +2783,7 @@ func TestUpdate(t *testing.T) {
 		require.NotNil(t, output.Result)
 		payloads := converter.GetPayloads(output.Result)
 		require.NotNil(t, payloads)
-                require.Equal(t, outPayloads, payloads)
+		require.Equal(t, outPayloads, payloads)
 		require.Len(t, payloads.GetPayloads(), 1)
 	})
 	t.Run("sync error exposes failure proto", func(t *testing.T) {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Title

## Why?
If `GetSystemInfo` returns `UNIMPLEMENTED` for whatever reason (recent ex: gzip compression not working specifically for this endpoint), then we will fail to respect flags already written into history. Fix that.

Additionally allow downgrading to not using compression if a specific RPC fails when trying to use it.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
Upgrade existing tests

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
