### PR TITLE
fix: Avoid blocking eager TryReserveSlot during resource tuner ramp wait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ to docs, or any other relevant information.
   declining slots. Previously the retry loop observed the context only while the ramp throttle was making
   the caller wait, so a poller goroutine could outlive worker shutdown, keeping the worker's stop
   `WaitGroup` from draining and continuing to sample system resources for the life of the process.
+- Resource-based tuner: `TryReserveSlot` (used for eager task dispatch) no longer blocks for up to
+  `RampThrottle` while a concurrent `ReserveSlot` waits out the ramp throttle. The throttle behavior
+  is unchanged; only the unnecessary lock contention on the eager path is removed.
 
 ## [1.46.0] - 2026-07-07
 

--- a/internal/resource_tuner.go
+++ b/internal/resource_tuner.go
@@ -193,15 +193,17 @@ func (r *ResourceBasedSlotSupplier) ReserveSlot(ctx context.Context, info SlotRe
 		if r.options.RampThrottle > 0 {
 			r.lastIssuedMu.Lock()
 			mustWaitFor := r.options.RampThrottle - time.Since(r.lastSlotIssuedAt)
+			// Release before waiting: holding lastIssuedMu across the wait would stall the
+			// non-blocking TryReserveSlot used for eager dispatch. The throttle is still
+			// enforced by TryReserveSlot's own lastSlotIssuedAt check.
+			r.lastIssuedMu.Unlock()
 			if mustWaitFor > 0 {
 				select {
 				case <-time.After(mustWaitFor):
 				case <-ctx.Done():
-					r.lastIssuedMu.Unlock()
 					return nil, ctx.Err()
 				}
 			}
-			r.lastIssuedMu.Unlock()
 		}
 
 		maybePermit := r.TryReserveSlot(info)

--- a/internal/resource_tuner_eager_test.go
+++ b/internal/resource_tuner_eager_test.go
@@ -2,6 +2,8 @@ package internal
 
 import (
 	"context"
+	"sort"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -13,8 +15,8 @@ import (
 	"go.temporal.io/sdk/log"
 )
 
-// countingReserveInfo is a minimal SlotReservationInfo that records how many times
-// NumIssuedSlots is called, so a test can observe that ReserveSlot has begun without a fixed sleep.
+// countingReserveInfo counts NumIssuedSlots calls so a test can observe that ReserveSlot has begun
+// without resorting to a fixed sleep.
 type countingReserveInfo struct {
 	issued         int
 	numIssuedCalls atomic.Int32
@@ -30,27 +32,26 @@ func (c *countingReserveInfo) NumIssuedSlots() int             { c.numIssuedCall
 func (c *countingReserveInfo) Logger() log.Logger              { return ilog.NewNopLogger() }
 func (c *countingReserveInfo) MetricsHandler() metrics.Handler { return metrics.NopHandler }
 
-// TestTryReserveSlotDoesNotBlockDuringRampWait verifies that the non-blocking eager path
-// (TryReserveSlot) is not stalled by a concurrent ReserveSlot that is waiting out the ramp throttle.
-//
-// Regression: ReserveSlot used to hold lastIssuedMu across its time.After(RampThrottle) wait, so a
-// concurrent TryReserveSlot blocked on that mutex for up to RampThrottle.
+// TestTryReserveSlotDoesNotBlockDuringRampWait covers the regression this fix addresses: ReserveSlot
+// used to hold lastIssuedMu across its ramp wait, so the eager, non-blocking TryReserveSlot could
+// block on that mutex for up to RampThrottle.
 func TestTryReserveSlotDoesNotBlockDuringRampWait(t *testing.T) {
 	const ramp = 2 * time.Second
 
 	rcOpts := DefaultResourceControllerOptions()
 	rcOpts.MemTargetPercent = 0.8
 	rcOpts.CpuTargetPercent = 0.9
-	rcOpts.InfoSupplier = &FakeSystemInfoSupplier{memUse: 0.1, cpuUse: 0.1} // well under target => issue
+	// Usage well under target, so the controller always grants and RampThrottle is the only gate.
+	rcOpts.InfoSupplier = &FakeSystemInfoSupplier{memUse: 0.1, cpuUse: 0.1}
 
 	supplier, err := NewResourceBasedSlotSupplier(NewResourceController(rcOpts),
 		ResourceBasedSlotSupplierOptions{MinSlots: 0, MaxSlots: 1000, RampThrottle: ramp})
 	require.NoError(t, err)
 
-	info := &countingReserveInfo{issued: 10} // >= MinSlots, so the throttle path is exercised
+	info := &countingReserveInfo{issued: 10} // past MinSlots, so the throttle applies
 
-	// Seed lastSlotIssuedAt to "now" so the next reservation must wait out the ramp.
-	require.NotNil(t, supplier.TryReserveSlot(info), "precondition: first eager reserve should succeed")
+	// Stamps lastSlotIssuedAt, so the ReserveSlot below has a full ramp to wait out.
+	require.NotNil(t, supplier.TryReserveSlot(info), "first eager reserve should succeed")
 	callsBeforeReserve := info.numIssuedCalls.Load()
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -61,26 +62,85 @@ func TestTryReserveSlotDoesNotBlockDuringRampWait(t *testing.T) {
 		close(reserveReturned)
 	}()
 
-	// Known race: ReserveSlot calls NumIssuedSlots() once, immediately before entering the ramp
-	// wait. Wait for that call instead of sleeping a fixed duration.
+	// ReserveSlot calls NumIssuedSlots once, just before entering the ramp wait. Syncing on that
+	// beats sleeping a fixed duration.
 	require.Eventually(t, func() bool {
 		return info.numIssuedCalls.Load() > callsBeforeReserve
 	}, ramp, time.Millisecond, "ReserveSlot did not start")
 
-	// The eager, non-blocking check must return promptly, not wait out RampThrottle.
 	start := time.Now()
 	supplier.TryReserveSlot(info)
 	elapsed := time.Since(start)
 	require.Less(t, elapsed, ramp/4,
-		"TryReserveSlot (eager, non-blocking) blocked for %v — it should not wait on ReserveSlot's ramp throttle", elapsed)
+		"eager TryReserveSlot blocked for %v; it should not wait on ReserveSlot's ramp throttle", elapsed)
 
 	cancel()
 	<-reserveReturned
 }
 
-// TestRampThrottleStillBoundsIssuance guards the invariant the fix must preserve: even though
-// ReserveSlot no longer holds lastIssuedMu across its wait, issuance beyond MinSlots is still
-// gated to at most one slot per RampThrottle (enforced by TryReserveSlot's lastSlotIssuedAt check).
+// TestRampThrottleBoundsIssuanceAcrossConcurrentReserveSlot covers what the sequential test below
+// cannot: several ReserveSlot callers contending at once, each having independently decided it need
+// not wait. Issuance must still be spaced by RampThrottle.
+func TestRampThrottleBoundsIssuanceAcrossConcurrentReserveSlot(t *testing.T) {
+	const ramp = 100 * time.Millisecond
+	const reservers = 4
+
+	rcOpts := DefaultResourceControllerOptions()
+	rcOpts.MemTargetPercent = 0.8
+	rcOpts.CpuTargetPercent = 0.9
+	rcOpts.InfoSupplier = &FakeSystemInfoSupplier{memUse: 0.1, cpuUse: 0.1}
+
+	supplier, err := NewResourceBasedSlotSupplier(NewResourceController(rcOpts),
+		ResourceBasedSlotSupplierOptions{MinSlots: 0, MaxSlots: 1000, RampThrottle: ramp})
+	require.NoError(t, err)
+
+	// Past MinSlots so the throttle applies, and lastSlotIssuedAt is still the zero time, so every
+	// goroutine computes a non-positive wait and goes straight for a slot.
+	info := &countingReserveInfo{issued: 10}
+
+	var mu sync.Mutex
+	issuedAt := make([]time.Time, 0, reservers)
+	var reserveErrs []error
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < reservers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			permit, err := supplier.ReserveSlot(context.Background(), info)
+			at := time.Now()
+
+			mu.Lock()
+			defer mu.Unlock()
+			if err != nil || permit == nil {
+				reserveErrs = append(reserveErrs, err)
+				return
+			}
+			issuedAt = append(issuedAt, at)
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	require.Empty(t, reserveErrs)
+	require.Len(t, issuedAt, reservers)
+
+	sort.Slice(issuedAt, func(i, j int) bool { return issuedAt[i].Before(issuedAt[j]) })
+	for i := 1; i < len(issuedAt); i++ {
+		gap := issuedAt[i].Sub(issuedAt[i-1])
+		t.Logf("slots %d and %d issued %v apart", i-1, i, gap)
+		// Half a ramp absorbs scheduling noise and still catches the failure mode, which issues
+		// slots microseconds apart.
+		require.Greater(t, gap, ramp/2, "RampThrottle of %v was not applied between slots %d and %d",
+			ramp, i-1, i)
+	}
+}
+
+// TestRampThrottleStillBoundsIssuance guards the invariant the fix must preserve: dropping
+// lastIssuedMu before the ramp wait must not let issuance past MinSlots exceed one slot per
+// RampThrottle.
 func TestRampThrottleStillBoundsIssuance(t *testing.T) {
 	const ramp = 100 * time.Millisecond
 
@@ -93,7 +153,7 @@ func TestRampThrottleStillBoundsIssuance(t *testing.T) {
 		ResourceBasedSlotSupplierOptions{MinSlots: 0, MaxSlots: 1000, RampThrottle: ramp})
 	require.NoError(t, err)
 
-	info := &countingReserveInfo{issued: 10} // >= MinSlots, so the throttle gate applies
+	info := &countingReserveInfo{issued: 10} // past MinSlots, so the throttle applies
 
 	require.NotNil(t, supplier.TryReserveSlot(info), "first slot should issue")
 	require.Nil(t, supplier.TryReserveSlot(info), "second slot within RampThrottle must be throttled")

--- a/internal/resource_tuner_eager_test.go
+++ b/internal/resource_tuner_eager_test.go
@@ -1,0 +1,104 @@
+package internal
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/sdk/internal/common/metrics"
+	ilog "go.temporal.io/sdk/internal/log"
+	"go.temporal.io/sdk/log"
+)
+
+// countingReserveInfo is a minimal SlotReservationInfo that records how many times
+// NumIssuedSlots is called, so a test can observe that ReserveSlot has begun without a fixed sleep.
+type countingReserveInfo struct {
+	issued         int
+	numIssuedCalls atomic.Int32
+}
+
+func (c *countingReserveInfo) TaskQueue() string { return "test-tq" }
+func (c *countingReserveInfo) TaskQueueKind() enumspb.TaskQueueKind {
+	return enumspb.TASK_QUEUE_KIND_NORMAL
+}
+func (c *countingReserveInfo) WorkerBuildId() string           { return "" }
+func (c *countingReserveInfo) WorkerIdentity() string          { return "" }
+func (c *countingReserveInfo) NumIssuedSlots() int             { c.numIssuedCalls.Add(1); return c.issued }
+func (c *countingReserveInfo) Logger() log.Logger              { return ilog.NewNopLogger() }
+func (c *countingReserveInfo) MetricsHandler() metrics.Handler { return metrics.NopHandler }
+
+// TestTryReserveSlotDoesNotBlockDuringRampWait verifies that the non-blocking eager path
+// (TryReserveSlot) is not stalled by a concurrent ReserveSlot that is waiting out the ramp throttle.
+//
+// Regression: ReserveSlot used to hold lastIssuedMu across its time.After(RampThrottle) wait, so a
+// concurrent TryReserveSlot blocked on that mutex for up to RampThrottle.
+func TestTryReserveSlotDoesNotBlockDuringRampWait(t *testing.T) {
+	const ramp = 2 * time.Second
+
+	rcOpts := DefaultResourceControllerOptions()
+	rcOpts.MemTargetPercent = 0.8
+	rcOpts.CpuTargetPercent = 0.9
+	rcOpts.InfoSupplier = &FakeSystemInfoSupplier{memUse: 0.1, cpuUse: 0.1} // well under target => issue
+
+	supplier, err := NewResourceBasedSlotSupplier(NewResourceController(rcOpts),
+		ResourceBasedSlotSupplierOptions{MinSlots: 0, MaxSlots: 1000, RampThrottle: ramp})
+	require.NoError(t, err)
+
+	info := &countingReserveInfo{issued: 10} // >= MinSlots, so the throttle path is exercised
+
+	// Seed lastSlotIssuedAt to "now" so the next reservation must wait out the ramp.
+	require.NotNil(t, supplier.TryReserveSlot(info), "precondition: first eager reserve should succeed")
+	callsBeforeReserve := info.numIssuedCalls.Load()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	reserveReturned := make(chan struct{})
+	go func() {
+		_, _ = supplier.ReserveSlot(ctx, info)
+		close(reserveReturned)
+	}()
+
+	// Known race: ReserveSlot calls NumIssuedSlots() once, immediately before entering the ramp
+	// wait. Wait for that call instead of sleeping a fixed duration.
+	require.Eventually(t, func() bool {
+		return info.numIssuedCalls.Load() > callsBeforeReserve
+	}, ramp, time.Millisecond, "ReserveSlot did not start")
+
+	// The eager, non-blocking check must return promptly, not wait out RampThrottle.
+	start := time.Now()
+	supplier.TryReserveSlot(info)
+	elapsed := time.Since(start)
+	require.Less(t, elapsed, ramp/4,
+		"TryReserveSlot (eager, non-blocking) blocked for %v — it should not wait on ReserveSlot's ramp throttle", elapsed)
+
+	cancel()
+	<-reserveReturned
+}
+
+// TestRampThrottleStillBoundsIssuance guards the invariant the fix must preserve: even though
+// ReserveSlot no longer holds lastIssuedMu across its wait, issuance beyond MinSlots is still
+// gated to at most one slot per RampThrottle (enforced by TryReserveSlot's lastSlotIssuedAt check).
+func TestRampThrottleStillBoundsIssuance(t *testing.T) {
+	const ramp = 100 * time.Millisecond
+
+	rcOpts := DefaultResourceControllerOptions()
+	rcOpts.MemTargetPercent = 0.8
+	rcOpts.CpuTargetPercent = 0.9
+	rcOpts.InfoSupplier = &FakeSystemInfoSupplier{memUse: 0.1, cpuUse: 0.1}
+
+	supplier, err := NewResourceBasedSlotSupplier(NewResourceController(rcOpts),
+		ResourceBasedSlotSupplierOptions{MinSlots: 0, MaxSlots: 1000, RampThrottle: ramp})
+	require.NoError(t, err)
+
+	info := &countingReserveInfo{issued: 10} // >= MinSlots, so the throttle gate applies
+
+	require.NotNil(t, supplier.TryReserveSlot(info), "first slot should issue")
+	require.Nil(t, supplier.TryReserveSlot(info), "second slot within RampThrottle must be throttled")
+
+	require.Eventually(t, func() bool {
+		return supplier.TryReserveSlot(info) != nil
+	}, ramp*5, ramp/10, "slot should issue again after RampThrottle elapses")
+}


### PR DESCRIPTION
### What

`ResourceBasedSlotSupplier.ReserveSlot` held `lastIssuedMu` across its `time.After(mustWaitFor)` ramp-throttle wait. Because the non-blocking `TryReserveSlot` (used for eager task dispatch) locks the same mutex, a concurrent `TryReserveSlot` could block for up to `RampThrottle` (50ms by default for activities, higher if configured). This releases the lock before the wait.

### Why

Fixes #2443.

Eager dispatch exists to start a task immediately and avoid a poll round-trip; blocking its `Try*` path for up to `RampThrottle` works against that. Holding the lock during the wait is unnecessary: the ramp throttle is independently enforced by `TryReserveSlot`'s own `time.Since(lastSlotIssuedAt) > RampThrottle` check under the lock, so slot issuance stays bounded to ~one per `RampThrottle` regardless of how many `ReserveSlot` goroutines wait concurrently.

### Changes

- `internal/resource_tuner.go`: snapshot `lastSlotIssuedAt` under `lastIssuedMu`, unlock, then wait instead of holding the lock across the wait.
- `internal/resource_tuner_eager_test.go`:
  - `TestTryReserveSlotDoesNotBlockDuringRampWait` -- regression test; fails before the change (eager `TryReserveSlot` blocks ~`RampThrottle`), passes after.
  - `TestRampThrottleStillBoundsIssuance` -- confirms the throttle still bounds issuance to ~one slot per `RampThrottle` after the concurrency change.
- `CHANGELOG.md`: entry under `## [Unreleased]` → `### Fixed`.

### Testing

- `cd internal/cmd/build && go run . check` -- clean (`vet` / `errcheck` / `staticcheck` / `doclink`).
- `go run . unit-test -run 'TestTryReserveSlotDoesNotBlockDuringRampWait|TestRampThrottleStillBoundsIssuance|TestPidDecisions|TestPidDecisionEmitsUsageMetrics'` -- pass (also verified locally under `-race`; regression test verified red→green).