### PR TITLE
Report poller scale decisions in worker heartbeat

### DIFF
--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -2516,6 +2516,9 @@ func NewAggregatedWorker(client *WorkflowClient, taskQueue string, options Worke
 			if aw.nexusWorker != nil {
 				populateOpts.nexusSlotSupplierKind = aw.nexusWorker.worker.slotSupplier.GetSlotSupplierKind()
 			}
+			// Drain each autoscaler's scale decisions since the last heartbeat, grouped by
+			// poller type.
+			populateOpts.scaleDecisionsByPollerType = aw.collectScaleDecisions()
 			heartbeatTime := time.Now()
 			elapsedSinceLastHeartbeat := heartbeatTime.Sub(previousHeartbeatTime)
 			previousHeartbeatTime = heartbeatTime
@@ -2586,6 +2589,51 @@ func NewAggregatedWorker(client *WorkflowClient, taskQueue string, options Worke
 		})
 	})
 	return aw
+}
+
+// collectScaleDecisions drains and aggregates each poller autoscaler's scale-decision counts
+// since the last heartbeat, keyed by poller type then reason. Pollers of the same type (e.g.
+// the mixed and non-sticky workflow pollers) are summed. Returns nil if no autoscaling poller
+// recorded a decision this interval.
+func (aw *AggregatedWorker) collectScaleDecisions() map[string]map[string]int64 {
+	var out map[string]map[string]int64
+	addWorker := func(bw *baseWorker) {
+		if bw == nil {
+			return
+		}
+		for i := range bw.options.taskPollers {
+			tp := &bw.options.taskPollers[i]
+			if tp.pollerAutoscaler == nil {
+				continue
+			}
+			interval := tp.pollerAutoscaler.drainDecisions()
+			if len(interval) == 0 {
+				continue
+			}
+			if out == nil {
+				out = make(map[string]map[string]int64)
+			}
+			byReason := out[tp.taskPollerType]
+			if byReason == nil {
+				byReason = make(map[string]int64, len(interval))
+				out[tp.taskPollerType] = byReason
+			}
+			for reason, count := range interval {
+				byReason[reason] += count
+			}
+		}
+	}
+	if aw.workflowWorker != nil {
+		addWorker(aw.workflowWorker.worker)
+		addWorker(aw.workflowWorker.localActivityWorker)
+	}
+	if aw.activityWorker != nil {
+		addWorker(aw.activityWorker.worker)
+	}
+	if aw.nexusWorker != nil {
+		addWorker(aw.nexusWorker.worker)
+	}
+	return out
 }
 
 func processTestTags(wOptions *WorkerOptions, ep *workerExecutionParameters) {

--- a/internal/internal_worker_base.go
+++ b/internal/internal_worker_base.go
@@ -289,6 +289,10 @@ type (
 		ingestedThisPeriod        atomic.Int64
 		ingestedLastPeriod        atomic.Int64
 		scaleUpAllowed            atomic.Bool
+		// decisions counts scale decisions since the last worker heartbeat, keyed by reason
+		// (see pollerScaleReasons). Pre-populated in newPollerAutoscaler so recording is a
+		// lock-free atomic increment; drainDecisions reads and resets the counts each heartbeat.
+		decisions map[string]*atomic.Int64
 	}
 
 	barrier chan struct{}
@@ -914,6 +918,26 @@ func (bw *baseWorker) stopPolling() {
 	bw.noRepoll.Store(true)
 }
 
+// pollerScaleReasons enumerates the reasons the poller autoscaler adjusts (or declines
+// to adjust) its target, reported per poller type in the worker heartbeat.
+var pollerScaleReasons = []string{
+	pollerScaleServerUp,
+	pollerScaleServerUpSuppressed,
+	pollerScaleServerDown,
+	pollerScaleEmptyPollDown,
+	pollerScaleReHalve,
+	pollerScaleErrorDown,
+}
+
+const (
+	pollerScaleServerUp           = "server_up"
+	pollerScaleServerUpSuppressed = "server_up_suppressed"
+	pollerScaleServerDown         = "server_down"
+	pollerScaleEmptyPollDown      = "empty_poll_down"
+	pollerScaleReHalve            = "re_halve"
+	pollerScaleErrorDown          = "error_down"
+)
+
 func newPollerAutoscaler(options pollerAutoscalerOptions) *pollerAutoscaler {
 	logger := options.logger
 	if logger == nil {
@@ -923,15 +947,44 @@ func newPollerAutoscaler(options pollerAutoscalerOptions) *pollerAutoscaler {
 	if serverSupportsAutoscaling == nil {
 		serverSupportsAutoscaling = &atomic.Bool{}
 	}
+	decisions := make(map[string]*atomic.Int64, len(pollerScaleReasons))
+	for _, reason := range pollerScaleReasons {
+		decisions[reason] = new(atomic.Int64)
+	}
 	psr := &pollerAutoscaler{
 		maxPollerCount:            options.maxPollerCount,
 		minPollerCount:            options.minPollerCount,
 		logger:                    logger,
 		targetChangedCallback:     options.targetChangedCallback,
 		serverSupportsAutoscaling: serverSupportsAutoscaling,
+		decisions:                 decisions,
 	}
 	psr.target.Store(int64(options.initialPollerCount))
 	return psr
+}
+
+// recordDecision increments the cumulative count for a scale-decision reason. Reasons are
+// pre-populated in newPollerAutoscaler, so an unrecognized reason is a no-op, not a panic.
+func (prh *pollerAutoscaler) recordDecision(reason string) {
+	if c, ok := prh.decisions[reason]; ok {
+		c.Add(1)
+	}
+}
+
+// drainDecisions returns the scale-decision counts recorded since the previous call and
+// resets them, so each worker heartbeat reports the per-interval breakdown. Reasons with no
+// new decisions are omitted; returns nil if there were none (so the heartbeat stays compact).
+func (prh *pollerAutoscaler) drainDecisions() map[string]int64 {
+	var m map[string]int64
+	for reason, c := range prh.decisions {
+		if v := c.Swap(0); v > 0 {
+			if m == nil {
+				m = make(map[string]int64, len(prh.decisions))
+			}
+			m[reason] = v
+		}
+	}
+	return m
 }
 
 func (prh *pollerAutoscaler) handleTask(task taskForWorker) {
@@ -944,11 +997,17 @@ func (prh *pollerAutoscaler) handleTask(task taskForWorker) {
 		ds := sd.pollRequestDeltaSuggestion
 		if ds > 0 {
 			if prh.scaleUpAllowed.Load() {
+				prh.recordDecision(pollerScaleServerUp)
 				prh.updateTarget(func(target int64) int64 {
 					return target + int64(ds)
 				})
+			} else {
+				// Server asked to scale up but the throughput gate is closed, so the
+				// suggestion is dropped. No target change — recorded for attribution.
+				prh.recordDecision(pollerScaleServerUpSuppressed)
 			}
 		} else if ds < 0 {
+			prh.recordDecision(pollerScaleServerDown)
 			prh.updateTarget(func(target int64) int64 {
 				return target + int64(ds)
 			})
@@ -958,6 +1017,7 @@ func (prh *pollerAutoscaler) handleTask(task taskForWorker) {
 		// scaling decisions - otherwise we might never scale up again. If the server
 		// supports poller autoscaling, it's safe to scale down without having seen a
 		// decision.
+		prh.recordDecision(pollerScaleEmptyPollDown)
 		prh.updateTarget(func(target int64) int64 {
 			return target - 1
 		})
@@ -996,10 +1056,12 @@ func (prh *pollerAutoscaler) handleError(err error) {
 	if prh.everSawScalingDecision.Load() || prh.serverSupportsAutoscaling.Load() {
 		_, resourceExhausted := err.(*serviceerror.ResourceExhausted)
 		if resourceExhausted {
+			prh.recordDecision(pollerScaleReHalve)
 			prh.updateTarget(func(target int64) int64 {
 				return target / 2
 			})
 		} else {
+			prh.recordDecision(pollerScaleErrorDown)
 			prh.updateTarget(func(target int64) int64 {
 				return target - 1
 			})

--- a/internal/internal_worker_heartbeat_metrics.go
+++ b/internal/internal_worker_heartbeat_metrics.go
@@ -161,6 +161,11 @@ type populateHeartbeatOptions struct {
 	prevNexusFailed            *int64
 
 	pollTimeTracker *pollTimeTracker
+
+	// scaleDecisionsByPollerType holds poller autoscaler scale-decision counts since the last
+	// heartbeat, keyed by pollerType then reason. Refreshed each heartbeat from the live
+	// autoscalers (which reset their counts when read).
+	scaleDecisionsByPollerType map[string]map[string]int64
 }
 
 // PopulateHeartbeat fills in the metrics-related fields of the WorkerHeartbeat proto.
@@ -221,21 +226,25 @@ func (h *heartbeatMetricsHandler) PopulateHeartbeat(hb *workerpb.WorkerHeartbeat
 		int32(h.get(metrics.NumPoller+":"+metrics.PollerTypeWorkflowTask)),
 		opts.pollTimeTracker.getLastPollTime(metrics.PollerTypeWorkflowTask),
 		opts.workflowPollerBehavior,
+		opts.scaleDecisionsByPollerType[metrics.PollerTypeWorkflowTask],
 	)
 	hb.WorkflowStickyPollerInfo = buildPollerInfo(
 		int32(h.get(metrics.NumPoller+":"+metrics.PollerTypeWorkflowStickyTask)),
 		opts.pollTimeTracker.getLastPollTime(metrics.PollerTypeWorkflowStickyTask),
 		opts.workflowPollerBehavior,
+		opts.scaleDecisionsByPollerType[metrics.PollerTypeWorkflowStickyTask],
 	)
 	hb.ActivityPollerInfo = buildPollerInfo(
 		int32(h.get(metrics.NumPoller+":"+metrics.PollerTypeActivityTask)),
 		opts.pollTimeTracker.getLastPollTime(metrics.PollerTypeActivityTask),
 		opts.activityPollerBehavior,
+		opts.scaleDecisionsByPollerType[metrics.PollerTypeActivityTask],
 	)
 	hb.NexusPollerInfo = buildPollerInfo(
 		int32(h.get(metrics.NumPoller+":"+metrics.PollerTypeNexusTask)),
 		opts.pollTimeTracker.getLastPollTime(metrics.PollerTypeNexusTask),
 		opts.nexusPollerBehavior,
+		opts.scaleDecisionsByPollerType[metrics.PollerTypeNexusTask],
 	)
 }
 
@@ -269,7 +278,7 @@ func buildSlotsInfo(
 	}
 }
 
-func buildPollerInfo(currentPollers int32, lastSuccessfulPollTime time.Time, pollerBehavior PollerBehavior) *workerpb.WorkerPollerInfo {
+func buildPollerInfo(currentPollers int32, lastSuccessfulPollTime time.Time, pollerBehavior PollerBehavior, scaleDecisions map[string]int64) *workerpb.WorkerPollerInfo {
 	var isAutoscaling bool
 	switch pollerBehavior.(type) {
 	case *pollerBehaviorAutoscaling:
@@ -284,6 +293,7 @@ func buildPollerInfo(currentPollers int32, lastSuccessfulPollTime time.Time, pol
 		CurrentPollers:         currentPollers,
 		LastSuccessfulPollTime: pollTime,
 		IsAutoscaling:          isAutoscaling,
+		ScaleDecisions:         scaleDecisions,
 	}
 }
 

--- a/internal/internal_worker_heartbeat_metrics_test.go
+++ b/internal/internal_worker_heartbeat_metrics_test.go
@@ -1,0 +1,72 @@
+package internal
+
+import (
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/api/serviceerror"
+	workerpb "go.temporal.io/api/worker/v1"
+
+	"go.temporal.io/sdk/internal/common/metrics"
+)
+
+// TestPollerAutoscalerDrainDecisions verifies the autoscaler counts scale decisions and that
+// draining returns the counts since the previous drain (i.e. per-interval, not cumulative).
+func TestPollerAutoscalerDrainDecisions(t *testing.T) {
+	serverSupportsAutoscaling := &atomic.Bool{}
+	serverSupportsAutoscaling.Store(true)
+	ps := newPollerAutoscaler(pollerAutoscalerOptions{
+		initialPollerCount:        8,
+		maxPollerCount:            100,
+		minPollerCount:            1,
+		serverSupportsAutoscaling: serverSupportsAutoscaling,
+	})
+
+	// scaleUpAllowed starts closed, so server-requested scale-ups are suppressed (dropped).
+	ps.handleTask(newTestTask(1))
+	ps.handleTask(newTestTask(1))
+	// ResourceExhausted halves the target (8 -> 4): re_halve, no clamp.
+	ps.handleError(serviceerror.NewResourceExhausted(enumspb.RESOURCE_EXHAUSTED_CAUSE_CONCURRENT_LIMIT, ""))
+
+	// First drain returns everything recorded so far.
+	first := ps.drainDecisions()
+	assert.Equal(t, int64(2), first[pollerScaleServerUpSuppressed], "two suppressed server scale-ups")
+	assert.Equal(t, int64(1), first[pollerScaleReHalve], "one re-halve on ResourceExhausted")
+	_, ok := first[pollerScaleServerDown]
+	assert.False(t, ok, "server_down should not appear when it never fired")
+
+	// Draining again with no new decisions is empty (counts were reset).
+	assert.Empty(t, ps.drainDecisions())
+
+	// A new suppressed scale-up shows as a delta of 1, not the cumulative total.
+	ps.handleTask(newTestTask(1))
+	third := ps.drainDecisions()
+	assert.Equal(t, int64(1), third[pollerScaleServerUpSuppressed])
+	_, ok = third[pollerScaleReHalve]
+	assert.False(t, ok, "re_halve had no new decisions this interval")
+}
+
+// TestScaleDecisionsHeartbeat verifies the per-poller-type decision breakdown is written onto
+// the WorkerHeartbeat's poller info.
+func TestScaleDecisionsHeartbeat(t *testing.T) {
+	hm := newHeartbeatMetricsHandler(metrics.NopHandler)
+	hb := &workerpb.WorkerHeartbeat{}
+	hm.PopulateHeartbeat(hb, &populateHeartbeatOptions{
+		pollTimeTracker: &pollTimeTracker{},
+		scaleDecisionsByPollerType: map[string]map[string]int64{
+			metrics.PollerTypeActivityTask: {
+				pollerScaleServerUpSuppressed: 2,
+				pollerScaleReHalve:            1,
+			},
+		},
+	})
+
+	decisions := hb.ActivityPollerInfo.GetScaleDecisions()
+	assert.Equal(t, int64(2), decisions[pollerScaleServerUpSuppressed])
+	assert.Equal(t, int64(1), decisions[pollerScaleReHalve])
+	// Poller types with no decisions have an empty breakdown.
+	assert.Empty(t, hb.WorkflowPollerInfo.GetScaleDecisions())
+	assert.Empty(t, hb.NexusPollerInfo.GetScaleDecisions())
+}


### PR DESCRIPTION
## What changed

The poller autoscaler now counts its scale decisions, keyed by reason (`server_up`, `server_up_suppressed`, `server_down`, `empty_poll_down`, `re_halve`, `error_down`), and each worker heartbeat reports the **per-interval** breakdown per poller type via `WorkerPollerInfo.scale_decisions`.

- `internal_worker_base.go` — autoscaler records decisions into a pre-populated `map[string]*atomic.Int64` (lock-free increment); `drainDecisions()` reads and resets the counts, so each read yields the counts since the previous heartbeat.
- `internal_worker.go` — `collectScaleDecisions()` drains and sums each autoscaler's counts across a worker's pollers by poller type, wired into the heartbeat callback.
- `internal_worker_heartbeat_metrics.go` — sets `WorkerPollerInfo.ScaleDecisions` from that per-interval map.

## Why

Surfaces poller autoscaling behavior — notably server-requested scale-ups suppressed by the throughput gate — to the server via heartbeat, without requiring a metrics pipeline.

## Testing

- `TestPollerAutoscalerDrainDecisions` — drives suppressed scale-ups and a re-halve, then asserts drain returns per-interval counts (first drain has the accumulated counts, a quiet interval is empty, a later decision is a delta of 1 rather than a cumulative total).
- `TestScaleDecisionsHeartbeat` — asserts the per-poller-type breakdown lands on the heartbeat's poller info.

## Dependency

⚠️ Draft: depends on the `scale_decisions` proto field from **temporalio/api#823**. Needs that released and `go.temporal.io/api` bumped in go.mod before CI will build. Verified locally against the generated proto.