### PR TITLE
CI: shard integration tests

### DIFF
--- a/.github/integration-shards.yml
+++ b/.github/integration-shards.yml
@@ -1,8 +1,7 @@
 integration-shards:
-  core:
+  core-a:
     - TestChildWorkflowByName_NoGoroutineLeak
     - TestDynamicWorkflowTestSuite
-    - TestIntegrationSuite
     - Test_StructuredLogger
     - TestInterceptors
     - TestWorkflowTestSuite_NexusSyncOperation
@@ -16,6 +15,12 @@ integration-shards:
     - TestWorkflowTestSuite_NexusListeners
     - TestWorkflowTestSuite_WorkflowRunOperation_ScheduleToStartTimeout
     - TestWorkflowTestSuite_WorkflowRunOperation_StartToCloseTimeout
+
+  core-b:
+    - "@regex:TestIntegrationSuite/Test(A|B|C|D|E|F|G|H|I|J|K|L|M).*"
+
+  core-c:
+    - "@regex:TestIntegrationSuite/Test(N|O|P|Q|R|S|T|U|V|W|X|Y|Z).*"
 
   payload:
     - TestExternalStorageSuite

--- a/.github/integration-shards.yml
+++ b/.github/integration-shards.yml
@@ -1,0 +1,53 @@
+integration-shards:
+  core:
+    - TestChildWorkflowByName_NoGoroutineLeak
+    - TestDynamicWorkflowTestSuite
+    - TestIntegrationSuite
+    - Test_StructuredLogger
+    - TestInterceptors
+    - TestWorkflowTestSuite_NexusSyncOperation
+    - TestWorkflowTestSuite_WorkflowRunOperation
+    - TestWorkflowTestSuite_WorkflowRunOperation_ScheduleToCloseTimeout
+    - TestWorkflowTestSuite_WorkflowRunOperation_WithCancel
+    - TestWorkflowTestSuite_WorkflowRunOperation_MultipleCallers
+    - TestWorkflowTestSuite_NexusSyncOperation_ScheduleToCloseTimeout
+    - TestWorkflowTestSuite_NexusSyncOperation_ClientMethods_Panic
+    - TestWorkflowTestSuite_MockNexusOperation
+    - TestWorkflowTestSuite_NexusListeners
+    - TestWorkflowTestSuite_WorkflowRunOperation_ScheduleToStartTimeout
+    - TestWorkflowTestSuite_WorkflowRunOperation_StartToCloseTimeout
+
+  payload:
+    - TestExternalStorageSuite
+    - TestPayloadLimitsTestSuite
+
+  nexus:
+    - TestNexusSyncOperation
+    - TestNexusWorkflowRunOperation
+    - TestOperationSummary
+    - TestOperationInfo
+    - TestSyncOperationFromWorkflow
+    - TestInvalidOperationInput
+    - TestAsyncOperationFromWorkflow
+    - TestAsyncOperationFromWorkflow_CancellationTypes
+    - TestAsyncOperationFromWorkflow_MultipleCallers
+    - TestAsyncOperationCompletionCustomFailureConverter
+    - TestNewNexusClientValidation
+    - TestNexusTracingInterceptor
+    - TestNexusTimeoutInteraction
+    - TestNexusSignalOperationLinks
+    - TestNexusMultiSignalOperationLinks
+    - TestNexusAsyncSignalOperationLinks
+
+  worker:
+    - TestAsyncBindingsTestSuite
+    - TestWorkerDeploymentTestSuite
+    - TestWorkerHeartbeatSuite
+    - TestWorkerTunerTestSuite
+    - TestWorkerVersioningTestSuite
+
+  replay:
+    - TestReplay
+    - TestReplayTestSuite
+    - TestReplayCustomConverter
+    - TestReplayDeadlockDetection

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-intel, macos-arm, windows-latest]
         go-version: ["oldstable", "stable"]
-        shard: [core, payload, nexus, worker, replay]
+        shard: [core-a, core-b, core-c, payload, nexus, worker, replay]
         include:
           - os: macos-intel
             runsOn: macos-15-intel
