### PR TITLE
Use last non-canceled context for batched heartbeats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,11 @@ to docs, or any other relevant information.
 
 ### Fixed
 
+- `activity.RecordHeartbeat` no longer loses a throttled heartbeat when the context it was called
+  with is canceled before the throttling window closes. The deferred send now uses the most recent
+  context passed to `RecordHeartbeat` that was not canceled. This fixes activities that heartbeat
+  from a short-lived context, such as one from `errgroup.WithContext`, timing out with
+  `activity Heartbeat timeout`.
 - Allow query results to use external storage before payload size enforcement.
 - Correct schedule catch-up window documentation to state that an unset value is omitted and the
   server applies its one-year default.

--- a/activity/activity.go
+++ b/activity/activity.go
@@ -72,6 +72,14 @@ func GetMetricsHandler(ctx context.Context) metrics.Handler {
 // details - The details that you provide here can be seen in the workflow when it receives TimeoutError. You
 // can check error with TimeoutType()/Details().
 //
+// Heartbeats are throttled, so a call does not always send a request to the server. A call made
+// inside a throttling window records the details and the SDK sends them when the window closes.
+// Cancelling ctx does not cancel a heartbeat that is already recorded: the deferred send uses the
+// most recent context passed to RecordHeartbeat that was not cancelled, so passing a short-lived
+// context, such as a context from [golang.org/x/sync/errgroup.WithContext], does not drop progress
+// recorded through it. If every context passed has been cancelled by the time the window closes,
+// the SDK still sends the heartbeat using the values from the most recent one.
+//
 // Note: If using asynchronous activity completion,
 // after returning [ErrResultPending] users should heartbeat with [go.temporal.io/sdk/client.Client.RecordActivityHeartbeat]
 func RecordHeartbeat(ctx context.Context, details ...interface{}) {

--- a/activity/activity.go
+++ b/activity/activity.go
@@ -75,9 +75,9 @@ func GetMetricsHandler(ctx context.Context) metrics.Handler {
 // Heartbeats are throttled, so a call does not always send a request to the server. A call made
 // inside a throttling window records the details and the SDK sends them when the window closes.
 // Cancelling ctx does not cancel a heartbeat that is already recorded: the deferred send uses the
-// most recent context passed to RecordHeartbeat that was not cancelled, so passing a short-lived
+// most recent context passed to RecordHeartbeat that was not canceled, so passing a short-lived
 // context, such as a context from [golang.org/x/sync/errgroup.WithContext], does not drop progress
-// recorded through it. If every context passed has been cancelled by the time the window closes,
+// recorded through it. If every context passed has been canceled by the time the window closes,
 // the SDK still sends the heartbeat using the values from the most recent one.
 //
 // Note: If using asynchronous activity completion,

--- a/internal/activity.go
+++ b/internal/activity.go
@@ -289,6 +289,13 @@ func GetWorkerStopChannel(ctx context.Context) <-chan struct{} {
 // can check error TimeoutType()/Details(). Heartbeat responses may also deliver server requests such as activity
 // cancellation, pause, and reset to the activity context.
 //
+// Heartbeats are throttled, so a call does not always send a request to the server. A call made
+// inside a throttling window records the details and the SDK sends them when the window closes.
+// Cancelling ctx does not cancel a heartbeat that is already recorded: the deferred send uses the
+// most recent context passed to RecordActivityHeartbeat that was not cancelled. If every context
+// passed has been cancelled by the time the window closes, the SDK still sends the heartbeat using
+// the values from the most recent one.
+//
 // Exposed as: [go.temporal.io/sdk/activity.RecordHeartbeat]
 func RecordActivityHeartbeat(ctx context.Context, details ...interface{}) {
 	getActivityOutboundInterceptor(ctx).RecordHeartbeat(ctx, details...)

--- a/internal/activity.go
+++ b/internal/activity.go
@@ -292,8 +292,8 @@ func GetWorkerStopChannel(ctx context.Context) <-chan struct{} {
 // Heartbeats are throttled, so a call does not always send a request to the server. A call made
 // inside a throttling window records the details and the SDK sends them when the window closes.
 // Cancelling ctx does not cancel a heartbeat that is already recorded: the deferred send uses the
-// most recent context passed to RecordActivityHeartbeat that was not cancelled. If every context
-// passed has been cancelled by the time the window closes, the SDK still sends the heartbeat using
+// most recent context passed to RecordActivityHeartbeat that was not canceled. If every context
+// passed has been canceled by the time the window closes, the SDK still sends the heartbeat using
 // the values from the most recent one.
 //
 // Exposed as: [go.temporal.io/sdk/activity.RecordHeartbeat]

--- a/internal/activity_test.go
+++ b/internal/activity_test.go
@@ -246,6 +246,76 @@ func (s *activityTestSuite) TestActivityHeartbeat_WorkerStop() {
 	<-waitC2
 }
 
+// A caller may heartbeat with a context it cancels once part of its work is done,
+// as errgroup.WithContext does on Wait. The batched flush must not use that
+// context when a later call supplied one that is still live.
+func (s *activityTestSuite) TestActivityHeartbeat_BatchFlushUsesLastNonCanceledContext() {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+	workerStopChannel := make(chan struct{})
+	invoker := newServiceInvoker([]byte("task-token"), "identity", s.service, metrics.NopHandler, cancel,
+		time.Minute, workerStopChannel, s.namespace, &atomic.Bool{}, nil, nil)
+	ctx, _ = newActivityContext(ctx, nil, &activityEnvironment{
+		serviceInvoker: invoker,
+		logger:         getLogger()})
+
+	flushCtxErr := make(chan error, 1)
+	s.service.EXPECT().RecordActivityTaskHeartbeat(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(&workflowservice.RecordActivityTaskHeartbeatResponse{}, nil).
+		Do(func(rpcCtx context.Context, request *workflowservice.RecordActivityTaskHeartbeatRequest, opts ...grpc.CallOption) {
+			var details string
+			s.NoError(newEncodedValues(request.Details, nil).Get(&details))
+			if details == "buffered" {
+				flushCtxErr <- rpcCtx.Err()
+			}
+		}).Times(2)
+
+	groupCtx, cancelGroup := context.WithCancel(ctx)
+	RecordActivityHeartbeat(groupCtx, "opens-batch-window")
+	RecordActivityHeartbeat(groupCtx, "buffered")
+	cancelGroup()
+	// The activity is still running and heartbeats with a context that is not canceled.
+	RecordActivityHeartbeat(ctx, "buffered")
+
+	// Close the batch window deterministically instead of waiting on the throttle timer.
+	close(workerStopChannel)
+	s.NoError(<-flushCtxErr)
+	invoker.Close(ctx, false)
+}
+
+// When every context the caller supplied has been canceled by the time the batch
+// window closes, the buffered progress is still reported.
+func (s *activityTestSuite) TestActivityHeartbeat_BatchFlushWithAllContextsCanceled() {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+	workerStopChannel := make(chan struct{})
+	invoker := newServiceInvoker([]byte("task-token"), "identity", s.service, metrics.NopHandler, cancel,
+		time.Minute, workerStopChannel, s.namespace, &atomic.Bool{}, nil, nil)
+	ctx, _ = newActivityContext(ctx, nil, &activityEnvironment{
+		serviceInvoker: invoker,
+		logger:         getLogger()})
+
+	flushCtxErr := make(chan error, 1)
+	s.service.EXPECT().RecordActivityTaskHeartbeat(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(&workflowservice.RecordActivityTaskHeartbeatResponse{}, nil).
+		Do(func(rpcCtx context.Context, request *workflowservice.RecordActivityTaskHeartbeatRequest, opts ...grpc.CallOption) {
+			var details string
+			s.NoError(newEncodedValues(request.Details, nil).Get(&details))
+			if details == "buffered" {
+				flushCtxErr <- rpcCtx.Err()
+			}
+		}).Times(2)
+
+	groupCtx, cancelGroup := context.WithCancel(ctx)
+	RecordActivityHeartbeat(groupCtx, "opens-batch-window")
+	RecordActivityHeartbeat(groupCtx, "buffered")
+	cancelGroup()
+
+	close(workerStopChannel)
+	s.NoError(<-flushCtxErr)
+	invoker.Close(ctx, false)
+}
+
 func (s *activityTestSuite) TestGetWorkerStopChannel() {
 	ch := make(chan struct{}, 1)
 	ctx, _ := newActivityContext(context.Background(), nil, &activityEnvironment{workerStopChannel: ch})

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -2167,6 +2167,11 @@ type temporalInvoker struct {
 	heartbeatThrottleInterval time.Duration
 	hbBatchEndTimer           *time.Timer // Whether we started a batch of operations that need to be reported in the cycle. This gets started on a user call.
 	lastDetailsToReport       **commonpb.Payloads
+	// lastHeartbeatCtx is the most recent context a caller passed to Heartbeat that
+	// was not already cancelled. Callers may heartbeat with different contexts, and
+	// the context that opens a batch window is often cancelled before the window
+	// closes, so the batched flush uses this instead of the opening context.
+	lastHeartbeatCtx context.Context
 	// closeCh is closed by temporalInvoker.Close() when the activity execution finishes.
 	closeCh chan struct{}
 	// workerStopChannel is a read-only view of activityWorker.stopC.
@@ -2180,6 +2185,18 @@ type temporalInvoker struct {
 }
 
 func (i *temporalInvoker) Heartbeat(ctx context.Context, details *commonpb.Payloads, skipBatching bool) error {
+	i.Lock()
+	if ctx.Err() == nil {
+		i.lastHeartbeatCtx = ctx
+	}
+	i.Unlock()
+	return i.heartbeat(ctx, details, skipBatching)
+}
+
+// heartbeat is Heartbeat without the caller-context bookkeeping. The batching
+// goroutine calls this so the context it derives for a flush is not itself
+// recorded as a caller context.
+func (i *temporalInvoker) heartbeat(ctx context.Context, details *commonpb.Payloads, skipBatching bool) error {
 	i.Lock()
 	defer i.Unlock()
 
@@ -2216,6 +2233,7 @@ func (i *temporalInvoker) Heartbeat(ctx context.Context, details *commonpb.Paylo
 
 			i.Lock()
 			detailsToReport = i.lastDetailsToReport
+			reportCtx := i.reportContextLocked(ctx)
 			i.hbBatchEndTimer.Stop()
 			i.hbBatchEndTimer = nil
 			i.Unlock()
@@ -2225,12 +2243,33 @@ func (i *temporalInvoker) Heartbeat(ctx context.Context, details *commonpb.Paylo
 				// locked again in the Hearbeat() method. This possible that a heartbeat call from
 				// user activity grabs the lock first and calls internalHeartBeat before this
 				// batching goroutine, which means some activity progress will be lost.
-				_ = i.Heartbeat(ctx, *detailsToReport, false)
+				_ = i.heartbeat(reportCtx, *detailsToReport, false)
 			}
 		}()
 	}
 
 	return err
+}
+
+// reportContextLocked picks the context used to flush a batched heartbeat. The
+// caller must hold i's lock.
+//
+// batchCtx is the context that opened the batch window and is only used when no
+// caller context was ever live. When every recorded context has since been
+// cancelled the values are kept but the cancellation is dropped: cancellation of
+// a context a caller passed says nothing about whether the activity is still
+// running, and the batching goroutine already returns on closeCh so a flush is
+// only sent while the activity is alive. internalHeartBeat still bounds the RPC
+// with its own timeout.
+func (i *temporalInvoker) reportContextLocked(batchCtx context.Context) context.Context {
+	switch {
+	case i.lastHeartbeatCtx == nil:
+		return batchCtx
+	case i.lastHeartbeatCtx.Err() == nil:
+		return i.lastHeartbeatCtx
+	default:
+		return context.WithoutCancel(i.lastHeartbeatCtx)
+	}
 }
 
 func (i *temporalInvoker) internalHeartBeat(ctx context.Context, details *commonpb.Payloads) (bool, error) {

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -2168,8 +2168,8 @@ type temporalInvoker struct {
 	hbBatchEndTimer           *time.Timer // Whether we started a batch of operations that need to be reported in the cycle. This gets started on a user call.
 	lastDetailsToReport       **commonpb.Payloads
 	// lastHeartbeatCtx is the most recent context a caller passed to Heartbeat that
-	// was not already cancelled. Callers may heartbeat with different contexts, and
-	// the context that opens a batch window is often cancelled before the window
+	// was not already canceled. Callers may heartbeat with different contexts, and
+	// the context that opens a batch window is often canceled before the window
 	// closes, so the batched flush uses this instead of the opening context.
 	lastHeartbeatCtx context.Context
 	// closeCh is closed by temporalInvoker.Close() when the activity execution finishes.
@@ -2185,12 +2185,20 @@ type temporalInvoker struct {
 }
 
 func (i *temporalInvoker) Heartbeat(ctx context.Context, details *commonpb.Payloads, skipBatching bool) error {
+	i.recordHeartbeatContext(ctx)
+	return i.heartbeat(ctx, details, skipBatching)
+}
+
+// recordHeartbeatContext remembers ctx if it is still usable, so a batched
+// heartbeat flushed later does not depend on a context the caller has since
+// canceled. It is separate from heartbeat because that method takes the same
+// non-reentrant lock.
+func (i *temporalInvoker) recordHeartbeatContext(ctx context.Context) {
 	i.Lock()
+	defer i.Unlock()
 	if ctx.Err() == nil {
 		i.lastHeartbeatCtx = ctx
 	}
-	i.Unlock()
-	return i.heartbeat(ctx, details, skipBatching)
 }
 
 // heartbeat is Heartbeat without the caller-context bookkeeping. The batching
@@ -2256,7 +2264,7 @@ func (i *temporalInvoker) heartbeat(ctx context.Context, details *commonpb.Paylo
 //
 // batchCtx is the context that opened the batch window and is only used when no
 // caller context was ever live. When every recorded context has since been
-// cancelled the values are kept but the cancellation is dropped: cancellation of
+// canceled the values are kept but the cancellation is dropped: cancellation of
 // a context a caller passed says nothing about whether the activity is still
 // running, and the batching goroutine already returns on closeCh so a flush is
 // only sent while the activity is alive. internalHeartBeat still bounds the RPC


### PR DESCRIPTION
## What was changed

`temporalInvoker` now tracks the most recent context passed to `Heartbeat` that
was not already canceled, and the batching goroutine uses that context to flush
buffered heartbeat details instead of the context that opened the batch window.

Also documents the cancellation behavior on `activity.RecordHeartbeat` and
`internal.RecordActivityHeartbeat`.

## Why?

Heartbeats are throttled. The first call in a window sends an RPC and starts a
timer; later calls only record details. When the timer fires, the goroutine sent
the buffered details using the context captured when the window opened. If the
caller had canceled that context by then, the send failed with `context
canceled` and the activity timed out with `activity Heartbeat timeout` even
though it was alive and heartbeating with a live context.

The reported case passes an `errgroup` context to `RecordHeartbeat` from the
group's goroutines. `g.Wait()` cancels it, but the activity keeps running and
keeps heartbeating with its own context. The buffered send still used the dead
`errgroup` context.

This follows the direction in the issue thread: clarify the documentation, and
use the last non-canceled context when `RecordHeartbeat` is called with more
than one.

### Design notes

- The new `lastHeartbeatCtx` field is guarded by the struct's existing embedded
  mutex, in the same critical section that already reads `lastDetailsToReport`.
  No new lock and no new lock ordering.
- Only the `ServiceInvoker.Heartbeat` entry point records a context. The
  batching goroutine calls an unexported `heartbeat` that shares the body but
  does not record, so a context derived for a flush is never itself recorded.
- The acknowledged lock-release race TODO in the batching goroutine is left
  as-is. The new field is read in the same critical section as
  `lastDetailsToReport`, so that race is neither widened nor narrowed.

### One decision worth a maintainer call

If every context the caller supplied has been canceled by the time the window
closes, the flush uses `context.WithoutCancel` of the most recent one rather
than giving up. This is not `context.Background()`: it keeps the activity
context values the heartbeat path needs (activity logger, data converter,
payload visitor, propagated headers) and only drops the cancellation.
`internalHeartBeat` still bounds the RPC with its own timeout, and the batching
goroutine already returns on `closeCh`, so a heartbeat is only ever sent while
the activity is still running. Cancellation of a context a caller passed says
nothing about whether the activity is alive, which is the whole point of the
reported bug.

If you would rather the SDK drop the heartbeat in that case, the `default` arm
of `reportContextLocked` is the only thing to change and the primary behavior
stays intact.

## Checklist

1. Closes #1574

2. How was this tested:

Two new cases in `internal/activity_test.go`, both following the existing
`activityTestSuite` and gomock pattern with no fixed sleeps. They close the
batch window through `workerStopChannel` rather than waiting on the throttle
timer, and assert on `ctx.Err()` seen by the flush RPC.

- `TestActivityHeartbeat_BatchFlushUsesLastNonCanceledContext` reproduces the
  issue: open the window with a child context, buffer through it, cancel it,
  then heartbeat with the still-live parent.
- `TestActivityHeartbeat_BatchFlushWithAllContextsCanceled` covers the fallback.

Both fail on `main` with `context canceled` and pass with this change. Also ran
`go run . check` and the full `go.temporal.io/sdk/internal` package with `-race`.

3. Any docs updates needed?

Included. The doc comments on `activity.RecordHeartbeat` and
`internal.RecordActivityHeartbeat` now state that heartbeats are throttled and
what happens when the calling context is canceled. `CHANGELOG.md` has an entry
under `### Fixed`.

---
🤖 Opened with [Superhuman](https://github.com/gaurav0107/superhuman), an open-source contribution agent.