### PR TITLE
Fix ambiguities caused by activity and workflow registration aliasing

### DIFF
--- a/internal/internal_activity.go
+++ b/internal/internal_activity.go
@@ -273,10 +273,9 @@ func getValidatedActivityFunction(f interface{}, args []interface{}, registry *r
 		if err := validateFunctionArgs(f, args, false); err != nil {
 			return nil, err
 		}
-		fnName, _ = getFunctionName(f)
-		if alias, ok := registry.getActivityAlias(fnName); ok {
-			fnName = alias
-		}
+		// Resolve the function to the name it should be scheduled/dispatched
+		// under, honoring the registry's aliasing mode.
+		fnName = getActivityFunctionName(registry, f)
 
 	default:
 		return nil, fmt.Errorf(

--- a/internal/internal_event_handlers.go
+++ b/internal/internal_event_handlers.go
@@ -1020,6 +1020,13 @@ func (wc *workflowEnvironmentImpl) TryUse(flag sdkFlag) bool {
 	return wc.sdkFlags.tryUse(flag, !wc.isReplay)
 }
 
+func (wc *workflowEnvironmentImpl) UseRegistrationAntiAliasing() bool {
+	// Read-only: never record here. The flag is recorded once, at workflow start
+	// (handleWorkflowExecutionStarted), so an execution that started before the
+	// worker enabled anti-aliasing keeps using legacy resolution on replay.
+	return wc.sdkFlags.tryUse(SDKFlagRegistrationAntiAliasing, false)
+}
+
 func (wc *workflowEnvironmentImpl) QueueUpdate(name string, f func()) {
 	wc.bufferedUpdateRequests[name] = append(wc.bufferedUpdateRequests[name], f)
 }
@@ -1504,6 +1511,15 @@ func (weh *workflowExecutionEventHandlerImpl) handleWorkflowExecutionStarted(
 	// replay sees the _final_ value of applied flags, not intermediate values
 	// as the value varies by WFT)
 	weh.sdkFlags.tryUse(SDKFlagProtocolMessageCommand, !weh.isReplay)
+
+	// Record anti-aliasing at workflow start (and only when the worker opted in),
+	// for the same reason: name resolution regenerates commands on every replay,
+	// so the mode must be fixed for the whole execution. An execution that
+	// started before the worker enabled anti-aliasing has no flag in its history
+	// and therefore keeps using legacy resolution on replay — no NDE.
+	if weh.registry.antiAliasing {
+		weh.sdkFlags.tryUse(SDKFlagRegistrationAntiAliasing, !weh.isReplay)
+	}
 
 	// Invoke the workflow.
 	weh.workflowDefinition.Execute(weh, attributes.Header, attributes.Input)

--- a/internal/internal_flags.go
+++ b/internal/internal_flags.go
@@ -38,7 +38,15 @@ const (
 	// we will fallback onto the default data converter. If the default DC fails, the user DC error will be returned.
 	SDKFlagMemoUserDCEncode               = 7
 	SDKFlagWorkflowNewChannelLostMessages = 8
-	SDKFlagUnknown                        = math.MaxUint32
+	// SDKFlagRegistrationAntiAliasing records that a workflow execution resolves
+	// workflow/activity function references to their registered name (see
+	// worker.Options.RegistrationAntiAliasing). It is set once, at genuine
+	// workflow start, and only when the worker opted in. Because it is persisted
+	// in history, an execution that started before the worker enabled
+	// anti-aliasing (no flag) keeps using the legacy resolution on replay, so
+	// enabling the mode never breaks in-flight workflows.
+	SDKFlagRegistrationAntiAliasing = 9
+	SDKFlagUnknown                  = math.MaxUint32
 )
 
 // sdkFlagsAllowed holds the enabled state for each flag.
@@ -55,6 +63,10 @@ var sdkFlagsAllowed = map[sdkFlag]bool{
 	SDKFlagCancelAwaitTimerOnCondition:    false,
 	SDKFlagMemoUserDCEncode:               true,
 	SDKFlagWorkflowNewChannelLostMessages: true,
+	// Allowed so opted-in workers can record it; recording is additionally gated
+	// on worker.Options.RegistrationAntiAliasing, so it never activates for
+	// workers that did not opt in.
+	SDKFlagRegistrationAntiAliasing: true,
 }
 
 func init() {

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -655,6 +655,9 @@ type registry struct {
 	workflowVersioningBehaviorMap map[string]VersioningBehavior
 	activityFuncMap               map[string]activity
 	activityAliasMap              map[string]string
+	workflowRegisteredNameMap     map[string]string
+	activityRegisteredNameMap     map[string]string
+	antiAliasing                  bool
 	dynamicWorkflow               interface{}
 	dynamicWorkflowOptions        DynamicRegisterWorkflowOptions
 	dynamicActivity               activity
@@ -664,6 +667,7 @@ type registry struct {
 
 type registryOptions struct {
 	disableAliasing bool
+	antiAliasing    bool
 }
 
 func (r *registry) RegisterWorkflow(af interface{}) {
@@ -718,6 +722,9 @@ func (r *registry) RegisterWorkflowWithOptions(
 
 	if len(alias) > 0 && r.workflowAliasMap != nil {
 		r.workflowAliasMap[fnName] = alias
+	}
+	if r.antiAliasing {
+		r.workflowRegisteredNameMap[funcRegistryKey(wf)] = registerName
 	}
 }
 
@@ -799,6 +806,9 @@ func (r *registry) RegisterActivityWithOptions(
 	if len(alias) > 0 && r.activityAliasMap != nil {
 		r.activityAliasMap[fnName] = alias
 	}
+	if r.antiAliasing {
+		r.activityRegisteredNameMap[funcRegistryKey(af)] = registerName
+	}
 }
 
 func (r *registry) registerActivityStructWithOptions(aStruct interface{}, options RegisterActivityOptions) error {
@@ -830,6 +840,14 @@ func (r *registry) registerActivityStructWithOptions(aStruct interface{}, option
 			}
 		}
 		r.activityFuncMap[registerName] = &activityExecutor{name: registerName, fn: methodValue.Interface()}
+		if r.antiAliasing {
+			// Struct-registered methods must also be resolvable by function
+			// reference (e.g. ExecuteActivity(ctx, s.DoWork)); record their
+			// registered name here since this path never touches the alias map.
+			// A reflect-created method value has no usable runtime name, so build
+			// the key from the struct type and method name instead.
+			r.activityRegisteredNameMap[structMethodRegistryKey(structType, name)] = registerName
+		}
 		count++
 	}
 	if count == 0 {
@@ -907,6 +925,99 @@ func (r *registry) getActivityAlias(fnName string) (string, bool) {
 	defer r.Unlock()
 	alias, ok := r.activityAliasMap[fnName]
 	return alias, ok
+}
+
+// getActivityRegisteredName returns the name an activity function was registered
+// under, keyed by its fully qualified name. Only populated in anti-aliasing mode.
+func (r *registry) getActivityRegisteredName(fullName string) (string, bool) {
+	r.Lock()
+	defer r.Unlock()
+	name, ok := r.activityRegisteredNameMap[fullName]
+	return name, ok
+}
+
+// getWorkflowRegisteredName returns the name a workflow function was registered
+// under, keyed by its fully qualified name. Only populated in anti-aliasing mode.
+func (r *registry) getWorkflowRegisteredName(fullName string) (string, bool) {
+	r.Lock()
+	defer r.Unlock()
+	name, ok := r.workflowRegisteredNameMap[fullName]
+	return name, ok
+}
+
+// detectRegistrationAmbiguities returns a warning for each registered function
+// whose registered name differs from the name that a reference to that function
+// resolves to under the current mode. When they differ, invoking the
+// activity/workflow by function reference (or by a string that collides with
+// another function's short name) silently reaches a different registration —
+// this is the class of bug that anti-aliasing eliminates. Returns nil in
+// anti-aliasing mode, which has no such ambiguity.
+func (r *registry) detectRegistrationAmbiguities() []string {
+	if r.antiAliasing {
+		return nil
+	}
+
+	type entry struct {
+		registeredName string
+		fn             interface{}
+	}
+	var activities, workflows []entry
+
+	// Snapshot the registered functions under lock; the resolver helpers below
+	// acquire the same (non-reentrant) lock, so they must run outside it.
+	r.Lock()
+	for name, a := range r.activityFuncMap {
+		ae, ok := a.(*activityExecutor)
+		if !ok || ae.fn == nil || reflect.TypeOf(ae.fn).Kind() != reflect.Func {
+			continue
+		}
+		activities = append(activities, entry{name, ae.fn})
+	}
+	for name, wf := range r.workflowFuncMap {
+		if wf == nil || reflect.TypeOf(wf).Kind() != reflect.Func {
+			continue
+		}
+		workflows = append(workflows, entry{name, wf})
+	}
+	r.Unlock()
+
+	var warnings []string
+	for _, e := range activities {
+		if resolved := getActivityFunctionName(r, e.fn); resolved != e.registeredName {
+			warnings = append(warnings, fmt.Sprintf(
+				"activity registered as %q is unreachable by function reference: a reference to it resolves to %q instead",
+				e.registeredName, resolved))
+		}
+	}
+	for _, e := range workflows {
+		if resolved, err := getWorkflowFunctionName(r, e.fn); err == nil && resolved != e.registeredName {
+			warnings = append(warnings, fmt.Sprintf(
+				"workflow registered as %q is unreachable by function reference: a reference to it resolves to %q instead",
+				e.registeredName, resolved))
+		}
+	}
+	return warnings
+}
+
+// warnOnRegistrationAmbiguities prints a warning to stdout if any registration
+// ambiguities are detected, recommending the anti-aliasing mode. It is a no-op
+// in anti-aliasing mode or when no ambiguities exist.
+func (r *registry) warnOnRegistrationAmbiguities() {
+	warnings := r.detectRegistrationAmbiguities()
+	if len(warnings) == 0 {
+		return
+	}
+	var b strings.Builder
+	b.WriteString("WARNING: Ambiguous workflow/activity registration detected. ")
+	b.WriteString("The following functions cannot be invoked by function reference because their name collides with another registration:\n")
+	for _, w := range warnings {
+		b.WriteString("  - ")
+		b.WriteString(w)
+		b.WriteString("\n")
+	}
+	b.WriteString("To resolve this, set worker.Options.RegistrationAntiAliasing = true, which resolves function references to the exact name they were registered under. ")
+	b.WriteString("Note: enabling it changes the scheduled type names for the affected registrations, so enable it on a new worker/task queue or after confirming no in-flight workflows depend on the current (ambiguous) behavior.\n")
+	fmt.Print(b.String())
 }
 
 func (r *registry) addActivityWithLock(fnName string, a activity) {
@@ -1085,7 +1196,15 @@ func newRegistryWithOptions(options registryOptions) *registry {
 		activityFuncMap:               make(map[string]activity),
 		nexusServices:                 make(map[string]*nexus.Service),
 	}
-	if !options.disableAliasing {
+	// Anti-aliasing takes precedence over the legacy DisableRegistrationAliasing
+	// option. In anti-aliasing mode the legacy short-name alias maps are left nil
+	// (so no alias substitution ever happens); we instead track each function's
+	// registered name keyed by its unique fully qualified name.
+	if options.antiAliasing {
+		r.antiAliasing = true
+		r.workflowRegisteredNameMap = make(map[string]string)
+		r.activityRegisteredNameMap = make(map[string]string)
+	} else if !options.disableAliasing {
 		r.workflowAliasMap = make(map[string]string)
 		r.activityAliasMap = make(map[string]string)
 	}
@@ -1340,6 +1459,10 @@ func (aw *AggregatedWorker) Start() error {
 // start the worker. This method is memoized using sync.OnceValue in memoizedStart.
 func (aw *AggregatedWorker) start() error {
 	aw.started.Store(true)
+
+	// Warn about registration ambiguities now that all registrations are done.
+	// No-op in anti-aliasing mode or when there are no ambiguities.
+	aw.registry.warnOnRegistrationAmbiguities()
 
 	if err := initBinaryChecksum(); err != nil {
 		return fmt.Errorf("failed to get executable checksum: %v", err)
@@ -1735,6 +1858,11 @@ type WorkflowReplayerOptions struct {
 	// documentation for that field for more information.
 	DisableRegistrationAliasing bool
 
+	// Resolve function references to their registered name during registration.
+	// This should be set if it was set on worker.Options.RegistrationAntiAliasing
+	// when originally run. See documentation for that field for more information.
+	RegistrationAntiAliasing bool
+
 	// Optional: Enable logging in replay.
 	// In the workflow code you can use workflow.GetLogger(ctx) to write logs. By default, the logger will skip log
 	// entry during replay mode so you won't see duplicate logs. This option will enable the logging in replay mode.
@@ -1791,7 +1919,7 @@ func NewWorkflowReplayer(options WorkflowReplayerOptions) (*WorkflowReplayer, er
 		return nil, fmt.Errorf("invalid ExternalStorage options: %w", err)
 	}
 
-	registry := newRegistryWithOptions(registryOptions{disableAliasing: options.DisableRegistrationAliasing})
+	registry := newRegistryWithOptions(registryOptions{disableAliasing: options.DisableRegistrationAliasing, antiAliasing: options.RegistrationAntiAliasing})
 	registry.interceptors = options.Interceptors
 	return &WorkflowReplayer{
 		registry:                    registry,
@@ -2407,7 +2535,7 @@ func NewAggregatedWorker(client *WorkflowClient, taskQueue string, options Worke
 	processTestTags(&options, &workerParams)
 
 	// worker specific registry
-	registry := newRegistryWithOptions(registryOptions{disableAliasing: options.DisableRegistrationAliasing})
+	registry := newRegistryWithOptions(registryOptions{disableAliasing: options.DisableRegistrationAliasing, antiAliasing: options.RegistrationAntiAliasing})
 	// Build set of interceptors using the applicable client ones first (being
 	// careful not to append to the existing slice)
 	registry.interceptors = make([]WorkerInterceptor, 0, len(client.workerInterceptors)+len(options.Interceptors))
@@ -2654,7 +2782,67 @@ func getFunctionName(i interface{}) (name string, isMethod bool) {
 	return strings.TrimSuffix(shortName, "-fm"), isMethod
 }
 
+// getFullFunctionName returns the fully qualified runtime name of a function
+// (e.g. "github.com/org/pkg/activities_v2.Activity"), or the string itself if a
+// string is passed. Unlike getFunctionName, it does not strip the package path,
+// so it is unique across functions that share a short name.
+func getFullFunctionName(i interface{}) string {
+	if fullName, ok := i.(string); ok {
+		return fullName
+	}
+	return runtime.FuncForPC(reflect.ValueOf(i).Pointer()).Name()
+}
+
+// normalizeFuncName canonicalizes a runtime function name so that the same
+// method produces the same key regardless of how it was referenced. It strips
+// the "-fm" suffix that Go adds to bound method values and removes the pointer
+// marker from a pointer receiver, so "pkg.(*T).M-fm" and "pkg.T.M-fm" both
+// normalize to "pkg.T.M".
+func normalizeFuncName(name string) string {
+	name = strings.TrimSuffix(name, "-fm")
+	name = strings.ReplaceAll(name, "(*", "")
+	name = strings.ReplaceAll(name, ")", "")
+	return name
+}
+
+// funcRegistryKey returns the key used for the anti-aliasing registered-name
+// maps. It is the normalized fully qualified name, which is unique per
+// function/method and stable across value/pointer receiver references. Struct
+// registration cannot use this (a reflect-created method value has no usable
+// runtime name); it builds the equivalent key via structMethodRegistryKey.
+func funcRegistryKey(i interface{}) string {
+	if _, ok := i.(string); ok {
+		return getFullFunctionName(i)
+	}
+	return normalizeFuncName(getFullFunctionName(i))
+}
+
+// structMethodRegistryKey builds the same key funcRegistryKey would produce for
+// a bound method value of the given struct type, so activities registered via a
+// struct are reachable by function reference in anti-aliasing mode.
+func structMethodRegistryKey(structType reflect.Type, methodName string) string {
+	elem := structType
+	if elem.Kind() == reflect.Ptr {
+		elem = elem.Elem()
+	}
+	return elem.PkgPath() + "." + elem.Name() + "." + methodName
+}
+
 func getActivityFunctionName(r *registry, i interface{}) string {
+	if r.antiAliasing {
+		// A string is a registered name and is used verbatim; a function
+		// resolves to the name it was registered under.
+		if s, ok := i.(string); ok {
+			return s
+		}
+		if name, ok := r.getActivityRegisteredName(funcRegistryKey(i)); ok {
+			return name
+		}
+		// Unregistered function: fall back to its short name, matching how an
+		// unregistered function is treated in the other modes.
+		result, _ := getFunctionName(i)
+		return result
+	}
 	result, _ := getFunctionName(i)
 	if alias, ok := r.getActivityAlias(result); ok {
 		result = alias
@@ -2669,6 +2857,14 @@ func getWorkflowFunctionName(r *registry, workflowFunc interface{}) (string, err
 	case reflect.String:
 		fnName = reflect.ValueOf(workflowFunc).String()
 	case reflect.Func:
+		if r.antiAliasing {
+			if name, ok := r.getWorkflowRegisteredName(funcRegistryKey(workflowFunc)); ok {
+				return name, nil
+			}
+			// Unregistered function: fall back to its short name.
+			fnName, _ = getFunctionName(workflowFunc)
+			return fnName, nil
+		}
 		fnName, _ = getFunctionName(workflowFunc)
 		if alias, ok := r.getWorkflowAlias(fnName); ok {
 			fnName = alias

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -2828,10 +2828,14 @@ func structMethodRegistryKey(structType reflect.Type, methodName string) string 
 	return elem.PkgPath() + "." + elem.Name() + "." + methodName
 }
 
-func getActivityFunctionName(r *registry, i interface{}) string {
-	if r.antiAliasing {
-		// A string is a registered name and is used verbatim; a function
-		// resolves to the name it was registered under.
+// resolveActivityName resolves an activity (a func or a string) to the type name
+// to schedule/dispatch under. When antiAliasing is true a string is used
+// verbatim and a function resolves to its registered name; otherwise the legacy
+// short-name-plus-alias-map behavior is used. The mode is passed explicitly
+// because during workflow execution it is a per-execution decision (see
+// WorkflowEnvironment.UseRegistrationAntiAliasing), not the worker-wide setting.
+func resolveActivityName(r *registry, i interface{}, antiAliasing bool) string {
+	if antiAliasing {
 		if s, ok := i.(string); ok {
 			return s
 		}
@@ -2850,14 +2854,23 @@ func getActivityFunctionName(r *registry, i interface{}) string {
 	return result
 }
 
-func getWorkflowFunctionName(r *registry, workflowFunc interface{}) (string, error) {
+// getActivityFunctionName resolves using the worker-wide setting. Use this only
+// outside of workflow execution (client, schedule, test-env, ambiguity
+// detection); in-workflow scheduling must use resolveActivityName with the
+// per-execution decision to stay replay-safe.
+func getActivityFunctionName(r *registry, i interface{}) string {
+	return resolveActivityName(r, i, r.antiAliasing)
+}
+
+// resolveWorkflowName is the workflow counterpart of resolveActivityName.
+func resolveWorkflowName(r *registry, workflowFunc interface{}, antiAliasing bool) (string, error) {
 	fnName := ""
 	fType := reflect.TypeOf(workflowFunc)
 	switch getKind(fType) {
 	case reflect.String:
 		fnName = reflect.ValueOf(workflowFunc).String()
 	case reflect.Func:
-		if r.antiAliasing {
+		if antiAliasing {
 			if name, ok := r.getWorkflowRegisteredName(funcRegistryKey(workflowFunc)); ok {
 				return name, nil
 			}
@@ -2874,6 +2887,12 @@ func getWorkflowFunctionName(r *registry, workflowFunc interface{}) (string, err
 	}
 
 	return fnName, nil
+}
+
+// getWorkflowFunctionName resolves using the worker-wide setting. See the note
+// on getActivityFunctionName about in-workflow use.
+func getWorkflowFunctionName(r *registry, workflowFunc interface{}) (string, error) {
+	return resolveWorkflowName(r, workflowFunc, r.antiAliasing)
 }
 
 func getReadOnlyChannel(c chan struct{}) <-chan struct{} {

--- a/internal/internal_worker_base.go
+++ b/internal/internal_worker_base.go
@@ -159,6 +159,11 @@ type (
 		DrainUnhandledUpdates() bool
 		// TryUse returns true if this flag may currently be used.
 		TryUse(flag sdkFlag) bool
+		// UseRegistrationAntiAliasing reports whether this workflow execution
+		// resolves function references to their registered name. The decision is
+		// fixed at workflow start and read (never recorded) here, so it is stable
+		// across replays and does not change for in-flight executions.
+		UseRegistrationAntiAliasing() bool
 		GenerateSequence() int64
 	}
 

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -3384,6 +3384,176 @@ func TestAliasUnqualifiedNameClash(t *testing.T) {
 	require.Equal(t, "func1", executeWorkflow(true))
 }
 
+// The following types simulate the scenario from
+// https://github.com/temporalio/sdk-go/issues/2379: two activity functions from
+// different packages that share the same short name ("MyActivity"). Distinct
+// struct types stand in for distinct packages: the short name collides but the
+// fully qualified name does not.
+type antiAliasV1 struct{}
+
+func (antiAliasV1) MyActivity(context.Context) (string, error) { return "func1", nil }
+
+type antiAliasV2 struct{}
+
+func (antiAliasV2) MyActivity(context.Context) (string, error) { return "func2", nil }
+
+// TestAntiAliasingByFunctionReference covers the core promise of anti-aliasing:
+// given a function, invoke that function under the name it was registered with —
+// even when a different registration shares its short name (issue #2379 and
+// "New issue 1"). It also confirms strings are used verbatim ("New issue 5").
+func TestAntiAliasingByFunctionReference(t *testing.T) {
+	wf := func(ctx Context) ([]string, error) {
+		ctx = WithActivityOptions(ctx, ActivityOptions{ScheduleToCloseTimeout: 5 * time.Second})
+		out := make([]string, 4)
+		// By function reference: each must reach its own registration despite the
+		// shared short name "MyActivity".
+		if err := ExecuteActivity(ctx, antiAliasV1{}.MyActivity).Get(ctx, &out[0]); err != nil {
+			return nil, err
+		}
+		if err := ExecuteActivity(ctx, antiAliasV2{}.MyActivity).Get(ctx, &out[1]); err != nil {
+			return nil, err
+		}
+		// By string: used verbatim, never redirected through an alias map.
+		if err := ExecuteActivity(ctx, "MyActivity").Get(ctx, &out[2]); err != nil {
+			return nil, err
+		}
+		if err := ExecuteActivity(ctx, "MyActivity_v2").Get(ctx, &out[3]); err != nil {
+			return nil, err
+		}
+		return out, nil
+	}
+
+	var suite WorkflowTestSuite
+	suite.SetRegistrationAntiAliasing(true)
+	env := suite.NewTestWorkflowEnvironment()
+	env.RegisterActivity(antiAliasV1{}.MyActivity) // registered as "MyActivity"
+	env.RegisterActivityWithOptions(antiAliasV2{}.MyActivity, RegisterActivityOptions{Name: "MyActivity_v2"})
+	env.ExecuteWorkflow(wf)
+	require.NoError(t, env.GetWorkflowError())
+	var result []string
+	require.NoError(t, env.GetWorkflowResult(&result))
+	require.Equal(t, []string{"func1", "func2", "func1", "func2"}, result)
+}
+
+// TestAntiAliasingLocalActivity confirms anti-aliasing resolution also applies
+// to the ExecuteLocalActivity code path ("New issue 2" — path consistency).
+func TestAntiAliasingLocalActivity(t *testing.T) {
+	wf := func(ctx Context) ([]string, error) {
+		ctx = WithLocalActivityOptions(ctx, LocalActivityOptions{ScheduleToCloseTimeout: 5 * time.Second})
+		out := make([]string, 2)
+		if err := ExecuteLocalActivity(ctx, antiAliasV1{}.MyActivity).Get(ctx, &out[0]); err != nil {
+			return nil, err
+		}
+		if err := ExecuteLocalActivity(ctx, antiAliasV2{}.MyActivity).Get(ctx, &out[1]); err != nil {
+			return nil, err
+		}
+		return out, nil
+	}
+
+	var suite WorkflowTestSuite
+	suite.SetRegistrationAntiAliasing(true)
+	env := suite.NewTestWorkflowEnvironment()
+	env.RegisterActivity(antiAliasV1{}.MyActivity)
+	env.RegisterActivityWithOptions(antiAliasV2{}.MyActivity, RegisterActivityOptions{Name: "MyActivity_v2"})
+	env.ExecuteWorkflow(wf)
+	require.NoError(t, env.GetWorkflowError())
+	var result []string
+	require.NoError(t, env.GetWorkflowResult(&result))
+	require.Equal(t, []string{"func1", "func2"}, result)
+}
+
+type antiAliasStruct struct{}
+
+func (antiAliasStruct) DoWork(context.Context) (string, error) { return "struct", nil }
+
+// antiAliasDoWork is a top-level activity whose short name ("antiAliasDoWork")
+// differs from the struct method; to force the "New issue 4" collision we
+// register it under the bare name "DoWork".
+func antiAliasDoWork(context.Context) (string, error) { return "plain", nil }
+
+// TestAntiAliasingStructRegistration covers "New issue 4": struct-based
+// registration must record its methods so they are reachable by function
+// reference and do not collide with a same-short-named standalone activity.
+func TestAntiAliasingStructRegistration(t *testing.T) {
+	wf := func(ctx Context) ([]string, error) {
+		ctx = WithActivityOptions(ctx, ActivityOptions{ScheduleToCloseTimeout: 5 * time.Second})
+		out := make([]string, 2)
+		if err := ExecuteActivity(ctx, antiAliasDoWork).Get(ctx, &out[0]); err != nil {
+			return nil, err
+		}
+		if err := ExecuteActivity(ctx, antiAliasStruct{}.DoWork).Get(ctx, &out[1]); err != nil {
+			return nil, err
+		}
+		return out, nil
+	}
+
+	var suite WorkflowTestSuite
+	suite.SetRegistrationAntiAliasing(true)
+	env := suite.NewTestWorkflowEnvironment()
+	env.RegisterActivityWithOptions(antiAliasDoWork, RegisterActivityOptions{Name: "DoWork"})
+	env.RegisterActivityWithOptions(&antiAliasStruct{}, RegisterActivityOptions{Name: "Prefix_"})
+	env.ExecuteWorkflow(wf)
+	require.NoError(t, env.GetWorkflowError())
+	var result []string
+	require.NoError(t, env.GetWorkflowResult(&result))
+	// Function reference to the struct method must reach "Prefix_DoWork", not the
+	// standalone "DoWork".
+	require.Equal(t, []string{"plain", "struct"}, result)
+}
+
+func antiAliasWorkflowV1(ctx Context) (string, error) { return "wf1", nil }
+func antiAliasWorkflowV2(ctx Context) (string, error) { return "wf2", nil }
+
+// TestAntiAliasingWorkflowDispatch covers "New issue 3": with anti-aliasing the
+// workflow scheduling side and the getWorkflowDefinition dispatch side agree,
+// because scheduling emits the registered name and dispatch is an exact lookup.
+func TestAntiAliasingWorkflowDispatch(t *testing.T) {
+	parent := func(ctx Context) (string, error) {
+		ctx = WithChildWorkflowOptions(ctx, ChildWorkflowOptions{WorkflowRunTimeout: 5 * time.Second})
+		var got string
+		// Dispatch the v1 child by function reference; must reach v1's
+		// registration, not v2's aliased one.
+		if err := ExecuteChildWorkflow(ctx, antiAliasWorkflowV1).Get(ctx, &got); err != nil {
+			return "", err
+		}
+		return got, nil
+	}
+
+	var suite WorkflowTestSuite
+	suite.SetRegistrationAntiAliasing(true)
+	env := suite.NewTestWorkflowEnvironment()
+	env.RegisterWorkflow(parent)
+	env.RegisterWorkflow(antiAliasWorkflowV1)
+	env.RegisterWorkflowWithOptions(antiAliasWorkflowV2, RegisterWorkflowOptions{Name: "antiAliasWorkflowV1_v2"})
+	env.ExecuteWorkflow(parent)
+	require.NoError(t, env.GetWorkflowError())
+	var result string
+	require.NoError(t, env.GetWorkflowResult(&result))
+	require.Equal(t, "wf1", result)
+}
+
+// TestDetectRegistrationAmbiguities verifies the startup detection: in the
+// default (non-anti-aliasing) mode the collisions from the issue are flagged,
+// while anti-aliasing mode reports none.
+func TestDetectRegistrationAmbiguities(t *testing.T) {
+	register := func(r *registry) {
+		// "New issue 1": two functions with the same short name, one aliased —
+		// the plain one becomes unreachable by function reference.
+		r.RegisterActivityWithOptions(antiAliasV1{}.MyActivity, RegisterActivityOptions{Name: "MyActivity_v1"})
+		r.RegisterActivityWithOptions(antiAliasV2{}.MyActivity, RegisterActivityOptions{Name: "MyActivity_v2"})
+	}
+
+	// Default mode: at least one ambiguity is detected.
+	def := newRegistryWithOptions(registryOptions{})
+	register(def)
+	require.NotEmpty(t, def.detectRegistrationAmbiguities())
+
+	// Anti-aliasing mode: no ambiguities.
+	anti := newRegistryWithOptions(registryOptions{antiAliasing: true})
+	register(anti)
+	require.Empty(t, anti.detectRegistrationAmbiguities())
+}
+
 func (s *internalWorkerTestSuite) TestReservedTemporalName() {
 	// workflow
 	worker := createWorker(s.service)

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -22,6 +22,7 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	historypb "go.temporal.io/api/history/v1"
 	namespacepb "go.temporal.io/api/namespace/v1"
+	"go.temporal.io/api/sdk/v1"
 	"go.temporal.io/api/serviceerror"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	"go.temporal.io/api/workflowservice/v1"
@@ -3552,6 +3553,137 @@ func TestDetectRegistrationAmbiguities(t *testing.T) {
 	anti := newRegistryWithOptions(registryOptions{antiAliasing: true})
 	register(anti)
 	require.Empty(t, anti.detectRegistrationAmbiguities())
+}
+
+// antiAliasReproWorkflow schedules antiAliasV1{}.MyActivity by function
+// reference. In the default (aliasing) mode this schedules "MyActivity_v2" (the
+// bug from #2379); in anti-aliasing mode it schedules "MyActivity".
+func antiAliasReproWorkflow(ctx Context) error {
+	ctx = WithActivityOptions(ctx, ActivityOptions{
+		ScheduleToStartTimeout: time.Second,
+		StartToCloseTimeout:    time.Second,
+	})
+	return ExecuteActivity(ctx, antiAliasV1{}.MyActivity).Get(ctx, nil)
+}
+
+// makeAntiAliasReproHistory builds a workflow history for antiAliasReproWorkflow.
+// The activity is recorded under activityName (a legacy worker records
+// "MyActivity_v2"; an anti-aliasing worker records "MyActivity"). If flagged, the
+// first WorkflowTaskCompleted carries the anti-aliasing SDK flag, as an
+// anti-aliasing worker would persist. If partial, the history ends at a pending
+// (not-yet-completed) workflow task, modelling an in-flight execution.
+func makeAntiAliasReproHistory(activityName string, flagged bool, partial bool) *historypb.History {
+	taskQueue := "taskQueue1"
+	var firstCompletedMetadata *sdk.WorkflowTaskCompletedMetadata
+	if flagged {
+		firstCompletedMetadata = &sdk.WorkflowTaskCompletedMetadata{
+			LangUsedFlags: []uint32{uint32(SDKFlagRegistrationAntiAliasing)},
+		}
+	}
+	events := []*historypb.HistoryEvent{
+		createTestEventWorkflowExecutionStarted(1, &historypb.WorkflowExecutionStartedEventAttributes{
+			WorkflowType: &commonpb.WorkflowType{Name: "antiAliasReproWorkflow"},
+			TaskQueue:    &taskqueuepb.TaskQueue{Name: taskQueue},
+			Input:        testEncodeFunctionArgs(converter.GetDefaultDataConverter()),
+		}),
+		createTestEventWorkflowTaskScheduled(2, &historypb.WorkflowTaskScheduledEventAttributes{}),
+		createTestEventWorkflowTaskStarted(3),
+		createTestEventWorkflowTaskCompleted(4, &historypb.WorkflowTaskCompletedEventAttributes{
+			SdkMetadata: firstCompletedMetadata,
+		}),
+		createTestEventActivityTaskScheduled(5, &historypb.ActivityTaskScheduledEventAttributes{
+			ActivityId:   "5",
+			ActivityType: &commonpb.ActivityType{Name: activityName},
+			TaskQueue:    &taskqueuepb.TaskQueue{Name: taskQueue},
+		}),
+		createTestEventActivityTaskStarted(6, &historypb.ActivityTaskStartedEventAttributes{ScheduledEventId: 5}),
+		createTestEventActivityTaskCompleted(7, &historypb.ActivityTaskCompletedEventAttributes{
+			ScheduledEventId: 5,
+			StartedEventId:   6,
+		}),
+		createTestEventWorkflowTaskScheduled(8, &historypb.WorkflowTaskScheduledEventAttributes{}),
+		createTestEventWorkflowTaskStarted(9),
+	}
+	if !partial {
+		events = append(events,
+			createTestEventWorkflowTaskCompleted(10, &historypb.WorkflowTaskCompletedEventAttributes{
+				ScheduledEventId: 8,
+				StartedEventId:   9,
+			}),
+			createTestEventWorkflowExecutionCompleted(11, &historypb.WorkflowExecutionCompletedEventAttributes{
+				WorkflowTaskCompletedEventId: 10,
+			}),
+		)
+	}
+	return &historypb.History{Events: events}
+}
+
+// TestAntiAliasingReplayNonDeterminism demonstrates why flipping a worker to
+// anti-aliasing is NOT safe if it changed resolution unconditionally: a history
+// recorded by a legacy (aliasing) worker no longer matches the commands an
+// anti-aliasing worker produces for the same workflow code. This replays a
+// COMPLETE legacy history, which the replayer validates by re-producing the
+// first workflow task fresh (as if the workflow had started under the new code),
+// so the anti-aliasing flag is set and the divergence surfaces as an NDE. This
+// is the divergence that the SDK flag gating (see the following tests) contains
+// to genuinely new executions.
+func TestAntiAliasingReplayNonDeterminism(t *testing.T) {
+	// First, prove the two modes resolve the SAME function reference to DIFFERENT
+	// scheduled activity type names. This divergence is the root cause of the NDE.
+	makeReg := func(antiAliasing bool) *registry {
+		r := newRegistryWithOptions(registryOptions{antiAliasing: antiAliasing})
+		r.RegisterActivity(antiAliasV1{}.MyActivity)
+		r.RegisterActivityWithOptions(antiAliasV2{}.MyActivity, RegisterActivityOptions{Name: "MyActivity_v2"})
+		return r
+	}
+	// Legacy worker records "MyActivity_v2" for antiAliasV1{}.MyActivity (the bug).
+	require.Equal(t, "MyActivity_v2", getActivityFunctionName(makeReg(false), antiAliasV1{}.MyActivity))
+	// Anti-aliasing worker records "MyActivity" for the very same reference.
+	require.Equal(t, "MyActivity", getActivityFunctionName(makeReg(true), antiAliasV1{}.MyActivity))
+
+	// A complete history as a legacy worker would have written it (no flag,
+	// activity scheduled under "MyActivity_v2"). Replaying it with an
+	// anti-aliasing worker fails: re-producing the first task fresh sets the flag,
+	// so the worker schedules "MyActivity", which mismatches "MyActivity_v2".
+	history := makeAntiAliasReproHistory("MyActivity_v2", false /*flagged*/, false /*partial*/)
+	replayer, err := NewWorkflowReplayer(WorkflowReplayerOptions{RegistrationAntiAliasing: true})
+	require.NoError(t, err)
+	replayer.RegisterWorkflow(antiAliasReproWorkflow)
+	err = replayer.ReplayWorkflowHistory(getLogger(), history)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "nondeterministic")
+}
+
+// TestAntiAliasingReplaySafeForInFlight is the payoff: an in-flight execution
+// that STARTED under a legacy worker (no anti-aliasing flag in history, activity
+// recorded as "MyActivity_v2") is replayed by an anti-aliasing worker without a
+// non-determinism error. Because the flag is set only at genuine workflow start
+// (which is replayed here with isReplay=true), the anti-aliasing worker keeps
+// using legacy resolution for this execution and reproduces "MyActivity_v2". The
+// history is partial (ends at a pending workflow task) to model an open
+// execution, which is exactly what a live worker replays.
+func TestAntiAliasingReplaySafeForInFlight(t *testing.T) {
+	history := makeAntiAliasReproHistory("MyActivity_v2", false /*flagged*/, true /*partial*/)
+	replayer, err := NewWorkflowReplayer(WorkflowReplayerOptions{RegistrationAntiAliasing: true})
+	require.NoError(t, err)
+	replayer.RegisterWorkflow(antiAliasReproWorkflow)
+	require.NoError(t, replayer.ReplayWorkflowHistory(getLogger(), history))
+}
+
+// TestAntiAliasingReplayWithFlagIsConsistent shows that once a workflow started
+// under anti-aliasing (the flag is present in history, activity recorded as
+// "MyActivity"), it replays cleanly regardless of the replaying worker's own
+// setting. The flag in history is the source of truth, so a mixed fleet of
+// anti-aliasing and legacy workers stays deterministic.
+func TestAntiAliasingReplayWithFlagIsConsistent(t *testing.T) {
+	history := makeAntiAliasReproHistory("MyActivity", true /*flagged*/, false /*partial*/)
+	for _, workerAntiAliasing := range []bool{true, false} {
+		replayer, err := NewWorkflowReplayer(WorkflowReplayerOptions{RegistrationAntiAliasing: workerAntiAliasing})
+		require.NoError(t, err)
+		replayer.RegisterWorkflow(antiAliasReproWorkflow)
+		require.NoError(t, replayer.ReplayWorkflowHistory(getLogger(), history),
+			"flagged history must replay cleanly with worker anti-aliasing=%v", workerAntiAliasing)
+	}
 }
 
 func (s *internalWorkerTestSuite) TestReservedTemporalName() {

--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -281,7 +281,7 @@ type (
 func newTestWorkflowEnvironmentImpl(s *WorkflowTestSuite, parentRegistry *registry) *testWorkflowEnvironmentImpl {
 	var r *registry
 	if parentRegistry == nil {
-		r = newRegistryWithOptions(registryOptions{disableAliasing: s.disableRegistrationAliasing})
+		r = newRegistryWithOptions(registryOptions{disableAliasing: s.disableRegistrationAliasing, antiAliasing: s.registrationAntiAliasing})
 	} else {
 		r = parentRegistry
 	}

--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -694,6 +694,12 @@ func (env *testWorkflowEnvironmentImpl) TryUse(flag sdkFlag) bool {
 	return env.sdkFlags.tryUse(flag, true)
 }
 
+func (env *testWorkflowEnvironmentImpl) UseRegistrationAntiAliasing() bool {
+	// The test environment does not replay against recorded history, so the
+	// configured mode is used directly.
+	return env.registry.antiAliasing
+}
+
 func (env *testWorkflowEnvironmentImpl) GenerateSequence() int64 {
 	return env.nextID()
 }

--- a/internal/worker.go
+++ b/internal/worker.go
@@ -331,7 +331,45 @@ type (
 		// false, the historical default, ambiguity can occur between function names
 		// and aliased names when not using string names when executing child
 		// workflow or activities.
+		//
+		// Deprecated: prefer RegistrationAntiAliasing, which resolves function
+		// references to the name they were registered under instead of dropping
+		// the custom name. This option only stops applying the alias map; a
+		// function reference still resolves to its (unqualified) short name, which
+		// can still collide with another registration. See RegistrationAntiAliasing.
 		DisableRegistrationAliasing bool
+
+		// Optional: Resolve workflow and activity function references to the exact
+		// name they were registered under, and treat string arguments as registered
+		// names verbatim (no alias substitution).
+		//
+		// This is the recommended setting. It removes the ambiguities that occur in
+		// the default mode (and in DisableRegistrationAliasing mode) when function
+		// short names collide across packages, when a short name overlaps a
+		// registered/aliased name, or when activities are registered via a struct.
+		// Concretely:
+		//   - Given a function, the worker schedules and dispatches the name it was
+		//     registered under (its custom name if one was given, otherwise its
+		//     short name).
+		//   - Given a string, the worker uses it as-is; it is never redirected
+		//     through the alias map.
+		//
+		// This mode is opt-in and does not change the name resolution of any other
+		// mode, so enabling it will not retroactively alter histories of workflows
+		// that never relied on the ambiguous behavior. However, a workflow that was
+		// (perhaps unknowingly) relying on the ambiguous resolution — for example
+		// invoking one function by reference and silently reaching a different
+		// registration — will schedule a different activity/workflow type name once
+		// this is enabled, which can cause a non-determinism error on replay of
+		// in-flight executions. Enable it for new workers/task queues, or after
+		// confirming no open workflows depend on the ambiguous behavior.
+		//
+		// When this is false, the worker checks for such ambiguities at startup and
+		// logs a warning recommending this option if any are found.
+		//
+		// If both this and DisableRegistrationAliasing are set, this takes
+		// precedence.
+		RegistrationAntiAliasing bool
 
 		// Assign a BuildID to this worker. This replaces the deprecated binary checksum concept,
 		// and is used to provide a unique identifier for a set of worker code, and is necessary

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -1020,7 +1020,10 @@ func ExecuteActivity(ctx Context, activity interface{}, args ...interface{}) Fut
 	assertNotInReadOnlyState(ctx)
 	i := getWorkflowOutboundInterceptor(ctx)
 	registry := getRegistryFromWorkflowContext(ctx)
-	activityType := getActivityFunctionName(registry, activity)
+	// Use the per-execution anti-aliasing decision (fixed at workflow start), not
+	// the worker-wide setting, so enabling the mode never changes the scheduled
+	// type name of an already-running execution on replay.
+	activityType := resolveActivityName(registry, activity, getWorkflowEnvironment(ctx).UseRegistrationAntiAliasing())
 	// Put header on context before executing
 	ctx = workflowContextWithNewHeader(ctx)
 	return i.ExecuteActivity(ctx, activityType, args...)
@@ -1170,13 +1173,9 @@ func ExecuteLocalActivity(ctx Context, activity interface{}, args ...interface{}
 	assertNotInReadOnlyState(ctx)
 	i := getWorkflowOutboundInterceptor(ctx)
 	env := getWorkflowEnvironment(ctx)
-	activityType, isMethod := getFunctionName(activity)
-	reg := env.GetRegistry()
-	if reg.antiAliasing {
-		activityType = getActivityFunctionName(reg, activity)
-	} else if alias, ok := reg.getActivityAlias(activityType); ok {
-		activityType = alias
-	}
+	_, isMethod := getFunctionName(activity)
+	// Use the per-execution anti-aliasing decision (see ExecuteActivity).
+	activityType := resolveActivityName(env.GetRegistry(), activity, env.UseRegistrationAntiAliasing())
 	var fn interface{}
 	if _, ok := activity.(string); ok {
 		fn = nil
@@ -1377,7 +1376,8 @@ func ExecuteChildWorkflow(ctx Context, childWorkflow interface{}, args ...interf
 	assertNotInReadOnlyState(ctx)
 	i := getWorkflowOutboundInterceptor(ctx)
 	env := getWorkflowEnvironment(ctx)
-	workflowType, err := getWorkflowFunctionName(env.GetRegistry(), childWorkflow)
+	// Use the per-execution anti-aliasing decision (see ExecuteActivity).
+	workflowType, err := resolveWorkflowName(env.GetRegistry(), childWorkflow, env.UseRegistrationAntiAliasing())
 	if err != nil {
 		panic(err)
 	}

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -1171,7 +1171,10 @@ func ExecuteLocalActivity(ctx Context, activity interface{}, args ...interface{}
 	i := getWorkflowOutboundInterceptor(ctx)
 	env := getWorkflowEnvironment(ctx)
 	activityType, isMethod := getFunctionName(activity)
-	if alias, ok := env.GetRegistry().getActivityAlias(activityType); ok {
+	reg := env.GetRegistry()
+	if reg.antiAliasing {
+		activityType = getActivityFunctionName(reg, activity)
+	} else if alias, ok := reg.getActivityAlias(activityType); ok {
 		activityType = alias
 	}
 	var fn interface{}

--- a/internal/workflow_testsuite.go
+++ b/internal/workflow_testsuite.go
@@ -39,6 +39,7 @@ type (
 		contextPropagators          []ContextPropagator
 		header                      *commonpb.Header
 		disableRegistrationAliasing bool
+		registrationAntiAliasing    bool
 	}
 
 	// TestWorkflowEnvironment is the environment that you use to test workflow
@@ -188,6 +189,16 @@ func (s *WorkflowTestSuite) SetHeader(header *commonpb.Header) {
 // This must be set before obtaining new test workflow or activity environments.
 func (s *WorkflowTestSuite) SetDisableRegistrationAliasing(disableRegistrationAliasing bool) {
 	s.disableRegistrationAliasing = disableRegistrationAliasing
+}
+
+// SetRegistrationAntiAliasing enables registration anti-aliasing the same way it
+// is enabled when set for worker.Options.RegistrationAntiAliasing. This is the
+// recommended setting for tests of custom-named workflows and activities. See
+// the documentation on worker.Options.RegistrationAntiAliasing for more details.
+//
+// This must be set before obtaining new test workflow or activity environments.
+func (s *WorkflowTestSuite) SetRegistrationAntiAliasing(registrationAntiAliasing bool) {
+	s.registrationAntiAliasing = registrationAntiAliasing
 }
 
 // RegisterActivity registers activity implementation with TestWorkflowEnvironment


### PR DESCRIPTION
## What was changed
Bring activity and workflow resolution in line with core. Guard against NDEs using an SDK flag.

## Why?
Both values of `WorkerOptions.DisableRegistrationAliasing` cause unexpected ambiguities in which workflow or activity gets invoked.

## Checklist

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
