### PR TITLE
fix(nexus): clear operation callbacks on 'abandon' cancellation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,8 @@ to docs, or any other relevant information.
   environment. This lets host processes that register a single shared factory (e.g.
   `roadrunner-temporal` / the PHP SDK) use dynamic workflows.
 - Merged link-converter class in the server and sdk-go and moved it to api-go
+- Nexus operations with `NexusOperationCancellationTypeAbandon` no longer panic the workflow task when
+  the operation later starts or completes after the caller is canceled.
 
 ## [1.46.0] - 2026-07-07
 

--- a/internal/internal_command_state_machine.go
+++ b/internal/internal_command_state_machine.go
@@ -1215,12 +1215,16 @@ func (h *commandsHelper) handleNexusOperationScheduled(event *historypb.HistoryE
 	command.handleInitiatedEvent()
 }
 
+func (h *commandsHelper) getNexusOperationCommand(seq int64) commandStateMachine {
+	return h.getCommand(makeCommandID(commandTypeNexusOperation, strconv.FormatInt(seq, 10)))
+}
+
 func (h *commandsHelper) handleNexusOperationStarted(scheduledEventID int64) commandStateMachine {
 	seq, ok := h.scheduledEventIDToNexusSeq[scheduledEventID]
 	if !ok {
 		panicIllegalState(fmt.Sprintf("[TMPRL1100] unable to find nexus operation state machine for event ID: %v", scheduledEventID))
 	}
-	command := h.getCommand(makeCommandID(commandTypeNexusOperation, strconv.FormatInt(seq, 10)))
+	command := h.getNexusOperationCommand(seq)
 	command.handleStartedEvent()
 	return command
 }
@@ -1232,7 +1236,7 @@ func (h *commandsHelper) handleNexusOperationCompleted(scheduledEventID int64) c
 	}
 	// We don't need this anymore, the state will not transition after completion.
 	delete(h.scheduledEventIDToNexusSeq, scheduledEventID)
-	command := h.getCommand(makeCommandID(commandTypeNexusOperation, strconv.FormatInt(seq, 10)))
+	command := h.getNexusOperationCommand(seq)
 	command.handleCompletionEvent()
 	return command
 }
