### PR TITLE
feat(extstore): Add support for Nexus task handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,6 @@ to docs, or any other relevant information.
 
 ## [Unreleased]
 - Add support for Workflow Updates as Nexus Operations 
-- Add support for external storage to Nexus task handling
 
 ### Changed
 
@@ -41,6 +40,8 @@ to docs, or any other relevant information.
 - Added `worker.Options.PreferredVersionProvider`, which can select the version recorded by a
   newly encountered `workflow.GetVersion` call. This supports gradual rollout of a new
   `GetVersion` call before activating its new behavior.
+
+- Add support for external storage to Nexus task handling.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ to docs, or any other relevant information.
 
 ## [Unreleased]
 - Add support for Workflow Updates as Nexus Operations 
+- Add support for external storage to Nexus task handling
 
 ### Changed
 

--- a/internal/internal_nexus_task_poller.go
+++ b/internal/internal_nexus_task_poller.go
@@ -15,16 +15,16 @@ import (
 
 type nexusTaskPoller struct {
 	basePoller
-	namespace       string
-	taskQueueName   string
-	identity        string
-	service         workflowservice.WorkflowServiceClient
-	taskHandler     *nexusTaskHandler
-	logger          log.Logger
-	numPollerMetric *numPollerMetric
-
+	namespace              string
+	taskQueueName          string
+	identity               string
+	service                workflowservice.WorkflowServiceClient
+	taskHandler            *nexusTaskHandler
+	logger                 log.Logger
+	numPollerMetric        *numPollerMetric
 	inboundPayloadVisitor  PayloadVisitor
 	outboundPayloadVisitor PayloadVisitor
+	backgroundContext      context.Context
 }
 
 type nexusTask struct {
@@ -38,6 +38,10 @@ func newNexusTaskPoller(
 	service workflowservice.WorkflowServiceClient,
 	params workerExecutionParameters,
 ) *nexusTaskPoller {
+	backgroundContext := params.BackgroundContext
+	if backgroundContext == nil {
+		backgroundContext = context.Background()
+	}
 	return &nexusTaskPoller{
 		basePoller: basePoller{
 			metricsHandler:               params.MetricsHandler,
@@ -60,6 +64,7 @@ func newNexusTaskPoller(
 
 		inboundPayloadVisitor:  params.inboundPayloadVisitor,
 		outboundPayloadVisitor: params.outboundPayloadVisitor,
+		backgroundContext:      backgroundContext,
 	}
 }
 
@@ -150,7 +155,7 @@ func (ntp *nexusTaskPoller) ProcessTask(task interface{}) error {
 	// before the handler consumes them. A Nexus task carries at most one input and
 	// one result payload, so payload visits are unconcurrent (the configurable
 	// visit concurrency is scoped to workflow tasks).
-	if visitErr := visitProtoPayloads(context.Background(), ntp.inboundPayloadVisitor, response, 0); visitErr != nil {
+	if visitErr := visitProtoPayloads(ntp.backgroundContext, ntp.inboundPayloadVisitor, response, 0); visitErr != nil {
 		return ntp.reportExternalStorageFailure(response, "retrieve Nexus operation input from external storage", visitErr)
 	}
 
@@ -219,11 +224,11 @@ func (ntp *nexusTaskPoller) ProcessTask(task interface{}) error {
 
 	// Offload any large result or failure payloads to external storage before reporting.
 	if res != nil {
-		if visitErr := visitProtoPayloads(context.Background(), ntp.outboundPayloadVisitor, res, 0); visitErr != nil {
+		if visitErr := visitProtoPayloads(ntp.backgroundContext, ntp.outboundPayloadVisitor, res, 0); visitErr != nil {
 			return ntp.reportExternalStorageFailure(response, "store Nexus operation result in external storage", visitErr)
 		}
 	} else if failure != nil {
-		if visitErr := visitProtoPayloads(context.Background(), ntp.outboundPayloadVisitor, failure, 0); visitErr != nil {
+		if visitErr := visitProtoPayloads(ntp.backgroundContext, ntp.outboundPayloadVisitor, failure, 0); visitErr != nil {
 			return ntp.reportExternalStorageFailure(response, "store Nexus operation failure in external storage", visitErr)
 		}
 	}

--- a/internal/internal_nexus_task_poller.go
+++ b/internal/internal_nexus_task_poller.go
@@ -22,6 +22,9 @@ type nexusTaskPoller struct {
 	taskHandler     *nexusTaskHandler
 	logger          log.Logger
 	numPollerMetric *numPollerMetric
+
+	inboundPayloadVisitor  PayloadVisitor
+	outboundPayloadVisitor PayloadVisitor
 }
 
 type nexusTask struct {
@@ -54,6 +57,9 @@ func newNexusTaskPoller(
 		identity:        params.Identity,
 		logger:          params.Logger,
 		numPollerMetric: newNumPollerMetric(params.MetricsHandler, metrics.PollerTypeNexusTask),
+
+		inboundPayloadVisitor:  params.inboundPayloadVisitor,
+		outboundPayloadVisitor: params.outboundPayloadVisitor,
 	}
 }
 
@@ -140,6 +146,14 @@ func (ntp *nexusTaskPoller) ProcessTask(task interface{}) error {
 		return err
 	}
 
+	// Retrieve any operation input payloads that were offloaded to external storage
+	// before the handler consumes them. A Nexus task carries at most one input and
+	// one result payload, so payload visits are unconcurrent (the configurable
+	// visit concurrency is scoped to workflow tasks).
+	if visitErr := visitProtoPayloads(context.Background(), ntp.inboundPayloadVisitor, response, 0); visitErr != nil {
+		return ntp.reportExternalStorageFailure(response, "retrieve Nexus operation input from external storage", visitErr)
+	}
+
 	// Process the nexus task.
 	res, failure, err := ntp.taskHandler.ExecuteContext(nctx, response)
 
@@ -203,6 +217,17 @@ func (ntp *nexusTaskPoller) ProcessTask(task interface{}) error {
 		return err
 	}
 
+	// Offload any large result or failure payloads to external storage before reporting.
+	if res != nil {
+		if visitErr := visitProtoPayloads(context.Background(), ntp.outboundPayloadVisitor, res, 0); visitErr != nil {
+			return ntp.reportExternalStorageFailure(response, "store Nexus operation result in external storage", visitErr)
+		}
+	} else if failure != nil {
+		if visitErr := visitProtoPayloads(context.Background(), ntp.outboundPayloadVisitor, failure, 0); visitErr != nil {
+			return ntp.reportExternalStorageFailure(response, "store Nexus operation failure in external storage", visitErr)
+		}
+	}
+
 	if err := ntp.reportCompletion(res, failure); err != nil {
 		traceLog(func() {
 			ntp.logger.Debug("reportNexusTaskComplete failed", tagError, err)
@@ -235,4 +260,23 @@ func (ntp *nexusTaskPoller) reportCompletion(
 	}
 	_, err := ntp.taskHandler.client.WorkflowService().RespondNexusTaskCompleted(ctx, completion)
 	return err
+}
+
+// reportExternalStorageFailure fails the task with a retryable internal error when
+// external storage retrieval or offload fails, so the server redelivers the task.
+func (ntp *nexusTaskPoller) reportExternalStorageFailure(
+	response *workflowservice.PollNexusTaskQueueResponse,
+	action string,
+	cause error,
+) error {
+	handlerErr := nexus.NewHandlerErrorf(nexus.HandlerErrorTypeInternal, "failed to %s: %v", action, cause)
+	failedRequest, err := ntp.taskHandler.fillInFailure(
+		response.TaskToken,
+		handlerErr,
+		getEffectiveTemporalFailureResponses(response.GetRequest().GetCapabilities().GetTemporalFailureResponses()),
+	)
+	if err != nil {
+		return err
+	}
+	return ntp.reportCompletion(nil, failedRequest)
 }

--- a/internal/payload_limits.go
+++ b/internal/payload_limits.go
@@ -212,6 +212,14 @@ func (v *payloadLimitsVisitorImpl) ContextHook(ctx context.Context, msg proto.Me
 	case *workflowservice.RespondWorkflowTaskFailedRequest:
 		ctx = withPayloadLimitChecks(ctx, limitCheckWarning)
 		ctx = withMemoLimitChecks(ctx, limitCheckWarning)
+	// Nexus handler failures are passed through to the server with warnings only,
+	// like other task failures.
+	case *workflowservice.RespondNexusTaskFailedRequest:
+		ctx = withPayloadLimitChecks(ctx, limitCheckWarning)
+	// Nexus sync results and operation-error failures are not size-checked, mirroring
+	// the server and the other SDKs.
+	case *workflowservice.RespondNexusTaskCompletedRequest:
+		ctx = withPayloadLimitChecks(ctx, limitCheckNone)
 	}
 	// These are the additional protos that server checks that the SDK does not currently check:
 	// - UpsertWorkflowSearchAttributesCommandAttributes has another SearchAttributes size check that combines execution info,

--- a/internal/payload_limits_test.go
+++ b/internal/payload_limits_test.go
@@ -11,6 +11,7 @@ import (
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	failurepb "go.temporal.io/api/failure/v1"
+	nexuspb "go.temporal.io/api/nexus/v1"
 	"go.temporal.io/api/proxy"
 	querypb "go.temporal.io/api/query/v1"
 	schedulepb "go.temporal.io/api/schedule/v1"
@@ -427,6 +428,15 @@ func TestPayloadLimitsVisitorSpecializations(t *testing.T) {
 				},
 			},
 		}},
+		{"RespondNexusTaskFailedRequest", &workflowservice.RespondNexusTaskFailedRequest{
+			Failure: &failurepb.Failure{
+				FailureInfo: &failurepb.Failure_ApplicationFailureInfo{
+					ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{
+						Details: &commonpb.Payloads{Payloads: []*commonpb.Payload{makeTestPayload(200)}},
+					},
+				},
+			},
+		}},
 	}
 
 	for _, tc := range skipErrorOnlyTypes {
@@ -440,6 +450,35 @@ func TestPayloadLimitsVisitorSpecializations(t *testing.T) {
 			require.True(t, hasWarningLine(logger))
 		})
 	}
+
+	// A Nexus task completion is not size-checked at all: an operation-error failure
+	// produces neither an error nor a warning (the sync result payload is likewise
+	// skipped as a single-payload field).
+	t.Run("RespondNexusTaskCompletedRequest skips payload error and warning limits", func(t *testing.T) {
+		logger := ilog.NewMemoryLogger()
+		visitor, setErrorLimits := newPayloadLimitsVisitor(payloadLimits{payloadSize: 10}, logger)
+		setErrorLimits(&payloadLimits{payloadSize: 10})
+		msg := &workflowservice.RespondNexusTaskCompletedRequest{
+			Response: &nexuspb.Response{
+				Variant: &nexuspb.Response_StartOperation{
+					StartOperation: &nexuspb.StartOperationResponse{
+						Variant: &nexuspb.StartOperationResponse_Failure{
+							Failure: &failurepb.Failure{
+								FailureInfo: &failurepb.Failure_ApplicationFailureInfo{
+									ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{
+										Details: &commonpb.Payloads{Payloads: []*commonpb.Payload{makeTestPayload(200)}},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		err := visitProtoPayloads(context.Background(), visitor, msg, 0)
+		require.NoError(t, err)
+		require.Empty(t, logger.Lines())
+	})
 }
 
 func TestCreateScheduleRequestSpecialization(t *testing.T) {

--- a/test/external_storage_nexus_test.go
+++ b/test/external_storage_nexus_test.go
@@ -48,13 +48,15 @@ func extStoreNexusSizeCaller(ctx workflow.Context, endpoint string) (int, error)
 	return res, err
 }
 
-func extStoreNexusBigResultCaller(ctx workflow.Context, endpoint string) (string, error) {
+func extStoreNexusBigResultCaller(ctx workflow.Context, endpoint string) (int, error) {
 	c := workflow.NewNexusClient(endpoint, extStoreNexusServiceName)
 	var res string
 	err := c.ExecuteOperation(ctx, extStoreNexusBigResultOp, "small", workflow.NexusOperationOptions{
 		ScheduleToCloseTimeout: 20 * time.Second,
 	}).Get(ctx, &res)
-	return res, err
+	// Return only the length so the workflow's own result isn't offloaded; that keeps
+	// the store/retrieve counts attributable to the Nexus operation result alone.
+	return len(res), err
 }
 
 // transientFailDriver fails the first store and/or retrieve call, then delegates to
@@ -189,9 +191,9 @@ func TestNexusExternalStorageOperationResult(t *testing.T) {
 	defer w.Stop()
 
 	run := startNexusExtStoreCaller(t, ctx, c, taskQueue, extStoreNexusBigResultCaller, endpoint)
-	var res string
+	var res int
 	require.NoError(t, run.Get(ctx, &res))
-	require.Equal(t, oversized(72), res)
+	require.Equal(t, len(oversized(72)), res)
 
 	store, retrieve := driver.getStoreCounts()
 	require.Greater(t, store, 0, "handler should have offloaded the large result")
@@ -212,9 +214,9 @@ func TestNexusExternalStorageTransientStoreFailureRecovers(t *testing.T) {
 	defer w.Stop()
 
 	run := startNexusExtStoreCaller(t, ctx, c, taskQueue, extStoreNexusBigResultCaller, endpoint)
-	var res string
+	var res int
 	require.NoError(t, run.Get(ctx, &res))
-	require.Equal(t, oversized(72), res)
+	require.Equal(t, len(oversized(72)), res)
 
 	store, _ := driver.attempts()
 	require.GreaterOrEqual(t, store, 2, "store should have been retried after the transient failure")

--- a/test/external_storage_nexus_test.go
+++ b/test/external_storage_nexus_test.go
@@ -1,0 +1,221 @@
+package test_test
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/nexus-rpc/sdk-go/nexus"
+	"github.com/stretchr/testify/require"
+	commonpb "go.temporal.io/api/common/v1"
+	nexuspb "go.temporal.io/api/nexus/v1"
+	"go.temporal.io/api/operatorservice/v1"
+
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/converter"
+	ilog "go.temporal.io/sdk/internal/log"
+	"go.temporal.io/sdk/worker"
+	"go.temporal.io/sdk/workflow"
+)
+
+const extStoreNexusServiceName = "test"
+
+// sizeOp returns the length of its input; exercised with a large (offloaded) input.
+var extStoreNexusSizeOp = nexus.NewSyncOperation(
+	"size-op",
+	func(ctx context.Context, input string, _ nexus.StartOperationOptions) (int, error) {
+		return len(input), nil
+	},
+)
+
+// bigResultOp returns a large (offloaded) result.
+var extStoreNexusBigResultOp = nexus.NewSyncOperation(
+	"big-result-op",
+	func(ctx context.Context, _ string, _ nexus.StartOperationOptions) (string, error) {
+		return oversized(72), nil
+	},
+)
+
+func extStoreNexusSizeCaller(ctx workflow.Context, endpoint string) (int, error) {
+	c := workflow.NewNexusClient(endpoint, extStoreNexusServiceName)
+	var res int
+	err := c.ExecuteOperation(ctx, extStoreNexusSizeOp, oversized(72), workflow.NexusOperationOptions{
+		ScheduleToCloseTimeout: 20 * time.Second,
+	}).Get(ctx, &res)
+	return res, err
+}
+
+func extStoreNexusBigResultCaller(ctx workflow.Context, endpoint string) (string, error) {
+	c := workflow.NewNexusClient(endpoint, extStoreNexusServiceName)
+	var res string
+	err := c.ExecuteOperation(ctx, extStoreNexusBigResultOp, "small", workflow.NexusOperationOptions{
+		ScheduleToCloseTimeout: 20 * time.Second,
+	}).Get(ctx, &res)
+	return res, err
+}
+
+// transientFailDriver fails the first store and/or retrieve call, then delegates to
+// the embedded in-memory driver. It simulates a transient storage-driver outage.
+type transientFailDriver struct {
+	*memStorageDriver
+	mu                sync.Mutex
+	failFirstStore    bool
+	failFirstRetrieve bool
+	storeAttempts     int
+	retrieveAttempts  int
+}
+
+func (d *transientFailDriver) Store(ctx converter.StorageDriverStoreContext, payloads []*commonpb.Payload) ([]converter.StorageDriverClaim, error) {
+	d.mu.Lock()
+	d.storeAttempts++
+	fail := d.failFirstStore && d.storeAttempts == 1
+	d.mu.Unlock()
+	if fail {
+		return nil, fmt.Errorf("transient store failure")
+	}
+	return d.memStorageDriver.Store(ctx, payloads)
+}
+
+func (d *transientFailDriver) Retrieve(ctx converter.StorageDriverRetrieveContext, claims []converter.StorageDriverClaim) ([]*commonpb.Payload, error) {
+	d.mu.Lock()
+	d.retrieveAttempts++
+	fail := d.failFirstRetrieve && d.retrieveAttempts == 1
+	d.mu.Unlock()
+	if fail {
+		return nil, fmt.Errorf("transient retrieve failure")
+	}
+	return d.memStorageDriver.Retrieve(ctx, claims)
+}
+
+func (d *transientFailDriver) attempts() (store, retrieve int) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.storeAttempts, d.retrieveAttempts
+}
+
+// newNexusExtStoreClient dials a client with external storage configured and creates a
+// Nexus endpoint targeting a fresh task queue, returning the client, task queue, and
+// endpoint name.
+func newNexusExtStoreClient(t *testing.T, ctx context.Context, driver converter.StorageDriver) (client.Client, string, string) {
+	config := NewConfig()
+	require.NoError(t, WaitForTCP(time.Minute, config.ServiceAddr))
+	c, err := client.DialContext(ctx, client.Options{
+		HostPort:          config.ServiceAddr,
+		Namespace:         config.Namespace,
+		Logger:            ilog.NewDefaultLogger(),
+		ConnectionOptions: client.ConnectionOptions{TLS: config.TLS},
+		ExternalStorage: converter.ExternalStorage{
+			Drivers:              []converter.StorageDriver{driver},
+			PayloadSizeThreshold: extStoreThreshold,
+		},
+	})
+	require.NoError(t, err)
+
+	taskQueue := "sdk-go-nexus-ext-tq-" + uuid.NewString()
+	endpoint := "sdk-go-nexus-ext-ep-" + uuid.NewString()
+	_, err = c.OperatorService().CreateNexusEndpoint(ctx, &operatorservice.CreateNexusEndpointRequest{
+		Spec: &nexuspb.EndpointSpec{
+			Name: endpoint,
+			Target: &nexuspb.EndpointTarget{
+				Variant: &nexuspb.EndpointTarget_Worker_{
+					Worker: &nexuspb.EndpointTarget_Worker{
+						Namespace: config.Namespace,
+						TaskQueue: taskQueue,
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	return c, taskQueue, endpoint
+}
+
+func newNexusExtStoreWorker(t *testing.T, c client.Client, taskQueue string, callerWorkflow any) worker.Worker {
+	w := worker.New(c, taskQueue, worker.Options{})
+	service := nexus.NewService(extStoreNexusServiceName)
+	require.NoError(t, service.Register(extStoreNexusSizeOp, extStoreNexusBigResultOp))
+	w.RegisterNexusService(service)
+	w.RegisterWorkflow(callerWorkflow)
+	require.NoError(t, w.Start())
+	return w
+}
+
+func startNexusExtStoreCaller(t *testing.T, ctx context.Context, c client.Client, taskQueue string, callerWorkflow any, endpoint string) client.WorkflowRun {
+	run, err := c.ExecuteWorkflow(ctx, client.StartWorkflowOptions{
+		TaskQueue: taskQueue,
+		// The endpoint registry may take a bit to propagate; a short workflow task
+		// timeout speeds up retries.
+		WorkflowTaskTimeout: time.Second,
+	}, callerWorkflow, endpoint)
+	require.NoError(t, err)
+	return run
+}
+
+// TestNexusExternalStorageOperationInput verifies that an operation input offloaded to
+// external storage by the caller is retrieved before the handler runs.
+func TestNexusExternalStorageOperationInput(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	driver := newMemDriver("test")
+	c, taskQueue, endpoint := newNexusExtStoreClient(t, ctx, driver)
+	defer c.Close()
+	w := newNexusExtStoreWorker(t, c, taskQueue, extStoreNexusSizeCaller)
+	defer w.Stop()
+
+	run := startNexusExtStoreCaller(t, ctx, c, taskQueue, extStoreNexusSizeCaller, endpoint)
+	var res int
+	require.NoError(t, run.Get(ctx, &res))
+	require.Equal(t, len(oversized(72)), res)
+
+	store, retrieve := driver.getStoreCounts()
+	require.Greater(t, store, 0, "caller should have offloaded the large input")
+	require.Greater(t, retrieve, 0, "handler should have retrieved the offloaded input")
+}
+
+// TestNexusExternalStorageOperationResult verifies that a large synchronous result is
+// offloaded when completing the task and retrieved by the caller.
+func TestNexusExternalStorageOperationResult(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	driver := newMemDriver("test")
+	c, taskQueue, endpoint := newNexusExtStoreClient(t, ctx, driver)
+	defer c.Close()
+	w := newNexusExtStoreWorker(t, c, taskQueue, extStoreNexusBigResultCaller)
+	defer w.Stop()
+
+	run := startNexusExtStoreCaller(t, ctx, c, taskQueue, extStoreNexusBigResultCaller, endpoint)
+	var res string
+	require.NoError(t, run.Get(ctx, &res))
+	require.Equal(t, oversized(72), res)
+
+	store, retrieve := driver.getStoreCounts()
+	require.Greater(t, store, 0, "handler should have offloaded the large result")
+	require.Greater(t, retrieve, 0, "caller should have retrieved the offloaded result")
+}
+
+// TestNexusExternalStorageTransientStoreFailureRecovers verifies that a transient
+// storage failure while offloading the result fails the task retryably and then
+// recovers on redelivery.
+func TestNexusExternalStorageTransientStoreFailureRecovers(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	driver := &transientFailDriver{memStorageDriver: newMemDriver("test"), failFirstStore: true}
+	c, taskQueue, endpoint := newNexusExtStoreClient(t, ctx, driver)
+	defer c.Close()
+	w := newNexusExtStoreWorker(t, c, taskQueue, extStoreNexusBigResultCaller)
+	defer w.Stop()
+
+	run := startNexusExtStoreCaller(t, ctx, c, taskQueue, extStoreNexusBigResultCaller, endpoint)
+	var res string
+	require.NoError(t, run.Get(ctx, &res))
+	require.Equal(t, oversized(72), res)
+
+	store, _ := driver.attempts()
+	require.GreaterOrEqual(t, store, 2, "store should have been retried after the transient failure")
+}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

- Add external storage support to Nexus task handling.
- Disable payload limit check for Nexus task completions but only warn for Nexus task failures. Parity with server and core-based SDKs.

## Why?

Round out the support for external storage for all task handlers.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:  Integration tests

3. Any docs updates needed? No