### PR TITLE
CLAUDE.md that's symlinked to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- This file is symlinked to AGENTS.md — they are the same file. -->
+<!-- AGENTS.md is symlinked to CLAUDE.md — they are the same file. -->
 
 # Contributor Guidance for `sdk-go`
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,5 @@
+<!-- This file is symlinked to AGENTS.md — they are the same file. -->
+
 # Contributor Guidance for `sdk-go`
 
 This repository provides the Go SDK for Temporal. Use this document as the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION


## What was changed
Added CLAUDE.md that's just a symlink to AGENTS.md

## Why?
AGENTS AGENTS AGENTS

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only symlink and comment; no SDK runtime or API behavior changes.
> 
> **Overview**
> Adds **`CLAUDE.md`** as a symlink to **`AGENTS.md`** so Claude and other tools that look for `CLAUDE.md` get the same contributor guidance as agents using `AGENTS.md`.
> 
> A short HTML comment at the top of **`AGENTS.md`** documents that the two paths are the same file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3341bc0d3fa7fe1a16118b72e9acbfe5bbfa3fad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->