### PR TITLE
Make changelog check smarter

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -18,11 +18,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Reminds contributors to record user-facing changes. Passes when the PR
-      # touches CHANGELOG.md, or when a maintainer applies the
+      # touches any CHANGELOG.md, or when a maintainer applies the
       # `skip-changelog` label to confirm no entry is needed. Otherwise
       # fails with guidance. It does not judge whether the entry is meaningful,
       # it is purely a nudge.
-      - name: Require CHANGELOG.md update or override label
+      - name: Require a CHANGELOG.md update or override label
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
@@ -34,9 +34,9 @@ jobs:
             exit 0
           fi
           if gh api "repos/$REPO/pulls/$PR_NUMBER/files" --paginate --jq '.[].filename' \
-            | grep -qx 'CHANGELOG.md'; then
-            echo "CHANGELOG.md was updated."
+            | grep -Eq '(^|/)CHANGELOG\.md$'; then
+            echo "A CHANGELOG.md was updated."
             exit 0
           fi
-          echo "::error::This PR does not update CHANGELOG.md. If it includes a user-facing change, add an entry under [Unreleased] in CHANGELOG.md. If no changelog entry is needed, a maintainer can apply the 'skip-changelog' label."
+          echo "::error::This PR does not update a CHANGELOG.md. If it includes a user-facing change, add an entry under [Unreleased] in the affected module's CHANGELOG.md. If no changelog entry is needed, a maintainer can apply the 'skip-changelog' label."
           exit 1


### PR DESCRIPTION
## What was changed
Check any **/CHANGELOG.md, not just the root one.

## Why?
`contrib/*` packages now have their own changelogs

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow wording and filename matching; no runtime or API impact.
> 
> **Overview**
> The **Changelog checkpoint** workflow no longer requires edits to the repository-root `CHANGELOG.md` only. It now passes when the PR touches **any** file named `CHANGELOG.md` (e.g. under `contrib/*`), using `grep -Eq '(^|/)CHANGELOG\.md$'` instead of an exact match on `CHANGELOG.md`.
> 
> Comments, step name, success messages, and the failure error were updated to refer to **a** / **any** `CHANGELOG.md` and to tell contributors to add entries under `[Unreleased]` in the **affected module’s** changelog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6367ad5cd9987790907d4613dd5cf8ebe4c5f31c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->