### PR TITLE
Remove experimental markers from user metadata fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ to docs, or any other relevant information.
 ## [Unreleased]
 - Add support for Workflow Updates as Nexus Operations 
 
+### Changed
+
+- User metadata fields (StaticSummary, StaticDetails, CurrentDetails, Activity Summary, Timer
+  Summary, AwaitOptions) are no longer marked as experimental.
+
 ### Added
 
 - Automatically enroll workers into poller autoscaling when the namespace advertises the

--- a/internal/activity.go
+++ b/internal/activity.go
@@ -179,8 +179,6 @@ type (
 		// in single-line Temporal Markdown format.
 		//
 		// Optional: defaults to none/empty.
-		//
-		// NOTE: Experimental
 		Summary string
 
 		// Priority - Optional priority settings that control relative ordering of
@@ -214,8 +212,6 @@ type (
 		// in single-line Temporal Markdown format.
 		//
 		// Optional: defaults to none/empty.
-		//
-		// NOTE: Experimental
 		Summary string
 	}
 )

--- a/internal/client.go
+++ b/internal/client.go
@@ -1206,8 +1206,6 @@ type (
 		// in single-line Temporal markdown format.
 		//
 		// Optional: defaults to none/empty.
-		//
-		// NOTE: Experimental
 		StaticSummary string
 
 		// Details - General fixed details for this workflow execution that will appear in UI/CLI. This can be in
@@ -1215,8 +1213,6 @@ type (
 		// updated. For details that can be updated, use SetCurrentDetails within the workflow.
 		//
 		// Optional: defaults to none/empty.
-		//
-		// NOTE: Experimental
 		StaticDetails string
 
 		// VersioningOverride - Sets the versioning configuration of a specific workflow execution, ignoring current

--- a/internal/schedule_client.go
+++ b/internal/schedule_client.go
@@ -295,8 +295,6 @@ type (
 		// in single-line Temporal Markdown format.
 		//
 		// Optional: defaults to none/empty.
-		//
-		// NOTE: Experimental
 		StaticSummary string
 
 		// Details - General fixed details for this child workflow execution that will appear in UI/CLI. This can be in
@@ -304,8 +302,6 @@ type (
 		// updated. For details that can be updated, use SetCurrentDetails within the workflow.
 		//
 		// Optional: defaults to none/empty.
-		//
-		// NOTE: Experimental
 		StaticDetails string
 
 		// Priority - Optional priority settings that control relative ordering of

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -552,8 +552,6 @@ type (
 		// in single-line Temporal Markdown format.
 		//
 		// Optional: defaults to none/empty.
-		//
-		// NOTE: Experimental
 		StaticSummary string
 
 		// Details - General fixed details for this child workflow execution that will appear in UI/CLI. This can be in
@@ -561,8 +559,6 @@ type (
 		// updated. For details that can be updated, use SetCurrentDetails within the workflow.
 		//
 		// Optional: defaults to none/empty.
-		//
-		// NOTE: Experimental
 		StaticDetails string
 
 		// Priority - Optional priority settings that control relative ordering of
@@ -678,31 +674,21 @@ type (
 
 	// TimerOptions are options set when creating a timer.
 	//
-	// NOTE: Experimental
-	//
 	// Exposed as: [go.temporal.io/sdk/workflow.TimerOptions]
 	TimerOptions struct {
 		// Summary is a simple string identifying this timer. While it can be
 		// normal text, it is best to treat as a timer ID. This value will be
 		// visible in UI and CLI.
-		//
-		// NOTE: Experimental
 		Summary string
 	}
 
 	// AwaitOptions are options set when creating an await.
 	//
-	// NOTE: Experimental
-	//
 	// Exposed as: [go.temporal.io/sdk/workflow.AwaitOptions]
 	AwaitOptions struct {
 		// Timeout is the await timeout if the await condition is not met.
-		//
-		// NOTE: Experimental
 		Timeout time.Duration
 		// TimerOptions are options set for the underlying timer created.
-		//
-		// NOTE: Experimental
 		TimerOptions TimerOptions
 	}
 

--- a/workflow/deterministic_wrappers.go
+++ b/workflow/deterministic_wrappers.go
@@ -45,13 +45,9 @@ type (
 	Semaphore = internal.Semaphore
 
 	// TimerOptions are options for [NewTimerWithOptions]
-	//
-	// NOTE: Experimental
 	TimerOptions = internal.TimerOptions
 
 	// AwaitOptions are options for [AwaitWithOptions]
-	//
-	// NOTE: Experimental
 	AwaitOptions = internal.AwaitOptions
 )
 
@@ -101,8 +97,6 @@ func AwaitWithTimeout(ctx Context, timeout time.Duration, condition func() bool)
 //	workflow.AwaitWithOptions(ctx, AwaitOptions{Timeout: time.Hour, TimerOptions: TimerOptions{Summary:"Example"}}, func() bool {
 //	  return count == 5
 //	})
-//
-// NOTE: Experimental
 func AwaitWithOptions(ctx Context, options AwaitOptions, condition func() bool) (ok bool, err error) {
 	return internal.AwaitWithOptions(ctx, options, condition)
 }
@@ -197,8 +191,6 @@ func NewTimer(ctx Context, d time.Duration) Future {
 // use this NewTimerWithOptions() to get the timer, instead of Go's timer.NewTimer(). You can cancel the pending timer
 // by canceling the Context (using the context from workflow.WithCancel(ctx)) and that will cancel the timer. After the
 // timer is canceled, the returned Future becomes ready, and Future.Get() will return *CanceledError.
-//
-// NOTE: Experimental
 func NewTimerWithOptions(ctx Context, d time.Duration, options TimerOptions) Future {
 	return internal.NewTimerWithOptions(ctx, d, options)
 }

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -676,8 +676,6 @@ func SetUpdateHandlerWithOptions(ctx Context, updateName string, handler interfa
 // GetCurrentDetails gets the current details for this workflow. This is simply
 // the value set by [SetCurrentDetails] or empty if never set. See that function
 // for more details.
-//
-// NOTE: Experimental
 func GetCurrentDetails(ctx Context) string {
 	return internal.GetCurrentDetails(ctx)
 }
@@ -685,8 +683,6 @@ func GetCurrentDetails(ctx Context) string {
 // SetCurrentDetails sets the current details for this workflow. This is
 // typically an arbitrary string in Temporal markdown format may be displayed in
 // the UI or CLI.
-//
-// NOTE: Experimental
 func SetCurrentDetails(ctx Context, details string) {
 	internal.SetCurrentDetails(ctx, details)
 }


### PR DESCRIPTION
## Summary
- Remove `NOTE: Experimental` from user metadata fields: StaticSummary, StaticDetails, CurrentDetails, Activity Summary, Timer Summary, AwaitOptions
- These features are stable and shipping across all SDKs - graduating to GA API surface
- 6 files changed, 38 deletions

## Test plan
- [ ] Verify no compilation errors
- [ ] Confirm NexusOperationOptions, SideEffectOptions, MutableSideEffectOptions experimental markers are untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)