@@ -1242,7 +1246,7 @@ func (h *commandsHelper) handleNexusOperationCancelRequested(scheduledEventID in
 	if !ok {
 		panicIllegalState(fmt.Sprintf("[TMPRL1100] unable to find nexus operation state machine for event ID: %v", scheduledEventID))
 	}
-	command := h.getCommand(makeCommandID(commandTypeNexusOperation, strconv.FormatInt(seq, 10)))
+	command := h.getNexusOperationCommand(seq)
 	sm := command.(*nexusOperationStateMachine)
 	sm.cancelation.handleInitiatedEvent()
 	return command
@@ -1253,14 +1257,14 @@ func (h *commandsHelper) handleNexusOperationCancelRequestDelivered(scheduledEve
 	if !ok {
 		panicIllegalState(fmt.Sprintf("[TMPRL1100] unable to find nexus operation state machine for event ID: %v", scheduledEventID))
 	}
-	command := h.getCommand(makeCommandID(commandTypeNexusOperation, strconv.FormatInt(seq, 10)))
+	command := h.getNexusOperationCommand(seq)
 	sm := command.(*nexusOperationStateMachine)
 	sm.cancelation.handleCompletionEvent()
 	return command
 }
 
 func (h *commandsHelper) requestCancelNexusOperation(seq int64) commandStateMachine {
-	command := h.getCommand(makeCommandID(commandTypeNexusOperation, strconv.FormatInt(seq, 10)))
+	command := h.getNexusOperationCommand(seq)
 	command.cancel()
 	// If we haven't sent the command yet, ensure that it doesn't get mapped to the wrong scheduledEventID.
 	if command.getState() != commandStateCanceledBeforeSent {

--- a/internal/internal_event_handlers.go
+++ b/internal/internal_event_handlers.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strconv"
 	"sync"
 	"time"
 
@@ -692,6 +693,20 @@ func (wc *workflowEnvironmentImpl) RequestCancelNexusOperation(seq int64) {
 		}
 	}
 	wc.logger.Debug("RequestCancelNexusOperation",
+		tagNexusEndpoint, data.endpoint,
+		tagNexusService, data.service,
+		tagNexusOperation, data.operation,
+	)
+}
+
+func (wc *workflowEnvironmentImpl) AbandonNexusOperation(seq int64) {
+	command := wc.commandsHelper.getCommand(makeCommandID(commandTypeNexusOperation, strconv.FormatInt(seq, 10)))
+	data := command.getData().(*scheduledNexusOperation)
+
+	data.startedCallback = nil
+	data.completedCallback = nil
+
+	wc.logger.Debug("AbandonNexusOperation",
 		tagNexusEndpoint, data.endpoint,
 		tagNexusService, data.service,
 		tagNexusOperation, data.operation,

--- a/internal/internal_event_handlers.go
+++ b/internal/internal_event_handlers.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-	"strconv"
 	"sync"
 	"time"
 
@@ -700,7 +699,7 @@ func (wc *workflowEnvironmentImpl) RequestCancelNexusOperation(seq int64) {
 }
 
 func (wc *workflowEnvironmentImpl) AbandonNexusOperation(seq int64) {
-	command := wc.commandsHelper.getCommand(makeCommandID(commandTypeNexusOperation, strconv.FormatInt(seq, 10)))
+	command := wc.commandsHelper.getNexusOperationCommand(seq)
 	data := command.getData().(*scheduledNexusOperation)
 
 	data.startedCallback = nil

--- a/internal/internal_worker_base.go
+++ b/internal/internal_worker_base.go
@@ -115,6 +115,7 @@ type (
 		ExecuteChildWorkflow(params ExecuteWorkflowParams, callback ResultHandler, startedHandler func(r WorkflowExecution, e error))
 		ExecuteNexusOperation(params ExecuteNexusOperationParams, callback func(*commonpb.Payload, error), startedHandler func(token string, e error)) int64
 		RequestCancelNexusOperation(seq int64)
+		AbandonNexusOperation(seq int64)
 		GetLogger() log.Logger
 		GetMetricsHandler() metrics.Handler
 		// Must be called before WorkflowDefinition.Execute returns

--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -2910,6 +2910,15 @@ func (env *testWorkflowEnvironmentImpl) RequestCancelNexusOperation(seq int64) {
 	}
 }
 
+func (env *testWorkflowEnvironmentImpl) AbandonNexusOperation(seq int64) {
+	handle, ok := env.getNexusOperationHandle(seq)
+	if !ok {
+		return
+	}
+	handle.onStarted = func(string, error) {}
+	handle.onCompleted = func(*commonpb.Payload, error) {}
+}
+
 func (env *testWorkflowEnvironmentImpl) RegisterNexusAsyncOperationCompletion(
 	service string,
 	operation string,

--- a/internal/nexus_operations_cancellation_test.go
+++ b/internal/nexus_operations_cancellation_test.go
@@ -1,0 +1,68 @@
+package internal
+
+import (
+	"testing"
+
+	commonpb "go.temporal.io/api/common/v1"
+)
+
+type captureNexusEnv struct {
+	WorkflowEnvironment
+	started   func(token string, err error)
+	completed func(*commonpb.Payload, error)
+}
+
+func (e *captureNexusEnv) ExecuteNexusOperation(
+	_ ExecuteNexusOperationParams,
+	callback func(*commonpb.Payload, error),
+	startedHandler func(token string, e error),
+) int64 {
+	e.started = startedHandler
+	e.completed = callback
+	return 1
+}
+
+func (e *captureNexusEnv) AbandonNexusOperation(int64) {
+	e.started = nil
+	e.completed = nil
+}
+
+// deliverStarted and deliverCompleted mimic the event handlers, which invoke a callback only
+// while it is still set (see handleNexusOperationStarted / handleNexusOperationCompleted).
+func (e *captureNexusEnv) deliverStarted(token string, err error) {
+	if e.started != nil {
+		e.started(token, err)
+	}
+}
+
+func (e *captureNexusEnv) deliverCompleted(result *commonpb.Payload, err error) {
+	if e.completed != nil {
+		e.completed(result, err)
+	}
+}
+
+// This cannot be reproduced through the workflow test environment as an ordinary workflow: its
+// Nexus operation handle independently guards duplicate starts/completions (see
+// testNexusOperationHandle), which masks the unguarded callbacks in the real event handler. So we
+// drive the interceptor directly and feed it the late events a real environment would deliver.
+func TestNexusAbandonCancellationClearsCallbacks(t *testing.T) {
+	interceptor, ctx := createRootTestContext()
+	capture := &captureNexusEnv{WorkflowEnvironment: interceptor.env}
+	interceptor.env = capture
+
+	d, _ := newDispatcher(ctx, interceptor, func(ctx Context) {
+		cancelCtx, cancel := WithCancel(ctx)
+		interceptor.ExecuteNexusOperation(cancelCtx, ExecuteNexusOperationInput{
+			Client:    NewNexusClient("endpoint", "service"),
+			Operation: "operation",
+			Options:   NexusOperationOptions{CancellationType: NexusOperationCancellationTypeAbandon},
+		})
+		cancel()
+		capture.deliverStarted("token", nil)
+		capture.deliverCompleted(nil, nil)
+	}, func() bool { return false })
+	d.interceptor = interceptor
+	defer d.Close()
+
+	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked(defaultDeadlockDetectionTimeout))
+}

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -3188,6 +3188,7 @@ func (wc *workflowEnvironmentInterceptor) ExecuteNexusOperation(ctx Context, inp
 					if !executionFuture.IsReady() {
 						executionSettable.Set(nil, ErrCanceled)
 					}
+					wc.env.AbandonNexusOperation(seq)
 				} else {
 					// Go back to the top of the interception chain.
 					getWorkflowOutboundInterceptor(ctx).RequestCancelNexusOperation(ctx, RequestCancelNexusOperationInput{


### PR DESCRIPTION
Was seeing a flakey test (`TestAsyncOperationFromWorkflow_CancellationTypes/Abandon`) and traced it back to a bug.

## What was changed

- Cancelling with`NexusOperationCancellationTypeAbandon` now correctly clears nexus callbacks.
- Added a small helper for getting the nexus operation command.

## Why?

When you cancel a workflow running a nexus operation with `NexusOperationCancellationTypeAbandon`, it operations futures directly but doesn't clear the `startedCallback` or `completedCallback`. Then, when a NexusOperationStarted (or completed) event is received, the stale callbacks fires and attempts to set an already resolved future which panics, which WFT fails.

Fixes #2495

## Checklist
- Added tests to verify that we clear callbacks.