### PR TITLE
Allow query results to use external storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ to docs, or any other relevant information.
 
 ### Fixed
 
+- Allow query results to use external storage before payload size enforcement.
 - Correct schedule catch-up window documentation to state that an unset value is omitted and the
   server applies its one-year default.
 - Resource-based tuner: `ReserveSlot` now honors context cancellation while the resource controller is

--- a/internal/internal_event_handlers.go
+++ b/internal/internal_event_handlers.go
@@ -28,7 +28,6 @@ import (
 )
 
 const (
-	queryResultSizeLimit             = 2000000 // 2MB
 	changeVersionSearchAttrSizeLimit = 2048
 )
 
@@ -1505,14 +1504,6 @@ func (weh *workflowExecutionEventHandlerImpl) ProcessQuery(
 		result, err := weh.queryHandler(queryType, queryArgs, header)
 		if err != nil {
 			return nil, err
-		}
-
-		if result.Size() > queryResultSizeLimit {
-			weh.logger.Error("Query result size exceeds limit.",
-				tagQueryType, queryType,
-				tagWorkflowID, weh.workflowInfo.WorkflowExecution.ID,
-				tagRunID, weh.workflowInfo.WorkflowExecution.RunID)
-			return nil, fmt.Errorf("query result size (%v) exceeds limit (%v)", result.Size(), queryResultSizeLimit)
 		}
 
 		return result, nil

--- a/test/external_storage_test.go
+++ b/test/external_storage_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -326,7 +327,7 @@ func (s *ExternalStorageTestSuite) TestQuery() {
 	s.worker.RegisterWorkflow(extStoreQueryWorkflow)
 	s.NoError(s.worker.Start())
 
-	large := oversized(72)
+	large := strings.Repeat("a", 2_000_000+1024)
 	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
 	defer cancel()
 

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -1855,7 +1855,7 @@ func (ts *IntegrationTestSuite) TestLargeQueryResultError() {
 	ts.Error(err)
 
 	ts.IsType(&serviceerror.QueryFailed{}, err)
-	ts.Equal("query result size (3000036) exceeds limit (2000000)", err.Error())
+	ts.Equal("Blob data size exceeds limit.", err.Error())
 	ts.Nil(value)
 }
 


### PR DESCRIPTION
## What was changed

This PR removes the early hardcoded query result size check in `ProcessQuery`.

Query results now continue through the normal outbound payload visitor path, allowing external storage to offload oversized query payloads before payload size enforcement.

The existing external storage query integration test was updated to use a query result larger than 2 MB, verifying that large query results can be stored externally and retrieved by the client.

## Why?

Previously, query results were checked against a hardcoded 2 MB limit immediately after the query handler returned.

That meant external storage never had a chance to replace the large payload with a small external-storage reference, even when external storage was configured.

This made query results behave differently from other outbound payloads that already pass through the external storage visitor before payload size enforcement.

## Checklist

1. Closes #2456

2. How was this tested:

- `go test ./internal -run 'TestPayloadLimits' -count=1`
- `cd test && go test . -run 'TestExternalStorageSuite/TestQuery' -count=3`
- `cd test && go test . -run 'TestExternalStorageSuite' -count=1`

3. Any docs updates needed?

No docs updates needed. This fixes query result handling to use the existing external storage path.