### PR TITLE
CI: Tighten unit test timeout to 5 minutes

### DIFF
--- a/internal/cmd/build/main.go
+++ b/internal/cmd/build/main.go
@@ -278,7 +278,7 @@ func (b *builder) unitTest() error {
 	log.Printf("Running unit tests in dirs: %v", testDirs)
 	for _, testDir := range testDirs {
 		// Run unit test
-		args := []string{"go", "test", "-count", "1", "-race", "-v", "-timeout", "15m"}
+		args := []string{"go", "test", "-count", "1", "-race", "-v", "-timeout", "5m"}
 		if *runFlag != "" {
 			args = append(args, "-run", *runFlag)
 		}


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->
Set individual test package timeout to 5 minutes

## Why?
<!-- Tell your future self why have you made these changes -->
When unit tests hang, they hang for the full 15 minutes, which makes CI times go an extra 10+ minutes before failing. From Codex's search of the last 50 runs on main, the longest package test took less than 3 minutes. So a 5 minute cutoff seems okay.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only timeout tuning for unit tests; no production or application logic changes. The only risk is a legitimately slow unit package failing sooner than before.
> 
> **Overview**
> Reduces the per-package `go test` **timeout from 15 minutes to 5 minutes** in the internal build runner’s unit-test loop (`internal/cmd/build/main.go`).
> 
> The goal is faster CI failure when a package hangs, based on recent main-branch runs where package tests stayed under ~3 minutes. **Integration tests are unchanged** and still use a 15-minute timeout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 420d4c53ad3cd7d04ccc47ad6037fd9aa61decb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->