### PR TITLE
googleadk: add NewPlugin worker-plugin wiring (v0.2.0)

### DIFF
--- a/contrib/googleadk/CHANGELOG.md
+++ b/contrib/googleadk/CHANGELOG.md
@@ -11,6 +11,15 @@ or Security.
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-07-22
+
+### Added
+
+- `NewPlugin` wires the integration as a worker plugin: add it to `worker.Options.Plugins`
+  to register the `InvokeModel` / `ListMcpTools` / `CallMcpTool` Activities at worker start
+  and close cached MCP toolsets at worker stop. `NewActivities` + `Register` remain for the
+  test environments (which do not run plugins) and manual wiring.
+
 ## [0.1.0] - 2026-07-20
 
 ### Added

--- a/contrib/googleadk/README.md
+++ b/contrib/googleadk/README.md
@@ -20,7 +20,8 @@ Tools run **in-workflow by default** — the idiomatic Temporal model: your work
 is deterministic, and anything that touches the network, clock, or disk goes
 through an Activity. Opt a tool into an Activity with `googleadk.ActivityAsTool`,
 or use `googleadk.NewMCPToolset` for MCP. The real model and any activity/MCP tool
-handlers live worker-side in the registry built by `googleadk.NewActivities(...)`.
+handlers live worker-side in the registry declared by `googleadk.Config` and
+wired onto the worker by `googleadk.NewPlugin(...)`.
 
 ## Add to your project
 
@@ -134,12 +135,11 @@ func main() {
 	}
 	defer c.Close()
 
