### PR TITLE
Make eager activity reservation limit configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ to docs, or any other relevant information.
 
 ### Added
 
+- Added `worker.Options.MaxEagerActivityReservationsPerWorkflowTask` to configure the maximum
+  number of eager activity slots reserved per workflow task. The default remains three.
+
 - Automatically enroll workers into poller autoscaling when the namespace advertises the
   `PollerAutoscalingAutoEnroll` capability. This only applies to poller types left at their default
   (i.e. the worker set neither `MaxConcurrent<Type>TaskPollers` nor `<Type>TaskPollerBehavior`);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,8 @@ to docs, or any other relevant information.
 ### Added
 
 - Added `worker.Options.MaxEagerActivityReservationsPerWorkflowTask` to configure the maximum
-  number of eager activity slots reserved per workflow task. The default remains three.
+  number of eager activity slots reserved per workflow task. The default remains three. Configured
+  values must be positive; use `DisableEagerActivities` to disable eager activity execution.
 
 - Automatically enroll workers into poller autoscaling when the namespace advertises the
   `PollerAutoscalingAutoEnroll` capability. This only applies to poller types left at their default

--- a/internal/internal_eager_activity.go
+++ b/internal/internal_eager_activity.go
@@ -30,7 +30,7 @@ type eagerActivityExecutorOptions struct {
 // before it will be able to execute activities.
 func newEagerActivityExecutor(options eagerActivityExecutorOptions) *eagerActivityExecutor {
 	if options.maxPerTask <= 0 {
-		options.maxPerTask = defaultMaxEagerActivityReservationsPerWorkflowTask
+		panic("maxPerTask must be positive")
 	}
 	return &eagerActivityExecutor{eagerActivityExecutorOptions: options}
 }

--- a/internal/internal_eager_activity.go
+++ b/internal/internal_eager_activity.go
@@ -22,20 +22,22 @@ type eagerActivityExecutorOptions struct {
 	taskQueue string
 	// If 0, there is no maximum
 	maxConcurrent int
+	maxPerTask    int
 }
 
 // newEagerActivityExecutor creates a new worker-scoped executor without an
 // activityWorker set. The activityWorker must be set on the responding executor
 // before it will be able to execute activities.
 func newEagerActivityExecutor(options eagerActivityExecutorOptions) *eagerActivityExecutor {
+	if options.maxPerTask <= 0 {
+		options.maxPerTask = defaultMaxEagerActivityReservationsPerWorkflowTask
+	}
 	return &eagerActivityExecutor{eagerActivityExecutorOptions: options}
 }
 
 func (e *eagerActivityExecutor) applyToRequest(
 	req *workflowservice.RespondWorkflowTaskCompletedRequest,
 ) []*SlotPermit {
-	// Don't allow more than this hardcoded amount per workflow task for now
-	const maxPerTask = 3
 	reservedPermits := make([]*SlotPermit, 0)
 
 	// Go over every command checking for activities that can be eagerly executed
@@ -50,7 +52,7 @@ func (e *eagerActivityExecutor) applyToRequest(
 				!attrs.RequestEagerExecution ||
 				e.activityWorker == nil ||
 				e.taskQueue != attrs.TaskQueue.GetName() ||
-				eagerRequestsThisTask >= maxPerTask
+				eagerRequestsThisTask >= e.maxPerTask
 			if eagerDisallowed {
 				attrs.RequestEagerExecution = false
 			} else {

--- a/internal/internal_eager_activity_test.go
+++ b/internal/internal_eager_activity_test.go
@@ -13,7 +13,11 @@ import (
 )
 
 func TestEagerActivityDisabled(t *testing.T) {
-	exec := newEagerActivityExecutor(eagerActivityExecutorOptions{disabled: true, taskQueue: "task-queue1"})
+	exec := newEagerActivityExecutor(eagerActivityExecutorOptions{
+		disabled:   true,
+		taskQueue:  "task-queue1",
+		maxPerTask: defaultMaxEagerActivityReservationsPerWorkflowTask,
+	})
 	exec.activityWorker = newActivityWorker(nil,
 		workerExecutionParameters{TaskQueue: "task-queue1"}, nil, newRegistry(), nil).worker
 
@@ -25,7 +29,10 @@ func TestEagerActivityDisabled(t *testing.T) {
 }
 
 func TestEagerActivityNoActivityWorker(t *testing.T) {
-	exec := newEagerActivityExecutor(eagerActivityExecutorOptions{taskQueue: "task-queue1"})
+	exec := newEagerActivityExecutor(eagerActivityExecutorOptions{
+		taskQueue:  "task-queue1",
+		maxPerTask: defaultMaxEagerActivityReservationsPerWorkflowTask,
+	})
 
 	// Turns requests to false without activity worker
 	var req workflowservice.RespondWorkflowTaskCompletedRequest
@@ -35,7 +42,10 @@ func TestEagerActivityNoActivityWorker(t *testing.T) {
 }
 
 func TestEagerActivityWrongTaskQueue(t *testing.T) {
-	exec := newEagerActivityExecutor(eagerActivityExecutorOptions{taskQueue: "task-queue1"})
+	exec := newEagerActivityExecutor(eagerActivityExecutorOptions{
+		taskQueue:  "task-queue1",
+		maxPerTask: defaultMaxEagerActivityReservationsPerWorkflowTask,
+	})
 	tuner, err := NewFixedSizeTuner(FixedSizeTunerOptions{
 		NumWorkflowSlots:      defaultMaxConcurrentTaskExecutionSize,
 		NumActivitySlots:      10,
@@ -91,7 +101,8 @@ func TestEagerActivityCounts(t *testing.T) {
 	// We'll create an eager activity executor with 3 max eager concurrent and 5
 	// max concurrent
 	exec := newEagerActivityExecutor(eagerActivityExecutorOptions{taskQueue: "task-queue1",
-		maxConcurrent: 3})
+		maxConcurrent: 3,
+		maxPerTask:    defaultMaxEagerActivityReservationsPerWorkflowTask})
 	tuner, err := NewFixedSizeTuner(FixedSizeTunerOptions{
 		NumWorkflowSlots:      defaultMaxConcurrentTaskExecutionSize,
 		NumActivitySlots:      5,

--- a/internal/internal_eager_activity_test.go
+++ b/internal/internal_eager_activity_test.go
@@ -59,7 +59,10 @@ func TestEagerActivityWrongTaskQueue(t *testing.T) {
 }
 
 func TestEagerActivityMaxPerTask(t *testing.T) {
-	exec := newEagerActivityExecutor(eagerActivityExecutorOptions{taskQueue: "task-queue1"})
+	exec := newEagerActivityExecutor(eagerActivityExecutorOptions{
+		taskQueue:  "task-queue1",
+		maxPerTask: 2,
+	})
 	tuner, err := NewFixedSizeTuner(FixedSizeTunerOptions{
 		NumWorkflowSlots:      defaultMaxConcurrentTaskExecutionSize,
 		NumActivitySlots:      10,
@@ -73,14 +76,14 @@ func TestEagerActivityMaxPerTask(t *testing.T) {
 
 	exec.activityWorker = activityWorker.worker
 
-	// Add 8, but it limits to only the first 3
+	// Add 8, but it limits to only the first 2
 	var req workflowservice.RespondWorkflowTaskCompletedRequest
 	for i := 0; i < 8; i++ {
 		addScheduleTaskCommand(&req, "task-queue1")
 	}
-	require.Equal(t, 3, len(exec.applyToRequest(&req)))
+	require.Equal(t, 2, len(exec.applyToRequest(&req)))
 	for i := 0; i < 8; i++ {
-		require.Equal(t, i < 3, req.Commands[i].GetScheduleActivityTaskCommandAttributes().RequestEagerExecution)
+		require.Equal(t, i < 2, req.Commands[i].GetScheduleActivityTaskCommandAttributes().RequestEagerExecution)
 	}
 }
 

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -67,6 +67,8 @@ const (
 
 	defaultMaxConcurrentSessionExecutionSize = 1000 // Large concurrent session execution size (1k)
 
+	defaultMaxEagerActivityReservationsPerWorkflowTask = 3
+
 	defaultDeadlockDetectionTimeout = time.Second // By default kill workflow tasks that are running more than 1 sec.
 	// Unlimited deadlock detection timeout is used when we want to allow workflow tasks to run indefinitely, such
 	// as during debugging.
@@ -2421,6 +2423,7 @@ func NewAggregatedWorker(client *WorkflowClient, taskQueue string, options Worke
 			disabled:      options.DisableEagerActivities,
 			taskQueue:     taskQueue,
 			maxConcurrent: options.MaxConcurrentEagerActivityExecutionSize,
+			maxPerTask:    options.MaxEagerActivityReservationsPerWorkflowTask,
 		}),
 		capabilities:                  &capabilities,
 		pollTimeTracker:               &pollTimeTracker{},
@@ -2840,6 +2843,10 @@ func setWorkerOptionsDefaults(options *WorkerOptions) autoEnrollEligibility {
 	}
 	if options.MaxConcurrentSessionExecutionSize == 0 {
 		options.MaxConcurrentSessionExecutionSize = defaultMaxConcurrentSessionExecutionSize
+	}
+	if options.MaxEagerActivityReservationsPerWorkflowTask <= 0 {
+		options.MaxEagerActivityReservationsPerWorkflowTask =
+			defaultMaxEagerActivityReservationsPerWorkflowTask
 	}
 	if options.DeadlockDetectionTimeout == 0 {
 		if debugMode {

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -2423,7 +2423,7 @@ func NewAggregatedWorker(client *WorkflowClient, taskQueue string, options Worke
 			disabled:      options.DisableEagerActivities,
 			taskQueue:     taskQueue,
 			maxConcurrent: options.MaxConcurrentEagerActivityExecutionSize,
-			maxPerTask:    options.MaxEagerActivityReservationsPerWorkflowTask,
+			maxPerTask:    *options.MaxEagerActivityReservationsPerWorkflowTask,
 		}),
 		capabilities:                  &capabilities,
 		pollTimeTracker:               &pollTimeTracker{},
@@ -2844,9 +2844,11 @@ func setWorkerOptionsDefaults(options *WorkerOptions) autoEnrollEligibility {
 	if options.MaxConcurrentSessionExecutionSize == 0 {
 		options.MaxConcurrentSessionExecutionSize = defaultMaxConcurrentSessionExecutionSize
 	}
-	if options.MaxEagerActivityReservationsPerWorkflowTask <= 0 {
-		options.MaxEagerActivityReservationsPerWorkflowTask =
-			defaultMaxEagerActivityReservationsPerWorkflowTask
+	if options.MaxEagerActivityReservationsPerWorkflowTask == nil {
+		defaultValue := defaultMaxEagerActivityReservationsPerWorkflowTask
+		options.MaxEagerActivityReservationsPerWorkflowTask = &defaultValue
+	} else if *options.MaxEagerActivityReservationsPerWorkflowTask <= 0 {
+		panic("MaxEagerActivityReservationsPerWorkflowTask must be positive; set DisableEagerActivities to disable eager activity execution")
 	}
 	if options.DeadlockDetectionTimeout == 0 {
 		if debugMode {

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -3151,6 +3151,11 @@ func TestWorkerOptionDefaults(t *testing.T) {
 	aggWorker := NewAggregatedWorker(client, taskQueue, WorkerOptions{})
 
 	workflowWorker := aggWorker.workflowWorker
+	require.Equal(
+		t,
+		defaultMaxEagerActivityReservationsPerWorkflowTask,
+		workflowWorker.executionParameters.eagerActivityExecutor.maxPerTask,
+	)
 	require.True(t, workflowWorker.executionParameters.Identity != "")
 	require.NotNil(t, workflowWorker.executionParameters.Logger)
 	require.NotNil(t, workflowWorker.executionParameters.MetricsHandler)
@@ -3225,11 +3230,17 @@ func TestWorkerOptionNonDefaults(t *testing.T) {
 		StickyScheduleToStartTimeout:                   555 * time.Minute,
 		BackgroundActivityContext:                      context.Background(),
 		MaxConcurrentWorkflowTaskExternalStorageVisits: 7,
+		MaxEagerActivityReservationsPerWorkflowTask:    17,
 	}
 
 	aggWorker := NewAggregatedWorker(client, taskQueue, options)
 
 	workflowWorker := aggWorker.workflowWorker
+	require.Equal(
+		t,
+		options.MaxEagerActivityReservationsPerWorkflowTask,
+		workflowWorker.executionParameters.eagerActivityExecutor.maxPerTask,
+	)
 	require.Len(t, workflowWorker.executionParameters.ContextPropagators, 0)
 
 	tuner, err := NewFixedSizeTuner(FixedSizeTunerOptions{

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -3143,6 +3143,20 @@ func TestWorkerOptionInvalid(t *testing.T) {
 	require.Panics(t, func() {
 		NewAggregatedWorker(&WorkflowClient{}, "worker-options-tq", WorkerOptions{MaxConcurrentWorkflowTaskExternalStorageVisits: -1})
 	})
+	for _, value := range []int{0, -1} {
+		value := value
+		require.PanicsWithValue(
+			t,
+			"MaxEagerActivityReservationsPerWorkflowTask must be positive; set DisableEagerActivities to disable eager activity execution",
+			func() {
+				NewAggregatedWorker(
+					&WorkflowClient{},
+					"worker-options-tq",
+					WorkerOptions{MaxEagerActivityReservationsPerWorkflowTask: &value},
+				)
+			},
+		)
+	}
 }
 
 func TestWorkerOptionDefaults(t *testing.T) {
@@ -3204,6 +3218,7 @@ func TestWorkerOptionDefaults(t *testing.T) {
 
 func TestWorkerOptionNonDefaults(t *testing.T) {
 	taskQueue := "worker-options-tq"
+	maxEagerActivityReservationsPerWorkflowTask := 17
 
 	client := &WorkflowClient{
 		workflowService:    nil,
@@ -3230,7 +3245,7 @@ func TestWorkerOptionNonDefaults(t *testing.T) {
 		StickyScheduleToStartTimeout:                   555 * time.Minute,
 		BackgroundActivityContext:                      context.Background(),
 		MaxConcurrentWorkflowTaskExternalStorageVisits: 7,
-		MaxEagerActivityReservationsPerWorkflowTask:    17,
+		MaxEagerActivityReservationsPerWorkflowTask:    &maxEagerActivityReservationsPerWorkflowTask,
 	}
 
 	aggWorker := NewAggregatedWorker(client, taskQueue, options)
@@ -3238,7 +3253,7 @@ func TestWorkerOptionNonDefaults(t *testing.T) {
 	workflowWorker := aggWorker.workflowWorker
 	require.Equal(
 		t,
-		options.MaxEagerActivityReservationsPerWorkflowTask,
+		*options.MaxEagerActivityReservationsPerWorkflowTask,
 		workflowWorker.executionParameters.eagerActivityExecutor.maxPerTask,
 	)
 	require.Len(t, workflowWorker.executionParameters.ContextPropagators, 0)

--- a/internal/worker.go
+++ b/internal/worker.go
@@ -373,9 +373,9 @@ type (
 		// Optional: Maximum number of activity slots that may be reserved for
 		// eager execution when completing a workflow task.
 		//
-		// The default is 3. A non-positive value uses the default. To disable
-		// eager activity execution, set DisableEagerActivities.
-		MaxEagerActivityReservationsPerWorkflowTask int
+		// The default is 3. A configured value must be positive. To disable eager
+		// activity execution, set DisableEagerActivities.
+		MaxEagerActivityReservationsPerWorkflowTask *int
 
 		// Optional: Maximum number of eager activities that can be running.
 		//

--- a/internal/worker.go
+++ b/internal/worker.go
@@ -360,6 +360,7 @@ type (
 
 		// Optional: Disable eager activities. If set to true, activities will not
 		// be requested to execute eagerly from the same workflow regardless of
+		// MaxEagerActivityReservationsPerWorkflowTask or
 		// MaxConcurrentEagerActivityExecutionSize.
 		//
 		// Eager activity execution means the server returns requested eager
@@ -368,6 +369,13 @@ type (
 		//
 		// NOTE: Eager activities will automatically be disabled if TaskQueueActivitiesPerSecond is set.
 		DisableEagerActivities bool
+
+		// Optional: Maximum number of activity slots that may be reserved for
+		// eager execution when completing a workflow task.
+		//
+		// The default is 3. A non-positive value uses the default. To disable
+		// eager activity execution, set DisableEagerActivities.
+		MaxEagerActivityReservationsPerWorkflowTask int
 
 		// Optional: Maximum number of eager activities that can be running.
 		//


### PR DESCRIPTION
## What changed

- Added `worker.Options.MaxEagerActivityReservationsPerWorkflowTask` to configure how many activity slots may be reserved for eager execution while completing one workflow task.
- Replaced the hardcoded limit of three with the configured value while preserving three as the default.
- Made the option nullable so an omitted value uses the default, while explicitly configured zero or negative values are rejected with guidance to use `DisableEagerActivities`.
- Kept the separate worker-wide `MaxConcurrentEagerActivityExecutionSize` limit unchanged.
- Added coverage for configured reservation behavior, default and non-default option plumbing, and invalid values.

## Why

Go already limits the number of slots it attempts to reserve for eager activities during each workflow-task completion. Exposing that existing burst cap lets applications tune reservation behavior independently from the worker-wide concurrent eager execution limit.

Using the explicit disable option for disabling eager execution avoids two ways to express the same state and makes invalid configuration actionable.

## Validation

- `go test -count 1 -race -v -run 'TestEagerActivity|TestWorkerOptionInvalid|TestWorkerOptionDefaults|TestWorkerOptionNonDefaults' ./internal`
- `go run . check` from `internal/cmd/build`