### PR TITLE
Add CHANGELOG.md for each contrib package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,8 @@ quick reference for coding-agent work and pull requests.
   change is explicit and reviewed. User-facing changes, including new features,
   behavior changes, deprecations, breaking changes, notable bug fixes, and
   security fixes, require a `CHANGELOG.md` entry under `## [Unreleased]`.
+  Use the affected module's `CHANGELOG.md` for independently released `contrib`
+  modules and the repository-root `CHANGELOG.md` for the main SDK module.
 - Behavior changes require tests. Public API or public behavior changes also
   need documentation or examples when existing user-facing guidance would become
   incomplete or misleading.
@@ -120,7 +122,8 @@ externally.
 - For workflow execution, replay/cache, worker lifecycle, cancellation, update,
   or local activity changes, run focused integration tests in both default-cache
   mode and with `WORKFLOW_CACHE_SIZE=0`.
-- Update public docs, examples, and `CHANGELOG.md` for user-facing changes.
+- Update public docs, examples, and the affected module's `CHANGELOG.md` for
+  user-facing changes.
 - Keep commit messages short and imperative.
 
 ## Where things are
@@ -141,7 +144,8 @@ externally.
 - `contrib/` - optional integrations such as OpenTelemetry, OpenTracing, Tally,
   Datadog, envconfig, sysinfo, and workflow streams.
 - `mocks/` - generated or maintained mocks used by tests.
-- `CHANGELOG.md` - user-facing release notes.
+- `CHANGELOG.md` - user-facing release notes for the main SDK module. Each
+  independently released `contrib` module has its own `CHANGELOG.md`.
 
 ## Notes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 <!--
-High-level release notes.
+High-level release notes for the main Go SDK module. Changes to independently
+released modules under `contrib` belong in the `CHANGELOG.md` for that module.
 Loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 When your PR includes a user-facing change, add an entry below under the

--- a/contrib/aws/lambdaworker/CHANGELOG.md
+++ b/contrib/aws/lambdaworker/CHANGELOG.md
@@ -1,0 +1,12 @@
+<!--
+Release notes for go.temporal.io/sdk/contrib/aws/lambdaworker.
+Loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+Add user-facing changes below under the appropriate heading (create the heading
+if it does not yet exist): Added, Changed, Deprecated, Breaking Changes, Fixed,
+or Security.
+-->
+
+# Changelog
+
+## [Unreleased]

--- a/contrib/aws/lambdaworker/otel/CHANGELOG.md
+++ b/contrib/aws/lambdaworker/otel/CHANGELOG.md
@@ -1,0 +1,12 @@
+<!--
+Release notes for go.temporal.io/sdk/contrib/aws/lambdaworker/otel.
+Loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+Add user-facing changes below under the appropriate heading (create the heading
+if it does not yet exist): Added, Changed, Deprecated, Breaking Changes, Fixed,
+or Security.
+-->
+
+# Changelog
+
+## [Unreleased]

--- a/contrib/aws/s3driver/CHANGELOG.md
+++ b/contrib/aws/s3driver/CHANGELOG.md
@@ -1,0 +1,12 @@
+<!--
+Release notes for go.temporal.io/sdk/contrib/aws/s3driver.
+Loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+Add user-facing changes below under the appropriate heading (create the heading
+if it does not yet exist): Added, Changed, Deprecated, Breaking Changes, Fixed,
+or Security.
+-->
+
+# Changelog
+
+## [Unreleased]

--- a/contrib/aws/s3driver/awssdkv2/CHANGELOG.md
+++ b/contrib/aws/s3driver/awssdkv2/CHANGELOG.md
@@ -1,0 +1,12 @@
+<!--
+Release notes for go.temporal.io/sdk/contrib/aws/s3driver/awssdkv2.
+Loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+Add user-facing changes below under the appropriate heading (create the heading
+if it does not yet exist): Added, Changed, Deprecated, Breaking Changes, Fixed,
+or Security.
+-->
+
+# Changelog
+
+## [Unreleased]

