### PR TITLE
Bump auto-enroll autoscaling minimum to the fixed poller default

### DIFF
--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -1434,7 +1434,11 @@ func (aw *AggregatedWorker) start() error {
 	// support, including scaling down, so it also enables serverSupportsAutoscaling.
 	if nsData.capabilities.GetPollerAutoscalingAutoEnroll() {
 		aw.executionParams.serverSupportsAutoscaling.Store(true)
-		autoscaling := NewPollerBehaviorAutoscaling(PollerBehaviorAutoscalingOptions{})
+		autoscaling := NewPollerBehaviorAutoscaling(PollerBehaviorAutoscalingOptions{
+			MinimumNumberOfPollers: 2,
+			MaximumNumberOfPollers: 100,
+			InitialNumberOfPollers: 5,
+		})
 		if aw.executionParams.pollerAutoEnrollEligibility.nexusTask {
 			aw.executionParams.NexusTaskPollerBehavior = autoscaling
 		}


### PR DESCRIPTION
## Why

When a worker auto-enrolls into poller autoscaling (via the `PollerAutoscalingAutoEnroll` namespace capability), it previously started with a minimum of **1** poller. That's fewer than the fixed default (**2**) a worker would otherwise run, so auto-enrolling could cause a throughput regression from too few pollers.

This sets the autoscaling **minimum equal to the fixed default poller count**, so auto-enrolling never starts below what a non-autoscaling worker would use.

## What

Auto-enroll now uses explicit values:

| min | max | initial |
|-----|-----|---------|
| **2** (fixed default) | 100 | 5 |

Applies to workflow, activity, and nexus pollers.

**Tested:** `go test ./internal/ -run TestInternalWorkerTestSuite/TestPollerAutoscalingAutoEnroll` passes.