### PR TITLE
Fix schedule catchup window documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ to docs, or any other relevant information.
 
 ### Fixed
 
+- Correct schedule catch-up window documentation to state that an unset value is omitted and the
+  server applies its one-year default.
 - Resource-based tuner: `ReserveSlot` now honors context cancellation while the resource controller is
   declining slots. Previously the retry loop observed the context only while the ramp throttle was making
   the caller wait, so a poller goroutine could outlive worker shutdown, keeping the worker's stop

--- a/internal/internal_schedule_client.go
+++ b/internal/internal_schedule_client.go
@@ -103,8 +103,7 @@ func (w *workflowClientInterceptor) CreateSchedule(ctx context.Context, in *Sche
 
 	var catchupWindow *durationpb.Duration
 	if in.Options.CatchupWindow != 0 {
-		// Convert to nil so the server uses the default
-		// catchup window,otherwise it will use the minimum (10s).
+		// Leave zero unset so the server applies its default catchup window.
 		catchupWindow = durationpb.New(in.Options.CatchupWindow)
 	}
 

--- a/internal/internal_schedule_client_test.go
+++ b/internal/internal_schedule_client_test.go
@@ -66,7 +66,12 @@ func (s *scheduleClientTestSuite) TestCreateScheduleClient() {
 		},
 	}
 	createResp := &workflowservice.CreateScheduleResponse{}
-	s.service.EXPECT().CreateSchedule(gomock.Any(), gomock.Any(), gomock.Any()).Return(createResp, nil).Times(1)
+	s.service.EXPECT().CreateSchedule(gomock.Any(), gomock.Any(), gomock.Any()).
+		Do(func(_ interface{}, req *workflowservice.CreateScheduleRequest, _ ...interface{}) {
+			s.Nil(req.Schedule.Policies.CatchupWindow)
+		}).
+		Return(createResp, nil).
+		Times(1)
 
 	scheduleHandle, err := s.client.ScheduleClient().Create(context.Background(), options)
 	s.Nil(err)

--- a/internal/schedule_client.go
+++ b/internal/schedule_client.go
@@ -335,11 +335,11 @@ type (
 
 		// CatchupWindow - The Temporal Server might be down or unavailable at the time when a Schedule should take an Action.
 		// When the Server comes back up, CatchupWindow controls which missed Actions should be taken at that point. The default is one
-		// minute, which means that the Schedule attempts to take any Actions that wouldn't be more than one minute late. It
+		// year, which means that the Schedule attempts to take any Actions that wouldn't be more than one year late. It
 		// takes those Actions according to the Overlap. An outage that lasts longer than the Catchup
 		// Window could lead to missed Actions.
 		//
-		// Optional: defaulted to 1 minute
+		// Optional: zero leaves this unset so the Temporal Server applies its default (currently one year).
 		CatchupWindow time.Duration
 
 		// PauseOnFailure - When an Action times out or reaches the end of its Retry Policy the Schedule will pause.

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -5970,11 +5970,14 @@ func (ts *IntegrationTestSuite) TestScheduleCreate() {
 	})
 	ts.NoError(err)
 	ts.EqualValues("test-schedule-create-schedule", handle.GetID())
+	description, err := handle.Describe(ctx)
+	ts.NoError(err)
+	ts.Equal(365*24*time.Hour, description.Schedule.Policy.CatchupWindow)
 
 	err = handle.Delete(ctx)
 	ts.NoError(err)
 
-	description, err := handle.Describe(ctx)
+	description, err = handle.Describe(ctx)
 	ts.IsType(&serviceerror.NotFound{}, err)
 	ts.Nil(description)
 }


### PR DESCRIPTION
## What changed
- Correct the documented default catch-up window from one minute to the server’s current one-year default.
- Clarify that zero is omitted so the server selects the default.
- Add request-level and create/describe integration coverage.

## Why
The SDK already omitted an unspecified catch-up window, but its documentation was stale and the create path lacked regression coverage.

## Validation
- Focused internal unit test
- Focused schedule integration test with Temporal dev server

## Breaking changes
None.