### PR TITLE
Prep changelogs for contrib/opentelemetry and contrib/datadog releases

### DIFF
--- a/contrib/datadog/CHANGELOG.md
+++ b/contrib/datadog/CHANGELOG.md
@@ -11,7 +11,13 @@ or Security.
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-07-16
+
+### Changed
+
+- Increased the module's minimum required Go version from 1.24 to 1.25.4.
+
 ### Security
 
-- Upgrade `github.com/DataDog/dd-trace-go/v2` to v2.8.1 to address a potential
+- Upgraded `github.com/DataDog/dd-trace-go/v2` from v2.4.0 to v2.8.1 to address a potential
   denial of service when extracting W3C baggage headers.

--- a/contrib/opentelemetry/CHANGELOG.md
+++ b/contrib/opentelemetry/CHANGELOG.md
@@ -11,9 +11,15 @@ or Security.
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-07-16
+
 ### Added
 
 - Added `UseMonotonicCounters` to `MetricsHandlerOptions`. When enabled, SDK counters use
   OpenTelemetry monotonic counters so exporters can classify them as counters. The option defaults
   to false to preserve existing metric types and names. Custom counters used with this option must
   not decrement; doing so may produce invalid or backend-dependent metric data.
+
+### Changed
+
+- Increased the module's minimum required Go version from 1.23 to 1.25.4.


### PR DESCRIPTION
## What was changed
Prep changelogs for contrib/opentelemetry and contrib/datadog releases

## Why?
New releases

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog edits with no runtime or API code changes in this PR.
> 
> **Overview**
> Prepares release notes for **contrib/datadog v0.6.0** and **contrib/opentelemetry v0.8.0** (dated 2026-07-16), moving content out of `[Unreleased]` into versioned sections.
> 
> For **datadog**, the new section documents raising the minimum Go version to **1.25.4** and rewords the existing **dd-trace-go** security note to state an upgrade from **v2.4.0** to **v2.8.1** (W3C baggage DoS fix).
> 
> For **opentelemetry**, **v0.8.0** records the **`UseMonotonicCounters`** option on `MetricsHandlerOptions` under **Added**, and documents the minimum Go bump from **1.23** to **1.25.4** under **Changed**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39744db58e6903cb328adee4a07a3bf1f8caba8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->