### PR TITLE
Implement preferred version provider callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ to docs, or any other relevant information.
 
 ## [Unreleased]
 
+### Added
+
+- Added `worker.Options.PreferredVersionProvider`, which can select the version recorded by a
+  newly encountered `workflow.GetVersion` call. This supports gradual rollout of a new
+  `GetVersion` call before activating its new behavior.
 
 ## [1.46.0] - 2026-07-07
 

--- a/internal/internal_event_handlers.go
+++ b/internal/internal_event_handlers.go
@@ -160,6 +160,7 @@ type (
 		failureConverter         converter.FailureConverter
 		contextPropagators       []ContextPropagator
 		deadlockDetectionTimeout time.Duration
+		preferredVersionProvider PreferredVersionProvider
 		sdkFlags                 *sdkFlags
 		sdkVersionUpdated        bool
 		sdkVersion               string
@@ -223,6 +224,7 @@ func newWorkflowExecutionEventHandler(
 	contextPropagators []ContextPropagator,
 	deadlockDetectionTimeout time.Duration,
 	capabilities *workflowservice.GetSystemInfoResponse_Capabilities,
+	preferredVersionProvider PreferredVersionProvider,
 ) workflowExecutionEventHandler {
 	wfCtx := converter.WorkflowSerializationContext{
 		Namespace:  workflowInfo.Namespace,
@@ -247,6 +249,7 @@ func newWorkflowExecutionEventHandler(
 		failureConverter:             failureConverter,
 		contextPropagators:           contextPropagators,
 		deadlockDetectionTimeout:     deadlockDetectionTimeout,
+		preferredVersionProvider:     preferredVersionProvider,
 		protocols:                    protocol.NewRegistry(),
 		mutableSideEffectCallCounter: make(map[string]int),
 		sdkFlags:                     newSDKFlagSet(capabilities),
@@ -931,7 +934,12 @@ func (wc *workflowEnvironmentImpl) GetVersion(changeID string, minSupported, max
 	} else {
 		// GetVersion for changeID is called first time (non-replay mode), generate a marker command for it.
 		// Also upsert search attributes to enable ability to search by changeVersion.
-		version = maxSupported
+		version = resolvePreferredVersion(wc.preferredVersionProvider, PreferredVersionProviderInput{
+			WorkflowInfo: wc.workflowInfo,
+			ChangeID:     changeID,
+			MinSupported: minSupported,
+			MaxSupported: maxSupported,
+		})
 		changeVersionSA := createSearchAttributesForChangeVersion(changeID, version, wc.changeVersions)
 		attr, err := validateAndSerializeSearchAttributes(changeVersionSA)
 		if err != nil {
@@ -957,6 +965,38 @@ func (wc *workflowEnvironmentImpl) GetVersion(changeID string, minSupported, max
 	validateVersion(changeID, version, minSupported, maxSupported)
 	wc.changeVersions[changeID] = version
 	return version
+}
+
+func resolvePreferredVersion(
+	preferredVersionProvider PreferredVersionProvider,
+	input PreferredVersionProviderInput,
+) Version {
+	if preferredVersionProvider == nil {
+		return input.MaxSupported
+	}
+
+	preference := preferredVersionProvider(input)
+	if preference == nil {
+		return input.MaxSupported
+	}
+	if preference.Version >= input.MinSupported && preference.Version <= input.MaxSupported {
+		return preference.Version
+	}
+	if preference.ClampToSupportedRange {
+		if preference.Version < input.MinSupported {
+			return input.MinSupported
+		}
+		return input.MaxSupported
+	}
+
+	panicIllegalState(fmt.Sprintf(
+		"[TMPRL1100] Preferred version %v for %q change ID is not supported. Supported versions are between %v and %v.",
+		preference.Version,
+		input.ChangeID,
+		input.MinSupported,
+		input.MaxSupported,
+	))
+	return input.MaxSupported
 }
 
 func createSearchAttributesForChangeVersion(changeID string, version Version, existingChangeVersions map[string]Version) map[string]interface{} {

--- a/internal/internal_event_handlers_test.go
+++ b/internal/internal_event_handlers_test.go
@@ -126,6 +126,37 @@ func Test_ValidateAndSerializeSearchAttributes(t *testing.T) {
 	require.Equal(t, 1, resp)
 }
 
+func TestPreferredVersionProviderOutOfRange(t *testing.T) {
+	input := PreferredVersionProviderInput{
+		WorkflowInfo: &WorkflowInfo{},
+		ChangeID:     "change-id",
+		MinSupported: DefaultVersion,
+		MaxSupported: 1,
+	}
+
+	t.Run("fails", func(t *testing.T) {
+		require.Panics(t, func() {
+			resolvePreferredVersion(
+				func(PreferredVersionProviderInput) *VersionPreference {
+					return &VersionPreference{Version: 2}
+				},
+				input,
+			)
+		})
+	})
+
+	t.Run("clamps", func(t *testing.T) {
+		provider := func(input PreferredVersionProviderInput) *VersionPreference {
+			return &VersionPreference{Version: 2, ClampToSupportedRange: true}
+		}
+		require.Equal(
+			t,
+			Version(1),
+			resolvePreferredVersion(provider, input),
+		)
+	})
+}
+
 func Test_UpsertSearchAttributes(t *testing.T) {
 	t.Parallel()
 	helper := newCommandsHelper()

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -135,6 +135,7 @@ type (
 		useBuildIDForVersioning   bool
 		workerDeploymentVersion   WorkerDeploymentVersion
 		defaultVersioningBehavior VersioningBehavior
+		preferredVersionProvider  PreferredVersionProvider
 		enableLoggingInReplay     bool
 		registry                  *registry
 		laTunnel                  *localActivityTunnel
@@ -585,6 +586,7 @@ func newWorkflowTaskHandler(params workerExecutionParameters, ppMgr pressurePoin
 		useBuildIDForVersioning:   params.UseBuildIDForVersioning,
 		workerDeploymentVersion:   params.DeploymentOptions.Version,
 		defaultVersioningBehavior: params.DeploymentOptions.DefaultVersioningBehavior,
+		preferredVersionProvider:  params.PreferredVersionProvider,
 		enableLoggingInReplay:     params.EnableLoggingInReplay,
 		registry:                  registry,
 		workflowPanicPolicy:       params.WorkflowPanicPolicy,
@@ -706,6 +708,7 @@ func (w *workflowExecutionContextImpl) createEventHandler() {
 		w.wth.contextPropagators,
 		w.wth.deadlockDetectionTimeout,
 		w.wth.capabilities,
+		w.wth.preferredVersionProvider,
 	)
 
 	w.eventHandler = &eventHandler

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -161,6 +161,8 @@ type (
 		// Worker deployment options containing all deployment versioning configuration.
 		DeploymentOptions WorkerDeploymentOptions
 
+		PreferredVersionProvider PreferredVersionProvider
+
 		MetricsHandler metrics.Handler
 
 		Logger log.Logger
@@ -2330,6 +2332,7 @@ func NewAggregatedWorker(client *WorkflowClient, taskQueue string, options Worke
 		WorkerBuildID:                    options.BuildID,
 		UseBuildIDForVersioning:          options.UseBuildIDForVersioning || options.DeploymentOptions.UseVersioning,
 		DeploymentOptions:                options.DeploymentOptions,
+		PreferredVersionProvider:         options.PreferredVersionProvider,
 		MetricsHandler:                   metricsHandler,
 		Logger:                           logger,
 		EnableLoggingInReplay:            options.EnableLoggingInReplay,

--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -3080,9 +3080,18 @@ func (env *testWorkflowEnvironmentImpl) GetVersion(changeID string, minSupported
 		validateVersion(changeID, version, minSupported, maxSupported)
 		return version
 	}
-	_ = env.UpsertSearchAttributes(createSearchAttributesForChangeVersion(changeID, maxSupported, env.changeVersions))
-	env.changeVersions[changeID] = maxSupported
-	return maxSupported
+	version := resolvePreferredVersion(
+		env.workerOptions.PreferredVersionProvider,
+		PreferredVersionProviderInput{
+			WorkflowInfo: env.workflowInfo,
+			ChangeID:     changeID,
+			MinSupported: minSupported,
+			MaxSupported: maxSupported,
+		},
+	)
+	_ = env.UpsertSearchAttributes(createSearchAttributesForChangeVersion(changeID, version, env.changeVersions))
+	env.changeVersions[changeID] = version
+	return version
 }
 
 func (env *testWorkflowEnvironmentImpl) getMockedVersion(mockedChangeID, changeID string, minSupported, maxSupported Version) (Version, bool) {

--- a/internal/internal_workflow_testsuite_test.go
+++ b/internal/internal_workflow_testsuite_test.go
@@ -1781,6 +1781,34 @@ func (s *WorkflowTestSuiteUnitTest) Test_GetVersion() {
 	env.AssertExpectations(s.T())
 }
 
+func (s *WorkflowTestSuiteUnitTest) Test_PreferredVersionProvider() {
+	providerCalls := 0
+	var providerInput PreferredVersionProviderInput
+	env := s.NewTestWorkflowEnvironment()
+	env.SetWorkerOptions(WorkerOptions{
+		PreferredVersionProvider: func(input PreferredVersionProviderInput) *VersionPreference {
+			providerCalls++
+			providerInput = input
+			return &VersionPreference{Version: DefaultVersion}
+		},
+	})
+	env.ExecuteWorkflow(func(ctx Context) (Version, error) {
+		version := GetVersion(ctx, "preferred-version", DefaultVersion, 1)
+		s.Equal(version, GetVersion(ctx, "preferred-version", DefaultVersion, 1))
+		return version, nil
+	})
+
+	s.True(env.IsWorkflowCompleted())
+	s.NoError(env.GetWorkflowError())
+	var result Version
+	s.NoError(env.GetWorkflowResult(&result))
+	s.Equal(DefaultVersion, result)
+	s.Equal(1, providerCalls)
+	s.Equal("preferred-version", providerInput.ChangeID)
+	s.Equal(DefaultVersion, providerInput.MinSupported)
+	s.Equal(Version(1), providerInput.MaxSupported)
+}
+
 func (s *WorkflowTestSuiteUnitTest) Test_MockGetVersion() {
 	oldActivity := func(ctx context.Context, msg string) (string, error) {
 		return "hello" + "_" + msg, nil

--- a/internal/worker.go
+++ b/internal/worker.go
@@ -94,6 +94,52 @@ type (
 		DefaultVersioningBehavior VersioningBehavior
 	}
 
+	// PreferredVersionProvider provides the version to record for a GetVersion call when the
+	// version marker is created for the first time.
+	//
+	// It is called only during non-replay workflow task execution, before the SDK records a
+	// version marker for the change ID. It is not called during replay or after a version was
+	// already recorded for the same change ID. Returning nil uses the default of MaxSupported.
+	//
+	// The provider runs on a workflow goroutine. It can read a configuration file or another
+	// nondeterministic source because the selected version is recorded in workflow history.
+	// A panic from the provider fails the current workflow task, which Temporal retries.
+	//
+	// NOTE: Experimental
+	//
+	// Exposed as: [go.temporal.io/sdk/worker.PreferredVersionProvider]
+	PreferredVersionProvider func(PreferredVersionProviderInput) *VersionPreference
+
+	// PreferredVersionProviderInput is the input passed to a PreferredVersionProvider.
+	//
+	// NOTE: Experimental
+	//
+	// Exposed as: [go.temporal.io/sdk/worker.PreferredVersionProviderInput]
+	PreferredVersionProviderInput struct {
+		// WorkflowInfo is information about the workflow execution handling the GetVersion call.
+		WorkflowInfo *WorkflowInfo
+		// ChangeID is the change ID passed to GetVersion.
+		ChangeID string
+		// MinSupported is the minimum version supported by the GetVersion call.
+		MinSupported Version
+		// MaxSupported is the maximum version supported by the GetVersion call.
+		MaxSupported Version
+	}
+
+	// VersionPreference is the version preference returned by a PreferredVersionProvider.
+	//
+	// NOTE: Experimental
+	//
+	// Exposed as: [go.temporal.io/sdk/worker.VersionPreference]
+	VersionPreference struct {
+		// Version is the version to record. It must be in the range passed to GetVersion unless
+		// ClampToSupportedRange is true.
+		Version Version
+		// ClampToSupportedRange controls whether Version is clamped to the range passed to
+		// GetVersion instead of failing the workflow task when it is out of range.
+		ClampToSupportedRange bool
+	}
+
 	// WorkerOptions is used to configure a worker instance.
 	// The current timeout resolution implementation is in seconds and uses math.Ceil(d.Seconds()) as the duration. But is
 	// subjected to change in the future.
@@ -352,6 +398,15 @@ type (
 		// Optional: If set it configures Worker Versioning for this worker. See [WorkerDeploymentOptions]
 		// for more.
 		DeploymentOptions WorkerDeploymentOptions
+
+		// Optional: Provides the version to record the first time a non-replay
+		// [workflow.GetVersion] call is encountered for a change ID. If unset, or if the provider
+		// returns nil, the SDK records maxSupported. This can support a rolling deployment that
+		// introduces a GetVersion call: initially return [workflow.DefaultVersion] so workers with
+		// the old code can replay, then return the desired version after the new code is deployed.
+		//
+		// NOTE: Experimental
+		PreferredVersionProvider PreferredVersionProvider
 
 		// Optional: If set, use a custom tuner for this worker. See WorkerTuner for more.
 		// Mutually exclusive with MaxConcurrentWorkflowTaskExecutionSize,

--- a/internal/worker.go
+++ b/internal/worker.go
@@ -99,7 +99,8 @@ type (
 	//
 	// It is called only during non-replay workflow task execution, before the SDK records a
 	// version marker for the change ID. It is not called during replay or after a version was
-	// already recorded for the same change ID. Returning nil uses the default of MaxSupported.
+	// already recorded for the same change ID. Returning nil is equivalent to choosing
+	// [PreferredVersionProviderInput.MaxSupported].
 	//
 	// The provider runs on a workflow goroutine. It can read a configuration file or another
 	// nondeterministic source because the selected version is recorded in workflow history.
@@ -400,9 +401,9 @@ type (
 		DeploymentOptions WorkerDeploymentOptions
 
 		// Optional: Provides the version to record the first time a non-replay
-		// [workflow.GetVersion] call is encountered for a change ID. If unset, or if the provider
-		// returns nil, the SDK records maxSupported. This can support a rolling deployment that
-		// introduces a GetVersion call: initially return [workflow.DefaultVersion] so workers with
+		// workflow.GetVersion call is encountered for a change ID. If unset, or if the provider
+		// returns nil, the SDK records GetVersion's maxSupported argument. This can support a rolling deployment that
+		// introduces a GetVersion call: initially return workflow.DefaultVersion so workers with
 		// the old code can replay, then return the desired version after the new code is deployed.
 		//
 		// NOTE: Experimental

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -310,6 +310,189 @@ func (ts *IntegrationTestSuite) TestBasic() {
 	ts.assertMetricCountAtLeast("temporal_long_request", 3, "operation", "PollWorkflowTaskQueue")
 }
 
+func (ts *IntegrationTestSuite) TestPreferredVersionProvider() {
+	ts.worker.Stop()
+	ts.workerStopped = true
+
+	providerInputs := make(chan worker.PreferredVersionProviderInput, 1)
+	var providerCalls atomic.Int32
+	preferredWorker := worker.New(ts.client, ts.taskQueueName, worker.Options{
+		PreferredVersionProvider: func(input worker.PreferredVersionProviderInput) *worker.VersionPreference {
+			if providerCalls.Add(1) == 1 {
+				providerInputs <- input
+			}
+			return &worker.VersionPreference{Version: workflow.DefaultVersion}
+		},
+	})
+	defer preferredWorker.Stop()
+
+	preferredWorkflow := func(ctx workflow.Context) (string, error) {
+		version := workflow.GetVersion(ctx, "preferred-version", workflow.DefaultVersion, 1)
+		if version != workflow.DefaultVersion {
+			return "", fmt.Errorf("unexpected version: %v", version)
+		}
+		if workflow.GetVersion(ctx, "preferred-version", workflow.DefaultVersion, 1) != version {
+			return "", errors.New("GetVersion returned different versions for the same change ID")
+		}
+		return "old", nil
+	}
+	preferredWorker.RegisterWorkflow(preferredWorkflow)
+	ts.NoError(preferredWorker.Start())
+
+	var result string
+	ts.NoError(ts.executeWorkflow("preferred-version-provider", preferredWorkflow, &result))
+	ts.Equal("old", result)
+	ts.Equal(int32(1), providerCalls.Load())
+	input := <-providerInputs
+	ts.Equal("preferred-version-provider", input.WorkflowInfo.WorkflowExecution.ID)
+	ts.Equal("preferred-version", input.ChangeID)
+	ts.Equal(workflow.DefaultVersion, input.MinSupported)
+	ts.Equal(workflow.Version(1), input.MaxSupported)
+}
+
+func (ts *IntegrationTestSuite) TestPreferredVersionProviderRollout() {
+	const (
+		workflowName = "preferred-version-provider-rollout"
+		changeID     = "preferred-version"
+		signalName   = "release"
+		queryName    = "state"
+	)
+
+	ts.worker.Stop()
+	ts.workerStopped = true
+
+	newWorkflow := func(ctx workflow.Context) (string, error) {
+		releases := 0
+		if err := workflow.SetQueryHandler(ctx, queryName, func() (string, error) {
+			return fmt.Sprintf("new-%d", releases), nil
+		}); err != nil {
+			return "", err
+		}
+
+		version := workflow.GetVersion(ctx, changeID, workflow.DefaultVersion, 1)
+		release := workflow.GetSignalChannel(ctx, signalName)
+		release.Receive(ctx, nil)
+		releases++
+		if replayedVersion := workflow.GetVersion(ctx, changeID, workflow.DefaultVersion, 1); replayedVersion != version {
+			return "", fmt.Errorf("GetVersion returned %v after returning %v", replayedVersion, version)
+		}
+		release.Receive(ctx, nil)
+		releases++
+		if version == workflow.DefaultVersion {
+			return "old", nil
+		}
+		return "new", nil
+	}
+	oldWorkflow := func(ctx workflow.Context) (string, error) {
+		releases := 0
+		if err := workflow.SetQueryHandler(ctx, queryName, func() (string, error) {
+			return fmt.Sprintf("old-%d", releases), nil
+		}); err != nil {
+			return "", err
+		}
+
+		release := workflow.GetSignalChannel(ctx, signalName)
+		release.Receive(ctx, nil)
+		releases++
+		release.Receive(ctx, nil)
+		return "old", nil
+	}
+
+	startWorker := func(options worker.Options, workflowFn interface{}) worker.Worker {
+		w := worker.New(ts.client, ts.taskQueueName, options)
+		w.RegisterWorkflowWithOptions(workflowFn, workflow.RegisterOptions{Name: workflowName})
+		ts.NoError(w.Start())
+		return w
+	}
+	assertState := func(ctx context.Context, run client.WorkflowRun, expected string) {
+		ts.Eventually(func() bool {
+			value, err := ts.client.QueryWorkflow(ctx, run.GetID(), run.GetRunID(), queryName)
+			if err != nil {
+				return false
+			}
+			var state string
+			return value.Get(&state) == nil && state == expected
+		}, 10*time.Second, 100*time.Millisecond, "timed out waiting for workflow state %q", expected)
+	}
+	startWorkflow := func(ctx context.Context, workflowID string) client.WorkflowRun {
+		options := ts.startWorkflowOptions(workflowID)
+		options.EnableEagerStart = false
+		run, err := ts.client.ExecuteWorkflow(ctx, options, workflowName)
+		ts.NoError(err)
+		return run
+	}
+	signal := func(ctx context.Context, run client.WorkflowRun) {
+		ts.NoError(ts.client.SignalWorkflow(ctx, run.GetID(), run.GetRunID(), signalName, nil))
+	}
+
+	ts.Run("unactivated new code replays on old worker", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
+		defer cancel()
+
+		var unactivatedProviderCalls atomic.Int32
+		newWorker := startWorker(worker.Options{
+			PreferredVersionProvider: func(worker.PreferredVersionProviderInput) *worker.VersionPreference {
+				unactivatedProviderCalls.Add(1)
+				return &worker.VersionPreference{Version: workflow.DefaultVersion}
+			},
+		}, newWorkflow)
+		defer newWorker.Stop()
+
+		run := startWorkflow(ctx, "preferred-version-provider-unactivated-"+uuid.NewString())
+		ts.waitForHistoryEvent(run.GetID(), run.GetRunID(), enumspb.EVENT_TYPE_MARKER_RECORDED, 10*time.Second)
+		assertState(ctx, run, "new-0")
+		ts.Equal(int32(1), unactivatedProviderCalls.Load())
+
+		newWorker.Stop()
+		oldWorker := startWorker(worker.Options{}, oldWorkflow)
+		defer oldWorker.Stop()
+
+		signal(ctx, run)
+		assertState(ctx, run, "old-1")
+		signal(ctx, run)
+		var result string
+		ts.NoError(run.Get(ctx, &result))
+		ts.Equal("old", result)
+	})
+
+	ts.Run("activated marker replays on unactivated new worker", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
+		defer cancel()
+
+		var activatedProviderCalls atomic.Int32
+		activatedWorker := startWorker(worker.Options{
+			PreferredVersionProvider: func(worker.PreferredVersionProviderInput) *worker.VersionPreference {
+				activatedProviderCalls.Add(1)
+				return &worker.VersionPreference{Version: 1}
+			},
+		}, newWorkflow)
+		defer activatedWorker.Stop()
+
+		run := startWorkflow(ctx, "preferred-version-provider-activated-"+uuid.NewString())
+		ts.waitForHistoryEvent(run.GetID(), run.GetRunID(), enumspb.EVENT_TYPE_MARKER_RECORDED, 10*time.Second)
+		assertState(ctx, run, "new-0")
+		ts.Equal(int32(1), activatedProviderCalls.Load())
+
+		activatedWorker.Stop()
+		var unactivatedProviderCalls atomic.Int32
+		unactivatedWorker := startWorker(worker.Options{
+			PreferredVersionProvider: func(worker.PreferredVersionProviderInput) *worker.VersionPreference {
+				unactivatedProviderCalls.Add(1)
+				return &worker.VersionPreference{Version: workflow.DefaultVersion}
+			},
+		}, newWorkflow)
+		defer unactivatedWorker.Stop()
+
+		signal(ctx, run)
+		assertState(ctx, run, "new-1")
+		signal(ctx, run)
+		var result string
+		ts.NoError(run.Get(ctx, &result))
+		ts.Equal("new", result)
+		ts.Zero(unactivatedProviderCalls.Load())
+	})
+}
+
 // TestLocalActivityRetryBehavior verifies local activity retry behaviors:
 // 1) local activity retry with local timer backoff when backoff duration is less than or equal to workflow task timeout
 // 2) workflow task heartbeat is happening when local activity takes longer than workflow task timeout

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -208,7 +208,7 @@ type (
 	// WorkerDeploymentVersion represents a specific version of a worker in a deployment.
 	WorkerDeploymentVersion = internal.WorkerDeploymentVersion
 
-	// PreferredVersionProvider provides the version to record when a GetVersion marker is first created.
+	// PreferredVersionProvider provides the version to record when a [workflow.GetVersion] marker is first created.
 	//
 	// NOTE: Experimental
 	PreferredVersionProvider = internal.PreferredVersionProvider

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -208,6 +208,21 @@ type (
 	// WorkerDeploymentVersion represents a specific version of a worker in a deployment.
 	WorkerDeploymentVersion = internal.WorkerDeploymentVersion
 
+	// PreferredVersionProvider provides the version to record when a GetVersion marker is first created.
+	//
+	// NOTE: Experimental
+	PreferredVersionProvider = internal.PreferredVersionProvider
+
+	// PreferredVersionProviderInput is the input passed to a PreferredVersionProvider.
+	//
+	// NOTE: Experimental
+	PreferredVersionProviderInput = internal.PreferredVersionProviderInput
+
+	// VersionPreference is the version preference returned by a PreferredVersionProvider.
+	//
+	// NOTE: Experimental
+	VersionPreference = internal.VersionPreference
+
 	// Options is used to configure a worker instance.
 	Options = internal.WorkerOptions
 

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -497,8 +497,8 @@ const DefaultVersion Version = internal.DefaultVersion
 // It is not allowed to update workflow code while there are workflows running as it is going to break
 // determinism. The solution is to have both old code that is used to replay existing workflows
 // as well as the new one that is used when it is executed for the first time.
-// GetVersion returns maxSupported version when it is executed for the first time, unless the worker configures a
-// [worker.Options.PreferredVersionProvider] that selects a different supported version. This version is recorded into
+// GetVersion returns its maxSupported argument when executed for the first time, unless the worker configures a
+// [go.temporal.io/sdk/worker.Options.PreferredVersionProvider]. The returned version is recorded into
 // the workflow history as a marker event. Even if maxSupported version is changed, the version that was recorded is
 // returned on replay. DefaultVersion constant contains version of code that wasn't versioned before.
 // For example initially workflow has the following code:

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -497,8 +497,9 @@ const DefaultVersion Version = internal.DefaultVersion
 // It is not allowed to update workflow code while there are workflows running as it is going to break
 // determinism. The solution is to have both old code that is used to replay existing workflows
 // as well as the new one that is used when it is executed for the first time.
-// GetVersion returns maxSupported version when is executed for the first time. This version is recorded into the
-// workflow history as a marker event. Even if maxSupported version is changed the version that was recorded is
+// GetVersion returns maxSupported version when it is executed for the first time, unless the worker configures a
+// [worker.Options.PreferredVersionProvider] that selects a different supported version. This version is recorded into
+// the workflow history as a marker event. Even if maxSupported version is changed, the version that was recorded is
 // returned on replay. DefaultVersion constant contains version of code that wasn't versioned before.
 // For example initially workflow has the following code:
 //


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Per a customer request, added a way to specify a "preferred" version to use when making a get version call which may not necessarily be the `maxVersion` which would normally be used when a `GetVersion` call is encountered for the first time.

This is accomplished by adding a worker option: `PreferredVersionProvider` which accepts a callback that can be used to determine the version for a given call.

## Why?
Users would like to have a way to perform a rolling deployment of a worker change that includes an introduction of a `GetVersion` call to a workflow. Without this capability, such a rolling deployment means that if a worker with the new code picks up a task, runs the call, and then the workflow replays on the old code, a WFT failure occurs because the old code is missing the call. (The other direction is acceptable). 

This makes rolling deployments noisy, especially if they proceed slowly.

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-go/issues/2446

2. How was this tested:
Added tests

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
