### PR TITLE
fix spans' durations underflowing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ to docs, or any other relevant information.
 ### Fixed
 
 - Allow query results to use external storage before payload size enforcement.
+- Use the worker clock for `RunWorkflow` and `RunActivity` tracing span start times to avoid negative
+  durations when the server clock is ahead of the worker clock.
 - Correct schedule catch-up window documentation to state that an unset value is omitted and the
   server applies its one-year default.
 - Resource-based tuner: `ReserveSlot` now honors context cancellation while the resource controller is

--- a/interceptor/tracing_interceptor.go
+++ b/interceptor/tracing_interceptor.go
@@ -114,8 +114,7 @@ type TracerStartSpanOptions struct {
 
 	// Time indicates the start time of the span.
 	//
-	// For RunWorkflow and RunActivity operation types, this will match workflow.Info.WorkflowStartTime and
-	// activity.Info.StartedTime respectively. All other operations use time.Now().
+	// The tracing interceptor uses the worker's time.Now() for all operations.
 	Time time.Time
 
 	// DependedOn is true if the parent depends on this span or false if it just
@@ -455,7 +454,7 @@ func (t *tracingActivityInboundInterceptor) ExecuteActivity(
 			activityIDTagKey: info.ActivityID,
 		},
 		FromHeader: true,
-		Time:       info.StartedTime,
+		Time:       time.Now(),
 	}, t.root.headerReader(ctx), t.root.headerWriter(ctx))
 	if err != nil {
 		return nil, err
@@ -505,7 +504,7 @@ func (t *tracingWorkflowInboundInterceptor) ExecuteWorkflow(
 			runIDTagKey:      t.info.WorkflowExecution.RunID,
 		},
 		FromHeader:     true,
-		Time:           t.info.WorkflowStartTime,
+		Time:           time.Now(),
 		IdempotencyKey: t.newIdempotencyKey(),
 	}, t.root.workflowHeaderReader(ctx), t.root.workflowHeaderWriter(ctx))
 	if err != nil {

--- a/interceptor/tracing_interceptor_internal_test.go
+++ b/interceptor/tracing_interceptor_internal_test.go
@@ -1,10 +1,23 @@
 package interceptor
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	commonpb "go.temporal.io/api/common/v1"
+	"go.temporal.io/api/workflowservice/v1"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"go.temporal.io/sdk/converter"
+	"go.temporal.io/sdk/internal"
+	"go.temporal.io/sdk/internal/common/metrics"
+	ilog "go.temporal.io/sdk/internal/log"
+	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/worker"
 	"go.temporal.io/sdk/workflow"
 )
 
