### PR TITLE
feat(extstore): update s3 key encoding to be consistent with s3's safe characters and the other temporal sdks.

### DIFF
--- a/contrib/aws/s3driver/CHANGELOG.md
+++ b/contrib/aws/s3driver/CHANGELOG.md
@@ -10,3 +10,9 @@ or Security.
 # Changelog
 
 ## [Unreleased]
+
+### Changed
+
+- S3 object key path segments are now percent-encoded against S3's safe
+  character set (alphanumerics and `!-_.*'()`), encoding all other bytes of
+  their UTF-8 representation as `%XX`.

--- a/contrib/aws/s3driver/README.md
+++ b/contrib/aws/s3driver/README.md
@@ -73,7 +73,7 @@ v0/ns/<namespace>/at/<activity-type>/ai/<activity-id>/ri/<run-id>/d/sha256/<hash
 v0/d/sha256/<hash>
 ```
 
-Special characters in path segments are percent-encoded. Empty segments are replaced with `null`.
+Characters outside S3's safe set (alphanumerics and `!-_.*'()`) are percent-encoded per byte of their UTF-8 representation. Empty segments are replaced with `null`.
 
 ## Notes
 

--- a/contrib/aws/s3driver/driver.go
+++ b/contrib/aws/s3driver/driver.go
@@ -5,7 +5,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"net/url"
+	"strings"
 
 	commonpb "go.temporal.io/api/common/v1"
 	"go.temporal.io/sdk/converter"