-	w := worker.New(c, taskQueue, worker.Options{})
-	w.RegisterWorkflow(AgentWorkflow)
-
-	// Worker-side registry: the real model lives here. API keys are captured in
-	// the factory closure and never cross the Activity boundary.
-	acts, err := googleadk.NewActivities(googleadk.Config{
+	// Worker-side registry, wired as a worker plugin: the real model lives here.
+	// API keys are captured in the factory closure and never cross the Activity
+	// boundary. The plugin registers the Activities at worker start and closes
+	// cached MCP toolsets at worker stop.
+	adkPlugin, err := googleadk.NewPlugin(googleadk.Config{
 		Models: map[string]googleadk.ModelFactory{
 			"gemini-2.0-flash": func(ctx context.Context, name string) (model.LLM, error) {
 				// nil config reads GEMINI_API_KEY / GOOGLE_API_KEY from the env, worker-side.
@@ -150,7 +150,9 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	acts.Register(w)
+
+	w := worker.New(c, taskQueue, worker.Options{Plugins: []worker.Plugin{adkPlugin}})
+	w.RegisterWorkflow(AgentWorkflow)
 
 	if err := w.Run(worker.InterruptCh()); err != nil {
 		log.Fatal(err)
@@ -184,9 +186,10 @@ the model SDK's own retries (see below), or override the fallbacks.
   remote tools (full declarations, including parameters) via `ListMcpTools` and
   executes calls via `CallMcpTool`. The live, stateful `mcptoolset.New(...)` runs
   worker-side, never in the workflow. Your `MCPFactory` runs at most once per
-  toolset name — the toolset is cached on the `Activities` value and shared
-  across calls — and calling `Activities.Close` after `worker.Run` returns
-  closes any cached toolset that implements `Close() error`.
+  toolset name — the toolset is cached and shared across calls — and the plugin
+  closes any cached toolset that implements `Close() error` at worker stop
+  automatically; with manual wiring, call `Activities.Close` yourself after
+  `worker.Run` returns.
 - **Deterministic by construction.** `NewContext` binds ADK's `platform.Now` to
   `workflow.Now`, `platform.NewUUID` to a deterministic seeded generator, and
   `platform.RunTasks` to a `workflow.Go` fan-out, so the agent loop replays
@@ -201,7 +204,8 @@ the model SDK's own retries (see below), or override the fallbacks.
   a transient failure twice over. Let Temporal own retries.
 - **Test without a live LLM.** `testing.go` ships `FakeModel`, `FakeMCPServer`, and
   `TextResponse` / `FunctionCallResponse` so you can unit-test workflows with no
-  network.
+  network. The test environments do not run plugins; register the Activities
+  directly with `NewActivities` + `Register` (as this repo's own tests do).
 
 > **Determinism note.** Because plain tools run in-workflow, their code must be
 > deterministic and replay-safe — no direct network, clock, randomness, or
@@ -311,9 +315,10 @@ The bidirectional `RunLive` path (hard-coded goroutines/channels) is **not** sup
 
 ## Composing with other plugins
 
-The Temporal-side Activities use the default JSON data converter and ship no
-client/worker interceptor, so this integration composes with Temporal interceptor-
-or converter-based plugins (e.g. `sdk-go/contrib/opentelemetry`) without conflict.
+This integration's plugin only registers its Activities at worker start and
+closes cached MCP toolsets at worker stop — no interceptors, no data converter —
+so it composes with other entries in `worker.Options.Plugins` (e.g. interceptor-
+or converter-based plugins like `sdk-go/contrib/opentelemetry`) without conflict.
 On the ADK side, add other ADK plugins to `runner.PluginConfig.Plugins` as usual.
 ADK emits its own OpenTelemetry spans; register your tracing interceptor on the
 worker as usual.

--- a/contrib/googleadk/activities.go
+++ b/contrib/googleadk/activities.go
@@ -155,13 +155,28 @@ func (a *Activities) resolveModel(ctx context.Context, name string) (model.LLM, 
 	}
 }
 
-// Register wires InvokeModel, ListMcpTools and CallMcpTool onto the worker under
-// their stable Activity names. Call it once per worker that should be able to
-// service ADK model and MCP calls.
-func (a *Activities) Register(r worker.Registry) {
+// activityRegistry is the registration surface registerAll needs. Both
+// worker.Registry and the plugin run-context registry
+// (temporal.SimplePluginRunContextBeforeOptions.Registry) satisfy it.
+type activityRegistry interface {
+	RegisterActivityWithOptions(a any, options activity.RegisterOptions)
+}
+
+// registerAll wires InvokeModel, ListMcpTools and CallMcpTool onto r under
+// their stable Activity names.
+func (a *Activities) registerAll(r activityRegistry) {
 	r.RegisterActivityWithOptions(a.InvokeModel, activity.RegisterOptions{Name: InvokeModelActivityName})
 	r.RegisterActivityWithOptions(a.ListMcpTools, activity.RegisterOptions{Name: ListMcpToolsActivityName})
 	r.RegisterActivityWithOptions(a.CallMcpTool, activity.RegisterOptions{Name: CallMcpToolActivityName})
+}
+
+// Register wires InvokeModel, ListMcpTools and CallMcpTool onto the worker under
+// their stable Activity names. NewPlugin is the standard wiring — it performs
+// this registration at worker start; Register remains for the workflow/activity
+// test environments (which construct no real worker, so plugins do not run
+// there) and manual setups.
+func (a *Activities) Register(r worker.Registry) {
+	a.registerAll(r)
 }
 
 // Close closes every cached MCP toolset that implements `Close() error`,

--- a/contrib/googleadk/plugin.go
+++ b/contrib/googleadk/plugin.go
@@ -1,0 +1,78 @@
+package googleadk
+
+import (
+	"context"
+	"sync"
+
+	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/worker"
+)
+
+// NewPlugin wires the integration as a Temporal worker plugin: it builds the
+// worker-side Activities from cfg, registers InvokeModel, ListMcpTools and
+// CallMcpTool at worker start, and closes the cached MCP toolsets at worker
+// stop. Add it to worker.Options.Plugins:
+//
+//	adkPlugin, err := googleadk.NewPlugin(googleadk.Config{
+//		Models:      map[string]googleadk.ModelFactory{ /* ... */ },
+//		MCPToolsets: map[string]googleadk.MCPFactory{ /* ... */ },
+//	})
+//	if err != nil {
+//		log.Fatal(err)
+//	}
+//	w := worker.New(c, taskQueue, worker.Options{
+//		Plugins: []worker.Plugin{adkPlugin},
+//	})
+//
+// Create one plugin per worker: after its worker stops, the plugin's MCP
+// toolsets are closed (Activities.Close is terminal), so the same plugin value
+// must not serve a second worker. Toolset close failures at worker stop are
+// discarded — construct the Activities yourself and call Close if you need to
+// handle them. For the workflow/activity test environments use NewActivities +
+// Register instead: test environments construct no real worker, so plugins do
+// not run there.
+func NewPlugin(cfg Config) (worker.Plugin, error) {
+	acts, err := NewActivities(cfg)
+	if err != nil {
+		return nil, err
+	}
+	// A plugin can be shared between a worker and a workflow replayer, and the
+	// run-context hooks fire once per workflow replay too. replayerKeys records
+	// which run contexts are replays so RunContextAfter never closes the
+	// worker's shared toolsets on a replay: Close is terminal, so closing there
+	// would fail every later MCP Activity on the worker non-retryably. Entries
+	// are counted, not merely set, because every replay on one replayer shares
+	// its instance key — concurrent replays must each pair their own
+	// before/after without the last one falling through to Close.
+	var mu sync.Mutex
+	replayerKeys := make(map[string]int)
+	return temporal.NewSimplePlugin(temporal.SimplePluginOptions{
+		Name: "go.temporal.io/sdk/contrib/googleadk",
+		RunContextBefore: func(_ context.Context, o temporal.SimplePluginRunContextBeforeOptions) error {
+			if o.WorkflowReplayer {
+				// Activity registration is a no-op on a replayer; just record
+				// the key so RunContextAfter can tell this run was a replay.
+				mu.Lock()
+				replayerKeys[o.InstanceKey]++
+				mu.Unlock()
+				return nil
+			}
+			acts.registerAll(o.Registry)
+			return nil
+		},
+		RunContextAfter: func(_ context.Context, o temporal.SimplePluginRunContextAfterOptions) {
+			mu.Lock()
+			replay := replayerKeys[o.InstanceKey] > 0
+			if replay {
+				if replayerKeys[o.InstanceKey]--; replayerKeys[o.InstanceKey] == 0 {
+					delete(replayerKeys, o.InstanceKey)
+				}
+			}
+			mu.Unlock()
+			if replay {
+				return
+			}
+			_ = acts.Close()
+		},
+	})
+}

--- a/contrib/googleadk/plugin_test.go
+++ b/contrib/googleadk/plugin_test.go
@@ -1,0 +1,234 @@
+package googleadk_test
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/nexus-rpc/sdk-go/nexus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/worker"
+	"go.temporal.io/sdk/workflow"
+
+	"google.golang.org/genai"
+
+	"google.golang.org/adk/v2/tool"
+
+	"go.temporal.io/sdk/contrib/googleadk"
+)
+
+// pluginRecordingRegistry implements the plugin run-context registry (the full
+// worker.PluginStartWorkerOptions.WorkerRegistry interface) and records the
+// name of every registered activity, so a test can assert exactly what
+// StartWorker wired.
+type pluginRecordingRegistry struct {
+	activityNames []string
+}
+
+func (r *pluginRecordingRegistry) RegisterWorkflowWithOptions(any, workflow.RegisterOptions) {}
+
+func (r *pluginRecordingRegistry) RegisterDynamicWorkflow(any, workflow.DynamicRegisterOptions) {}
+
+func (r *pluginRecordingRegistry) RegisterActivityWithOptions(_ any, options activity.RegisterOptions) {
+	r.activityNames = append(r.activityNames, options.Name)
+}
+
+func (r *pluginRecordingRegistry) RegisterDynamicActivity(any, activity.DynamicRegisterOptions) {}
+
+func (r *pluginRecordingRegistry) RegisterNexusService(*nexus.Service) {}
+
+// pluginNoopReplayRegistry is the minimal WorkflowReplayRegistry for driving a
+// plugin's ReplayWorkflow hook directly: workflow registration is a no-op.
+type pluginNoopReplayRegistry struct{}
+
+func (pluginNoopReplayRegistry) RegisterWorkflowWithOptions(any, workflow.RegisterOptions) {}
+
+func (pluginNoopReplayRegistry) RegisterDynamicWorkflow(any, workflow.DynamicRegisterOptions) {}
+
+// pluginClosableToolset wraps a toolset with a counting Close method, so a test
+// can observe the plugin's worker-stop hook reaching the cached toolset.
+type pluginClosableToolset struct {
+	tool.Toolset
+	closed atomic.Int32
+}
+
+func (t *pluginClosableToolset) Close() error {
+	t.closed.Add(1)
+	return nil
+}
+
+// pluginSearchServer builds the fake MCP server the plugin tests share: one
+// "search" tool with a constant result.
+func pluginSearchServer() *googleadk.FakeMCPServer {
+	return googleadk.NewFakeMCPServer("search-server").AddTool(
+		"search", "search the web",
+		&genai.Schema{
+			Type: genai.TypeObject,
+			Properties: map[string]*genai.Schema{
+				"query": {Type: genai.TypeString, Description: "the search query"},
+			},
+			Required: []string{"query"},
+		},
+		func(map[string]any) (map[string]any, error) {
+			return map[string]any{"hits": 1}, nil
+		},
+	)
+}
+
+// newMCPPlugin builds a plugin whose Config caches ct as its one MCP toolset
+// and scripts one search call followed by a final text turn.
+func newMCPPlugin(t *testing.T, ct *pluginClosableToolset) worker.Plugin {
+	t.Helper()
+	plugin, err := googleadk.NewPlugin(googleadk.Config{
+		Models: map[string]googleadk.ModelFactory{
+			"fake-model": scriptedModelFactory(
+				googleadk.FunctionCallResponse("c1", "search", map[string]any{"query": "temporal"}),
+				googleadk.TextResponse("done"),
+			),
+		},
+		MCPToolsets: map[string]googleadk.MCPFactory{
+			"search-server": func(context.Context) (tool.Toolset, error) { return ct, nil },
+		},
+	})
+	require.NoError(t, err)
+	return plugin
+}
+
+// startPluginWorker drives the plugin's StartWorker hook — the same hook a real
+// worker start invokes — registering into reg, and requires next to be called.
+func startPluginWorker(t *testing.T, plugin worker.Plugin, key string, reg interface {
+	RegisterWorkflowWithOptions(any, workflow.RegisterOptions)
+	RegisterDynamicWorkflow(any, workflow.DynamicRegisterOptions)
+	RegisterActivityWithOptions(any, activity.RegisterOptions)
+	RegisterDynamicActivity(any, activity.DynamicRegisterOptions)
+	RegisterNexusService(*nexus.Service)
+}) {
+	t.Helper()
+	var nextCalled bool
+	require.NoError(t, plugin.StartWorker(context.Background(),
+		worker.PluginStartWorkerOptions{WorkerInstanceKey: key, WorkerRegistry: reg},
+		func(context.Context, worker.PluginStartWorkerOptions) error {
+			nextCalled = true
+			return nil
+		},
+	))
+	require.True(t, nextCalled, "StartWorker must invoke next")
+}
+
+// stopPluginWorker drives the plugin's StopWorker hook — the same hook a real
+// worker stop invokes — and requires next to be called.
+func stopPluginWorker(t *testing.T, plugin worker.Plugin, key string) {
+	t.Helper()
+	var nextCalled bool
+	plugin.StopWorker(context.Background(),
+		worker.PluginStopWorkerOptions{WorkerInstanceKey: key},
+		func(context.Context, worker.PluginStopWorkerOptions) { nextCalled = true },
+	)
+	require.True(t, nextCalled, "StopWorker must invoke next")
+}
+
+// runSearchWorkflow executes agentRunWorkflow with the scripted MCP search
+// against env and requires it to complete with the tool having run.
+func runSearchWorkflow(t *testing.T, env *testsuite.TestWorkflowEnvironment) {
+	t.Helper()
+	env.ExecuteWorkflow(agentRunWorkflow, runInput{
+		ModelName:   "fake-model",
+		UserMessage: "search once",
+		MCPToolset:  "search-server",
+	})
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+
+	var res runResult
+	require.NoError(t, env.GetWorkflowResult(&res))
+	assert.Contains(t, res.ToolResponses, "search", "the MCP tool must have run")
+}
+
+// TestNewPluginRejectsInvalidConfig proves NewPlugin surfaces a Config error at
+// plugin construction (worker wiring time) rather than mid-run in an Activity.
+func TestNewPluginRejectsInvalidConfig(t *testing.T) {
+	_, err := googleadk.NewPlugin(googleadk.Config{
+		Models: map[string]googleadk.ModelFactory{"broken-model": nil},
+	})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "broken-model")
+}
+
+// TestPluginRegistersActivitiesOnWorkerStart proves the plugin's StartWorker
+// hook registers exactly the three integration Activities under their stable
+// names and passes control on to next.
+func TestPluginRegistersActivitiesOnWorkerStart(t *testing.T) {
+	plugin, err := googleadk.NewPlugin(googleadk.Config{
+		Models: map[string]googleadk.ModelFactory{
+			"fake-model": scriptedModelFactory(googleadk.TextResponse("done")),
+		},
+	})
+	require.NoError(t, err)
+
+	reg := &pluginRecordingRegistry{}
+	startPluginWorker(t, plugin, "worker-1", reg)
+
+	assert.ElementsMatch(t, []string{
+		googleadk.InvokeModelActivityName,
+		googleadk.ListMcpToolsActivityName,
+		googleadk.CallMcpToolActivityName,
+	}, reg.activityNames)
+}
+
+// TestPluginClosesMCPToolsetsOnWorkerStop proves the plugin lifecycle
+// end-to-end: StartWorker registers the Activities (here into a test workflow
+// environment), a run constructs and caches the MCP toolset, and StopWorker —
+// and only StopWorker — closes it, exactly once, idempotently.
+func TestPluginClosesMCPToolsetsOnWorkerStop(t *testing.T) {
+	ct := &pluginClosableToolset{Toolset: pluginSearchServer()}
+	plugin := newMCPPlugin(t, ct)
+
+	var s testsuite.WorkflowTestSuite
+	env := s.NewTestWorkflowEnvironment()
+	env.RegisterWorkflow(agentRunWorkflow)
+	startPluginWorker(t, plugin, "worker-1", testRegistry{env})
+
+	runSearchWorkflow(t, env)
+	require.Zero(t, ct.closed.Load(), "toolset must stay open while the worker runs")
+
+	stopPluginWorker(t, plugin, "worker-1")
+	assert.Equal(t, int32(1), ct.closed.Load(), "worker stop must close the cached toolset")
+
+	stopPluginWorker(t, plugin, "worker-1")
+	assert.Equal(t, int32(1), ct.closed.Load(), "a second stop must not close again")
+}
+
+// TestPluginReplayDoesNotCloseToolsets proves the replay guard: a plugin shared
+// with a workflow replayer runs its after-hook once per replay, and that pass
+// must neither close nor terminally poison the worker's shared Activities —
+// Close is terminal, so closing on replay would fail every later MCP Activity
+// on the worker non-retryably. After the replay, the full worker lifecycle
+// still works and Close fires exactly once, at worker stop.
+func TestPluginReplayDoesNotCloseToolsets(t *testing.T) {
+	ct := &pluginClosableToolset{Toolset: pluginSearchServer()}
+	plugin := newMCPPlugin(t, ct)
+
+	require.NoError(t, plugin.ReplayWorkflow(context.Background(),
+		worker.PluginReplayWorkflowOptions{
+			WorkflowReplayerInstanceKey: "replayer-1",
+			WorkflowReplayRegistry:      pluginNoopReplayRegistry{},
+		},
+		func(context.Context, worker.PluginReplayWorkflowOptions) error { return nil },
+	))
+	require.Zero(t, ct.closed.Load(), "a replay must not close the worker's shared toolsets")
+
+	var s testsuite.WorkflowTestSuite
+	env := s.NewTestWorkflowEnvironment()
+	env.RegisterWorkflow(agentRunWorkflow)
+	startPluginWorker(t, plugin, "worker-1", testRegistry{env})
+
+	runSearchWorkflow(t, env)
+	require.Zero(t, ct.closed.Load(), "toolset must stay open while the worker runs")
+
+	stopPluginWorker(t, plugin, "worker-1")
+	assert.Equal(t, int32(1), ct.closed.Load(), "worker stop must close the cached toolset exactly once")
+}


### PR DESCRIPTION
## What

Adds `googleadk.NewPlugin`, packaging the worker side of the integration as a worker plugin built on `temporal.SimplePlugin`, and makes it the standard wiring:

```go
adkPlugin, err := googleadk.NewPlugin(googleadk.Config{Models: ..., MCPToolsets: ...})
w := worker.New(c, taskQueue, worker.Options{Plugins: []worker.Plugin{adkPlugin}})
```

- **Worker start** (`RunContextBefore`): registers the `InvokeModel` / `ListMcpTools` / `CallMcpTool` Activities.
- **Worker stop** (`RunContextAfter`): calls `Activities.Close()`, so cached MCP toolsets (sessions / CommandTransport subprocesses) shut down with the worker automatically instead of relying on a user-remembered `defer acts.Close()`.
- **Replay-safe sharing**: run-context hooks also fire once per workflow replay; replays are tracked by instance key (counted — concurrent replays share a key) so a plugin shared with a replayer never closes the worker's toolsets, which would be terminal.
- `NewActivities` + `Register` remain the path for the test environments (which construct no real worker, so plugins do not run there) and manual wiring; `Register` now delegates to a shared helper also used by the plugin.

This mirrors sdk-python's `GoogleAdkPlugin`, which packages the same integration as a `SimplePlugin`.

## Testing plan

- `TestNewPluginRejectsInvalidConfig` — config validation surfaces at construction.
- `TestPluginRegistersActivitiesOnWorkerStart` — exactly the three Activities register through the plugin registry.
- `TestPluginClosesMCPToolsetsOnWorkerStop` — end-to-end through the test env: MCP toolset constructed and cached by a workflow run, closed exactly once on `StopWorker`, second stop is a no-op.
- `TestPluginReplayDoesNotCloseToolsets` — a replay pass neither closes nor poisons the shared Activities; verified the test fails when the replay guard is stubbed to an unconditional Close.
- Full package suite green including `-race`; gofmt/vet clean.

## Release

`CHANGELOG.md` carries this under `## [0.2.0] - 2026-07-22` for today's release cut.
