### PR TITLE
docs: add snipsync markers to the GCP OpenTelemetry e2e sample

### DIFF
--- a/contrib/gcp/e2e/main.go
+++ b/contrib/gcp/e2e/main.go
@@ -108,6 +108,7 @@ func runWorker(ctx context.Context, cfg config) error {
 	}
 	log.Printf("collector_ready endpoint=%q", gcp.DefaultOTLPEndpoint)
 
+	// @@@SNIPSTART go-cloud-run-otel-plugin
 	otelPlugin, err := gcp.NewOpenTelemetryPlugin(ctx, gcp.OpenTelemetryPluginOptions{})
 	if err != nil {
 		return fmt.Errorf("creating GCP OpenTelemetry plugin: %w", err)
@@ -124,6 +125,7 @@ func runWorker(ctx context.Context, cfg config) error {
 		Credentials: client.NewAPIKeyStaticCredentials(cfg.apiKey),
 		Plugins:     []client.Plugin{otelPlugin},
 	})
+	// @@@SNIPEND
 	if err != nil {
 		shutdownPlugin(otelPlugin)
 		return fmt.Errorf("dialing Temporal: %w", err)
@@ -155,6 +157,7 @@ func runWorker(ctx context.Context, cfg config) error {
 	}
 	log.Printf("shutdown_started reason=%q", shutdownReason)
 
+	// @@@SNIPSTART go-cloud-run-otel-shutdown
 	temporalWorker.Stop()
 	log.Print("worker_stopped")
 	temporalClient.Close()
@@ -177,6 +180,7 @@ func runWorker(ctx context.Context, cfg config) error {
 	} else {
 		log.Print("plugin_shutdown_complete")
 	}
+	// @@@SNIPEND
 	return errors.Join(flushErr, shutdownErr)
 }
 


### PR DESCRIPTION
Targets `ea/gcp-opentelemetry-plugin` (#2467) rather than `main`, since `contrib/gcp` only exists on that branch.

## What

Adds two [snipsync](https://github.com/temporalio/snipsync) regions to `contrib/gcp/e2e/main.go` so the Temporal docs can pull this code directly instead of duplicating it by hand:

| Snippet ID | Region |
|---|---|
| `go-cloud-run-otel-plugin` | Creating the plugin and installing it on the Temporal Client via `client.Options.Plugins` |
| `go-cloud-run-otel-shutdown` | Stopping the Worker, closing the Client, and flushing telemetry before exit |

## Why

The Go SDK page for [Serverless Workers on GCP Cloud Run](https://docs.temporal.io/develop/go/workers/serverless-workers/cloud-run) needs an observability section. Pulling from a compiled sample means the docs cannot drift from working code, which is the convention for Go snippets elsewhere in the docs.

This mirrors what the Python side already does with `samples-python` for its Cloud Run OTel page.

## Notes

- Comment-only change, no behavior difference.
- `gofmt -l` clean, `go build ./...` passes in the `contrib/gcp` module.
- The docs render trims the e2e-specific `log.Printf` calls with `selectedLines`, so those staying in the source is fine.

If the surrounding code moves as #2467 evolves, the markers just need to travel with it.