### PR TITLE
fix: Honor context cancellation in `ResourceBasedSlotSupplier.ReserveSlot`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,13 @@ to docs, or any other relevant information.
   newly encountered `workflow.GetVersion` call. This supports gradual rollout of a new
   `GetVersion` call before activating its new behavior.
 
+### Fixed
+
+- Resource-based tuner: `ReserveSlot` now honors context cancellation while the resource controller is
+  declining slots. Previously the retry loop observed the context only while the ramp throttle was making
+  the caller wait, so a poller goroutine could outlive worker shutdown, keeping the worker's stop
+  `WaitGroup` from draining and continuing to sample system resources for the life of the process.
+
 ## [1.46.0] - 2026-07-07
 
 ### Fixed

--- a/internal/resource_tuner.go
+++ b/internal/resource_tuner.go
@@ -16,6 +16,10 @@ const (
 	resourceSlotsMemUsage = "temporal_resource_slots_mem_usage"
 )
 
+// retryReserveInterval is how long ReserveSlot waits before re-asking the controller for a slot
+// after it has declined one.
+const retryReserveInterval = 10 * time.Millisecond
+
 // SysInfoProvider implementations provide information about system resources.
 //
 // Exposed as: [go.temporal.io/sdk/worker.SysInfoProvider]
@@ -180,6 +184,9 @@ func NewResourceBasedSlotSupplier(
 
 func (r *ResourceBasedSlotSupplier) ReserveSlot(ctx context.Context, info SlotReservationInfo) (*SlotPermit, error) {
 	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		if info.NumIssuedSlots() < r.options.MinSlots {
 			return &SlotPermit{}, nil
 		}
@@ -201,7 +208,11 @@ func (r *ResourceBasedSlotSupplier) ReserveSlot(ctx context.Context, info SlotRe
 		if maybePermit != nil {
 			return maybePermit, nil
 		}
-		time.Sleep(10 * time.Millisecond)
+		select {
+		case <-time.After(retryReserveInterval):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
 	}
 }
 

--- a/internal/resource_tuner_cancel_test.go
+++ b/internal/resource_tuner_cancel_test.go
@@ -1,0 +1,103 @@
+package internal
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/sdk/internal/common/metrics"
+	ilog "go.temporal.io/sdk/internal/log"
+	"go.temporal.io/sdk/log"
+)
+
+// reserveCallCounter counts NumIssuedSlots calls, so a test can observe that ReserveSlot has entered
+// its retry loop without resorting to a fixed sleep.
+type reserveCallCounter struct {
+	calls atomic.Int64
+}
+
+func (c *reserveCallCounter) TaskQueue() string { return "test-tq" }
+func (c *reserveCallCounter) TaskQueueKind() enumspb.TaskQueueKind {
+	return enumspb.TASK_QUEUE_KIND_NORMAL
+}
+func (c *reserveCallCounter) WorkerBuildId() string           { return "" }
+func (c *reserveCallCounter) WorkerIdentity() string          { return "" }
+func (c *reserveCallCounter) NumIssuedSlots() int             { c.calls.Add(1); return 10 }
+func (c *reserveCallCounter) Logger() log.Logger              { return ilog.NewNopLogger() }
+func (c *reserveCallCounter) MetricsHandler() metrics.Handler { return metrics.NopHandler }
+
+// TestReserveSlotRejectsAlreadyCancelledContext covers the MinSlots fast path, which returns a permit
+// without consulting the controller. semaphore.Acquire, which FixedSizeSlotSupplier reserves through,
+// fails a cancelled context even when it could acquire without blocking; this keeps the two suppliers
+// consistent.
+func TestReserveSlotRejectsAlreadyCancelledContext(t *testing.T) {
+	rcOpts := DefaultResourceControllerOptions()
+	rcOpts.InfoSupplier = &FakeSystemInfoSupplier{memUse: 0.1, cpuUse: 0.1}
+
+	supplier, err := NewResourceBasedSlotSupplier(NewResourceController(rcOpts),
+		ResourceBasedSlotSupplierOptions{MinSlots: 100, MaxSlots: 1000, RampThrottle: 0})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	permit, err := supplier.ReserveSlot(ctx, &reserveCallCounter{}) // NumIssuedSlots is 10, under MinSlots
+	require.ErrorIs(t, err, context.Canceled)
+	require.Nil(t, permit)
+}
+
+// TestReserveSlotHonorsContextCancellation covers worker shutdown while the controller is declining
+// slots. Both cases below skip the ramp wait, which used to be the only place the context was
+// observed, leaving the retry loop with no cancellation point at all.
+func TestReserveSlotHonorsContextCancellation(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		ramp time.Duration
+	}{
+		// The default for workflow slot suppliers: the ramp block is skipped entirely.
+		{"no ramp throttle", 0},
+		// A ramp is configured, but the last issuance is old enough that no wait is required.
+		{"ramp throttle already elapsed", 50 * time.Millisecond},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rcOpts := DefaultResourceControllerOptions()
+			rcOpts.MemTargetPercent = 0.8
+			rcOpts.CpuTargetPercent = 0.9
+			// Over the memory target, so the controller always declines and TryReserveSlot always
+			// returns nil. This is the sustained-pressure case the tuner exists to handle.
+			rcOpts.InfoSupplier = &FakeSystemInfoSupplier{memUse: 0.95, cpuUse: 0.95}
+
+			supplier, err := NewResourceBasedSlotSupplier(NewResourceController(rcOpts),
+				ResourceBasedSlotSupplierOptions{MinSlots: 0, MaxSlots: 1000, RampThrottle: tc.ramp})
+			require.NoError(t, err)
+
+			info := &reserveCallCounter{} // NumIssuedSlots is 10, past MinSlots
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			reserveErr := make(chan error, 1)
+			go func() {
+				_, err := supplier.ReserveSlot(ctx, info)
+				reserveErr <- err
+			}()
+
+			// Each retry iteration calls NumIssuedSlots once. Waiting for a second call means the
+			// loop is spinning, so cancelling now exercises the retry path rather than entry.
+			require.Eventually(t, func() bool {
+				return info.calls.Load() > 1
+			}, 2*time.Second, time.Millisecond, "ReserveSlot did not enter its retry loop")
+
+			cancel()
+
+			select {
+			case err := <-reserveErr:
+				require.ErrorIs(t, err, context.Canceled)
+			case <-time.After(2 * time.Second):
+				t.Fatal("ReserveSlot did not return after its context was cancelled")
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What

`ResourceBasedSlotSupplier.ReserveSlot` did not return when its context was cancelled, as long as the resource controller was declining slots.

The retry loop ended in a bare `time.Sleep(10 * time.Millisecond)`, and the ramp wait above it (the only place the context was observed) is skipped whenever the throttle is not currently holding issuance back:

- `RampThrottle == 0`, which is the default for workflow slot suppliers, skips the block outright.
- `RampThrottle > 0` but `mustWaitFor <= 0`, which is the steady state once no slot has been issued recently, skips the `select`.

In those cases the loop had no cancellation point, and only exited by obtaining a permit. But `TryReserveSlot` returns `nil` for as long as `pidDecision` declines, which is exactly the sustained resource pressure the tuner exists to handle.

This checks the context at the top of the loop and makes the retry wait cancellable, following the approach agreed in [#2450](https://github.com/temporalio/sdk-go/issues/2450#issuecomment-4960701770).

### Why

Fixes #2450.

`reserveSlotAsync` runs `ReserveSlot` in a goroutine registered on the worker's stop `WaitGroup`, and `Stop()` waits on that group. So under resource pressure the goroutine outlived the worker: `Stop()` reported `"Worker graceful stop timed out."`, and the goroutine kept spinning on the 10ms loop, sampling the `SysInfoProvider` roughly 180 times a second, for the life of the process.

`runPoller` does cancel the context on its way out, so the signal was being delivered. It just was not being acted on.

This also aligns the implementation with the interface contract, which says *"Any returned error besides `context.Canceled` will be logged and the function will be retried"*, with `reserveSlotAsync`'s `errors.Is(err, context.Canceled)` handling, and with `FixedSizeSlotSupplier.ReserveSlot`, which already honors cancellation via `sem.Acquire(ctx, 1)`.

### Changes

- `internal/resource_tuner.go`: `ctx.Err()` is checked at the top of the retry loop, and the retry wait is now a `select` on a timer and `ctx.Done()` rather than a bare `time.Sleep`. The interval is unchanged; it is lifted into a named constant (`retryReserveInterval`).
- `internal/resource_tuner_cancel_test.go`:
  - `TestReserveSlotHonorsContextCancellation`, table-driven over both cases that skip the ramp wait (`RampThrottle == 0` and a ramp that has already elapsed), with a `SysInfoProvider` reporting memory above target so the controller always declines. On `main`, `ReserveSlot` never returns; it passes with the change.
  - `TestReserveSlotRejectsAlreadyCancelledContext`, covering the `MinSlots` fast path, which returns a permit without consulting the controller. On `main` it hands back a permit and a nil error.
- `CHANGELOG.md`: entry under `## [Unreleased]` → `### Fixed`.

### Why both changes, and not just the top-of-loop check

[The issue discussion](https://github.com/temporalio/sdk-go/issues/2450#issuecomment-4960701770) noted that the interruptible retry is optional, since the wait is only 10ms. It is included here for two reasons, and it can be dropped without affecting the fix if reviewers prefer the smaller diff:

- The two changes address different halves of the problem. The top-of-loop check makes the loop *notice* cancellation, one iteration late. The `select` makes the wait itself cancellable, so the goroutine returns at once rather than finishing a sleep it no longer has a reason to finish. The 10ms on its own is immaterial; what it buys is that termination no longer depends on reaching the top of the loop again.
- A bare `time.Sleep` inside a function that takes a `context.Context` is the shape that produced this bug. The `select` costs the same few lines and removes the trap for the next person to edit this loop.

### Testing

- `cd internal/cmd/build && go run . check` clean (vet / errcheck / staticcheck / doclink).
- `go run . unit-test`: full suite green (1443 tests, `-race`), no failures and no races.
- Both new tests verified red without the corresponding change and green with it.

### Notes

- No public API change.
- The `MinSlots` fast path now declines an already-cancelled context rather than returning a permit. That matches `FixedSizeSlotSupplier`: `semaphore.Acquire` checks `ctx.Done()` first and prefers to fail *"even if we could acquire the mutex without blocking"*. Both callers of `ReserveSlot` handle the error path already: `trackingSlotSupplier.ReserveSlot` propagates it, and `reserveSlotAsync` returns silently on `context.Canceled`.
- Touches the same function as #2444, but the hunks do not overlap and the two merge cleanly (verified locally). Happy to rebase in whichever order is preferred.