@@ -86,7 +86,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-intel, macos-arm, windows-latest]
         go-version: ["oldstable", "stable"]
-        shard: [core, payload, nexus, worker, replay]
+        shard: [core-a, core-b, core-c, payload, nexus, worker, replay]
         include:
           - os: macos-intel
             runsOn: macos-15-intel

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-intel, macos-arm, windows-latest]
         go-version: ["oldstable", "stable"]
+        shard: [core, payload, nexus, worker, replay]
         include:
           - os: macos-intel
             runsOn: macos-15-intel
@@ -74,7 +75,7 @@ jobs:
           go-version: ${{ matrix.go-version }}
 
       - name: Integration tests (without cache)
-        run: go run . integration-test -dev-server
+        run: go run . integration-test -dev-server -shard ${{ matrix.shard }}
         working-directory: ./internal/cmd/build
         env:
           WORKFLOW_CACHE_SIZE: "0"
@@ -85,6 +86,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-intel, macos-arm, windows-latest]
         go-version: ["oldstable", "stable"]
+        shard: [core, payload, nexus, worker, replay]
         include:
           - os: macos-intel
             runsOn: macos-15-intel
@@ -107,7 +109,7 @@ jobs:
           go-version: ${{ matrix.go-version }}
 
       - name: Integration tests (with cache)
-        run: go run . integration-test -dev-server
+        run: go run . integration-test -dev-server -shard ${{ matrix.shard }}
         working-directory: ./internal/cmd/build
 
   docker-compose-test:

--- a/internal/cmd/build/go.mod
+++ b/internal/cmd/build/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/BurntSushi/toml v1.4.1-0.20240526193622-a339e1f7089c
 	github.com/kisielk/errcheck v1.8.0
 	go.temporal.io/sdk v1.32.1
+	gopkg.in/yaml.v3 v3.0.1
 	honnef.co/go/tools v0.6.0
 )
 
@@ -36,7 +37,6 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260120221211-b8f7ae30c516 // indirect
 	google.golang.org/grpc v1.79.3 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 replace go.temporal.io/sdk => ../../../

--- a/internal/cmd/build/main.go
+++ b/internal/cmd/build/main.go
@@ -13,6 +13,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"sort"
 	"strings"
