### PR TITLE
OpenTelemetry: Fix stale SDK dep

### DIFF
--- a/contrib/aws/lambdaworker/otel/go.mod
+++ b/contrib/aws/lambdaworker/otel/go.mod
@@ -9,7 +9,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.42.0
 	go.opentelemetry.io/otel/sdk v1.42.0
 	go.opentelemetry.io/otel/sdk/metric v1.42.0
-	go.temporal.io/sdk v1.41.1
+	go.temporal.io/sdk v1.46.0
 	go.temporal.io/sdk/contrib/opentelemetry v0.7.0
 )
 

--- a/contrib/opentelemetry/CHANGELOG.md
+++ b/contrib/opentelemetry/CHANGELOG.md
@@ -15,8 +15,12 @@ or Security.
 
 ### Fixed
 
-- Fixed the module's published dependency metadata to require Temporal Go SDK v1.46.0 instead of
-  v1.12.0.
+- Corrected the module's minimum Temporal Go SDK requirement from v1.12.0 to v1.46.0. The stale
+  minimum could select SDK v1.12.0 alongside the modern Temporal API, gRPC, protobuf, and split
+  `genproto` dependencies used by this release, producing compilation failures or, in legacy
+  dependency graphs, ambiguous `genproto` imports. Applications already selecting a compatible
+  newer SDK are unaffected; this does not resolve `genproto` conflicts introduced by unrelated
+  dependencies.
 
 ## [0.8.0] - 2026-07-16
 

--- a/contrib/opentelemetry/CHANGELOG.md
+++ b/contrib/opentelemetry/CHANGELOG.md
@@ -11,6 +11,13 @@ or Security.
 
 ## [Unreleased]
 
+## [0.8.1] - 2026-07-21
+
+### Fixed
+
+- Fixed the module's published dependency metadata to require Temporal Go SDK v1.46.0 instead of
+  v1.12.0.
+
 ## [0.8.0] - 2026-07-16
 
 ### Added

--- a/contrib/opentelemetry/go.mod
+++ b/contrib/opentelemetry/go.mod
@@ -7,7 +7,7 @@ require (
 	go.opentelemetry.io/otel v1.41.0
 	go.opentelemetry.io/otel/sdk v1.41.0
 	go.opentelemetry.io/otel/trace v1.41.0
-	go.temporal.io/sdk v1.12.0
+	go.temporal.io/sdk v1.46.0
 )
 
 require (

--- a/test/go.mod
+++ b/test/go.mod
@@ -14,7 +14,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.41.0
 	go.opentelemetry.io/otel/trace v1.41.0
 	go.temporal.io/api v1.63.0
-	go.temporal.io/sdk v1.29.1
+	go.temporal.io/sdk v1.46.0
 	go.temporal.io/sdk/contrib/opentelemetry v0.0.0-00010101000000-000000000000
 	go.temporal.io/sdk/contrib/opentracing v0.0.0-00010101000000-000000000000
 	go.temporal.io/sdk/contrib/sysinfo v0.0.0-00010101000000-000000000000


### PR DESCRIPTION


## What was changed
Update `contrib/opentelemetry` to require SDK v1.46.0 instead of v1.12.0

Also prepping for 0.8.1 release to release this fix. Might as well do it all in the same PR

## Why?
The SDK version in a module's `require` directive is its advertised minimum. In v0.8.0, that minimum was stale: 
the module declared SDK v1.12.0.

A consumer without another requirement selecting a newer SDK could resolve SDK v1.12.0 alongside the 
modern Temporal API, gRPC, protobuf, and split `genproto` modules recorded by contrib v0.8.0. That is not a supported combination and can fail to compile. In legacy dependency graphs that retain the old monolithic `google.golang.org/genproto` module, it can also surface as an ambiguous import because both the monolithic and split modules provide the same packages.

Requiring SDK v1.46.0 makes the published metadata match the version used to develop and validate this contrib release. Go's minimal version selection will choose v1.46.0 when a consumer requests an older SDK and will continue to choose any newer SDK requested by the consumer.

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-go/issues/2472

2. How was this tested:
go mod tidied all repo Go modules

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency and release-metadata only; no runtime or API code changes, though consumers must satisfy the higher minimum SDK version.
> 
> **Overview**
> **Fixes a stale minimum SDK version** in `contrib/opentelemetry` and aligns related modules so dependency resolution matches the modern Temporal API/gRPC/protobuf graph shipped with recent releases.
> 
> The OpenTelemetry contrib module’s `go.mod` now requires **`go.temporal.io/sdk v1.46.0`** instead of **v1.12.0**. The **0.8.1** changelog entry documents that the old floor could pull in SDK v1.12.0 alongside newer transitive deps and cause **build failures or ambiguous `genproto` imports**. **`test/go.mod`** and **`contrib/aws/lambdaworker/otel/go.mod`** are updated to the same SDK version for consistency after `go mod tidy`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa8f43c09e5d97f013c5ef09e13037fd996ec192. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->