@@ -33,4 +46,129 @@ func TestIdempotencyKeyGeneration(t *testing.T) {
 	//                SDK version's release notes.
 	assert.Equal(t, i.newIdempotencyKey(), "WorkflowInboundInterceptor:default:foo:bar:1")
 	assert.Equal(t, i.newIdempotencyKey(), "WorkflowInboundInterceptor:default:foo:bar:2")
+}
+
+type recordingTracer struct {
+	BaseTracer
+	options []TracerStartSpanOptions
+}
+
+func (r *recordingTracer) Options() TracerOptions {
+	return TracerOptions{
+		SpanContextKey: "recording-tracer",
+		HeaderKey:      "recording-tracer",
+	}
+}
+
+func (r *recordingTracer) UnmarshalSpan(map[string]string) (TracerSpanRef, error) {
+	return nil, nil
+}
+
+func (r *recordingTracer) MarshalSpan(TracerSpan) (map[string]string, error) {
+	return nil, nil
+}
+
+func (r *recordingTracer) SpanFromContext(context.Context) TracerSpan {
+	return nil
+}
+
+func (r *recordingTracer) ContextWithSpan(ctx context.Context, span TracerSpan) context.Context {
+	return ctx
+}
+
+func (r *recordingTracer) StartSpan(options *TracerStartSpanOptions) (TracerSpan, error) {
+	r.options = append(r.options, *options)
+	return recordingSpan{}, nil
+}
+
+type recordingSpan struct{}
+
+func (recordingSpan) Finish(*TracerFinishSpanOptions) {}
+
+type recordingActivityInbound struct {
+	ActivityInboundInterceptorBase
+}
+
+func (recordingActivityInbound) Init(ActivityOutboundInterceptor) error {
+	return nil
+}
+
+func (recordingActivityInbound) ExecuteActivity(context.Context, *ExecuteActivityInput) (interface{}, error) {
+	return "activity-result", nil
+}
+
+func testRunWorkflowWorkerClockWorkflow(workflow.Context) error {
+	return nil
+}
+
+func TestRunWorkflowSpanUsesWorkerClock(t *testing.T) {
+	tracer := &recordingTracer{}
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+	serverWorkflowStartTime := time.Now().Add(time.Hour)
+	env.SetStartTime(serverWorkflowStartTime)
+	env.RegisterWorkflow(testRunWorkflowWorkerClockWorkflow)
+	env.SetWorkerOptions(worker.Options{
+		Interceptors: []WorkerInterceptor{NewTracingInterceptor(tracer)},
+	})
+
+	beforeRunWorkflow := time.Now()
+	env.ExecuteWorkflow(testRunWorkflowWorkerClockWorkflow)
+	afterRunWorkflow := time.Now()
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+	require.Len(t, tracer.options, 1)
+	require.Equal(t, "RunWorkflow", tracer.options[0].Operation)
+	require.False(t, tracer.options[0].Time.Before(beforeRunWorkflow))
+	require.False(t, tracer.options[0].Time.After(afterRunWorkflow))
+	require.True(t, tracer.options[0].Time.Before(serverWorkflowStartTime))
+}
+
+func TestRunActivitySpanUsesWorkerClock(t *testing.T) {
+	tracer := &recordingTracer{}
+	root := NewTracingInterceptor(tracer).(*tracingInterceptor)
+	inbound := &tracingActivityInboundInterceptor{
+		ActivityInboundInterceptorBase: ActivityInboundInterceptorBase{Next: &recordingActivityInbound{}},
+		root:                           root,
+	}
+
+	serverStartedTime := time.Now().Add(time.Hour)
+	ctx, err := internal.WithActivityTask(
+		context.Background(),
+		&workflowservice.PollActivityTaskQueueResponse{
+			ActivityId:             "activity-id",
+			ActivityType:           &commonpb.ActivityType{Name: "activity-type"},
+			ScheduledTime:          timestamppb.New(time.Now()),
+			StartedTime:            timestamppb.New(serverStartedTime),
+			StartToCloseTimeout:    durationpb.New(time.Minute),
+			WorkflowExecution:      &commonpb.WorkflowExecution{WorkflowId: "workflow-id", RunId: "run-id"},
+			WorkflowNamespace:      "default",
+			WorkflowType:           &commonpb.WorkflowType{Name: "workflow-type"},
+			ScheduleToCloseTimeout: durationpb.New(time.Minute),
+		},
+		"task-queue",
+		nil,
+		ilog.NewNopLogger(),
+		metrics.NopHandler,
+		converter.GetDefaultDataConverter(),
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+
+	beforeRunActivity := time.Now()
+	ret, err := inbound.ExecuteActivity(ctx, &ExecuteActivityInput{})
+	afterRunActivity := time.Now()
+
+	require.NoError(t, err)
+	require.Equal(t, "activity-result", ret)
+	require.Len(t, tracer.options, 1)
+	require.Equal(t, "RunActivity", tracer.options[0].Operation)
+	require.False(t, tracer.options[0].Time.Before(beforeRunActivity))
+	require.False(t, tracer.options[0].Time.After(afterRunActivity))
+	require.True(t, tracer.options[0].Time.Before(serverStartedTime))
 }

--- a/interceptor/tracing_interceptor_test.go
+++ b/interceptor/tracing_interceptor_test.go
@@ -47,12 +47,7 @@ func (t *testTracer) ContextWithSpan(ctx context.Context, span interceptor.Trace
 func (t *testTracer) StartSpan(options *interceptor.TracerStartSpanOptions) (interceptor.TracerSpan, error) {
 	// Require start time to be set
 	if options.Time.IsZero() {
-		switch options.Operation {
-		case "RunWorkflow", "RunActivity":
-		// Do nothing; the test env doesn't set these at the moment.
-		default:
-			t.T.Errorf("Got zero value for span start time: %v", options)
-		}
+		t.T.Errorf("Got zero value for span start time: %v", options)
 	}
 	return testSpan{}, nil
 }


### PR DESCRIPTION
## What was changed
Started using Worker's clock not only for Spans' finishes, but also for starts.

## Why?
I've noticed that using the Temporal Server clock makes the durations underflow sometime.

## Checklist

2. How was this tested:
Unit testing

3. Any docs updates needed?
Not really