@@ -20,6 +21,7 @@ import (
 
 	_ "github.com/BurntSushi/toml"
 	_ "github.com/kisielk/errcheck/errcheck"
+	"gopkg.in/yaml.v3"
 	_ "honnef.co/go/tools/staticcheck"
 
 	"go.temporal.io/sdk/client"
@@ -35,6 +37,7 @@ func main() {
 
 const coverageDir = ".build/coverage"
 const githubStepSummaryMaxDetailBytes = 64 * 1024
+const integrationShardManifestPath = ".github/integration-shards.yml"
 
 type builder struct {
 	thisDir string
@@ -52,19 +55,23 @@ func newBuilder() *builder {
 
 func (b *builder) run() error {
 	if len(os.Args) < 2 {
-		return fmt.Errorf("missing command name, 'check', 'integration-test', or 'unit-test' required")
+		return fmt.Errorf("missing command name, 'check', 'integration-test', 'integration-shard-regex', 'integration-shard-validate', or 'unit-test' required")
 	}
 	switch os.Args[1] {
 	case "check":
 		return b.check()
 	case "integration-test":
 		return b.integrationTest()
+	case "integration-shard-regex":
+		return b.integrationShardRegex()
+	case "integration-shard-validate":
+		return b.integrationShardValidate()
 	case "merge-coverage-files":
 		return b.mergeCoverageFiles()
 	case "unit-test":
 		return b.unitTest()
 	default:
-		return fmt.Errorf("unrecognized command %q, 'check', 'integration-test', or 'unit-test' required", os.Args[1])
+		return fmt.Errorf("unrecognized command %q, 'check', 'integration-test', 'integration-shard-regex', 'integration-shard-validate', or 'unit-test' required", os.Args[1])
 	}
 }
 
@@ -100,8 +107,19 @@ func (b *builder) integrationTest() error {
 	packagesFlag := flagSet.String("packages", "./...", "Packages passed to go test")
 	devServerFlag := flagSet.Bool("dev-server", false, "Use an embedded dev server")
 	coverageFileFlag := flagSet.String("coverage-file", "", "If set, enables coverage output to this filename")
+	shardFlag := flagSet.String("shard", "", "Integration test shard from "+integrationShardManifestPath)
 	if err := flagSet.Parse(os.Args[2:]); err != nil {
 		return fmt.Errorf("failed parsing flags: %w", err)
+	}
+	if *shardFlag != "" {
+		if *runFlag != "" {
+			return fmt.Errorf("-shard cannot be combined with -run")
+		}
+		shardRegex, err := b.integrationShardRegexForName(*shardFlag)
+		if err != nil {
+			return err
+		}
+		*runFlag = shardRegex
 	}
 
 	// Also accept coverage file as env var
@@ -201,6 +219,176 @@ func (b *builder) integrationTest() error {
 		return fmt.Errorf("integration test failed: %w", err)
 	}
 
+	return nil
+}
+
+type integrationShardManifest struct {
+	IntegrationShards map[string][]string `yaml:"integration-shards"`
+}
+
+func (b *builder) integrationShardRegex() error {
+	if len(os.Args) != 3 {
+		return fmt.Errorf("integration-shard-regex requires a shard name")
+	}
+
+	shardRegex, err := b.integrationShardRegexForName(os.Args[2])
+	if err != nil {
+		return err
+	}
+	fmt.Println(shardRegex)
+	return nil
+}
+
+func (b *builder) integrationShardRegexForName(shardName string) (string, error) {
+	manifest, discovered, err := b.loadAndValidateIntegrationShards()
+	if err != nil {
+		return "", err
+	}
+
+	tests, ok := manifest.IntegrationShards[shardName]
+	if !ok {
+		var shardNames []string
+		for name := range manifest.IntegrationShards {
+			shardNames = append(shardNames, name)
+		}
+		sort.Strings(shardNames)
+		return "", fmt.Errorf("unknown integration shard %q, available shards: %s", shardName, strings.Join(shardNames, ", "))
+	}
+	if len(tests) == 0 {
+		return "", fmt.Errorf("integration shard %q has no tests", shardName)
+	}
+
+	discoveredSet := map[string]struct{}{}
+	for _, testName := range discovered {
+		discoveredSet[testName] = struct{}{}
+	}
+	parts := make([]string, 0, len(tests))
+	for _, testName := range tests {
+		if _, ok := discoveredSet[testName]; !ok {
+			return "", fmt.Errorf("integration shard %q includes unknown test %q", shardName, testName)
+		}
+		parts = append(parts, regexp.QuoteMeta(testName))
+	}
+	return fmt.Sprintf("^(%s)$", strings.Join(parts, "|")), nil
+}
+
+func (b *builder) integrationShardValidate() error {
+	_, _, err := b.loadAndValidateIntegrationShards()
+	return err
+}
+
+func (b *builder) loadAndValidateIntegrationShards() (*integrationShardManifest, []string, error) {
+	manifest, err := b.loadIntegrationShardManifest()
+	if err != nil {
+		return nil, nil, err
+	}
+	discovered, err := b.discoverIntegrationTests()
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := validateIntegrationShardManifest(manifest, discovered); err != nil {
+		return nil, nil, err
+	}
+	return manifest, discovered, nil
+}
+
+func (b *builder) loadIntegrationShardManifest() (*integrationShardManifest, error) {
+	manifestPath := filepath.Join(b.rootDir, integrationShardManifestPath)
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed reading %s: %w", integrationShardManifestPath, err)
+	}
+	var manifest integrationShardManifest
+	if err := yaml.Unmarshal(data, &manifest); err != nil {
+		return nil, fmt.Errorf("failed parsing %s: %w", integrationShardManifestPath, err)
+	}
+	if len(manifest.IntegrationShards) == 0 {
+		return nil, fmt.Errorf("%s must define at least one integration shard", integrationShardManifestPath)
+	}
+	return &manifest, nil
+}
+
+func (b *builder) discoverIntegrationTests() ([]string, error) {
+	cmd := b.cmdFromRoot("go", "test", "-list", ".", "./...")
+	cmd.Dir = filepath.Join(b.rootDir, "test")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("failed listing integration tests: %w\n%s", err, string(output))
+	}
+	return parseGoTestListOutput(string(output)), nil
+}
+
+func parseGoTestListOutput(output string) []string {
+	testSet := map[string]struct{}{}
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "Test") {
+			testSet[line] = struct{}{}
+		}
+	}
+	tests := make([]string, 0, len(testSet))
+	for testName := range testSet {
+		tests = append(tests, testName)
+	}
+	sort.Strings(tests)
+	return tests
+}
+
+func validateIntegrationShardManifest(manifest *integrationShardManifest, discovered []string) error {
+	discoveredSet := map[string]struct{}{}
+	for _, testName := range discovered {
+		discoveredSet[testName] = struct{}{}
+	}
+
+	assignments := map[string][]string{}
+	for shardName, tests := range manifest.IntegrationShards {
+		if len(tests) == 0 {
+			return fmt.Errorf("integration shard %q has no tests", shardName)
+		}
+		for _, testName := range tests {
+			if strings.TrimSpace(testName) == "" {
+				return fmt.Errorf("integration shard %q contains an empty test name", shardName)
+			}
+			assignments[testName] = append(assignments[testName], shardName)
+		}
+	}
+
+	var unknown []string
+	var duplicates []string
+	for testName, shardNames := range assignments {
+		if _, ok := discoveredSet[testName]; !ok {
+			unknown = append(unknown, testName)
+		}
+		if len(shardNames) > 1 {
+			sort.Strings(shardNames)
+			duplicates = append(duplicates, fmt.Sprintf("%s in %s", testName, strings.Join(shardNames, ", ")))
+		}
+	}
+
+	var missing []string
+	for _, testName := range discovered {
+		if _, ok := assignments[testName]; !ok {
+			missing = append(missing, testName)
+		}
+	}
+
+	sort.Strings(unknown)
+	sort.Strings(duplicates)
+	sort.Strings(missing)
+
+	var problems []string
+	if len(missing) > 0 {
+		problems = append(problems, "unassigned integration tests: "+strings.Join(missing, ", "))
+	}
+	if len(unknown) > 0 {
+		problems = append(problems, "unknown integration tests in shard manifest: "+strings.Join(unknown, ", "))
+	}
+	if len(duplicates) > 0 {
+		problems = append(problems, "integration tests assigned to multiple shards: "+strings.Join(duplicates, "; "))
+	}
+	if len(problems) > 0 {
+		return fmt.Errorf("%s is out of sync: %s", integrationShardManifestPath, strings.Join(problems, "; "))
+	}
 	return nil
 }
 