--- a/contrib/datadog/CHANGELOG.md
+++ b/contrib/datadog/CHANGELOG.md
@@ -1,0 +1,12 @@
+<!--
+Release notes for go.temporal.io/sdk/contrib/datadog.
+Loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+Add user-facing changes below under the appropriate heading (create the heading
+if it does not yet exist): Added, Changed, Deprecated, Breaking Changes, Fixed,
+or Security.
+-->
+
+# Changelog
+
+## [Unreleased]

--- a/contrib/envconfig/CHANGELOG.md
+++ b/contrib/envconfig/CHANGELOG.md
@@ -1,0 +1,12 @@
+<!--
+Release notes for go.temporal.io/sdk/contrib/envconfig.
+Loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+Add user-facing changes below under the appropriate heading (create the heading
+if it does not yet exist): Added, Changed, Deprecated, Breaking Changes, Fixed,
+or Security.
+-->
+
+# Changelog
+
+## [Unreleased]

--- a/contrib/opentelemetry/CHANGELOG.md
+++ b/contrib/opentelemetry/CHANGELOG.md
@@ -1,0 +1,12 @@
+<!--
+Release notes for go.temporal.io/sdk/contrib/opentelemetry.
+Loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+Add user-facing changes below under the appropriate heading (create the heading
+if it does not yet exist): Added, Changed, Deprecated, Breaking Changes, Fixed,
+or Security.
+-->
+
+# Changelog
+
+## [Unreleased]

--- a/contrib/opentracing/CHANGELOG.md
+++ b/contrib/opentracing/CHANGELOG.md
@@ -1,0 +1,12 @@
+<!--
+Release notes for go.temporal.io/sdk/contrib/opentracing.
+Loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+Add user-facing changes below under the appropriate heading (create the heading
+if it does not yet exist): Added, Changed, Deprecated, Breaking Changes, Fixed,
+or Security.
+-->
+
+# Changelog
+
+## [Unreleased]

--- a/contrib/sysinfo/CHANGELOG.md
+++ b/contrib/sysinfo/CHANGELOG.md
@@ -1,0 +1,12 @@
+<!--
+Release notes for go.temporal.io/sdk/contrib/sysinfo.
+Loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+Add user-facing changes below under the appropriate heading (create the heading
+if it does not yet exist): Added, Changed, Deprecated, Breaking Changes, Fixed,
+or Security.
+-->
+
+# Changelog
+
+## [Unreleased]

--- a/contrib/tally/CHANGELOG.md
+++ b/contrib/tally/CHANGELOG.md
@@ -1,0 +1,12 @@
+<!--
+Release notes for go.temporal.io/sdk/contrib/tally.
+Loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+Add user-facing changes below under the appropriate heading (create the heading
+if it does not yet exist): Added, Changed, Deprecated, Breaking Changes, Fixed,
+or Security.
+-->
+
+# Changelog
+
+## [Unreleased]

--- a/contrib/tools/workflowcheck/CHANGELOG.md
+++ b/contrib/tools/workflowcheck/CHANGELOG.md
@@ -1,0 +1,12 @@
+<!--
+Release notes for go.temporal.io/sdk/contrib/tools/workflowcheck.
+Loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+Add user-facing changes below under the appropriate heading (create the heading
+if it does not yet exist): Added, Changed, Deprecated, Breaking Changes, Fixed,
+or Security.
+-->
+
+# Changelog
+
+## [Unreleased]

--- a/contrib/workflowstreams/CHANGELOG.md
+++ b/contrib/workflowstreams/CHANGELOG.md
@@ -1,0 +1,12 @@
+<!--
+Release notes for go.temporal.io/sdk/contrib/workflowstreams.
+Loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+Add user-facing changes below under the appropriate heading (create the heading
+if it does not yet exist): Added, Changed, Deprecated, Breaking Changes, Fixed,
+or Security.
+-->
+
+# Changelog
+
+## [Unreleased]


### PR DESCRIPTION
## What was changed
Add CHANGELOG.md for each contrib package

## Why?
Each of these `contrib/` packages release separately from the main Go SDK. Makes sense that we should keep separate changelogs for them.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
