### PR TITLE
CI: Move check into its own job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,31 @@ permissions:
   actions: read
 
 jobs:
+  check:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    permissions:
+      contents: read
+      checks: write
+      statuses: write
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          submodules: recursive
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: stable
+
+      - name: Check
+        run: go run . check
+        working-directory: ./internal/cmd/build
+
   unit-test:
     strategy:
       fail-fast: false
@@ -37,10 +62,6 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: ${{ matrix.go-version }}
-
-      - name: Check
-        run: go run . check
-        working-directory: ./internal/cmd/build
 
       - name: Unit test
         run: go run . unit-test


### PR DESCRIPTION
## What was changed
Moved `go check` into its own job

## Why?
No need to run it on every single os+go-version combo that unit tests run on. Also better parallelizes CI (although integration tests are the bottleneck today).

More improvements to come.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change; no product code or secrets handling is modified.
> 
> **Overview**
> **`go run . check`** is no longer run inside every **`unit-test`** matrix cell (OS × oldstable/stable). It now runs in a separate **`check`** job that only uses **stable** Go on **ubuntu-latest**, **macos-latest**, and **windows-latest**.
> 
> That cuts duplicate static-analysis runs and lets **check** run in parallel with **unit-test** and integration jobs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 916cdbef0c87586611f31216e15c1d2e4eca98df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->