### PR TITLE
Add installation sections to READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@
 
 "Temporal Go SDK" is Temporal's framework for authoring workflows and activities using the Go language.
 
+## Installation
+
+```
+go get go.temporal.io/sdk
+```
+
 ## How to use
 
 Clone this repo into the preferred location.

--- a/contrib/workflowstreams/README.md
+++ b/contrib/workflowstreams/README.md
@@ -9,6 +9,12 @@ Temporal's durable execution, giving ordered, durable, exactly-once delivery
 with client-side batching, publisher dedup, continue-as-new survival,
 truncation, and ~1 MB response paging.
 
+## Installation
+
+```
+go get go.temporal.io/sdk/contrib/workflowstreams
+```
+
 It is well suited to durable event streams whose cost scales with durable
 batches rather than message count. Each poll round-trip costs ~100 ms of
 latency, so it is not intended for ultra-low-latency streaming.


### PR DESCRIPTION
## What changed

Added an **Installation** section with the appropriate `go get` command to:

- `README.md` (main SDK) — `go get go.temporal.io/sdk`
- `contrib/workflowstreams/README.md` — `go get go.temporal.io/sdk/contrib/workflowstreams`

🤖 Generated with [Claude Code](https://claude.com/claude-code)