### PR TITLE
fix: honor worker stop while a session poller waits for a token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,9 @@ to docs, or any other relevant information.
   environment. This lets host processes that register a single shared factory (e.g.
   `roadrunner-temporal` / the PHP SDK) use dynamic workflows.
 - Merged link-converter class in the server and sdk-go and moved it to api-go
+- Session worker: stopping a worker while it is at its maximum concurrent session count no longer blocks
+  for the stop timeout. The session creation poller waited for an available session token without
+  observing the stop signal, so shutdown could not interrupt it and the poller goroutine leaked.
 
 ## [1.46.0] - 2026-07-07
 

--- a/internal/internal_worker_base.go
+++ b/internal/internal_worker_base.go
@@ -532,8 +532,8 @@ func (bw *baseWorker) runPoller(taskWorker scalableTaskPoller) {
 				}
 				continue
 			}
-			if bw.sessionTokenBucket != nil {
-				bw.sessionTokenBucket.waitForAvailableToken()
+			if bw.sessionTokenBucket != nil && !bw.sessionTokenBucket.waitForAvailableToken() {
+				return
 			}
 			if bw.pollerBalancer != nil {
 				bw.pollerBalancer.incrementPoller(taskWorker.taskPollerType)
@@ -597,8 +597,8 @@ func (bw *baseWorker) runAutoscalingPoller(taskWorker scalableTaskPoller) {
 			continue
 		}
 
-		if bw.sessionTokenBucket != nil {
-			bw.sessionTokenBucket.waitForAvailableToken()
+		if bw.sessionTokenBucket != nil && !bw.sessionTokenBucket.waitForAvailableToken() {
+			return
 		}
 		if bw.pollerBalancer != nil {
 			bw.pollerBalancer.incrementPoller(taskWorker.taskPollerType)
@@ -905,6 +905,9 @@ func (bw *baseWorker) Stop() {
 	}
 	close(bw.stopCh)
 	bw.limiterContextCancel()
+	if bw.sessionTokenBucket != nil {
+		bw.sessionTokenBucket.close()
+	}
 
 	// Wait for pollers, task dispatch, and task processing to complete, or until stopTimeout elapses.
 	// The task dispatcher drains taskQueueCh after the closer goroutine

--- a/internal/internal_worker_base.go
+++ b/internal/internal_worker_base.go
@@ -533,6 +533,7 @@ func (bw *baseWorker) runPoller(taskWorker scalableTaskPoller) {
 				continue
 			}
 			if bw.sessionTokenBucket != nil && !bw.sessionTokenBucket.waitForAvailableToken() {
+				bw.releaseSlot(permit, SlotReleaseReasonUnused)
 				return
 			}
 			if bw.pollerBalancer != nil {
@@ -598,6 +599,8 @@ func (bw *baseWorker) runAutoscalingPoller(taskWorker scalableTaskPoller) {
 		}
 
 		if bw.sessionTokenBucket != nil && !bw.sessionTokenBucket.waitForAvailableToken() {
+			bw.releaseSlot(permit, SlotReleaseReasonUnused)
+			releaseActive()
 			return
 		}
 		if bw.pollerBalancer != nil {

--- a/internal/internal_worker_base_test.go
+++ b/internal/internal_worker_base_test.go
@@ -1228,3 +1228,60 @@ func (s *ScalableTaskPollerSuite) TestNewScalableTaskPollerAllTypes() {
 		})
 	}
 }
+
+// signalOnReserveSlotSupplier grants a permit and signals once, so a test can tell the poller has a
+// permit and is committed to the session-token wait before it calls Stop().
+type signalOnReserveSlotSupplier struct{ reserved chan struct{} }
+
+func (s *signalOnReserveSlotSupplier) ReserveSlot(ctx context.Context, _ SlotReservationInfo) (*SlotPermit, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+	select {
+	case s.reserved <- struct{}{}:
+	default:
+	}
+	return &SlotPermit{}, nil
+}
+func (s *signalOnReserveSlotSupplier) TryReserveSlot(SlotReservationInfo) *SlotPermit {
+	return &SlotPermit{}
+}
+func (s *signalOnReserveSlotSupplier) MarkSlotUsed(SlotMarkUsedInfo) {}
+func (s *signalOnReserveSlotSupplier) ReleaseSlot(SlotReleaseInfo)   {}
+func (s *signalOnReserveSlotSupplier) MaxSlots() int                 { return 0 }
+
+// TestStopReturnsPromptlyWithPollerAwaitingSessionToken covers a session worker at its maximum session
+// count: the creation poller parks in sessionTokenBucket.waitForAvailableToken. Stop() must wake it,
+// rather than block for the whole stopTimeout while the poller goroutine leaks.
+func TestStopReturnsPromptlyWithPollerAwaitingSessionToken(t *testing.T) {
+	bucket := newSessionTokenBucket(1)
+	require.True(t, bucket.getToken(), "drain the only token so the poller parks in the token wait")
+
+	reserved := make(chan struct{}, 1)
+	tp := newBlockingProbeTaskPoller()
+	defer tp.Close()
+
+	bw := newBaseWorker(baseWorkerOptions{
+		slotSupplier:     &signalOnReserveSlotSupplier{reserved: reserved},
+		maxTaskPerSecond: 1000,
+		taskPollers: []scalableTaskPoller{
+			{taskPollerType: "test", pollerCount: 1, taskPoller: tp},
+		},
+		taskProcessor:      noopTaskProcessor{},
+		workerType:         "SessionTokenStopTest",
+		logger:             ilog.NewNopLogger(),
+		stopTimeout:        5 * time.Second,
+		metricsHandler:     metrics.NopHandler,
+		sessionTokenBucket: bucket,
+	})
+
+	bw.Start()
+	<-reserved // the poller holds a permit and is committed to the token wait
+
+	start := time.Now()
+	bw.Stop()
+	require.Less(t, time.Since(start), time.Second,
+		"Stop() should wake a poller waiting for a session token, not block for the full stopTimeout")
+}

--- a/internal/internal_worker_base_test.go
+++ b/internal/internal_worker_base_test.go
@@ -1229,42 +1229,59 @@ func (s *ScalableTaskPollerSuite) TestNewScalableTaskPollerAllTypes() {
 	}
 }
 
-// signalOnReserveSlotSupplier grants a permit and signals once, so a test can tell the poller has a
-// permit and is committed to the session-token wait before it calls Stop().
-type signalOnReserveSlotSupplier struct{ reserved chan struct{} }
+// sessionTokenWaitProbe is a token bucket lock that reports the first entry into
+// waitForAvailableToken. Entry is the signal a test needs: the poller holds this lock from there
+// until Cond.Wait parks it, and close() takes the same lock, so a Stop() beginning after the signal
+// cannot overtake the waiter.
+type sessionTokenWaitProbe struct {
+	sync.Mutex
+	entered chan struct{}
+	once    sync.Once
+}
 
-func (s *signalOnReserveSlotSupplier) ReserveSlot(ctx context.Context, _ SlotReservationInfo) (*SlotPermit, error) {
+func (p *sessionTokenWaitProbe) Lock() {
+	p.Mutex.Lock()
+	p.once.Do(func() { close(p.entered) })
+}
+
+// releaseRecordingSlotSupplier records the reason each permit is released with.
+type releaseRecordingSlotSupplier struct{ released chan SlotReleaseReason }
+
+func (s *releaseRecordingSlotSupplier) ReserveSlot(ctx context.Context, _ SlotReservationInfo) (*SlotPermit, error) {
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	default:
 	}
-	select {
-	case s.reserved <- struct{}{}:
-	default:
-	}
 	return &SlotPermit{}, nil
 }
-func (s *signalOnReserveSlotSupplier) TryReserveSlot(SlotReservationInfo) *SlotPermit {
+func (s *releaseRecordingSlotSupplier) TryReserveSlot(SlotReservationInfo) *SlotPermit {
 	return &SlotPermit{}
 }
-func (s *signalOnReserveSlotSupplier) MarkSlotUsed(SlotMarkUsedInfo) {}
-func (s *signalOnReserveSlotSupplier) ReleaseSlot(SlotReleaseInfo)   {}
-func (s *signalOnReserveSlotSupplier) MaxSlots() int                 { return 0 }
+func (s *releaseRecordingSlotSupplier) MarkSlotUsed(SlotMarkUsedInfo) {}
+func (s *releaseRecordingSlotSupplier) ReleaseSlot(info SlotReleaseInfo) {
+	select {
+	case s.released <- info.Reason():
+	default:
+	}
+}
+func (s *releaseRecordingSlotSupplier) MaxSlots() int { return 0 }
 
 // TestStopReturnsPromptlyWithPollerAwaitingSessionToken covers a session worker at its maximum session
-// count: the creation poller parks in sessionTokenBucket.waitForAvailableToken. Stop() must wake it,
-// rather than block for the whole stopTimeout while the poller goroutine leaks.
+// count: the creation poller parks in sessionTokenBucket.waitForAvailableToken. Stop() must wake it and
+// the poller must give its slot back, rather than blocking for the whole stopTimeout while the poller
+// goroutine and its permit leak.
 func TestStopReturnsPromptlyWithPollerAwaitingSessionToken(t *testing.T) {
-	bucket := newSessionTokenBucket(1)
-	require.True(t, bucket.getToken(), "drain the only token so the poller parks in the token wait")
+	probe := &sessionTokenWaitProbe{entered: make(chan struct{})}
+	// No available token is the at-capacity state: every session slot is in use.
+	bucket := &sessionTokenBucket{Cond: sync.NewCond(probe)}
 
-	reserved := make(chan struct{}, 1)
+	supplier := &releaseRecordingSlotSupplier{released: make(chan SlotReleaseReason, 1)}
 	tp := newBlockingProbeTaskPoller()
 	defer tp.Close()
 
 	bw := newBaseWorker(baseWorkerOptions{
-		slotSupplier:     &signalOnReserveSlotSupplier{reserved: reserved},
+		slotSupplier:     supplier,
 		maxTaskPerSecond: 1000,
 		taskPollers: []scalableTaskPoller{
 			{taskPollerType: "test", pollerCount: 1, taskPoller: tp},
@@ -1278,10 +1295,18 @@ func TestStopReturnsPromptlyWithPollerAwaitingSessionToken(t *testing.T) {
 	})
 
 	bw.Start()
-	<-reserved // the poller holds a permit and is committed to the token wait
+	<-probe.entered // the poller holds a permit and is inside the token wait
 
 	start := time.Now()
 	bw.Stop()
 	require.Less(t, time.Since(start), time.Second,
 		"Stop() should wake a poller waiting for a session token, not block for the full stopTimeout")
+
+	// The permit is released before the poller's stopWG.Done, so Stop() returning orders this.
+	select {
+	case reason := <-supplier.released:
+		require.Equal(t, SlotReleaseReasonUnused, reason)
+	default:
+		t.Fatal("poller left the session token wait without releasing its slot permit")
+	}
 }

--- a/internal/session.go
+++ b/internal/session.go
@@ -64,6 +64,7 @@ type (
 	sessionTokenBucket struct {
 		*sync.Cond
 		availableToken int
+		closed         bool
 	}
 
 	sessionEnvironment interface {
@@ -505,12 +506,23 @@ func newSessionTokenBucket(concurrentSessionExecutionSize int) *sessionTokenBuck
 	}
 }
 
-func (t *sessionTokenBucket) waitForAvailableToken() {
+// waitForAvailableToken blocks until a session token is free, returning true, or the bucket is closed,
+// returning false so a stopping worker does not wait for a session to finish.
+func (t *sessionTokenBucket) waitForAvailableToken() bool {
 	t.L.Lock()
 	defer t.L.Unlock()
-	for t.availableToken == 0 {
+	for t.availableToken == 0 && !t.closed {
 		t.Wait()
 	}
+	return !t.closed
+}
+
+// close wakes every poller parked in waitForAvailableToken and makes it report closed.
+func (t *sessionTokenBucket) close() {
+	t.L.Lock()
+	t.closed = true
+	t.L.Unlock()
+	t.Broadcast()
 }
 
 func (t *sessionTokenBucket) addToken() {


### PR DESCRIPTION
Opening this proactively with a fix, on the assumption that this is an unintended shutdown hang rather than designed behavior. If sessions are meant to drain before the worker stops, or I have misread the shutdown path, I am happy to close it.

### What

Stopping a session worker while it is at `MaxConcurrentSessionExecutionSize` blocks for the full `WorkerStopTimeout` and leaks the session creation poller. (`WorkerStopTimeout` defaults to 0, so at the default `Stop()` returns at once and only leaks; the block is real once a stop timeout is configured.)

The creation poller reserves a slot and then waits for a free session token before polling. That wait is a `sync.Cond` with no stop awareness ([`waitForAvailableToken`, `internal/session.go`](https://github.com/temporalio/sdk-go/blob/52a0ffa3d2f302fc86ba781ee1d0a6d8b8c2d1f3/internal/session.go#L508-L514)):

```go
func (t *sessionTokenBucket) waitForAvailableToken() {
    t.L.Lock()
    defer t.L.Unlock()
    for t.availableToken == 0 {
        t.Wait()
    }
}
```

The Cond is only signalled when a session finishes ([`addToken`](https://github.com/temporalio/sdk-go/blob/52a0ffa3d2f302fc86ba781ee1d0a6d8b8c2d1f3/internal/session.go#L516-L520)). At capacity `availableToken` is 0, so the poller parks in `t.Wait()`. [`Stop()`](https://github.com/temporalio/sdk-go/blob/52a0ffa3d2f302fc86ba781ee1d0a6d8b8c2d1f3/internal/internal_worker_base.go#L888) closes the poller's stop channel but never touches this Cond, and that goroutine is the one `Stop()` waits on, so `awaitWaitGroup` times out (`"Worker graceful stop timed out"`) and the poller lingers until a session completes, which during shutdown it will not.

### Why

Fixes #2461.

The other waits on this path already honor the stop signal (`FixedSizeSlotSupplier` via the semaphore's context, and the resource tuner's `ReserveSlot`), so the session token wait looks like an oversight rather than an intentional block.

On the new `closed` field: a `sync.Cond` wait can only be interrupted by broadcasting and having the waiter re-check its predicate; there is no channel or context to select on. So the stop state has to be readable by the waiter under the same lock, and a bool on the bucket is the minimal place for it. It is additive and does not change existing behavior: it defaults to `false`; `getToken` and `addToken` (the accounting behind `CreateSession` and `CompleteSession`) never read it; and the bucket is built once per session worker and is never reused across a restart (a stopped worker cannot be started again), so `close()` only affects a poller currently parked in the wait.

### Changes

- `internal/session.go`: the bucket gains a `closed` flag that its own predicate honors, so `waitForAvailableToken` returns `true` when a token is free and `false` once the bucket is closed. A new `close` method sets the flag and broadcasts the Cond. The stop condition lives in the bucket, not in a channel threaded through the wait, and the loop stays the standard Cond form.
- `internal/internal_worker_base.go`: the two pollers that wait for a token return when it reports the bucket closed; `Stop()` calls `bucket.close()` after closing the worker stop channel.
- `internal/internal_worker_base_test.go`: a regression test (`TestStopReturnsPromptlyWithPollerAwaitingSessionToken`) next to the existing worker-shutdown tests. It drains the token bucket so the creation poller parks in the token wait, then asserts `Stop()` returns well under the stop timeout. Fails on `main` (Stop blocks the full timeout), passes with this change.
- `CHANGELOG.md`: entry under `## [Unreleased]` → `### Fixed`.

### Testing

- `cd internal/cmd/build && go run . check` clean.
- Regression test verified red on `main`, green with the change, `-race`. Worker, session, and poller suites still pass under `-race`.