### PR TITLE
Defer poller initialization to start()

### DIFF
--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -361,13 +361,10 @@ func newWorkflowTaskWorkerInternal(
 	stickyUUID := uuid.NewString()
 	taskProcessor := newWorkflowTaskProcessor(taskHandler, contextManager, service, params, stickyUUID)
 
-	scalableTaskPollers := buildWorkflowScalableTaskPollers(taskProcessor, params.WorkflowTaskPollerBehavior, params)
-
 	bwo := baseWorkerOptions{
 		pollerRate:                   defaultPollerRate,
 		slotSupplier:                 params.Tuner.GetWorkflowTaskSlotSupplier(),
 		maxTaskPerSecond:             defaultWorkerTaskExecutionRate,
-		taskPollers:                  scalableTaskPollers,
 		taskProcessor:                taskProcessor,
 		workerType:                   "WorkflowWorker",
 		identity:                     params.Identity,
@@ -507,16 +504,10 @@ func buildWorkflowScalableTaskPollers(taskProcessor *workflowTaskProcessor, beha
 	}
 }
 
-// applyPollerBehavior rebuilds the workflow worker's task pollers to use the
-// given behavior. It must only be called before the worker is started, while
-// the poller list is still dormant.
-func (ww *workflowWorker) applyPollerBehavior(behavior PollerBehavior) {
-	taskProcessor, ok := ww.worker.options.taskProcessor.(*workflowTaskProcessor)
-	if !ok {
-		return
-	}
+func (ww *workflowWorker) initializeTaskPollers(behavior PollerBehavior) {
+	taskProcessor := ww.worker.options.taskProcessor.(*workflowTaskProcessor)
 	ww.executionParameters.WorkflowTaskPollerBehavior = behavior
-	ww.worker.setTaskPollers(buildWorkflowScalableTaskPollers(taskProcessor, behavior, ww.executionParameters))
+	ww.worker.initializeTaskPollers(buildWorkflowScalableTaskPollers(taskProcessor, behavior, ww.executionParameters))
 }
 
 func newSessionWorker(client *WorkflowClient, params workerExecutionParameters, env *registry, maxConcurrentSessionExecutionSize int) *sessionWorker {
@@ -627,12 +618,9 @@ func newActivityWorker(
 		slotSupplier = params.Tuner.GetActivityTaskSlotSupplier()
 	}
 	bwo := baseWorkerOptions{
-		pollerRate:       defaultPollerRate,
-		slotSupplier:     slotSupplier,
-		maxTaskPerSecond: params.WorkerActivitiesPerSecond,
-		taskPollers: []scalableTaskPoller{
-			newScalableTaskPoller(poller, params.Logger, params.ActivityTaskPollerBehavior, metrics.PollerTypeActivityTask, params.serverSupportsAutoscaling),
-		},
+		pollerRate:                   defaultPollerRate,
+		slotSupplier:                 slotSupplier,
+		maxTaskPerSecond:             params.WorkerActivitiesPerSecond,
 		taskProcessor:                poller,
 		workerType:                   "ActivityWorker",
 		identity:                     params.Identity,
@@ -673,12 +661,9 @@ func (aw *activityWorker) Stop() {
 	aw.worker.Stop()
 }
 
-// applyPollerBehavior rebuilds the activity worker's task poller to use the
-// given behavior. It must only be called before the worker is started, while
-// the poller list is still dormant.
-func (aw *activityWorker) applyPollerBehavior(behavior PollerBehavior) {
+func (aw *activityWorker) initializeTaskPollers(behavior PollerBehavior) {
 	aw.executionParameters.ActivityTaskPollerBehavior = behavior
-	aw.worker.setTaskPollers([]scalableTaskPoller{
+	aw.worker.initializeTaskPollers([]scalableTaskPoller{
 		newScalableTaskPoller(
 			aw.poller,
 			aw.executionParameters.Logger,
@@ -1427,10 +1412,6 @@ func (aw *AggregatedWorker) start() error {
 	// poller type that was left at its default (the user set neither a fixed
 	// poller count nor a poller behavior). Auto-enroll implies full autoscaling
 	// support, including scaling down, so it also enables serverSupportsAutoscaling.
-	// The workers are constructed but dormant at this point (no baseWorker.Start
-	// has run yet), so swapping their poller lists in place is safe. The nexus
-	// worker is built further below from aw.executionParams, so mutating the
-	// parameter is sufficient for it.
 	if nsData.capabilities.GetPollerAutoscalingAutoEnroll() {
 		aw.executionParams.serverSupportsAutoscaling.Store(true)
 		autoscaling := NewPollerBehaviorAutoscaling(PollerBehaviorAutoscalingOptions{})
@@ -1439,24 +1420,19 @@ func (aw *AggregatedWorker) start() error {
 		}
 		if aw.executionParams.pollerAutoEnrollEligibility.workflowTask && !util.IsInterfaceNil(aw.workflowWorker) {
 			aw.executionParams.WorkflowTaskPollerBehavior = autoscaling
-			aw.workflowWorker.applyPollerBehavior(autoscaling)
 		}
 		if aw.executionParams.pollerAutoEnrollEligibility.activityTask {
 			if !util.IsInterfaceNil(aw.activityWorker) {
 				aw.executionParams.ActivityTaskPollerBehavior = autoscaling
-				aw.activityWorker.applyPollerBehavior(autoscaling)
-			}
-			// The session activity worker polls a normal task queue and is
-			// enrolled like any other activity worker. The session creation
-			// worker is deliberately pinned to a single poller, so it is left
-			// unchanged.
-			if !util.IsInterfaceNil(aw.sessionWorker) {
-				aw.sessionWorker.activityWorker.applyPollerBehavior(autoscaling)
 			}
 		}
 	}
 
+	// Poller behavior can depend on namespace capabilities, so workflow and
+	// activity scalable task pollers are initialized only after those capabilities
+	// have been resolved.
 	if !util.IsInterfaceNil(aw.workflowWorker) {
+		aw.workflowWorker.initializeTaskPollers(aw.executionParams.WorkflowTaskPollerBehavior)
 		if err := aw.workflowWorker.Start(); err != nil {
 			return err
 		}
@@ -1465,6 +1441,7 @@ func (aw *AggregatedWorker) start() error {
 		}
 	}
 	if !util.IsInterfaceNil(aw.activityWorker) {
+		aw.activityWorker.initializeTaskPollers(aw.executionParams.ActivityTaskPollerBehavior)
 		if err := aw.activityWorker.Start(); err != nil {
 			// stop workflow worker.
 			if !util.IsInterfaceNil(aw.workflowWorker) {
@@ -1481,6 +1458,12 @@ func (aw *AggregatedWorker) start() error {
 
 	if !util.IsInterfaceNil(aw.sessionWorker) && len(aw.registry.getRegisteredActivities()) > 0 {
 		aw.logger.Info("Starting session worker")
+		// The session activity worker uses the effective activity poller behavior.
+		// The session creation worker retains its fixed single-poller behavior.
+		aw.sessionWorker.activityWorker.initializeTaskPollers(aw.executionParams.ActivityTaskPollerBehavior)
+		aw.sessionWorker.creationWorker.initializeTaskPollers(
+			aw.sessionWorker.creationWorker.executionParameters.ActivityTaskPollerBehavior,
+		)
 		if err := aw.sessionWorker.Start(); err != nil {
 			// stop workflow worker and activity worker.
 			if !util.IsInterfaceNil(aw.workflowWorker) {

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -82,6 +82,7 @@ type (
 	workflowWorker struct {
 		executionParameters workerExecutionParameters
 		workflowService     workflowservice.WorkflowServiceClient
+		taskProcessor       *workflowTaskProcessor
 		worker              *baseWorker
 		localActivityWorker *baseWorker
 		identity            string
@@ -437,6 +438,7 @@ func newWorkflowTaskWorkerInternal(
 	return &workflowWorker{
 		executionParameters: params,
 		workflowService:     service,
+		taskProcessor:       taskProcessor,
 		worker:              worker,
 		localActivityWorker: localActivityWorker,
 		identity:            params.Identity,
@@ -510,9 +512,8 @@ func buildWorkflowScalableTaskPollers(taskProcessor *workflowTaskProcessor, beha
 }
 
 func (ww *workflowWorker) initializeTaskPollers(behavior PollerBehavior) {
-	taskProcessor := ww.worker.options.taskProcessor.(*workflowTaskProcessor)
 	ww.executionParameters.WorkflowTaskPollerBehavior = behavior
-	ww.worker.initializeTaskPollers(buildWorkflowScalableTaskPollers(taskProcessor, behavior, ww.executionParameters))
+	ww.worker.initializeTaskPollers(buildWorkflowScalableTaskPollers(ww.taskProcessor, behavior, ww.executionParameters))
 }
 
 func newSessionWorker(client *WorkflowClient, params workerExecutionParameters, env *registry, maxConcurrentSessionExecutionSize int) *sessionWorker {

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -448,6 +448,11 @@ func newWorkflowTaskWorkerInternal(
 
 // Start the worker.
 func (ww *workflowWorker) Start() error {
+	// AggregatedWorker initializes pollers after resolving namespace capabilities.
+	// Fall back to the configured behavior for direct internal starts.
+	if ww.worker.options.taskPollers == nil {
+		ww.initializeTaskPollers(ww.executionParameters.WorkflowTaskPollerBehavior)
+	}
 	ww.localActivityWorker.Start()
 	ww.worker.Start()
 	return nil // TODO: propagate error
@@ -651,6 +656,11 @@ func newActivityWorker(
 
 // Start the worker.
 func (aw *activityWorker) Start() error {
+	// AggregatedWorker initializes pollers after resolving namespace capabilities.
+	// Fall back to the configured behavior for direct internal starts.
+	if aw.worker.options.taskPollers == nil {
+		aw.initializeTaskPollers(aw.executionParameters.ActivityTaskPollerBehavior)
+	}
 	aw.worker.Start()
 	return nil // TODO: propagate errors
 }

--- a/internal/internal_worker_base.go
+++ b/internal/internal_worker_base.go
@@ -413,13 +413,13 @@ func newBaseWorker(
 	return bw
 }
 
-// setTaskPollers replaces the worker's task pollers. It must only be called
-// before Start(), while no poller goroutines are reading the poller list, so it
-// needs no synchronization. It (re)creates the poller balancer when the new
-// poller list has more than one poller, mirroring newBaseWorker.
-func (bw *baseWorker) setTaskPollers(taskPollers []scalableTaskPoller) {
+// initializeTaskPollers must be called at most once and before Start().
+func (bw *baseWorker) initializeTaskPollers(taskPollers []scalableTaskPoller) {
+	if bw.options.taskPollers != nil {
+		panic("task pollers already initialized")
+	}
 	bw.options.taskPollers = taskPollers
-	if len(taskPollers) > 1 && bw.pollerBalancer == nil {
+	if len(taskPollers) > 1 {
 		bw.pollerBalancer = &pollerBalancer{
 			pollerCount:   make(map[string]int),
 			pollerBarrier: make(map[string]barrier),

--- a/internal/internal_worker_base_test.go
+++ b/internal/internal_worker_base_test.go
@@ -138,7 +138,7 @@ func (s *ScalableTaskPollerSuite) TestTrackingSlotSupplierPassesTaskQueueKind() 
 	s.Equal(enumspb.TASK_QUEUE_KIND_STICKY, supplier.taskQueueKind)
 }
 
-func (s *ScalableTaskPollerSuite) TestSetTaskPollersCreatesBalancerForMultiplePollers() {
+func (s *ScalableTaskPollerSuite) TestInitializeTaskPollersCreatesBalancerForMultiplePollers() {
 	newPoller := func(pollerType string) scalableTaskPoller {
 		return newScalableTaskPoller(
 			newBlockingProbeTaskPoller(),
@@ -149,19 +149,21 @@ func (s *ScalableTaskPollerSuite) TestSetTaskPollersCreatesBalancerForMultiplePo
 		)
 	}
 
-	// A single poller does not need a balancer.
-	bw := &baseWorker{}
-	bw.setTaskPollers([]scalableTaskPoller{newPoller(metrics.PollerTypeWorkflowTask)})
-	s.Len(bw.options.taskPollers, 1)
-	s.Nil(bw.pollerBalancer)
+	singlePollerWorker := &baseWorker{}
+	singlePollerWorker.initializeTaskPollers([]scalableTaskPoller{newPoller(metrics.PollerTypeWorkflowTask)})
+	s.Len(singlePollerWorker.options.taskPollers, 1)
+	s.Nil(singlePollerWorker.pollerBalancer)
 
-	// Growing to more than one poller creates the balancer.
-	bw.setTaskPollers([]scalableTaskPoller{
+	bw := &baseWorker{}
+	bw.initializeTaskPollers([]scalableTaskPoller{
 		newPoller(metrics.PollerTypeWorkflowTask),
 		newPoller(metrics.PollerTypeWorkflowStickyTask),
 	})
 	s.Len(bw.options.taskPollers, 2)
 	s.NotNil(bw.pollerBalancer)
+	s.Panics(func() {
+		bw.initializeTaskPollers([]scalableTaskPoller{newPoller(metrics.PollerTypeWorkflowTask)})
+	})
 }
 
 func TestScalableTaskPollerSuite(t *testing.T) {

--- a/internal/internal_worker_base_test.go
+++ b/internal/internal_worker_base_test.go
@@ -161,6 +161,7 @@ func (s *ScalableTaskPollerSuite) TestInitializeTaskPollersCreatesBalancerForMul
 	})
 	s.Len(bw.options.taskPollers, 2)
 	s.NotNil(bw.pollerBalancer)
+	// Panic if task pollers are initialized more than once
 	s.Panics(func() {
 		bw.initializeTaskPollers([]scalableTaskPoller{newPoller(metrics.PollerTypeWorkflowTask)})
 	})

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -1836,6 +1836,11 @@ func (s *internalWorkerTestSuite) TestPollerAutoscalingAutoEnrollWithDefaults() 
 	)))
 	worker.RegisterNexusService(nexusService)
 
+	// Workflow and activity scalable task pollers are not created until Start
+	// resolves the namespace capabilities.
+	s.Nil(worker.workflowWorker.worker.options.taskPollers)
+	s.Nil(worker.activityWorker.worker.options.taskPollers)
+
 	require.NoError(s.T(), worker.Start())
 	defer worker.Stop()
 
@@ -1845,9 +1850,11 @@ func (s *internalWorkerTestSuite) TestPollerAutoscalingAutoEnrollWithDefaults() 
 	s.IsType(&pollerBehaviorAutoscaling{}, worker.executionParams.NexusTaskPollerBehavior)
 
 	// The actual running pollers reflect the autoscaling structure.
+	require.NotEmpty(s.T(), worker.workflowWorker.worker.options.taskPollers)
 	for _, p := range worker.workflowWorker.worker.options.taskPollers {
 		s.NotNil(p.autoscalingRunner)
 	}
+	require.NotEmpty(s.T(), worker.activityWorker.worker.options.taskPollers)
 	for _, p := range worker.activityWorker.worker.options.taskPollers {
 		s.NotNil(p.autoscalingRunner)
 	}
@@ -1957,6 +1964,9 @@ func (s *internalWorkerTestSuite) TestPollerAutoscalingAutoEnrollSessionWorker()
 		WorkerOptions{EnableSessionWorker: true},
 	)
 	worker.RegisterActivity(testActivityNoResult)
+
+	s.Nil(worker.sessionWorker.activityWorker.worker.options.taskPollers)
+	s.Nil(worker.sessionWorker.creationWorker.worker.options.taskPollers)
 
 	require.NoError(s.T(), worker.Start())
 	defer worker.Stop()

--- a/internal/internal_workers_test.go
+++ b/internal/internal_workers_test.go
@@ -92,7 +92,9 @@ func (s *WorkersTestSuite) TestWorkflowWorker() {
 	overrides := &workerOverrides{workflowTaskHandler: newSampleWorkflowTaskHandler()}
 	client := &WorkflowClient{workflowService: s.service}
 	workflowWorker := newWorkflowWorkerInternal(client, executionParameters, nil, overrides, newRegistry())
+	s.Nil(workflowWorker.worker.options.taskPollers)
 	_ = workflowWorker.Start()
+	s.NotEmpty(workflowWorker.worker.options.taskPollers)
 	workflowWorker.Stop()
 
 	s.NoError(ctx.Err())
@@ -361,7 +363,9 @@ func (s *WorkersTestSuite) TestActivityWorker() {
 	registry.addActivityWithLock(a.ActivityType().Name, a)
 	client := WorkflowClient{workflowService: s.service}
 	activityWorker := newActivityWorker(&client, executionParameters, overrides, registry, nil)
+	s.Nil(activityWorker.worker.options.taskPollers)
 	_ = activityWorker.Start()
+	s.NotEmpty(activityWorker.worker.options.taskPollers)
 	activityWorker.Stop()
 }
 


### PR DESCRIPTION
## What was changed
Deferred poller initialization to start()


## Why?
Was an optional suggestion in https://github.com/temporalio/sdk-go/pull/2442#discussion_r3555317710, but while working on MCN I realize we want this, since `DescribeNamespace` having weights for autoscaling MCN means this deferred approach is a lot cleaner

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when pollers start and how autoscaling/session workers are configured; mistakes could affect polling behavior at worker startup, though the change is localized to internal worker lifecycle.
> 
> **Overview**
> **Workflow and activity workers no longer build scalable task pollers at construction time.** Pollers are created once via `initializeTaskPollers` after namespace capabilities are known (e.g. poller autoscaling auto-enroll), then `Start()` runs. Direct internal starts still lazily initialize from configured behavior if pollers were not set.
> 
> `baseWorker.setTaskPollers` is replaced by **`initializeTaskPollers`**, which panics on double init and sets up the poller balancer when there are multiple pollers. Session workers get explicit init: activity side uses the effective activity poller behavior; creation worker keeps its fixed single-poller behavior.
> 
> Tests assert pollers stay nil until `Start()` and cover the one-time init contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4eecd5fabc17b4a0686e3732fe1285b8a08d4ccc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->