### PR TITLE
contrib/opentelemetry: opt-in monotonic counters

### DIFF
--- a/contrib/opentelemetry/CHANGELOG.md
+++ b/contrib/opentelemetry/CHANGELOG.md
@@ -1,0 +1,18 @@
+<!--
+Release notes for go.temporal.io/sdk/contrib/opentelemetry.
+Loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Add user-facing changes below under the appropriate heading (create the heading
+if it does not yet exist): Added, Changed, Deprecated, Breaking Changes, Fixed,
+or Security.
+-->
+
+# Changelog
+
+## [Unreleased]
+
+### Added
+
+- Added `UseMonotonicCounters` to `MetricsHandlerOptions`. When enabled, SDK counters use
+  OpenTelemetry monotonic counters so exporters can classify them as counters. The option defaults
+  to false to preserve existing metric types and names. Custom counters used with this option must
+  not decrement; doing so may produce invalid or backend-dependent metric data.

--- a/contrib/opentelemetry/handler.go
+++ b/contrib/opentelemetry/handler.go
@@ -109,17 +109,13 @@ func (m MetricsHandler) WithTags(tags map[string]string) client.MetricsHandler {
 }
 
 func (m MetricsHandler) Counter(name string) client.MetricsCounter {
+	var c interface { Add(context.Context, int64, ...metric.AddOption) }
+	var err error
 	if m.useMonotonicCounters {
-		c, err := m.meter.Int64Counter(name)
-		if err != nil {
-			m.onError(err)
-			return client.MetricsNopHandler.Counter(name)
-		}
-		return metrics.CounterFunc(func(d int64) {
-			c.Add(context.Background(), d, metric.WithAttributeSet(m.attributes))
-		})
+	    c, err = m.meter.Int64Counter(name)
+	} else {
+	    c, err = m.meter.Int64UpDownCounter(name)
 	}
-	c, err := m.meter.Int64UpDownCounter(name)
 	if err != nil {
 		m.onError(err)
 		return client.MetricsNopHandler.Counter(name)

--- a/contrib/opentelemetry/handler.go
+++ b/contrib/opentelemetry/handler.go
@@ -35,12 +35,12 @@ type MetricsHandlerOptions struct {
 	//
 	// Optional: Defaults to panicking on any error.
 	OnError func(error)
-	// UseMonotonicCounters causes Counter to use OpenTelemetry's Int64Counter
+	// UseMonotonicCounters causes [MetricsHandler.Counter] to use OpenTelemetry's Int64Counter
 	// instead of Int64UpDownCounter. This allows exporters to identify SDK
 	// counters as monotonic sums.
 	//
-	// MetricsCounter is documented as ever-increasing, so values passed to Inc
-	// must be non-negative. Negative values may produce invalid or
+	// [client.MetricsCounter] is documented as ever-increasing, so values passed to
+	// [client.MetricsCounter.Inc] must be non-negative. Negative values may produce invalid or
 	// backend-dependent metric data.
 	//
 	// Optional: Defaults to false

--- a/contrib/opentelemetry/handler.go
+++ b/contrib/opentelemetry/handler.go
@@ -16,9 +16,10 @@ var _ client.MetricsHandler = MetricsHandler{}
 // MetricsHandler is an implementation of client.MetricsHandler
 // for open telemetry.
 type MetricsHandler struct {
-	meter      metric.Meter
-	attributes attribute.Set
-	onError    func(error)
+	meter                metric.Meter
+	attributes           attribute.Set
+	onError              func(error)
+	useMonotonicCounters bool
 }
 
 // MetricsHandlerOptions are options provided to NewMetricsHandler.
@@ -34,6 +35,16 @@ type MetricsHandlerOptions struct {
 	//
 	// Optional: Defaults to panicking on any error.
 	OnError func(error)
+	// UseMonotonicCounters causes Counter to use OpenTelemetry's Int64Counter
+	// instead of Int64UpDownCounter. This allows exporters to identify SDK
+	// counters as monotonic sums.
+	//
+	// MetricsCounter is documented as ever-increasing, so values passed to Inc
+	// must be non-negative. Negative values may produce invalid or
+	// backend-dependent metric data.
+	//
+	// Optional: Defaults to false
+	UseMonotonicCounters bool
 }
 
 // NewMetricsHandler returns a client.MetricsHandler that is backed by the given Meter
@@ -45,9 +56,10 @@ func NewMetricsHandler(options MetricsHandlerOptions) MetricsHandler {
 		options.OnError = func(err error) { panic(err) }
 	}
 	return MetricsHandler{
-		meter:      options.Meter,
-		attributes: options.InitialAttributes,
-		onError:    options.OnError,
+		meter:                options.Meter,
+		attributes:           options.InitialAttributes,
+		onError:              options.OnError,
+		useMonotonicCounters: options.UseMonotonicCounters,
 	}
 }
 
@@ -89,13 +101,24 @@ func (m MetricsHandler) WithTags(tags map[string]string) client.MetricsHandler {
 		attributes = append(attributes, attribute.String(k, v))
 	}
 	return MetricsHandler{
-		meter:      m.meter,
-		attributes: attribute.NewSet(attributes...),
-		onError:    m.onError,
+		meter:                m.meter,
+		attributes:           attribute.NewSet(attributes...),
+		onError:              m.onError,
+		useMonotonicCounters: m.useMonotonicCounters,
 	}
 }
 
 func (m MetricsHandler) Counter(name string) client.MetricsCounter {
+	if m.useMonotonicCounters {
+		c, err := m.meter.Int64Counter(name)
+		if err != nil {
+			m.onError(err)
+			return client.MetricsNopHandler.Counter(name)
+		}
+		return metrics.CounterFunc(func(d int64) {
+			c.Add(context.Background(), d, metric.WithAttributeSet(m.attributes))
+		})
+	}
 	c, err := m.meter.Int64UpDownCounter(name)
 	if err != nil {
 		m.onError(err)

--- a/contrib/opentelemetry/handler_test.go
+++ b/contrib/opentelemetry/handler_test.go
@@ -94,6 +94,39 @@ func TestCounterHandler(t *testing.T) {
 	metricdatatest.AssertEqual(t, want, metrics[0], metricdatatest.IgnoreTimestamp())
 }
 
+func TestCounterHandlerWithMonotonicCounters(t *testing.T) {
+	ctx := context.Background()
+	metricReader := metric.NewManualReader()
+	meterProvider := metric.NewMeterProvider(metric.WithReader(metricReader))
+	handler := opentelemetry.NewMetricsHandler(opentelemetry.MetricsHandlerOptions{
+		Meter:                meterProvider.Meter("test"),
+		UseMonotonicCounters: true,
+	})
+	taggedHandler := handler.WithTags(map[string]string{"tag1": "value1"})
+	taggedHandler.Counter("testCounter").Inc(2)
+	taggedHandler.Counter("testCounter").Inc(3)
+
+	var rm metricdata.ResourceMetrics
+	metricReader.Collect(ctx, &rm)
+	assert.Len(t, rm.ScopeMetrics, 1)
+	metrics := rm.ScopeMetrics[0].Metrics
+	assert.Len(t, metrics, 1)
+	want := metricdata.Metrics{
+		Name: "testCounter",
+		Data: metricdata.Sum[int64]{
+			Temporality: metricdata.CumulativeTemporality,
+			IsMonotonic: true,
+			DataPoints: []metricdata.DataPoint[int64]{
+				{
+					Value:      5,
+					Attributes: attribute.NewSet(attribute.String("tag1", "value1")),
+				},
+			},
+		},
+	}
+	metricdatatest.AssertEqual(t, want, metrics[0], metricdatatest.IgnoreTimestamp())
+}
+
 func TestGaugeHandler(t *testing.T) {
 	ctx := context.Background()
 	metricReader := metric.NewManualReader()


### PR DESCRIPTION
## What was changed
Add in option for monotonic counters

## Why?
See more details in linked issue. Adding this correction as opt-in, to not cause a wider-scoped breaking change. 

This decision can be revisited before `contrib/opentelemetry` reaches version 1.0.0, ideally alongside an explicit policy for handling negative counter increments, such as rejecting them.

Although `MetricsCounter` is documented as ever-increasing, `Inc` accepts an `int64`, so the type system permits negative increments. The existing OpenTelemetry handler uses `Int64UpDownCounter`, and custom user metrics may currently rely on that behavior.

Changing the default to `Int64Counter` would affect all counters, including custom metrics, and negative increments could produce invalid or backend-dependent metric data. The opt-in allows correctly implemented counters to receive the proper monotonic classification without changing existing behavior.

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-go/issues/2140

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to contrib/opentelemetry metrics mapping behind a default-off flag; no auth or core SDK runtime changes.
> 
> **Overview**
> Adds **`UseMonotonicCounters`** on `MetricsHandlerOptions` so OpenTelemetry **`Counter`** can emit **`Int64Counter`** (monotonic sums) instead of the existing **`Int64UpDownCounter`**. Default stays **false**, so metric types and behavior for current users are unchanged.
> 
> When the option is on, tagged handlers inherit the setting via **`WithTags`**, and a new test asserts exported sums have **`IsMonotonic: true`**. The changelog documents the option and warns that decrements/negative **`Inc`** values are unsafe with monotonic counters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e3283299e5241d5cfadbcacd9af083cf9f943de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->