--- a/internal/cmd/build/main.go
+++ b/internal/cmd/build/main.go
@@ -38,6 +38,7 @@ func main() {
 const coverageDir = ".build/coverage"
 const githubStepSummaryMaxDetailBytes = 64 * 1024
 const integrationShardManifestPath = ".github/integration-shards.yml"
+const integrationShardRegexPrefix = "@regex:"
 
 type builder struct {
 	thisDir string
@@ -194,8 +195,13 @@ func (b *builder) integrationTest() error {
 		defer func() { _ = devServer.Stop() }()
 	}
 
+	testTimeout := "15m"
+	if *shardFlag != "" {
+		testTimeout = "10m"
+	}
+
 	// Run integration test
-	args := []string{"go", "test", "-count", "1", "-race", "-v", "-timeout", "15m"}
+	args := []string{"go", "test", "-count", "1", "-race", "-v", "-timeout", testTimeout}
 	env := append(os.Environ(), "DISABLE_SERVER_1_25_TESTS=1")
 	if *runFlag != "" {
 		args = append(args, "-run", *runFlag)
@@ -257,17 +263,36 @@ func (b *builder) integrationShardRegexForName(shardName string) (string, error)
 	if len(tests) == 0 {
 		return "", fmt.Errorf("integration shard %q has no tests", shardName)
 	}
+	if len(tests) > 1 {
+		for _, testName := range tests {
+			if strings.HasPrefix(testName, integrationShardRegexPrefix) {
+				return "", fmt.Errorf("integration shard %q cannot mix an explicit regex with other entries", shardName)
+			}
+		}
+	}
 
 	discoveredSet := map[string]struct{}{}
 	for _, testName := range discovered {
 		discoveredSet[testName] = struct{}{}
 	}
 	parts := make([]string, 0, len(tests))
+	hasExplicitRegex := false
 	for _, testName := range tests {
+		if regex, ok := strings.CutPrefix(testName, integrationShardRegexPrefix); ok {
+			if _, err := regexp.Compile(regex); err != nil {
+				return "", fmt.Errorf("integration shard %q includes invalid regex %q: %w", shardName, regex, err)
+			}
+			hasExplicitRegex = true
+			parts = append(parts, regex)
+			continue
+		}
 		if _, ok := discoveredSet[testName]; !ok {
 			return "", fmt.Errorf("integration shard %q includes unknown test %q", shardName, testName)
 		}
 		parts = append(parts, regexp.QuoteMeta(testName))
+	}
+	if hasExplicitRegex {
+		return strings.Join(parts, "|"), nil
 	}
 	return fmt.Sprintf("^(%s)$", strings.Join(parts, "|")), nil
 }
@@ -341,15 +366,35 @@ func validateIntegrationShardManifest(manifest *integrationShardManifest, discov
 	}
 
 	assignments := map[string][]string{}
+	regexAssignments := map[string][]string{}
 	for shardName, tests := range manifest.IntegrationShards {
 		if len(tests) == 0 {
 			return fmt.Errorf("integration shard %q has no tests", shardName)
 		}
+		regexCount := 0
 		for _, testName := range tests {
 			if strings.TrimSpace(testName) == "" {
 				return fmt.Errorf("integration shard %q contains an empty test name", shardName)
 			}
+			if regex, ok := strings.CutPrefix(testName, integrationShardRegexPrefix); ok {
+				regexCount++
+				if _, err := regexp.Compile(regex); err != nil {
+					return fmt.Errorf("integration shard %q contains invalid regex %q: %w", shardName, regex, err)
+				}
+				topLevelTest := regex
+				if slashIndex := strings.IndexByte(topLevelTest, '/'); slashIndex >= 0 {
+					topLevelTest = topLevelTest[:slashIndex]
+				}
+				if topLevelTest == "" {
+					return fmt.Errorf("integration shard %q contains regex %q without a top-level test prefix", shardName, regex)
+				}
+				regexAssignments[topLevelTest] = append(regexAssignments[topLevelTest], shardName)
+				continue
+			}
 			assignments[testName] = append(assignments[testName], shardName)
+		}
+		if regexCount > 0 && len(tests) > 1 {
+			return fmt.Errorf("integration shard %q cannot mix an explicit regex with other entries", shardName)
 		}
 	}
 
@@ -359,15 +404,25 @@ func validateIntegrationShardManifest(manifest *integrationShardManifest, discov
 		if _, ok := discoveredSet[testName]; !ok {
 			unknown = append(unknown, testName)
 		}
+		if _, ok := regexAssignments[testName]; ok {
+			duplicates = append(duplicates, fmt.Sprintf("%s assigned both directly and by regex", testName))
+		}
 		if len(shardNames) > 1 {
 			sort.Strings(shardNames)
 			duplicates = append(duplicates, fmt.Sprintf("%s in %s", testName, strings.Join(shardNames, ", ")))
 		}
 	}
+	for testName := range regexAssignments {
+		if _, ok := discoveredSet[testName]; !ok {
+			unknown = append(unknown, testName)
+		}
+	}
 
 	var missing []string
 	for _, testName := range discovered {
-		if _, ok := assignments[testName]; !ok {
+		_, assignedDirectly := assignments[testName]
+		_, assignedByRegex := regexAssignments[testName]
+		if !assignedDirectly && !assignedByRegex {
 			missing = append(missing, testName)
 		}
 	}

--- a/internal/cmd/build/main_test.go
+++ b/internal/cmd/build/main_test.go
@@ -116,3 +116,53 @@ func TestAppendTestFailureSummary(t *testing.T) {
 		t.Fatalf("summary not written correctly:\n%s", string(data))
 	}
 }
+
+func TestParseGoTestListOutput(t *testing.T) {
+	tests := parseGoTestListOutput(strings.Join([]string{
+		"TestB",
+		"ok  \tgo.temporal.io/sdk/test\t0.001s",
+		"?   \tgo.temporal.io/sdk/test/nexusclient\t[no test files]",
+		"TestA",
+		"TestB",
+	}, "\n"))
+
+	if got, want := strings.Join(tests, ","), "TestA,TestB"; got != want {
+		t.Fatalf("unexpected tests: got %q want %q", got, want)
+	}
+}
+
+func TestValidateIntegrationShardManifest(t *testing.T) {
+	manifest := &integrationShardManifest{
+		IntegrationShards: map[string][]string{
+			"a": {"TestA"},
+			"b": {"TestB"},
+		},
+	}
+
+	if err := validateIntegrationShardManifest(manifest, []string{"TestA", "TestB"}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestValidateIntegrationShardManifestDetectsProblems(t *testing.T) {
+	manifest := &integrationShardManifest{
+		IntegrationShards: map[string][]string{
+			"a": {"TestA", "TestUnknown"},
+			"b": {"TestA"},
+		},
+	}
+
+	err := validateIntegrationShardManifest(manifest, []string{"TestA", "TestMissing"})
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	for _, want := range []string{
+		"unassigned integration tests: TestMissing",
+		"unknown integration tests in shard manifest: TestUnknown",
+		"integration tests assigned to multiple shards: TestA in a, b",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("expected error to contain %q, got %q", want, err.Error())
+		}
+	}
+}

--- a/internal/cmd/build/main_test.go
+++ b/internal/cmd/build/main_test.go
@@ -144,6 +144,35 @@ func TestValidateIntegrationShardManifest(t *testing.T) {
 	}
 }
 
+func TestValidateIntegrationShardManifestAllowsRegexShard(t *testing.T) {
+	manifest := &integrationShardManifest{
+		IntegrationShards: map[string][]string{
+			"a": {integrationShardRegexPrefix + "TestA/(One|Two)"},
+			"b": {"TestB"},
+		},
+	}
+
+	if err := validateIntegrationShardManifest(manifest, []string{"TestA", "TestB"}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestValidateIntegrationShardManifestRejectsMixedRegexShard(t *testing.T) {
+	manifest := &integrationShardManifest{
+		IntegrationShards: map[string][]string{
+			"a": {integrationShardRegexPrefix + "TestA/One", "TestB"},
+		},
+	}
+
+	err := validateIntegrationShardManifest(manifest, []string{"TestA", "TestB"})
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	if !strings.Contains(err.Error(), `integration shard "a" cannot mix an explicit regex with other entries`) {
+		t.Fatalf("unexpected error: %q", err.Error())
+	}
+}
+
 func TestValidateIntegrationShardManifestDetectsProblems(t *testing.T) {
 	manifest := &integrationShardManifest{
 		IntegrationShards: map[string][]string{
@@ -165,4 +194,97 @@ func TestValidateIntegrationShardManifestDetectsProblems(t *testing.T) {
 			t.Fatalf("expected error to contain %q, got %q", want, err.Error())
 		}
 	}
+}
+
+func TestValidateIntegrationShardManifestDetectsDirectAndRegexDuplicate(t *testing.T) {
+	manifest := &integrationShardManifest{
+		IntegrationShards: map[string][]string{
+			"a": {integrationShardRegexPrefix + "TestA/One"},
+			"b": {"TestA"},
+		},
+	}
+
+	err := validateIntegrationShardManifest(manifest, []string{"TestA"})
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	if !strings.Contains(err.Error(), "TestA assigned both directly and by regex") {
+		t.Fatalf("unexpected error: %q", err.Error())
+	}
+}
+
+func TestIntegrationShardRegexForNameAnchorsDirectTests(t *testing.T) {
+	builder := newTestIntegrationShardBuilder(t, strings.Join([]string{
+		"integration-shards:",
+		"  a:",
+		"    - TestA",
+		"    - TestB",
+		"    - TestIntegrationSuite",
+		"",
+	}, "\n"))
+
+	got, err := builder.integrationShardRegexForName("a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "^(TestA|TestB|TestIntegrationSuite)$" {
+		t.Fatalf("unexpected shard regex: %q", got)
+	}
+}
+
+func TestIntegrationShardRegexForNamePreservesExplicitRegex(t *testing.T) {
+	builder := newTestIntegrationShardBuilder(t, strings.Join([]string{
+		"integration-shards:",
+		"  a:",
+		"    - \"@regex:TestIntegrationSuite/Test(A|B).*\"",
+		"  b:",
+		"    - TestA",
+		"    - TestB",
+		"",
+	}, "\n"))
+
+	got, err := builder.integrationShardRegexForName("a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "TestIntegrationSuite/Test(A|B).*" {
+		t.Fatalf("unexpected shard regex: %q", got)
+	}
+}
+
+func newTestIntegrationShardBuilder(t *testing.T, manifest string) *builder {
+	t.Helper()
+
+	rootDir := t.TempDir()
+	for _, dir := range []string{
+		filepath.Join(rootDir, ".github"),
+		filepath.Join(rootDir, "test"),
+	} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	files := map[string]string{
+		filepath.Join(rootDir, "go.mod"):                            "module example.com/integration-shards\n\ngo 1.24\n",
+		filepath.Join(rootDir, ".github", "integration-shards.yml"): manifest,
+		filepath.Join(rootDir, "test", "integration_test.go"): strings.Join([]string{
+			"package test",
+			"",
+			"import \"testing\"",
+			"",
+			"func TestA(t *testing.T) {}",
+			"func TestB(t *testing.T) {}",
+			"func TestIntegrationSuite(t *testing.T) {",
+			"\tt.Run(\"TestA\", func(t *testing.T) {})",
+			"\tt.Run(\"TestB\", func(t *testing.T) {})",
+			"}",
+			"",
+		}, "\n"),
+	}
+	for path, content := range files {
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return &builder{rootDir: rootDir}
 }


### PR DESCRIPTION
## What was changed
Shard integration tests so we can run more jobs in parallel in CI, speeding up CI.

Also added a check that validates the manifest before generating the regex. It runs:

```
go test -list . ./...
```

from the test/ directory, parses discovered top-level tests, and fails if any discovered test is missing from the manifest, assigned to multiple shards, or listed in the manifest but no longer exists. This prevents new integration tests from being silently skipped.

## Why?
Faster CI.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI configuration and the internal build helper; SDK runtime behavior is unchanged, and manifest sync checks reduce the risk of incomplete test coverage.
> 
> **Overview**
> **Shards integration tests across CI** so each matrix job runs a subset instead of the full `test/` suite, increasing parallelism and shortening wall-clock time.
> 
> Adds **`.github/integration-shards.yml`** with five shards (`core`, `payload`, `nexus`, `worker`, `replay`) mapping top-level `Test*` names. The **`integration-test-no-cache`** and **`integration-test-with-cache`** workflows gain a `shard` matrix axis and pass **`-shard ${{ matrix.shard }}`** to the build CLI.
> 
> The **`internal/cmd/build`** tool loads that manifest, maps a shard to a `go test -run` regex, and adds **`integration-shard-regex`** / **`integration-shard-validate`** plus **`-shard`** (mutually exclusive with **`-run`**). Validation runs **`go test -list . ./...`** under `test/` and fails if tests are unassigned, duplicated across shards, or listed but missing. **`gopkg.in/yaml.v3`** is a direct dependency; unit tests cover list parsing and manifest validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b400b10d200178303b83bb27df7bcbe8bdec413. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->