@@ -19,6 +19,7 @@ const (
 	defaultDriverName     = "aws.s3driver"
 	hashAlgorithm         = "sha256"
 	keyVersion            = "v0"
+	s3SafeChars           = "!-_.*'()"
 
 	claimKeyBucket        = "bucket"
 	claimKeyKey           = "key"
@@ -237,17 +238,17 @@ func objectKey(target converter.StorageDriverTargetInfo, hexDigest string) strin
 	switch t := target.(type) {
 	case converter.StorageDriverWorkflowInfo:
 		return keyVersion +
-			"/ns/" + pathEscape(t.Namespace) +
-			"/wt/" + pathEscape(t.WorkflowType) +
-			"/wi/" + pathEscape(t.WorkflowID) +
-			"/ri/" + pathEscape(t.RunID) +
+			"/ns/" + percentEncode(t.Namespace) +
+			"/wt/" + percentEncode(t.WorkflowType) +
+			"/wi/" + percentEncode(t.WorkflowID) +
+			"/ri/" + percentEncode(t.RunID) +
 			digestSegment
 	case converter.StorageDriverActivityInfo:
 		return keyVersion +
-			"/ns/" + pathEscape(t.Namespace) +
-			"/at/" + pathEscape(t.ActivityType) +
-			"/ai/" + pathEscape(t.ActivityID) +
-			"/ri/" + pathEscape(t.RunID) +
+			"/ns/" + percentEncode(t.Namespace) +
+			"/at/" + percentEncode(t.ActivityType) +
+			"/ai/" + percentEncode(t.ActivityID) +
+			"/ri/" + percentEncode(t.RunID) +
 			digestSegment
 	default:
 		return keyVersion + digestSegment
@@ -264,11 +265,36 @@ func describeClient(c Client) string {
 	return s
 }
 
-func pathEscape(s string) string {
+func percentEncode(s string) string {
 	if s == "" {
 		return "null"
 	}
-	return url.PathEscape(s)
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if isS3SafeByte(c) {
+			b.WriteByte(c)
+		} else {
+			b.WriteByte('%')
+			b.WriteByte(upperHexDigit(c >> 4))
+			b.WriteByte(upperHexDigit(c & 0xf))
+		}
+	}
+	return b.String()
+}
+
+func isS3SafeByte(c byte) bool {
+	switch {
+	case c >= 'A' && c <= 'Z', c >= 'a' && c <= 'z', c >= '0' && c <= '9':
+		return true
+	default:
+		return strings.IndexByte(s3SafeChars, c) >= 0
+	}
+}
+
+func upperHexDigit(n byte) byte {
+	return "0123456789ABCDEF"[n]
 }
 
 func sha256Hex(data []byte) string {

--- a/contrib/aws/s3driver/driver_test.go
+++ b/contrib/aws/s3driver/driver_test.go
@@ -532,8 +532,67 @@ func TestObjectKey_WorkflowInfo_SpecialChars(t *testing.T) {
 	}
 	key := objectKey(target, "abc123")
 	assert.Equal(t,
-		"v0/ns/my%20namespace/wt/my%2Fworkflow/wi/wf%20id+1/ri/run=abc/d/sha256/abc123",
+		"v0/ns/my%20namespace/wt/my%2Fworkflow/wi/wf%20id%2B1/ri/run%3Dabc/d/sha256/abc123",
 		key,
+	)
+}
+
+func TestObjectKey_PreservesS3SafeSpecialChars(t *testing.T) {
+	target := converter.StorageDriverWorkflowInfo{
+		Namespace:  "ns1",
+		WorkflowID: "!-_.*'()",
+	}
+	assert.Equal(t,
+		"v0/ns/ns1/wt/null/wi/!-_.*'()/ri/null/d/sha256/abc123",
+		objectKey(target, "abc123"),
+	)
+}
+
+func TestObjectKey_EscapesTilde(t *testing.T) {
+	target := converter.StorageDriverWorkflowInfo{
+		Namespace:  "ns1",
+		WorkflowID: "wf~1",
+	}
+	assert.Equal(t,
+		"v0/ns/ns1/wt/null/wi/wf%7E1/ri/null/d/sha256/abc123",
+		objectKey(target, "abc123"),
+	)
+}
+
+func TestObjectKey_EscapesNonASCIIAsUTF8Bytes(t *testing.T) {
+	target := converter.StorageDriverWorkflowInfo{
+		Namespace:  "ns1",
+		WorkflowID: "café",
+	}
+	assert.Equal(t,
+		"v0/ns/ns1/wt/null/wi/caf%C3%A9/ri/null/d/sha256/abc123",
+		objectKey(target, "abc123"),
+	)
+}
+
+func TestObjectKey_WorkflowSpecExample(t *testing.T) {
+	target := converter.StorageDriverWorkflowInfo{
+		Namespace:    "payments prod",
+		WorkflowType: "ChargeWorkflow",
+		WorkflowID:   "order+123=abc",
+		RunID:        "3f1d6c7a-8b2e-4f7a-9d0a-87a6f95e4d31",
+	}
+	assert.Equal(t,
+		"v0/ns/payments%20prod/wt/ChargeWorkflow/wi/order%2B123%3Dabc/ri/3f1d6c7a-8b2e-4f7a-9d0a-87a6f95e4d31/d/sha256/abc123",
+		objectKey(target, "abc123"),
+	)
+}
+
+func TestObjectKey_ActivitySpecExample(t *testing.T) {
+	target := converter.StorageDriverActivityInfo{
+		Namespace:    "payments prod",
+		ActivityType: "Capture/Charge",
+		ActivityID:   "activity id+42",
+		RunID:        "9e1d1fd9-2f8a-4c40-93e2-731f31b9268b",
+	}
+	assert.Equal(t,
+		"v0/ns/payments%20prod/at/Capture%2FCharge/ai/activity%20id%2B42/ri/9e1d1fd9-2f8a-4c40-93e2-731f31b9268b/d/sha256/abc123",
+		objectKey(target, "abc123"),
 	)
 }
 


### PR DESCRIPTION
<!--- For ALL Contributors 👇 -->

## What was changed
- s3 driver now encodes keys according to s3's safelist. This makes sdk-go consistent with our other sdks.

## Checklist
- Added tests to ensure keys are encoded properly.