### PR TITLE
Print only test failures by default, full logs in files 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,15 @@ jobs:
         run: go run . unit-test
         working-directory: ./internal/cmd/build
 
+      - name: Upload full test logs
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test-logs-${{ github.job }}-${{ matrix.os }}-${{ matrix.go-version }}
+          path: .build/test-logs
+          if-no-files-found: warn
+          retention-days: 14
+
   integ-test:
     strategy:
       fail-fast: false
@@ -100,6 +109,15 @@ jobs:
         env:
           WORKFLOW_CACHE_SIZE: "0"
 
+      - name: Upload full test logs
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test-logs-${{ github.job }}-${{ matrix.os }}-${{ matrix.go-version }}
+          path: .build/test-logs
+          if-no-files-found: warn
+          retention-days: 14
+
   integ-test-cache:
     strategy:
       fail-fast: false
@@ -130,6 +148,15 @@ jobs:
       - name: Integration tests (with cache)
         run: go run . integration-test -dev-server
         working-directory: ./internal/cmd/build
+
+      - name: Upload full test logs
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test-logs-${{ github.job }}-${{ matrix.os }}-${{ matrix.go-version }}
+          path: .build/test-logs
+          if-no-files-found: warn
+          retention-days: 14
 
   docker-compose-test:
     runs-on: ubuntu-latest
@@ -174,6 +201,15 @@ jobs:
           DISABLE_NEW_NEXUS_ERROR_FORMAT_TESTS: "1"
         working-directory: ./internal/cmd/build
 
+      - name: Upload full test logs
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test-logs-${{ github.job }}
+          path: .build/test-logs
+          if-no-files-found: warn
+          retention-days: 14
+
   cloud-test:
     strategy:
       matrix:
@@ -203,6 +239,15 @@ jobs:
         # they cover behavior that cannot be validated against the local dev server.
         run: 'go run . integration-test -p 1 -packages . -run "TestIntegrationSuite/(TestBasic|TestShutdownDuringActiveTimerActivityWorkflows)$"'
         working-directory: ./internal/cmd/build
+
+      - name: Upload full test logs
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test-logs-${{ github.job }}-${{ matrix.go-version }}-fips-${{ matrix.fips }}
+          path: .build/test-logs
+          if-no-files-found: warn
+          retention-days: 14
 
   features-test:
     uses: temporalio/features/.github/workflows/go.yaml@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,8 +66,11 @@ jobs:
       - name: Unit test
         run: go run . unit-test
         working-directory: ./internal/cmd/build
+        env:
+          TEST_LOG_ARTIFACT_NAME: test-logs-${{ github.job }}-${{ matrix.os }}-${{ matrix.go-version }}
 
       - name: Upload full test logs
+        id: upload-test-logs
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -75,6 +78,13 @@ jobs:
           path: .build/test-logs
           if-no-files-found: warn
           retention-days: 14
+
+      - name: Link full test logs
+        if: always() && steps.upload-test-logs.outputs.artifact-url != ''
+        shell: bash
+        run: echo "### [Download full test logs]($ARTIFACT_URL)" >> "$GITHUB_STEP_SUMMARY"
+        env:
+          ARTIFACT_URL: ${{ steps.upload-test-logs.outputs.artifact-url }}
 
   integ-test:
     strategy:
@@ -107,9 +117,11 @@ jobs:
         run: go run . integration-test -dev-server
         working-directory: ./internal/cmd/build
         env:
+          TEST_LOG_ARTIFACT_NAME: test-logs-${{ github.job }}-${{ matrix.os }}-${{ matrix.go-version }}
           WORKFLOW_CACHE_SIZE: "0"
 
       - name: Upload full test logs
+        id: upload-test-logs
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -117,6 +129,13 @@ jobs:
           path: .build/test-logs
           if-no-files-found: warn
           retention-days: 14
+
+      - name: Link full test logs
+        if: always() && steps.upload-test-logs.outputs.artifact-url != ''
+        shell: bash
+        run: echo "### [Download full test logs]($ARTIFACT_URL)" >> "$GITHUB_STEP_SUMMARY"
+        env:
+          ARTIFACT_URL: ${{ steps.upload-test-logs.outputs.artifact-url }}
 
   integ-test-cache:
     strategy:
@@ -148,8 +167,11 @@ jobs:
       - name: Integration tests (with cache)
         run: go run . integration-test -dev-server
         working-directory: ./internal/cmd/build
+        env:
+          TEST_LOG_ARTIFACT_NAME: test-logs-${{ github.job }}-${{ matrix.os }}-${{ matrix.go-version }}
 
       - name: Upload full test logs
+        id: upload-test-logs
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -157,6 +179,13 @@ jobs:
           path: .build/test-logs
           if-no-files-found: warn
           retention-days: 14
+
+      - name: Link full test logs
+        if: always() && steps.upload-test-logs.outputs.artifact-url != ''
+        shell: bash
+        run: echo "### [Download full test logs]($ARTIFACT_URL)" >> "$GITHUB_STEP_SUMMARY"
+        env:
+          ARTIFACT_URL: ${{ steps.upload-test-logs.outputs.artifact-url }}
 
   docker-compose-test:
     runs-on: ubuntu-latest
@@ -191,6 +220,7 @@ jobs:
       - name: Docker compose - integration tests
         run: go run . integration-test
         env:
+          TEST_LOG_ARTIFACT_NAME: test-logs-${{ github.job }}
           # TODO(antlai-temporal): Remove this flag once server 1.27 released.
           DISABLE_SERVER_1_27_TESTS: "1"
           DISABLE_PRIORITY_TESTS: "1"
@@ -202,6 +232,7 @@ jobs:
         working-directory: ./internal/cmd/build
 
       - name: Upload full test logs
+        id: upload-test-logs
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -209,6 +240,13 @@ jobs:
           path: .build/test-logs
           if-no-files-found: warn
           retention-days: 14
+
+      - name: Link full test logs
+        if: always() && steps.upload-test-logs.outputs.artifact-url != ''
+        shell: bash
+        run: echo "### [Download full test logs]($ARTIFACT_URL)" >> "$GITHUB_STEP_SUMMARY"
+        env:
+          ARTIFACT_URL: ${{ steps.upload-test-logs.outputs.artifact-url }}
 
   cloud-test:
     strategy:
@@ -239,8 +277,11 @@ jobs:
         # they cover behavior that cannot be validated against the local dev server.
         run: 'go run . integration-test -p 1 -packages . -run "TestIntegrationSuite/(TestBasic|TestShutdownDuringActiveTimerActivityWorkflows)$"'
         working-directory: ./internal/cmd/build
+        env:
+          TEST_LOG_ARTIFACT_NAME: test-logs-${{ github.job }}-${{ matrix.go-version }}-fips-${{ matrix.fips }}
 
       - name: Upload full test logs
+        id: upload-test-logs
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -248,6 +289,13 @@ jobs:
           path: .build/test-logs
           if-no-files-found: warn
           retention-days: 14
+
+      - name: Link full test logs
+        if: always() && steps.upload-test-logs.outputs.artifact-url != ''
+        shell: bash
+        run: echo "### [Download full test logs]($ARTIFACT_URL)" >> "$GITHUB_STEP_SUMMARY"
+        env:
+          ARTIFACT_URL: ${{ steps.upload-test-logs.outputs.artifact-url }}
 
   features-test:
     uses: temporalio/features/.github/workflows/go.yaml@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,6 +231,13 @@ jobs:
           DISABLE_NEW_NEXUS_ERROR_FORMAT_TESTS: "1"
         working-directory: ./internal/cmd/build
 
+      - name: Docker compose - capture logs
+        if: always()
+        continue-on-error: true
+        run: |
+          mkdir -p .build/test-logs
+          docker compose --project-directory ./samples-server/compose logs --no-color --timestamps > .build/test-logs/docker-compose.log 2>&1
+
       - name: Upload full test logs
         id: upload-test-logs
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,14 +67,14 @@ jobs:
         run: go run . unit-test
         working-directory: ./internal/cmd/build
         env:
-          TEST_LOG_ARTIFACT_NAME: test-logs-${{ github.job }}-${{ matrix.os }}-${{ matrix.go-version }}
+          TEST_LOG_ARTIFACT_NAME: ${{ github.job }}-${{ matrix.os }}-${{ matrix.go-version }}
 
       - name: Upload full test logs
         id: upload-test-logs
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: test-logs-${{ github.job }}-${{ matrix.os }}-${{ matrix.go-version }}
+          name: ${{ github.job }}-${{ matrix.os }}-${{ matrix.go-version }}
           path: .build/test-logs
           if-no-files-found: warn
           retention-days: 14
@@ -117,7 +117,7 @@ jobs:
         run: go run . integration-test -dev-server
         working-directory: ./internal/cmd/build
         env:
-          TEST_LOG_ARTIFACT_NAME: test-logs-${{ github.job }}-${{ matrix.os }}-${{ matrix.go-version }}
+          TEST_LOG_ARTIFACT_NAME: ${{ github.job }}-${{ matrix.os }}-${{ matrix.go-version }}
           WORKFLOW_CACHE_SIZE: "0"
 
       - name: Upload full test logs
@@ -125,7 +125,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: test-logs-${{ github.job }}-${{ matrix.os }}-${{ matrix.go-version }}
+          name: ${{ github.job }}-${{ matrix.os }}-${{ matrix.go-version }}
           path: .build/test-logs
           if-no-files-found: warn
           retention-days: 14
@@ -168,14 +168,14 @@ jobs:
         run: go run . integration-test -dev-server
         working-directory: ./internal/cmd/build
         env:
-          TEST_LOG_ARTIFACT_NAME: test-logs-${{ github.job }}-${{ matrix.os }}-${{ matrix.go-version }}
+          TEST_LOG_ARTIFACT_NAME: ${{ github.job }}-${{ matrix.os }}-${{ matrix.go-version }}
 
       - name: Upload full test logs
         id: upload-test-logs
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: test-logs-${{ github.job }}-${{ matrix.os }}-${{ matrix.go-version }}
+          name: ${{ github.job }}-${{ matrix.os }}-${{ matrix.go-version }}
           path: .build/test-logs
           if-no-files-found: warn
           retention-days: 14
@@ -220,7 +220,7 @@ jobs:
       - name: Docker compose - integration tests
         run: go run . integration-test
         env:
-          TEST_LOG_ARTIFACT_NAME: test-logs-${{ github.job }}
+          TEST_LOG_ARTIFACT_NAME: ${{ github.job }}
           # TODO(antlai-temporal): Remove this flag once server 1.27 released.
           DISABLE_SERVER_1_27_TESTS: "1"
           DISABLE_PRIORITY_TESTS: "1"
@@ -236,7 +236,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: test-logs-${{ github.job }}
+          name: ${{ github.job }}
           path: .build/test-logs
           if-no-files-found: warn
           retention-days: 14
@@ -278,14 +278,14 @@ jobs:
         run: 'go run . integration-test -p 1 -packages . -run "TestIntegrationSuite/(TestBasic|TestShutdownDuringActiveTimerActivityWorkflows)$"'
         working-directory: ./internal/cmd/build
         env:
-          TEST_LOG_ARTIFACT_NAME: test-logs-${{ github.job }}-${{ matrix.go-version }}-fips-${{ matrix.fips }}
+          TEST_LOG_ARTIFACT_NAME: ${{ github.job }}-${{ matrix.go-version }}-fips-${{ matrix.fips }}
 
       - name: Upload full test logs
         id: upload-test-logs
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: test-logs-${{ github.job }}-${{ matrix.go-version }}-fips-${{ matrix.fips }}
+          name: ${{ github.job }}-${{ matrix.go-version }}-fips-${{ matrix.fips }}
           path: .build/test-logs
           if-no-files-found: warn
           retention-days: 14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
           retention-days: 14
 
       - name: Link full test logs
-        if: always() && steps.upload-test-logs.outputs.artifact-url != ''
+        if: failure() && steps.upload-test-logs.outputs.artifact-url != ''
         shell: bash
         run: echo "### [Download full test logs]($ARTIFACT_URL)" >> "$GITHUB_STEP_SUMMARY"
         env:
@@ -131,7 +131,7 @@ jobs:
           retention-days: 14
 
       - name: Link full test logs
-        if: always() && steps.upload-test-logs.outputs.artifact-url != ''
+        if: failure() && steps.upload-test-logs.outputs.artifact-url != ''
         shell: bash
         run: echo "### [Download full test logs]($ARTIFACT_URL)" >> "$GITHUB_STEP_SUMMARY"
         env:
@@ -181,7 +181,7 @@ jobs:
           retention-days: 14
 
       - name: Link full test logs
-        if: always() && steps.upload-test-logs.outputs.artifact-url != ''
+        if: failure() && steps.upload-test-logs.outputs.artifact-url != ''
         shell: bash
         run: echo "### [Download full test logs]($ARTIFACT_URL)" >> "$GITHUB_STEP_SUMMARY"
         env:
@@ -249,7 +249,7 @@ jobs:
           retention-days: 14
 
       - name: Link full test logs
-        if: always() && steps.upload-test-logs.outputs.artifact-url != ''
+        if: failure() && steps.upload-test-logs.outputs.artifact-url != ''
         shell: bash
         run: echo "### [Download full test logs]($ARTIFACT_URL)" >> "$GITHUB_STEP_SUMMARY"
         env:
@@ -298,7 +298,7 @@ jobs:
           retention-days: 14
 
       - name: Link full test logs
-        if: always() && steps.upload-test-logs.outputs.artifact-url != ''
+        if: failure() && steps.upload-test-logs.outputs.artifact-url != ''
         shell: bash
         run: echo "### [Download full test logs]($ARTIFACT_URL)" >> "$GITHUB_STEP_SUMMARY"
         env:

--- a/README.md
+++ b/README.md
@@ -111,6 +111,28 @@ go run . integration-test -dev-server
 
 If you omit `-dev-server`, integration tests connect to a server already running on `localhost:7233`.
 
+### Test output and logs
+
+Unit and integration tests default to `-console-output failures`. Test output is captured while the command runs; if a
+test fails, the command prints the failed test names, bounded failure snippets, rerun commands, and relevant embedded
+dev-server warnings and errors. Complete output is always written under `.build/test-logs` at the repository root.
+Unit tests produce `unit-test.log` and `unit-test.json`. Integration tests produce `go-test.log`, `go-test.json`, and
+`combined.log`; runs using `-dev-server` also produce `dev-server.log`.
+
+To stream full test and dev-server output to the console while still saving the log files, use `-console-output full`:
+
+```bash
+go run . unit-test -console-output full
+go run . integration-test -dev-server -console-output full
+```
+
+Use `-log-dir` to write the files elsewhere. Relative paths are resolved from the repository root, and absolute paths
+are also accepted:
+
+```bash
+go run . integration-test -dev-server -log-dir artifacts/test-logs
+```
+
 ### Running specific tests
 
 Use `-run` with the same semantics as `go test -run`.

--- a/README.md
+++ b/README.md
@@ -113,11 +113,8 @@ If you omit `-dev-server`, integration tests connect to a server already running
 
 ### Test output and logs
 
-Unit and integration tests default to `-console-output failures`. Test output is captured while the command runs; if a
-test fails, the command prints the failed test names, bounded failure snippets, rerun commands, and relevant embedded
-dev-server warnings and errors. Complete output is always written under `.build/test-logs` at the repository root.
-Unit tests produce `unit-test.log` and `unit-test.json`. Integration tests produce `go-test.log`, `go-test.json`, and
-`combined.log`; runs using `-dev-server` also produce `dev-server.log`.
+By default, the internal build tool only reports test failures. Full test output is written to `.build/test-logs` at 
+the repository root.
 
 To stream full test and dev-server output to the console while still saving the log files, use `-console-output full`:
 

--- a/internal/cmd/build/main.go
+++ b/internal/cmd/build/main.go
@@ -34,7 +34,15 @@ func main() {
 }
 
 const coverageDir = ".build/coverage"
+const defaultTestLogDir = ".build/test-logs"
 const githubStepSummaryMaxDetailBytes = 64 * 1024
+const testFailureSnippetMaxDetailBytes = 16 * 1024
+const testFailureSnippetMaxTotalBytes = 64 * 1024
+
+const (
+	testConsoleOutputFull     = "full"
+	testConsoleOutputFailures = "failures"
+)
 
 type builder struct {
 	thisDir string
@@ -100,8 +108,13 @@ func (b *builder) integrationTest() error {
 	packagesFlag := flagSet.String("packages", "./...", "Packages passed to go test")
 	devServerFlag := flagSet.Bool("dev-server", false, "Use an embedded dev server")
 	coverageFileFlag := flagSet.String("coverage-file", "", "If set, enables coverage output to this filename")
+	testOutputFlags := addTestOutputFlags(flagSet)
 	if err := flagSet.Parse(os.Args[2:]); err != nil {
 		return fmt.Errorf("failed parsing flags: %w", err)
+	}
+	testOutput, err := b.prepareTestOutput(*testOutputFlags, "integration-test.log")
+	if err != nil {
+		return err
 	}
 
 	// Also accept coverage file as env var
@@ -199,7 +212,7 @@ func (b *builder) integrationTest() error {
 	cmd := b.cmdFromRoot(args...)
 	cmd.Dir = filepath.Join(cmd.Dir, "test")
 	cmd.Env = env
-	if err := b.runTestCmd(cmd); err != nil {
+	if err := b.runTestCmd(cmd, testOutput); err != nil {
 		return fmt.Errorf("integration test failed: %w", err)
 	}
 
@@ -247,14 +260,19 @@ func (b *builder) unitTest() error {
 	flagSet := flag.NewFlagSet("unit-test", flag.ContinueOnError)
 	runFlag := flagSet.String("run", "", "Passed to go test as -run")
 	coverageFlag := flagSet.Bool("coverage", false, "If set, enables coverage output")
+	testOutputFlags := addTestOutputFlags(flagSet)
 	if err := flagSet.Parse(os.Args[2:]); err != nil {
 		return fmt.Errorf("failed parsing flags: %w", err)
+	}
+	testOutput, err := b.prepareTestOutput(*testOutputFlags, "unit-test.log")
+	if err != nil {
+		return err
 	}
 
 	// Find every non ./test-prefixed package that has a test file
 	testDirMap := map[string]struct{}{}
 	var testDirs []string
-	err := fs.WalkDir(os.DirFS(b.rootDir), ".", func(p string, d fs.DirEntry, err error) error {
+	err = fs.WalkDir(os.DirFS(b.rootDir), ".", func(p string, d fs.DirEntry, err error) error {
 		if (!strings.HasPrefix(p, "test") || strings.HasPrefix(p, "testsuite")) && strings.HasSuffix(p, "_test.go") {
 			dir := path.Dir(p)
 			if _, ok := testDirMap[dir]; !ok {
@@ -295,7 +313,7 @@ func (b *builder) unitTest() error {
 		cmd := b.cmdFromRoot(args...)
 		// Need to run inside directory
 		cmd.Dir = filepath.Join(b.rootDir, testDir)
-		if err := b.runTestCmd(cmd); err != nil {
+		if err := b.runTestCmd(cmd, testOutput); err != nil {
 			return fmt.Errorf("unit test failed in %v: %w", testDir, err)
 		}
 	}
@@ -316,21 +334,115 @@ func (b *builder) runCmd(cmd *exec.Cmd) error {
 	return cmd.Run()
 }
 
-// runTestCmd runs a go test command while capturing output for the GitHub step
-// summary. Output is still streamed to stdout/stderr as the command runs.
-func (b *builder) runTestCmd(cmd *exec.Cmd) error {
+type testOutputFlags struct {
+	logDir        string
+	consoleOutput string
+}
+
+func addTestOutputFlags(flagSet *flag.FlagSet) *testOutputFlags {
+	var flags testOutputFlags
+	flagSet.StringVar(
+		&flags.logDir,
+		"log-dir",
+		defaultTestLogDir,
+		"Directory for full test logs, relative to the repository root",
+	)
+	flagSet.StringVar(
+		&flags.consoleOutput,
+		"console-output",
+		testConsoleOutputFailures,
+		`Test output written to the console: "full" or "failures"`,
+	)
+	return &flags
+}
+
+type testOutput struct {
+	logPath       string
+	consoleOutput string
+	stdout        io.Writer
+	stderr        io.Writer
+}
+
+func (b *builder) prepareTestOutput(flags testOutputFlags, logName string) (testOutput, error) {
+	if strings.TrimSpace(flags.logDir) == "" {
+		return testOutput{}, fmt.Errorf("-log-dir must not be empty")
+	}
+	switch flags.consoleOutput {
+	case testConsoleOutputFull, testConsoleOutputFailures:
+	default:
+		return testOutput{}, fmt.Errorf(
+			"invalid -console-output %q: must be %q or %q",
+			flags.consoleOutput,
+			testConsoleOutputFull,
+			testConsoleOutputFailures,
+		)
+	}
+
+	logDir := filepath.FromSlash(flags.logDir)
+	if !filepath.IsAbs(logDir) {
+		logDir = filepath.Join(b.rootDir, logDir)
+	}
+	logDir = filepath.Clean(logDir)
+	if err := os.MkdirAll(logDir, 0777); err != nil {
+		return testOutput{}, fmt.Errorf("failed creating test log directory %q: %w", logDir, err)
+	}
+	logPath := filepath.Join(logDir, logName)
+	f, err := os.OpenFile(logPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0666)
+	if err != nil {
+		return testOutput{}, fmt.Errorf("failed preparing test log %q: %w", logPath, err)
+	}
+	if err := f.Close(); err != nil {
+		return testOutput{}, fmt.Errorf("failed closing test log %q: %w", logPath, err)
+	}
+	log.Printf("Writing full test output to %v", logPath)
+	return testOutput{
+		logPath:       logPath,
+		consoleOutput: flags.consoleOutput,
+		stdout:        os.Stdout,
+		stderr:        os.Stderr,
+	}, nil
+}
+
+// runTestCmd runs a go test command while saving full output and capturing
+// failures for the console and GitHub step summary.
+func (b *builder) runTestCmd(cmd *exec.Cmd, testOutput testOutput) error {
+	logFile, err := os.OpenFile(testOutput.logPath, os.O_WRONLY|os.O_APPEND, 0666)
+	if err != nil {
+		return fmt.Errorf("failed opening test log %q: %w", testOutput.logPath, err)
+	}
+
 	var output lockedBuffer
-	cmd.Stdout = io.MultiWriter(os.Stdout, &output)
-	cmd.Stderr = io.MultiWriter(os.Stderr, &output)
+	if testOutput.consoleOutput == testConsoleOutputFull {
+		cmd.Stdout = io.MultiWriter(testOutput.stdout, logFile, &output)
+		cmd.Stderr = io.MultiWriter(testOutput.stderr, logFile, &output)
+	} else {
+		cmd.Stdout = io.MultiWriter(logFile, &output)
+		cmd.Stderr = io.MultiWriter(logFile, &output)
+	}
 	log.Printf("Running %v in %v with args %v", cmd.Path, cmd.Dir, cmd.Args[1:])
-	err := cmd.Run()
+	if _, err := fmt.Fprintf(logFile, "Running %v in %v with args %v\n", cmd.Path, cmd.Dir, cmd.Args[1:]); err != nil {
+		_ = logFile.Close()
+		return fmt.Errorf("failed writing test log %q: %w", testOutput.logPath, err)
+	}
+	err = cmd.Run()
+	closeErr := logFile.Close()
 	if err != nil {
 		summaryErr := appendTestFailureSummary(os.Getenv("GITHUB_STEP_SUMMARY"), output.String())
 		if summaryErr != nil {
 			log.Printf("Failed writing test failure summary: %v", summaryErr)
 		}
+		if testOutput.consoleOutput == testConsoleOutputFailures {
+			snippetErr := writeTestFailureSnippets(testOutput.stderr, output.String(), testOutput.logPath)
+			if snippetErr != nil {
+				log.Printf("Failed writing test failure snippets: %v", snippetErr)
+			}
+		}
+		return err
 	}
-	return err
+	if closeErr != nil {
+		return fmt.Errorf("failed closing test log %q: %w", testOutput.logPath, closeErr)
+	}
+	return nil
 }
 
 type lockedBuffer struct {
@@ -354,6 +466,80 @@ type testFailureSummaryRow struct {
 	Test    string
 	Package string
 	Details string
+}
+
+func writeTestFailureSnippets(w io.Writer, output, logPath string) error {
+	rows := parseTestFailures(output)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "\nTest command failed. Full output: %s\n", logPath)
+	if len(rows) == 0 {
+		fmt.Fprintf(
+			&sb,
+			"No individual failed test was identified; showing up to %d KiB of command output:\n\n",
+			testFailureSnippetMaxTotalBytes/1024,
+		)
+		sb.WriteString(truncateTestFailureSnippet(output, testFailureSnippetMaxTotalBytes))
+		sb.WriteString("\n")
+		_, err := io.WriteString(w, sb.String())
+		return err
+	}
+
+	fmt.Fprintf(&sb, "\nFailed tests (%d):\n", len(rows))
+	for _, row := range rows {
+		fmt.Fprintf(&sb, "- %s\n", testFailureTitle(row))
+	}
+	fmt.Fprintf(
+		&sb,
+		"\nFailure details (up to %d KiB per test and %d KiB total):\n",
+		testFailureSnippetMaxDetailBytes/1024,
+		testFailureSnippetMaxTotalBytes/1024,
+	)
+	remaining := testFailureSnippetMaxTotalBytes
+	for i, row := range rows {
+		if remaining <= 0 {
+			omitted := len(rows) - i
+			testWord := "tests"
+			if omitted == 1 {
+				testWord = "test"
+			}
+			fmt.Fprintf(
+				&sb,
+				"\n... omitted details for %d additional failed %s after reaching the %d KiB total console limit; all failed tests are listed above\n",
+				omitted,
+				testWord,
+				testFailureSnippetMaxTotalBytes/1024,
+			)
+			break
+		}
+		fmt.Fprintf(&sb, "\n--- %s ---\n", testFailureTitle(row))
+		maxDetailBytes := min(testFailureSnippetMaxDetailBytes, remaining)
+		details := truncateTestFailureSnippet(row.Details, maxDetailBytes)
+		sb.WriteString(details)
+		sb.WriteString("\n")
+		remaining -= len(details)
+	}
+	_, err := io.WriteString(w, sb.String())
+	return err
+}
+
+func truncateTestFailureSnippet(value string, maxBytes int) string {
+	if len(value) <= maxBytes {
+		return value
+	}
+	const marker = "\n... (truncated; see full test log) ...\n"
+	if maxBytes <= len(marker) {
+		return value[:maxBytes]
+	}
+	prefixBytes := (maxBytes - len(marker)) / 2
+	suffixBytes := maxBytes - len(marker) - prefixBytes
+	return value[:prefixBytes] + marker + value[len(value)-suffixBytes:]
+}
+
+func testFailureTitle(row testFailureSummaryRow) string {
+	if row.Package == "" {
+		return row.Test
+	}
+	return row.Package + " / " + row.Test
 }
 
 func appendTestFailureSummary(summaryPath, output string) error {
@@ -473,19 +659,12 @@ func renderTestFailureSummary(rows []testFailureSummaryRow) string {
 	sb.WriteString("## Test failures\n\n")
 	sb.WriteString("<table>\n<tr><th>Kind</th><th>Test failure</th></tr>\n")
 	for _, row := range rows {
-		details := row.Details
-		if len(details) > githubStepSummaryMaxDetailBytes {
-			details = details[:githubStepSummaryMaxDetailBytes] + "\n... (truncated; see full job logs)"
-		}
-		title := row.Test
-		if row.Package != "" {
-			title = row.Package + " / " + title
-		}
+		details := truncateTestFailureSnippet(row.Details, githubStepSummaryMaxDetailBytes)
 		fmt.Fprintf(
 			&sb,
 			"<tr><td>%s</td><td><details><summary>%s</summary><pre>%s</pre></details></td></tr>\n",
 			html.EscapeString("Failed"),
-			html.EscapeString(title),
+			html.EscapeString(testFailureTitle(row)),
 			html.EscapeString(details),
 		)
 	}

--- a/internal/cmd/build/main.go
+++ b/internal/cmd/build/main.go
@@ -232,7 +232,13 @@ func (b *builder) integrationTest() error {
 			},
 		})
 		if err != nil {
-			return fmt.Errorf("failed starting dev server: %w", err)
+			startErr := fmt.Errorf("failed starting dev server: %w", err)
+			if testOutput.consoleOutput == testConsoleOutputFailures {
+				if reportErr := writeTestSetupFailureReport(testOutput.stderr, startErr, testOutput); reportErr != nil {
+					log.Printf("Failed writing test setup failure report: %v", reportErr)
+				}
+			}
+			return startErr
 		}
 		defer func() { _ = devServer.Stop() }()
 	}

--- a/internal/cmd/build/main.go
+++ b/internal/cmd/build/main.go
@@ -533,10 +533,6 @@ func (b *builder) runTestCmd(cmd *exec.Cmd, testOutput testOutput) error {
 	jsonCloseErr := jsonLogFile.Close()
 	rows := results.failures()
 	if runErr != nil {
-		summaryErr := appendTestFailureRows(os.Getenv("GITHUB_STEP_SUMMARY"), rows)
-		if summaryErr != nil {
-			log.Printf("Failed writing test failure summary: %v", summaryErr)
-		}
 		if testOutput.consoleOutput == testConsoleOutputFailures {
 			reportErr := writeStructuredTestFailureReport(
 				testOutput.stderr,

--- a/internal/cmd/build/main.go
+++ b/internal/cmd/build/main.go
@@ -495,7 +495,7 @@ func (b *builder) prepareLogPath(logDirFlag, logName string) (string, error) {
 }
 
 // runTestCmd runs a go test command while saving full output and capturing
-// failures for the console and GitHub step summary.
+// structured results for the concise console report and GitHub job summary.
 func (b *builder) runTestCmd(cmd *exec.Cmd, testOutput testOutput) error {
 	logFile, err := testOutput.openLog()
 	if err != nil {
@@ -533,6 +533,10 @@ func (b *builder) runTestCmd(cmd *exec.Cmd, testOutput testOutput) error {
 	jsonCloseErr := jsonLogFile.Close()
 	rows := results.failures()
 	if runErr != nil {
+		summaryErr := appendTestFailureRows(os.Getenv("GITHUB_STEP_SUMMARY"), rows)
+		if summaryErr != nil {
+			log.Printf("Failed writing test failure summary: %v", summaryErr)
+		}
 		if testOutput.consoleOutput == testConsoleOutputFailures {
 			reportErr := writeStructuredTestFailureReport(
 				testOutput.stderr,

--- a/internal/cmd/build/main.go
+++ b/internal/cmd/build/main.go
@@ -5,10 +5,10 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"html"
 	"io"
 	"io/fs"
 	"log"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path"
@@ -16,13 +16,13 @@ import (
 	"runtime"
 	"sort"
 	"strings"
-	"sync"
 
 	_ "github.com/BurntSushi/toml"
 	_ "github.com/kisielk/errcheck/errcheck"
 	_ "honnef.co/go/tools/staticcheck"
 
 	"go.temporal.io/sdk/client"
+	sdklog "go.temporal.io/sdk/log"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/testsuite"
 )
@@ -35,9 +35,6 @@ func main() {
 
 const coverageDir = ".build/coverage"
 const defaultTestLogDir = ".build/test-logs"
-const githubStepSummaryMaxDetailBytes = 64 * 1024
-const testFailureSnippetMaxDetailBytes = 16 * 1024
-const testFailureSnippetMaxTotalBytes = 64 * 1024
 
 const (
 	testConsoleOutputFull     = "full"
@@ -112,10 +109,36 @@ func (b *builder) integrationTest() error {
 	if err := flagSet.Parse(os.Args[2:]); err != nil {
 		return fmt.Errorf("failed parsing flags: %w", err)
 	}
-	testOutput, err := b.prepareTestOutput(*testOutputFlags, "integration-test.log")
+	testOutput, err := b.prepareTestOutput(*testOutputFlags, "go-test.log")
 	if err != nil {
 		return err
 	}
+	combinedLogPath, err := b.prepareLogPath(testOutputFlags.logDir, "combined.log")
+	if err != nil {
+		return err
+	}
+	combinedLog, err := os.OpenFile(combinedLogPath, os.O_WRONLY|os.O_APPEND, 0666)
+	if err != nil {
+		return fmt.Errorf("failed opening combined test log %q: %w", combinedLogPath, err)
+	}
+	defer func() {
+		if err := combinedLog.Close(); err != nil {
+			log.Printf("Failed closing combined test log: %v", err)
+		}
+	}()
+	testOutput.combinedLogPath = combinedLogPath
+	testOutput.combinedWriter = &lockedWriter{writer: combinedLog}
+	rerunArgs := []string{"go", "run", ".", "integration-test"}
+	if *devServerFlag {
+		rerunArgs = append(rerunArgs, "-dev-server")
+	}
+	if *pFlag != "" {
+		rerunArgs = append(rerunArgs, "-p", *pFlag)
+	}
+	if *packagesFlag != "./..." {
+		rerunArgs = append(rerunArgs, "-packages", *packagesFlag)
+	}
+	testOutput.rerunCommand = formatShellCommand(rerunArgs)
 
 	// Also accept coverage file as env var
 	if env := strings.TrimSpace(os.Getenv("TEMPORAL_COVERAGE_FILE")); *coverageFileFlag == "" && env != "" {
@@ -138,6 +161,26 @@ func (b *builder) integrationTest() error {
 
 	// Start dev server if wanted
 	if *devServerFlag {
+		devServerLogPath, err := b.prepareLogPath(testOutputFlags.logDir, "dev-server.log")
+		if err != nil {
+			return err
+		}
+		devServerLog, err := os.OpenFile(devServerLogPath, os.O_WRONLY|os.O_APPEND, 0666)
+		if err != nil {
+			return fmt.Errorf("failed opening dev server log %q: %w", devServerLogPath, err)
+		}
+		defer func() {
+			if err := devServerLog.Close(); err != nil {
+				log.Printf("Failed closing dev server log: %v", err)
+			}
+		}()
+		testOutput.serverLogPath = devServerLogPath
+		devServerLogWriter := &lockedWriter{writer: devServerLog}
+		devServerStdout, devServerStderr := testOutput.writers(
+			io.MultiWriter(devServerLogWriter, testOutput.combinedWriter),
+			nil,
+		)
+		devServerLogger := sdklog.NewStructuredLogger(slog.New(slog.NewTextHandler(devServerStdout, nil)))
 		devServer, err := testsuite.StartDevServer(context.Background(), testsuite.DevServerOptions{
 			CachedDownload: testsuite.CachedDownload{
 				Version: "v1.7.2-one-time-versioning-override",
@@ -145,10 +188,13 @@ func (b *builder) integrationTest() error {
 			ClientOptions: &client.Options{
 				HostPort:  "127.0.0.1:7233",
 				Namespace: "integration-test-namespace",
+				Logger:    devServerLogger,
 			},
 			DBFilename:       "temporal.sqlite",
 			LogLevel:         "warn",
 			SearchAttributes: searchAttributes,
+			Stdout:           devServerStdout,
+			Stderr:           devServerStderr,
 			ExtraArgs: []string{
 				"--sqlite-pragma", "journal_mode=WAL",
 				"--sqlite-pragma", "synchronous=OFF",
@@ -192,7 +238,7 @@ func (b *builder) integrationTest() error {
 	}
 
 	// Run integration test
-	args := []string{"go", "test", "-count", "1", "-race", "-v", "-timeout", "15m"}
+	args := []string{"go", "test", "-json", "-count", "1", "-race", "-v", "-timeout", "15m"}
 	env := append(os.Environ(), "DISABLE_SERVER_1_25_TESTS=1")
 	if *runFlag != "" {
 		args = append(args, "-run", *runFlag)
@@ -268,6 +314,7 @@ func (b *builder) unitTest() error {
 	if err != nil {
 		return err
 	}
+	testOutput.rerunCommand = "go run . unit-test"
 
 	// Find every non ./test-prefixed package that has a test file
 	testDirMap := map[string]struct{}{}
@@ -298,7 +345,7 @@ func (b *builder) unitTest() error {
 	log.Printf("Running unit tests in dirs: %v", testDirs)
 	for _, testDir := range testDirs {
 		// Run unit test
-		args := []string{"go", "test", "-count", "1", "-race", "-v", "-timeout", "5m"}
+		args := []string{"go", "test", "-json", "-count", "1", "-race", "-v", "-timeout", "5m"}
 		if *runFlag != "" {
 			args = append(args, "-run", *runFlag)
 		}
@@ -357,10 +404,38 @@ func addTestOutputFlags(flagSet *flag.FlagSet) *testOutputFlags {
 }
 
 type testOutput struct {
-	logPath       string
-	consoleOutput string
-	stdout        io.Writer
-	stderr        io.Writer
+	logPath         string
+	jsonLogPath     string
+	combinedLogPath string
+	serverLogPath   string
+	rerunCommand    string
+	combinedWriter  io.Writer
+	consoleOutput   string
+	stdout          io.Writer
+	stderr          io.Writer
+}
+
+func (t testOutput) openLog() (*os.File, error) {
+	f, err := os.OpenFile(t.logPath, os.O_WRONLY|os.O_APPEND, 0666)
+	if err != nil {
+		return nil, fmt.Errorf("failed opening test log %q: %w", t.logPath, err)
+	}
+	return f, nil
+}
+
+func (t testOutput) writers(logWriter io.Writer, capture io.Writer) (io.Writer, io.Writer) {
+	var stdoutWriters, stderrWriters []io.Writer
+	if t.consoleOutput == testConsoleOutputFull {
+		stdoutWriters = append(stdoutWriters, t.stdout)
+		stderrWriters = append(stderrWriters, t.stderr)
+	}
+	stdoutWriters = append(stdoutWriters, logWriter)
+	stderrWriters = append(stderrWriters, logWriter)
+	if capture != nil {
+		stdoutWriters = append(stdoutWriters, capture)
+		stderrWriters = append(stderrWriters, capture)
+	}
+	return io.MultiWriter(stdoutWriters...), io.MultiWriter(stderrWriters...)
 }
 
 func (b *builder) prepareTestOutput(flags testOutputFlags, logName string) (testOutput, error) {
@@ -377,299 +452,114 @@ func (b *builder) prepareTestOutput(flags testOutputFlags, logName string) (test
 			testConsoleOutputFailures,
 		)
 	}
-
-	logDir := filepath.FromSlash(flags.logDir)
-	if !filepath.IsAbs(logDir) {
-		logDir = filepath.Join(b.rootDir, logDir)
-	}
-	logDir = filepath.Clean(logDir)
-	if err := os.MkdirAll(logDir, 0777); err != nil {
-		return testOutput{}, fmt.Errorf("failed creating test log directory %q: %w", logDir, err)
-	}
-	logPath := filepath.Join(logDir, logName)
-	f, err := os.OpenFile(logPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0666)
+	logPath, err := b.prepareLogPath(flags.logDir, logName)
 	if err != nil {
-		return testOutput{}, fmt.Errorf("failed preparing test log %q: %w", logPath, err)
+		return testOutput{}, err
 	}
-	if err := f.Close(); err != nil {
-		return testOutput{}, fmt.Errorf("failed closing test log %q: %w", logPath, err)
+	jsonLogName := strings.TrimSuffix(logName, filepath.Ext(logName)) + ".json"
+	jsonLogPath, err := b.prepareLogPath(flags.logDir, jsonLogName)
+	if err != nil {
+		return testOutput{}, err
 	}
-	log.Printf("Writing full test output to %v", logPath)
 	return testOutput{
 		logPath:       logPath,
+		jsonLogPath:   jsonLogPath,
 		consoleOutput: flags.consoleOutput,
 		stdout:        os.Stdout,
 		stderr:        os.Stderr,
 	}, nil
 }
 
+func (b *builder) prepareLogPath(logDirFlag, logName string) (string, error) {
+	if strings.TrimSpace(logDirFlag) == "" {
+		return "", fmt.Errorf("-log-dir must not be empty")
+	}
+	logDir := filepath.FromSlash(logDirFlag)
+	if !filepath.IsAbs(logDir) {
+		logDir = filepath.Join(b.rootDir, logDir)
+	}
+	logDir = filepath.Clean(logDir)
+	if err := os.MkdirAll(logDir, 0777); err != nil {
+		return "", fmt.Errorf("failed creating test log directory %q: %w", logDir, err)
+	}
+	logPath := filepath.Join(logDir, logName)
+	f, err := os.OpenFile(logPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0666)
+	if err != nil {
+		return "", fmt.Errorf("failed preparing test log %q: %w", logPath, err)
+	}
+	if err := f.Close(); err != nil {
+		return "", fmt.Errorf("failed closing test log %q: %w", logPath, err)
+	}
+	log.Printf("Writing full test output to %v", logPath)
+	return logPath, nil
+}
+
 // runTestCmd runs a go test command while saving full output and capturing
 // failures for the console and GitHub step summary.
 func (b *builder) runTestCmd(cmd *exec.Cmd, testOutput testOutput) error {
-	logFile, err := os.OpenFile(testOutput.logPath, os.O_WRONLY|os.O_APPEND, 0666)
+	logFile, err := testOutput.openLog()
 	if err != nil {
-		return fmt.Errorf("failed opening test log %q: %w", testOutput.logPath, err)
+		return err
+	}
+	jsonLogFile, err := os.OpenFile(testOutput.jsonLogPath, os.O_WRONLY|os.O_APPEND, 0666)
+	if err != nil {
+		_ = logFile.Close()
+		return fmt.Errorf("failed opening test JSON log %q: %w", testOutput.jsonLogPath, err)
 	}
 
-	var output lockedBuffer
-	if testOutput.consoleOutput == testConsoleOutputFull {
-		cmd.Stdout = io.MultiWriter(testOutput.stdout, logFile, &output)
-		cmd.Stderr = io.MultiWriter(testOutput.stderr, logFile, &output)
-	} else {
-		cmd.Stdout = io.MultiWriter(logFile, &output)
-		cmd.Stderr = io.MultiWriter(logFile, &output)
+	logWriters := []io.Writer{&lockedWriter{writer: logFile}}
+	if testOutput.combinedWriter != nil {
+		logWriters = append(logWriters, testOutput.combinedWriter)
 	}
+	plainLogWriter := io.MultiWriter(logWriters...)
+	stdoutWriter, stderrWriter := testOutput.writers(plainLogWriter, nil)
+	results := newGoTestResults()
+	jsonWriter := &goTestJSONWriter{
+		rawWriter:    jsonLogFile,
+		outputWriter: stdoutWriter,
+		results:      results,
+	}
+	cmd.Stdout = jsonWriter
+	cmd.Stderr = io.MultiWriter(stderrWriter, writerFunc(results.recordRawOutput))
 	log.Printf("Running %v in %v with args %v", cmd.Path, cmd.Dir, cmd.Args[1:])
-	if _, err := fmt.Fprintf(logFile, "Running %v in %v with args %v\n", cmd.Path, cmd.Dir, cmd.Args[1:]); err != nil {
+	if _, err := fmt.Fprintf(plainLogWriter, "Running %v in %v with args %v\n", cmd.Path, cmd.Dir, cmd.Args[1:]); err != nil {
 		_ = logFile.Close()
+		_ = jsonLogFile.Close()
 		return fmt.Errorf("failed writing test log %q: %w", testOutput.logPath, err)
 	}
-	err = cmd.Run()
-	closeErr := logFile.Close()
-	if err != nil {
-		summaryErr := appendTestFailureSummary(os.Getenv("GITHUB_STEP_SUMMARY"), output.String())
+	runErr := cmd.Run()
+	flushErr := jsonWriter.Flush()
+	logCloseErr := logFile.Close()
+	jsonCloseErr := jsonLogFile.Close()
+	rows := results.failures()
+	if runErr != nil {
+		summaryErr := appendTestFailureRows(os.Getenv("GITHUB_STEP_SUMMARY"), rows)
 		if summaryErr != nil {
 			log.Printf("Failed writing test failure summary: %v", summaryErr)
 		}
 		if testOutput.consoleOutput == testConsoleOutputFailures {
-			snippetErr := writeTestFailureSnippets(testOutput.stderr, output.String(), testOutput.logPath)
-			if snippetErr != nil {
-				log.Printf("Failed writing test failure snippets: %v", snippetErr)
+			reportErr := writeStructuredTestFailureReport(
+				testOutput.stderr,
+				rows,
+				results.fallbackOutput(),
+				testOutput,
+			)
+			if reportErr != nil {
+				log.Printf("Failed writing test failure report: %v", reportErr)
 			}
 		}
-		return err
+		return runErr
 	}
-	if closeErr != nil {
-		return fmt.Errorf("failed closing test log %q: %w", testOutput.logPath, closeErr)
+	if flushErr != nil {
+		return fmt.Errorf("failed decoding test JSON output: %w", flushErr)
+	}
+	if logCloseErr != nil {
+		return fmt.Errorf("failed closing test log %q: %w", testOutput.logPath, logCloseErr)
+	}
+	if jsonCloseErr != nil {
+		return fmt.Errorf("failed closing test JSON log %q: %w", testOutput.jsonLogPath, jsonCloseErr)
 	}
 	return nil
-}
-
-type lockedBuffer struct {
-	mu sync.Mutex
-	bytes.Buffer
-}
-
-func (b *lockedBuffer) Write(p []byte) (int, error) {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	return b.Buffer.Write(p)
-}
-
-func (b *lockedBuffer) String() string {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	return b.Buffer.String()
-}
-
-type testFailureSummaryRow struct {
-	Test    string
-	Package string
-	Details string
-}
-
-func writeTestFailureSnippets(w io.Writer, output, logPath string) error {
-	rows := parseTestFailures(output)
-	var sb strings.Builder
-	fmt.Fprintf(&sb, "\nTest command failed. Full output: %s\n", logPath)
-	if len(rows) == 0 {
-		fmt.Fprintf(
-			&sb,
-			"No individual failed test was identified; showing up to %d KiB of command output:\n\n",
-			testFailureSnippetMaxTotalBytes/1024,
-		)
-		sb.WriteString(truncateTestFailureSnippet(output, testFailureSnippetMaxTotalBytes))
-		sb.WriteString("\n")
-		_, err := io.WriteString(w, sb.String())
-		return err
-	}
-
-	fmt.Fprintf(&sb, "\nFailed tests (%d):\n", len(rows))
-	for _, row := range rows {
-		fmt.Fprintf(&sb, "- %s\n", testFailureTitle(row))
-	}
-	fmt.Fprintf(
-		&sb,
-		"\nFailure details (up to %d KiB per test and %d KiB total):\n",
-		testFailureSnippetMaxDetailBytes/1024,
-		testFailureSnippetMaxTotalBytes/1024,
-	)
-	remaining := testFailureSnippetMaxTotalBytes
-	for i, row := range rows {
-		if remaining <= 0 {
-			omitted := len(rows) - i
-			testWord := "tests"
-			if omitted == 1 {
-				testWord = "test"
-			}
-			fmt.Fprintf(
-				&sb,
-				"\n... omitted details for %d additional failed %s after reaching the %d KiB total console limit; all failed tests are listed above\n",
-				omitted,
-				testWord,
-				testFailureSnippetMaxTotalBytes/1024,
-			)
-			break
-		}
-		fmt.Fprintf(&sb, "\n--- %s ---\n", testFailureTitle(row))
-		maxDetailBytes := min(testFailureSnippetMaxDetailBytes, remaining)
-		details := truncateTestFailureSnippet(row.Details, maxDetailBytes)
-		sb.WriteString(details)
-		sb.WriteString("\n")
-		remaining -= len(details)
-	}
-	_, err := io.WriteString(w, sb.String())
-	return err
-}
-
-func truncateTestFailureSnippet(value string, maxBytes int) string {
-	if len(value) <= maxBytes {
-		return value
-	}
-	const marker = "\n... (truncated; see full test log) ...\n"
-	if maxBytes <= len(marker) {
-		return value[:maxBytes]
-	}
-	prefixBytes := (maxBytes - len(marker)) / 2
-	suffixBytes := maxBytes - len(marker) - prefixBytes
-	return value[:prefixBytes] + marker + value[len(value)-suffixBytes:]
-}
-
-func testFailureTitle(row testFailureSummaryRow) string {
-	if row.Package == "" {
-		return row.Test
-	}
-	return row.Package + " / " + row.Test
-}
-
-func appendTestFailureSummary(summaryPath, output string) error {
-	if summaryPath == "" {
-		return nil
-	}
-	rows := parseTestFailures(output)
-	if len(rows) == 0 {
-		return nil
-	}
-	f, err := os.OpenFile(summaryPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-	_, err = f.WriteString(renderTestFailureSummary(rows))
-	return err
-}
-
-func parseTestFailures(output string) []testFailureSummaryRow {
-	lines := strings.Split(strings.ReplaceAll(output, "\r\n", "\n"), "\n")
-	rows := make([]testFailureSummaryRow, 0)
-	currentPackage := ""
-	packageStart := 0
-	for i := 0; i < len(lines); i++ {
-		line := lines[i]
-		if strings.HasPrefix(line, "FAIL\t") {
-			fields := strings.Fields(line)
-			if len(fields) >= 2 {
-				currentPackage = fields[1]
-				for rowIndex := packageStart; rowIndex < len(rows); rowIndex++ {
-					if rows[rowIndex].Package == "" {
-						rows[rowIndex].Package = currentPackage
-					}
-				}
-				packageStart = len(rows)
-			}
-			continue
-		}
-		const failPrefix = "--- FAIL: "
-		trimmedLine := strings.TrimLeft(line, " \t")
-		if !strings.HasPrefix(trimmedLine, failPrefix) {
-			continue
-		}
-		name := strings.TrimSpace(strings.TrimPrefix(trimmedLine, failPrefix))
-		if idx := strings.Index(name, " "); idx >= 0 {
-			name = name[:idx]
-		}
-		start := findMatchingRunLine(lines, i, name)
-		end := len(lines)
-		for j := start + 1; j < len(lines); j++ {
-			next := lines[j]
-			if isRunLine(next) || strings.HasPrefix(next, "FAIL\t") || strings.HasPrefix(next, "ok  \t") {
-				end = j
-				break
-			}
-		}
-		rows = append(rows, testFailureSummaryRow{
-			Test:    name,
-			Package: currentPackage,
-			Details: strings.Join(lines[start:end], "\n"),
-		})
-	}
-	sort.SliceStable(rows, func(i, j int) bool {
-		if rows[i].Package != rows[j].Package {
-			return rows[i].Package < rows[j].Package
-		}
-		return rows[i].Test < rows[j].Test
-	})
-	return filterParentFailureRows(rows)
-}
-
-func filterParentFailureRows(rows []testFailureSummaryRow) []testFailureSummaryRow {
-	hasFailedSubtest := make(map[testFailureSummaryKey]bool, len(rows))
-	for _, row := range rows {
-		if parent, _, ok := strings.Cut(row.Test, "/"); ok {
-			hasFailedSubtest[testFailureSummaryKey{Package: row.Package, Test: parent}] = true
-		}
-	}
-	filtered := rows[:0]
-	for _, row := range rows {
-		if !hasFailedSubtest[testFailureSummaryKey{Package: row.Package, Test: row.Test}] {
-			filtered = append(filtered, row)
-		}
-	}
-	return filtered
-}
-
-type testFailureSummaryKey struct {
-	Package string
-	Test    string
-}
-
-func findMatchingRunLine(lines []string, before int, testName string) int {
-	for i := before - 1; i >= 0; i-- {
-		if testNameFromRunLine(lines[i]) == testName {
-			return i
-		}
-	}
-	return before
-}
-
-func testNameFromRunLine(line string) string {
-	fields := strings.Fields(strings.TrimLeft(line, " \t"))
-	if len(fields) != 3 || fields[0] != "===" || fields[1] != "RUN" {
-		return ""
-	}
-	return fields[2]
-}
-
-func isRunLine(line string) bool {
-	return strings.HasPrefix(strings.TrimLeft(line, " \t"), "=== RUN ")
-}
-
-func renderTestFailureSummary(rows []testFailureSummaryRow) string {
-	var sb strings.Builder
-	sb.WriteString("## Test failures\n\n")
-	sb.WriteString("<table>\n<tr><th>Kind</th><th>Test failure</th></tr>\n")
-	for _, row := range rows {
-		details := truncateTestFailureSnippet(row.Details, githubStepSummaryMaxDetailBytes)
-		fmt.Fprintf(
-			&sb,
-			"<tr><td>%s</td><td><details><summary>%s</summary><pre>%s</pre></details></td></tr>\n",
-			html.EscapeString("Failed"),
-			html.EscapeString(testFailureTitle(row)),
-			html.EscapeString(details),
-		)
-	}
-	sb.WriteString("</table>\n\n")
-	return sb.String()
 }
 
 func (b *builder) getInstalledTool(modPath string) (string, error) {

--- a/internal/cmd/build/main.go
+++ b/internal/cmd/build/main.go
@@ -461,6 +461,7 @@ func (b *builder) prepareTestOutput(flags testOutputFlags, logName string) (test
 	if err != nil {
 		return testOutput{}, err
 	}
+	log.Printf("Writing full test logs to %v", filepath.Dir(logPath))
 	return testOutput{
 		logPath:       logPath,
 		jsonLogPath:   jsonLogPath,
@@ -490,7 +491,6 @@ func (b *builder) prepareLogPath(logDirFlag, logName string) (string, error) {
 	if err := f.Close(); err != nil {
 		return "", fmt.Errorf("failed closing test log %q: %w", logPath, err)
 	}
-	log.Printf("Writing full test output to %v", logPath)
 	return logPath, nil
 }
 

--- a/internal/cmd/build/main_test.go
+++ b/internal/cmd/build/main_test.go
@@ -468,6 +468,7 @@ func TestWriteStructuredTestFailureReportIncludesArtifactAndServerContext(t *tes
 	}
 	t.Setenv("TEST_LOG_ARTIFACT_NAME", "integ-test-ubuntu-latest-stable")
 	t.Setenv("GITHUB_RUN_ID", "12345")
+	t.Setenv("GITHUB_REPOSITORY", "temporalio/sdk-go")
 	var report bytes.Buffer
 	err := writeStructuredTestFailureReport(
 		&report,
@@ -510,11 +511,14 @@ func TestWriteStructuredTestFailureReportIncludesArtifactAndServerContext(t *tes
 		`msg="server boom"`,
 		"Combined Go and dev server:",
 		"CI artifact: integ-test-ubuntu-latest-stable",
-		"gh run download 12345 -n integ-test-ubuntu-latest-stable -D .build/ci-debug",
+		"gh run download 12345 -n integ-test-ubuntu-latest-stable -D .build/ci-debug --repo temporalio/sdk-go",
 	} {
 		if !strings.Contains(report.String(), want) {
 			t.Fatalf("failure report missing %q:\n%s", want, report.String())
 		}
+	}
+	if unexpected := `go run . integration-test -dev-server -run "^TestSuite$"`; strings.Contains(report.String(), unexpected) {
+		t.Fatalf("failure report included parent rerun command %q:\n%s", unexpected, report.String())
 	}
 }
 
@@ -607,19 +611,24 @@ func TestRenderTestFailureSummaryEscapesHTML(t *testing.T) {
 }
 
 func TestFilterParentFailureRowsUsesPackage(t *testing.T) {
-	rows := filterParentFailureRows([]testFailureSummaryRow{
+	input := []testFailureSummaryRow{
 		{Package: "example.com/a", Test: "TestSuite"},
 		{Package: "example.com/a", Test: "TestSuite/TestSub"},
+		{Package: "example.com/a", Test: "TestSuite/TestSub/TestNested"},
 		{Package: "example.com/b", Test: "TestSuite"},
-	})
+	}
+	rows := filterParentFailureRows(input)
 
 	if len(rows) != 2 {
 		t.Fatalf("expected 2 rows, got %d: %#v", len(rows), rows)
 	}
-	if rows[0].Package != "example.com/a" || rows[0].Test != "TestSuite/TestSub" {
+	if rows[0].Package != "example.com/a" || rows[0].Test != "TestSuite/TestSub/TestNested" {
 		t.Fatalf("expected package a subtest row first, got %#v", rows[0])
 	}
 	if rows[1].Package != "example.com/b" || rows[1].Test != "TestSuite" {
 		t.Fatalf("expected package b parent row to be preserved, got %#v", rows[1])
+	}
+	if input[0].Test != "TestSuite" {
+		t.Fatalf("filter mutated its input: %#v", input)
 	}
 }

--- a/internal/cmd/build/main_test.go
+++ b/internal/cmd/build/main_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -23,6 +24,10 @@ func TestTestOutputFlagsDefaultToFailures(t *testing.T) {
 func TestPrepareTestOutput(t *testing.T) {
 	rootDir := t.TempDir()
 	b := &builder{rootDir: rootDir}
+	var startupLogs bytes.Buffer
+	originalLogOutput := log.Writer()
+	log.SetOutput(&startupLogs)
+	t.Cleanup(func() { log.SetOutput(originalLogOutput) })
 
 	output, err := b.prepareTestOutput(testOutputFlags{
 		logDir:        defaultTestLogDir,
@@ -45,6 +50,15 @@ func TestPrepareTestOutput(t *testing.T) {
 	if _, err := os.Stat(expectedJSONPath); err != nil {
 		t.Fatalf("expected prepared JSON log file: %v", err)
 	}
+	if got := strings.Count(startupLogs.String(), "Writing full test logs to"); got != 1 {
+		t.Fatalf("expected one test log directory notice, got %d:\n%s", got, startupLogs.String())
+	}
+	if !strings.Contains(startupLogs.String(), filepath.Dir(expectedPath)) {
+		t.Fatalf("test log directory notice missing %q:\n%s", filepath.Dir(expectedPath), startupLogs.String())
+	}
+	if strings.Contains(startupLogs.String(), "unit-test.log") || strings.Contains(startupLogs.String(), "unit-test.json") {
+		t.Fatalf("test log directory notice listed individual files:\n%s", startupLogs.String())
+	}
 
 	output, err = b.prepareTestOutput(testOutputFlags{
 		logDir:        "artifacts/test-logs",
@@ -60,6 +74,9 @@ func TestPrepareTestOutput(t *testing.T) {
 	expectedJSONPath = filepath.Join(rootDir, "artifacts", "test-logs", "go-test.json")
 	if output.jsonLogPath != expectedJSONPath {
 		t.Fatalf("expected overridden JSON log path %q, got %q", expectedJSONPath, output.jsonLogPath)
+	}
+	if got := strings.Count(startupLogs.String(), "Writing full test logs to"); got != 2 {
+		t.Fatalf("expected one test log directory notice per preparation, got %d:\n%s", got, startupLogs.String())
 	}
 
 	_, err = b.prepareTestOutput(testOutputFlags{
@@ -251,12 +268,19 @@ func TestRunTestCmdFailureOutput(t *testing.T) {
 		`go run . unit-test -run "^TestFailed$"`,
 		"--- Go test output ---",
 		"--- Complete logs ---",
+		"--- Rerun failed tests ---",
 		"Go test JSON:",
 		"Combined Go and dev server:",
 	} {
 		if !strings.Contains(stderr.String(), want) {
 			t.Fatalf("failure report missing %q:\n%s", want, stderr.String())
 		}
+	}
+	report := stderr.String()
+	if goOutput, completeLogs, rerun := strings.Index(report, "--- Go test output ---"),
+		strings.Index(report, "--- Complete logs ---"),
+		strings.Index(report, "--- Rerun failed tests ---"); goOutput < 0 || completeLogs <= goOutput || rerun <= completeLogs {
+		t.Fatalf("failure report sections are out of order:\n%s", report)
 	}
 	if strings.Contains(stderr.String(), "--- Failed tests ---") {
 		t.Fatalf("failure report contains redundant failed-tests heading:\n%s", stderr.String())
@@ -532,6 +556,7 @@ func TestWriteStructuredTestFailureReportIncludesArtifactAndServerContext(t *tes
 		"::group::Go test output",
 		"::group::Related dev server output",
 		"::group::Complete logs",
+		"::group::Rerun failed tests",
 		"Lines mentioning the failed test",
 		`msg="server boom"`,
 		"Combined Go and dev server:",
@@ -550,6 +575,11 @@ func TestWriteStructuredTestFailureReportIncludesArtifactAndServerContext(t *tes
 	}
 	if starts, ends := strings.Count(report.String(), "::group::"), strings.Count(report.String(), "::endgroup::"); starts != ends {
 		t.Fatalf("failure report has %d group starts and %d group ends:\n%s", starts, ends, report.String())
+	}
+	if serverOutput, completeLogs, rerun := strings.Index(report.String(), "::group::Related dev server output"),
+		strings.Index(report.String(), "::group::Complete logs"),
+		strings.Index(report.String(), "::group::Rerun failed tests"); serverOutput < 0 || completeLogs <= serverOutput || rerun <= completeLogs {
+		t.Fatalf("failure report sections are out of order:\n%s", report.String())
 	}
 }
 
@@ -643,7 +673,11 @@ func TestRenderTestFailureSummaryEscapesHTML(t *testing.T) {
 
 func TestCollapseParentFailureRowsUsesPackage(t *testing.T) {
 	input := []testFailureSummaryRow{
-		{Package: "example.com/a", Test: "TestSuite", Details: "suite details"},
+		{
+			Package: "example.com/a",
+			Test:    "TestSuite",
+			Details: "=== RUN   TestSuite\nsuite details\n--- FAIL: TestSuite (1.00s)\n",
+		},
 		{Package: "example.com/a", Test: "TestSuite/TestSub", Details: "subtest details"},
 		{Package: "example.com/a", Test: "TestSuite/TestSub/TestNested", Details: "nested details"},
 		{Package: "example.com/b", Test: "TestSuite", Details: "other package details"},
@@ -662,6 +696,11 @@ func TestCollapseParentFailureRowsUsesPackage(t *testing.T) {
 	for _, want := range []string{"suite details", "subtest details", "nested details"} {
 		if !strings.Contains(rows[0].Details, want) {
 			t.Fatalf("collapsed nested failure missing %q: %q", want, rows[0].Details)
+		}
+	}
+	for _, unwanted := range []string{"=== RUN   TestSuite", "--- FAIL: TestSuite"} {
+		if strings.Contains(rows[0].Details, unwanted) {
+			t.Fatalf("collapsed nested failure retained parent harness output %q: %q", unwanted, rows[0].Details)
 		}
 	}
 	if rows[1].Details != "other package details" {

--- a/internal/cmd/build/main_test.go
+++ b/internal/cmd/build/main_test.go
@@ -181,12 +181,22 @@ func TestGoTestJSONWriterAttributesFailedSubtestOutput(t *testing.T) {
 	if decoded.String() != "    suite_test.go:42: boom\n    Error: intentional parent-attributed failure\n" {
 		t.Fatalf("unexpected decoded output: %q", decoded.String())
 	}
+	collapsed := collapseParentFailureRows(rows)
+	if len(collapsed) != 1 || collapsed[0].Test != "TestSuite/TestFailed" {
+		t.Fatalf("expected one collapsed child failure, got %#v", collapsed)
+	}
+	for _, want := range []string{"intentional parent-attributed failure", "suite_test.go:42: boom"} {
+		if !strings.Contains(collapsed[0].Details, want) {
+			t.Fatalf("collapsed child failure missing %q: %q", want, collapsed[0].Details)
+		}
+	}
 }
 
 func TestRunTestCmdFailureOutput(t *testing.T) {
 	rootDir := t.TempDir()
 	summaryPath := filepath.Join(rootDir, "summary.md")
 	t.Setenv("GITHUB_STEP_SUMMARY", summaryPath)
+	t.Setenv("GITHUB_ACTIONS", "false")
 	b := &builder{rootDir: rootDir}
 	output, err := b.prepareTestOutput(testOutputFlags{
 		logDir:        defaultTestLogDir,
@@ -235,15 +245,21 @@ func TestRunTestCmdFailureOutput(t *testing.T) {
 		t.Fatalf("expected stdout to be suppressed, got:\n%s", stdout.String())
 	}
 	for _, want := range []string{
+		"============================== TEST FAILURE REPORT ==============================",
 		"Failed tests (1)",
 		"example.com/pkg / TestFailed",
 		`go run . unit-test -run "^TestFailed$"`,
+		"--- Go test output ---",
+		"--- Complete logs ---",
 		"Go test JSON:",
 		"Combined Go and dev server:",
 	} {
 		if !strings.Contains(stderr.String(), want) {
 			t.Fatalf("failure report missing %q:\n%s", want, stderr.String())
 		}
+	}
+	if strings.Contains(stderr.String(), "--- Failed tests ---") {
+		t.Fatalf("failure report contains redundant failed-tests heading:\n%s", stderr.String())
 	}
 	jsonData, err := os.ReadFile(output.jsonLogPath)
 	if err != nil {
@@ -350,6 +366,7 @@ func TestRunTestCmdFullOutput(t *testing.T) {
 }
 
 func TestWriteStructuredTestFailureReportFallsBackToCommandOutput(t *testing.T) {
+	t.Setenv("GITHUB_ACTIONS", "false")
 	var output bytes.Buffer
 	err := writeStructuredTestFailureReport(
 		&output,
@@ -364,8 +381,10 @@ func TestWriteStructuredTestFailureReportFallsBackToCommandOutput(t *testing.T) 
 		t.Fatal(err)
 	}
 	for _, want := range []string{
+		"--- Command output ---",
 		"No individual failed test was identified",
 		"./main.go:10: undefined: missing",
+		"--- Complete logs ---",
 		".build/test-logs/unit-test.log",
 	} {
 		if !strings.Contains(output.String(), want) {
@@ -375,6 +394,7 @@ func TestWriteStructuredTestFailureReportFallsBackToCommandOutput(t *testing.T) 
 }
 
 func TestWriteStructuredTestFailureReportListsAllFailuresWhenDetailsAreOmitted(t *testing.T) {
+	t.Setenv("GITHUB_ACTIONS", "false")
 	var rows []testFailureSummaryRow
 	for i := 1; i <= 6; i++ {
 		rows = append(rows, testFailureSummaryRow{
@@ -398,13 +418,13 @@ func TestWriteStructuredTestFailureReportListsAllFailuresWhenDetailsAreOmitted(t
 		t.Fatal(err)
 	}
 	for i := 1; i <= 6; i++ {
-		want := fmt.Sprintf("- example.com/pkg / TestFailed%d", i)
+		want := fmt.Sprintf("\texample.com/pkg / TestFailed%d", i)
 		if !strings.Contains(snippets.String(), want) {
 			t.Fatalf("failure list missing %q", want)
 		}
 	}
 	for _, want := range []string{
-		"Failed Go test output (up to 16 KiB per test and 64 KiB total)",
+		"--- Go test output ---",
 		"... (truncated; see full test log) ...",
 		"omitted Go output for 2 additional failed tests after reaching the 64 KiB total console limit",
 	} {
@@ -469,6 +489,7 @@ func TestWriteStructuredTestFailureReportIncludesArtifactAndServerContext(t *tes
 	t.Setenv("TEST_LOG_ARTIFACT_NAME", "integ-test-ubuntu-latest-stable")
 	t.Setenv("GITHUB_RUN_ID", "12345")
 	t.Setenv("GITHUB_REPOSITORY", "temporalio/sdk-go")
+	t.Setenv("GITHUB_ACTIONS", "true")
 	var report bytes.Buffer
 	err := writeStructuredTestFailureReport(
 		&report,
@@ -502,11 +523,15 @@ func TestWriteStructuredTestFailureReportIncludesArtifactAndServerContext(t *tes
 	}
 	for _, want := range []string{
 		"TEST FAILURE REPORT",
-		"example.com/pkg / TestSuite",
+		"Failed tests (1)",
 		"example.com/pkg / TestSuite/TestFailed",
 		"parent-attributed failure",
 		`go run . integration-test -dev-server -run "^TestSuite/TestFailed$"`,
 		"suite_test.go:42: boom",
+		"::group::Failed tests",
+		"::group::Go test output",
+		"::group::Related dev server output",
+		"::group::Complete logs",
 		"Lines mentioning the failed test",
 		`msg="server boom"`,
 		"Combined Go and dev server:",
@@ -519,6 +544,12 @@ func TestWriteStructuredTestFailureReportIncludesArtifactAndServerContext(t *tes
 	}
 	if unexpected := `go run . integration-test -dev-server -run "^TestSuite$"`; strings.Contains(report.String(), unexpected) {
 		t.Fatalf("failure report included parent rerun command %q:\n%s", unexpected, report.String())
+	}
+	if unexpected := "--- example.com/pkg / TestSuite ---"; strings.Contains(report.String(), unexpected) {
+		t.Fatalf("failure report included parent failure section %q:\n%s", unexpected, report.String())
+	}
+	if starts, ends := strings.Count(report.String(), "::group::"), strings.Count(report.String(), "::endgroup::"); starts != ends {
+		t.Fatalf("failure report has %d group starts and %d group ends:\n%s", starts, ends, report.String())
 	}
 }
 
@@ -610,14 +641,14 @@ func TestRenderTestFailureSummaryEscapesHTML(t *testing.T) {
 	}
 }
 
-func TestFilterParentFailureRowsUsesPackage(t *testing.T) {
+func TestCollapseParentFailureRowsUsesPackage(t *testing.T) {
 	input := []testFailureSummaryRow{
-		{Package: "example.com/a", Test: "TestSuite"},
-		{Package: "example.com/a", Test: "TestSuite/TestSub"},
-		{Package: "example.com/a", Test: "TestSuite/TestSub/TestNested"},
-		{Package: "example.com/b", Test: "TestSuite"},
+		{Package: "example.com/a", Test: "TestSuite", Details: "suite details"},
+		{Package: "example.com/a", Test: "TestSuite/TestSub", Details: "subtest details"},
+		{Package: "example.com/a", Test: "TestSuite/TestSub/TestNested", Details: "nested details"},
+		{Package: "example.com/b", Test: "TestSuite", Details: "other package details"},
 	}
-	rows := filterParentFailureRows(input)
+	rows := collapseParentFailureRows(input)
 
 	if len(rows) != 2 {
 		t.Fatalf("expected 2 rows, got %d: %#v", len(rows), rows)
@@ -628,7 +659,32 @@ func TestFilterParentFailureRowsUsesPackage(t *testing.T) {
 	if rows[1].Package != "example.com/b" || rows[1].Test != "TestSuite" {
 		t.Fatalf("expected package b parent row to be preserved, got %#v", rows[1])
 	}
+	for _, want := range []string{"suite details", "subtest details", "nested details"} {
+		if !strings.Contains(rows[0].Details, want) {
+			t.Fatalf("collapsed nested failure missing %q: %q", want, rows[0].Details)
+		}
+	}
+	if rows[1].Details != "other package details" {
+		t.Fatalf("unexpected package b details: %q", rows[1].Details)
+	}
 	if input[0].Test != "TestSuite" {
 		t.Fatalf("filter mutated its input: %#v", input)
+	}
+}
+
+func TestCollapseParentFailureRowsPreservesAmbiguousParentOutput(t *testing.T) {
+	rows := collapseParentFailureRows([]testFailureSummaryRow{
+		{Package: "example.com/pkg", Test: "TestSuite", Details: "suite details"},
+		{Package: "example.com/pkg", Test: "TestSuite/TestOne", Details: "first details"},
+		{Package: "example.com/pkg", Test: "TestSuite/TestTwo", Details: "second details"},
+	})
+
+	if len(rows) != 3 {
+		t.Fatalf("expected ambiguous parent output to be preserved, got %#v", rows)
+	}
+	for _, row := range rows[1:] {
+		if strings.Contains(row.Details, "suite details") {
+			t.Fatalf("ambiguous parent output was copied to %q: %q", row.Test, row.Details)
+		}
 	}
 }

--- a/internal/cmd/build/main_test.go
+++ b/internal/cmd/build/main_test.go
@@ -1,11 +1,212 @@
 package main
 
 import (
+	"bytes"
+	"flag"
+	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 )
+
+func TestTestOutputFlagsDefaultToFailures(t *testing.T) {
+	flags := addTestOutputFlags(flag.NewFlagSet("test", flag.ContinueOnError))
+	if flags.consoleOutput != testConsoleOutputFailures {
+		t.Fatalf("expected default console output %q, got %q", testConsoleOutputFailures, flags.consoleOutput)
+	}
+}
+
+func TestPrepareTestOutput(t *testing.T) {
+	rootDir := t.TempDir()
+	b := &builder{rootDir: rootDir}
+
+	output, err := b.prepareTestOutput(testOutputFlags{
+		logDir:        defaultTestLogDir,
+		consoleOutput: testConsoleOutputFailures,
+	}, "unit-test.log")
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedPath := filepath.Join(rootDir, ".build", "test-logs", "unit-test.log")
+	if output.logPath != expectedPath {
+		t.Fatalf("expected log path %q, got %q", expectedPath, output.logPath)
+	}
+	if _, err := os.Stat(expectedPath); err != nil {
+		t.Fatalf("expected prepared log file: %v", err)
+	}
+
+	output, err = b.prepareTestOutput(testOutputFlags{
+		logDir:        "artifacts/test-logs",
+		consoleOutput: testConsoleOutputFull,
+	}, "integration-test.log")
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedPath = filepath.Join(rootDir, "artifacts", "test-logs", "integration-test.log")
+	if output.logPath != expectedPath {
+		t.Fatalf("expected overridden log path %q, got %q", expectedPath, output.logPath)
+	}
+
+	_, err = b.prepareTestOutput(testOutputFlags{
+		logDir:        defaultTestLogDir,
+		consoleOutput: "invalid",
+	}, "unit-test.log")
+	if err == nil || !strings.Contains(err.Error(), `must be "full" or "failures"`) {
+		t.Fatalf("expected invalid console output error, got %v", err)
+	}
+}
+
+func TestRunTestCmdFailureOutput(t *testing.T) {
+	rootDir := t.TempDir()
+	b := &builder{rootDir: rootDir}
+	output, err := b.prepareTestOutput(testOutputFlags{
+		logDir:        defaultTestLogDir,
+		consoleOutput: testConsoleOutputFailures,
+	}, "unit-test.log")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	output.stdout = &stdout
+	output.stderr = &stderr
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestRunTestCmdHelperProcess$")
+	cmd.Env = append(os.Environ(), "TEMPORAL_RUN_TEST_CMD_HELPER=fail")
+	if err := b.runTestCmd(cmd, output); err == nil {
+		t.Fatal("expected command to fail")
+	}
+
+	logData, err := os.ReadFile(output.logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"=== RUN   TestFailed", "main_test.go:10: boom"} {
+		if !strings.Contains(string(logData), want) {
+			t.Fatalf("full log missing %q:\n%s", want, logData)
+		}
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("failure output missing %q:\n%s", want, stderr.String())
+		}
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("expected stdout to be suppressed, got:\n%s", stdout.String())
+	}
+}
+
+func TestRunTestCmdFullOutput(t *testing.T) {
+	rootDir := t.TempDir()
+	b := &builder{rootDir: rootDir}
+	output, err := b.prepareTestOutput(testOutputFlags{
+		logDir:        defaultTestLogDir,
+		consoleOutput: testConsoleOutputFull,
+	}, "unit-test.log")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	output.stdout = &stdout
+	output.stderr = &stderr
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestRunTestCmdHelperProcess$")
+	cmd.Env = append(os.Environ(), "TEMPORAL_RUN_TEST_CMD_HELPER=pass")
+	if err := b.runTestCmd(cmd, output); err != nil {
+		t.Fatal(err)
+	}
+
+	logData, err := os.ReadFile(output.logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"stdout output", "stderr output"} {
+		if !strings.Contains(string(logData), want) {
+			t.Fatalf("full log missing %q:\n%s", want, logData)
+		}
+	}
+	if !strings.Contains(stdout.String(), "stdout output") {
+		t.Fatalf("stdout output was not streamed:\n%s", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "stderr output") {
+		t.Fatalf("stderr output was not streamed:\n%s", stderr.String())
+	}
+}
+
+func TestWriteTestFailureSnippetsFallsBackToCommandOutput(t *testing.T) {
+	var output bytes.Buffer
+	err := writeTestFailureSnippets(
+		&output,
+		"# example.com/pkg\n./main.go:10: undefined: missing\nFAIL\n",
+		".build/test-logs/unit-test.log",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"No individual failed test was identified",
+		"./main.go:10: undefined: missing",
+		".build/test-logs/unit-test.log",
+	} {
+		if !strings.Contains(output.String(), want) {
+			t.Fatalf("fallback output missing %q:\n%s", want, output.String())
+		}
+	}
+}
+
+func TestWriteTestFailureSnippetsListsAllFailuresWhenDetailsAreOmitted(t *testing.T) {
+	var testOutput strings.Builder
+	for i := 1; i <= 6; i++ {
+		fmt.Fprintf(&testOutput, "=== RUN   TestFailed%d\n", i)
+		testOutput.WriteString(strings.Repeat("x", 20*1024))
+		fmt.Fprintf(&testOutput, "\n--- FAIL: TestFailed%d (0.00s)\n", i)
+	}
+	testOutput.WriteString("FAIL\nFAIL\texample.com/pkg\t0.001s\n")
+
+	var snippets bytes.Buffer
+	err := writeTestFailureSnippets(
+		&snippets,
+		testOutput.String(),
+		".build/test-logs/unit-test.log",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 1; i <= 6; i++ {
+		want := fmt.Sprintf("- example.com/pkg / TestFailed%d", i)
+		if !strings.Contains(snippets.String(), want) {
+			t.Fatalf("failure list missing %q", want)
+		}
+	}
+	for _, want := range []string{
+		"Failure details (up to 16 KiB per test and 64 KiB total)",
+		"... (truncated; see full test log) ...",
+		"omitted details for 2 additional failed tests after reaching the 64 KiB total console limit",
+		"all failed tests are listed above",
+	} {
+		if !strings.Contains(snippets.String(), want) {
+			t.Fatalf("failure output missing %q:\n%s", want, snippets.String())
+		}
+	}
+}
+
+func TestRunTestCmdHelperProcess(t *testing.T) {
+	switch os.Getenv("TEMPORAL_RUN_TEST_CMD_HELPER") {
+	case "":
+		return
+	case "pass":
+		fmt.Fprintln(os.Stdout, "stdout output")
+		fmt.Fprintln(os.Stderr, "stderr output")
+	case "fail":
+		fmt.Fprintln(os.Stdout, "=== RUN   TestFailed")
+		fmt.Fprintln(os.Stdout, "--- FAIL: TestFailed (0.00s)")
+		fmt.Fprintln(os.Stdout, "    main_test.go:10: boom")
+		fmt.Fprintln(os.Stdout, "FAIL")
+		fmt.Fprintln(os.Stdout, "FAIL\texample.com/pkg\t0.001s")
+		os.Exit(1)
+	default:
+		t.Fatalf("unexpected helper mode")
+	}
+}
 
 func TestParseTestFailures(t *testing.T) {
 	output := strings.Join([]string{

--- a/internal/cmd/build/main_test.go
+++ b/internal/cmd/build/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
@@ -9,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestTestOutputFlagsDefaultToFailures(t *testing.T) {
@@ -36,17 +38,28 @@ func TestPrepareTestOutput(t *testing.T) {
 	if _, err := os.Stat(expectedPath); err != nil {
 		t.Fatalf("expected prepared log file: %v", err)
 	}
+	expectedJSONPath := filepath.Join(rootDir, ".build", "test-logs", "unit-test.json")
+	if output.jsonLogPath != expectedJSONPath {
+		t.Fatalf("expected JSON log path %q, got %q", expectedJSONPath, output.jsonLogPath)
+	}
+	if _, err := os.Stat(expectedJSONPath); err != nil {
+		t.Fatalf("expected prepared JSON log file: %v", err)
+	}
 
 	output, err = b.prepareTestOutput(testOutputFlags{
 		logDir:        "artifacts/test-logs",
 		consoleOutput: testConsoleOutputFull,
-	}, "integration-test.log")
+	}, "go-test.log")
 	if err != nil {
 		t.Fatal(err)
 	}
-	expectedPath = filepath.Join(rootDir, "artifacts", "test-logs", "integration-test.log")
+	expectedPath = filepath.Join(rootDir, "artifacts", "test-logs", "go-test.log")
 	if output.logPath != expectedPath {
 		t.Fatalf("expected overridden log path %q, got %q", expectedPath, output.logPath)
+	}
+	expectedJSONPath = filepath.Join(rootDir, "artifacts", "test-logs", "go-test.json")
+	if output.jsonLogPath != expectedJSONPath {
+		t.Fatalf("expected overridden JSON log path %q, got %q", expectedJSONPath, output.jsonLogPath)
 	}
 
 	_, err = b.prepareTestOutput(testOutputFlags{
@@ -55,6 +68,118 @@ func TestPrepareTestOutput(t *testing.T) {
 	}, "unit-test.log")
 	if err == nil || !strings.Contains(err.Error(), `must be "full" or "failures"`) {
 		t.Fatalf("expected invalid console output error, got %v", err)
+	}
+}
+
+func TestTestOutputWriters(t *testing.T) {
+	for _, mode := range []string{testConsoleOutputFailures, testConsoleOutputFull} {
+		t.Run(mode, func(t *testing.T) {
+			var logOutput, stdout, stderr bytes.Buffer
+			output := testOutput{
+				consoleOutput: mode,
+				stdout:        &stdout,
+				stderr:        &stderr,
+			}
+			stdoutWriter, stderrWriter := output.writers(&logOutput, nil)
+			fmt.Fprint(stdoutWriter, "server stdout")
+			fmt.Fprint(stderrWriter, "server stderr")
+
+			for _, want := range []string{"server stdout", "server stderr"} {
+				if !strings.Contains(logOutput.String(), want) {
+					t.Fatalf("log output missing %q:\n%s", want, logOutput.String())
+				}
+			}
+			if mode == testConsoleOutputFailures {
+				if stdout.Len() != 0 || stderr.Len() != 0 {
+					t.Fatalf("expected console output to be suppressed, got stdout %q and stderr %q", stdout.String(), stderr.String())
+				}
+			} else {
+				if !strings.Contains(stdout.String(), "server stdout") {
+					t.Fatalf("stdout was not streamed:\n%s", stdout.String())
+				}
+				if !strings.Contains(stderr.String(), "server stderr") {
+					t.Fatalf("stderr was not streamed:\n%s", stderr.String())
+				}
+			}
+		})
+	}
+}
+
+func TestGoTestJSONWriterAttributesFailedSubtestOutput(t *testing.T) {
+	start := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+	events := []goTestEvent{
+		{Time: start, Action: "run", Package: "example.com/pkg", Test: "TestSuite"},
+		{Time: start.Add(time.Second), Action: "run", Package: "example.com/pkg", Test: "TestSuite/TestFailed"},
+		{
+			Time:    start.Add(2 * time.Second),
+			Action:  "output",
+			Package: "example.com/pkg",
+			Test:    "TestSuite/TestFailed",
+			Output:  "    suite_test.go:42: boom\n",
+		},
+		{
+			Time:    start.Add(2 * time.Second),
+			Action:  "output",
+			Package: "example.com/pkg",
+			Test:    "TestSuite",
+			Output:  "    Error: intentional parent-attributed failure\n",
+		},
+		{
+			Time:    start.Add(3 * time.Second),
+			Action:  "fail",
+			Package: "example.com/pkg",
+			Test:    "TestSuite/TestFailed",
+		},
+		{Time: start.Add(4 * time.Second), Action: "fail", Package: "example.com/pkg", Test: "TestSuite"},
+	}
+	var encoded bytes.Buffer
+	for _, event := range events {
+		if err := json.NewEncoder(&encoded).Encode(event); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	var raw, decoded bytes.Buffer
+	results := newGoTestResults()
+	writer := &goTestJSONWriter{
+		rawWriter:    &raw,
+		outputWriter: &decoded,
+		results:      results,
+	}
+	data := encoded.Bytes()
+	split := len(data) / 2
+	if _, err := writer.Write(data[:split]); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := writer.Write(data[split:]); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Flush(); err != nil {
+		t.Fatal(err)
+	}
+
+	rows := results.failures()
+	if len(rows) != 2 {
+		t.Fatalf("expected parent and child failures, got %#v", rows)
+	}
+	if !strings.Contains(rows[0].Details, "intentional parent-attributed failure") {
+		t.Fatalf("parent-attributed failure output was not retained: %q", rows[0].Details)
+	}
+	row := rows[1]
+	if row.Test != "TestSuite/TestFailed" || row.Package != "example.com/pkg" {
+		t.Fatalf("unexpected failed test: %#v", row)
+	}
+	if !strings.Contains(row.Details, "suite_test.go:42: boom") {
+		t.Fatalf("failed test output was not attributed correctly: %q", row.Details)
+	}
+	if !row.StartTime.Equal(start.Add(time.Second)) || !row.EndTime.Equal(start.Add(3*time.Second)) {
+		t.Fatalf("unexpected test time window: %v to %v", row.StartTime, row.EndTime)
+	}
+	if raw.String() != encoded.String() {
+		t.Fatalf("raw JSON output changed:\n%s", raw.String())
+	}
+	if decoded.String() != "    suite_test.go:42: boom\n    Error: intentional parent-attributed failure\n" {
+		t.Fatalf("unexpected decoded output: %q", decoded.String())
 	}
 }
 
@@ -71,11 +196,25 @@ func TestRunTestCmdFailureOutput(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	output.stdout = &stdout
 	output.stderr = &stderr
+	output.rerunCommand = "go run . unit-test"
+	combinedPath, err := b.prepareLogPath(defaultTestLogDir, "combined.log")
+	if err != nil {
+		t.Fatal(err)
+	}
+	combinedFile, err := os.OpenFile(combinedPath, os.O_WRONLY|os.O_APPEND, 0666)
+	if err != nil {
+		t.Fatal(err)
+	}
+	output.combinedLogPath = combinedPath
+	output.combinedWriter = &lockedWriter{writer: combinedFile}
 
 	cmd := exec.Command(os.Args[0], "-test.run=^TestRunTestCmdHelperProcess$")
 	cmd.Env = append(os.Environ(), "TEMPORAL_RUN_TEST_CMD_HELPER=fail")
 	if err := b.runTestCmd(cmd, output); err == nil {
 		t.Fatal("expected command to fail")
+	}
+	if err := combinedFile.Close(); err != nil {
+		t.Fatal(err)
 	}
 
 	logData, err := os.ReadFile(output.logPath)
@@ -92,6 +231,31 @@ func TestRunTestCmdFailureOutput(t *testing.T) {
 	}
 	if stdout.Len() != 0 {
 		t.Fatalf("expected stdout to be suppressed, got:\n%s", stdout.String())
+	}
+	for _, want := range []string{
+		"Failed tests (1)",
+		"example.com/pkg / TestFailed",
+		`go run . unit-test -run "^TestFailed$"`,
+		"Go test JSON:",
+		"Combined Go and dev server:",
+	} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("failure report missing %q:\n%s", want, stderr.String())
+		}
+	}
+	jsonData, err := os.ReadFile(output.jsonLogPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(jsonData), `"Action":"fail"`) {
+		t.Fatalf("JSON log missing failure event:\n%s", jsonData)
+	}
+	combinedData, err := os.ReadFile(combinedPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(combinedData), "main_test.go:10: boom") {
+		t.Fatalf("combined log missing decoded test output:\n%s", combinedData)
 	}
 }
 
@@ -132,12 +296,16 @@ func TestRunTestCmdFullOutput(t *testing.T) {
 	}
 }
 
-func TestWriteTestFailureSnippetsFallsBackToCommandOutput(t *testing.T) {
+func TestWriteStructuredTestFailureReportFallsBackToCommandOutput(t *testing.T) {
 	var output bytes.Buffer
-	err := writeTestFailureSnippets(
+	err := writeStructuredTestFailureReport(
 		&output,
+		nil,
 		"# example.com/pkg\n./main.go:10: undefined: missing\nFAIL\n",
-		".build/test-logs/unit-test.log",
+		testOutput{
+			logPath:     ".build/test-logs/unit-test.log",
+			jsonLogPath: ".build/test-logs/unit-test.json",
+		},
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -153,20 +321,25 @@ func TestWriteTestFailureSnippetsFallsBackToCommandOutput(t *testing.T) {
 	}
 }
 
-func TestWriteTestFailureSnippetsListsAllFailuresWhenDetailsAreOmitted(t *testing.T) {
-	var testOutput strings.Builder
+func TestWriteStructuredTestFailureReportListsAllFailuresWhenDetailsAreOmitted(t *testing.T) {
+	var rows []testFailureSummaryRow
 	for i := 1; i <= 6; i++ {
-		fmt.Fprintf(&testOutput, "=== RUN   TestFailed%d\n", i)
-		testOutput.WriteString(strings.Repeat("x", 20*1024))
-		fmt.Fprintf(&testOutput, "\n--- FAIL: TestFailed%d (0.00s)\n", i)
+		rows = append(rows, testFailureSummaryRow{
+			Package: "example.com/pkg",
+			Test:    fmt.Sprintf("TestFailed%d", i),
+			Details: strings.Repeat("x", 20*1024),
+		})
 	}
-	testOutput.WriteString("FAIL\nFAIL\texample.com/pkg\t0.001s\n")
 
 	var snippets bytes.Buffer
-	err := writeTestFailureSnippets(
+	err := writeStructuredTestFailureReport(
 		&snippets,
-		testOutput.String(),
-		".build/test-logs/unit-test.log",
+		rows,
+		"",
+		testOutput{
+			logPath:     ".build/test-logs/unit-test.log",
+			jsonLogPath: ".build/test-logs/unit-test.json",
+		},
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -178,13 +351,116 @@ func TestWriteTestFailureSnippetsListsAllFailuresWhenDetailsAreOmitted(t *testin
 		}
 	}
 	for _, want := range []string{
-		"Failure details (up to 16 KiB per test and 64 KiB total)",
+		"Failed Go test output (up to 16 KiB per test and 64 KiB total)",
 		"... (truncated; see full test log) ...",
-		"omitted details for 2 additional failed tests after reaching the 64 KiB total console limit",
-		"all failed tests are listed above",
+		"omitted Go output for 2 additional failed tests after reaching the 64 KiB total console limit",
 	} {
 		if !strings.Contains(snippets.String(), want) {
 			t.Fatalf("failure output missing %q:\n%s", want, snippets.String())
+		}
+	}
+}
+
+func TestCollectServerFailureContexts(t *testing.T) {
+	start := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+	logPath := filepath.Join(t.TempDir(), "dev-server.log")
+	serverOutput := strings.Join([]string{
+		`time=2026-07-29T11:59:00Z level=ERROR msg="mentions test" queue=TestSuite/TestFailed`,
+		`time=2026-07-29T12:00:05Z level=WARN msg="inside test window"`,
+		`time=2026-07-29T12:00:06Z level=INFO msg="not a warning or error"`,
+		`time=2026-07-29T12:02:00Z level=ERROR msg="outside test window"`,
+		"",
+	}, "\n")
+	if err := os.WriteFile(logPath, []byte(serverOutput), 0666); err != nil {
+		t.Fatal(err)
+	}
+	row := testFailureSummaryRow{
+		Package:   "example.com/pkg",
+		Test:      "TestSuite/TestFailed",
+		StartTime: start,
+		EndTime:   start.Add(10 * time.Second),
+	}
+
+	contexts, err := collectServerFailureContexts(logPath, []testFailureSummaryRow{row})
+	if err != nil {
+		t.Fatal(err)
+	}
+	context := contexts[testFailureSummaryKey{Package: row.Package, Test: row.Test}]
+	if context == nil {
+		t.Fatal("expected server context")
+	}
+	if !strings.Contains(context.related.text.String(), "mentions test") {
+		t.Fatalf("expected directly related server line:\n%s", context.related.text.String())
+	}
+	if !strings.Contains(context.window.text.String(), "inside test window") {
+		t.Fatalf("expected time-window server line:\n%s", context.window.text.String())
+	}
+	for _, unexpected := range []string{"not a warning or error", "outside test window"} {
+		if strings.Contains(context.related.text.String()+context.window.text.String(), unexpected) {
+			t.Fatalf("unexpected server line %q was included", unexpected)
+		}
+	}
+}
+
+func TestWriteStructuredTestFailureReportIncludesArtifactAndServerContext(t *testing.T) {
+	start := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+	logDir := t.TempDir()
+	serverLogPath := filepath.Join(logDir, "dev-server.log")
+	if err := os.WriteFile(
+		serverLogPath,
+		[]byte(`time=2026-07-29T12:00:01Z level=ERROR msg="server boom" queue=TestSuite/TestFailed`+"\n"),
+		0666,
+	); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("TEST_LOG_ARTIFACT_NAME", "test-logs-integ-test-ubuntu-latest-stable")
+	t.Setenv("GITHUB_RUN_ID", "12345")
+	var report bytes.Buffer
+	err := writeStructuredTestFailureReport(
+		&report,
+		[]testFailureSummaryRow{
+			{
+				Package:   "example.com/pkg",
+				Test:      "TestSuite",
+				Details:   "    Error: parent-attributed failure\n",
+				StartTime: start,
+				EndTime:   start.Add(3 * time.Second),
+			},
+			{
+				Package:   "example.com/pkg",
+				Test:      "TestSuite/TestFailed",
+				Details:   "    suite_test.go:42: boom\n",
+				StartTime: start,
+				EndTime:   start.Add(2 * time.Second),
+			},
+		},
+		"",
+		testOutput{
+			logPath:         filepath.Join(logDir, "go-test.log"),
+			jsonLogPath:     filepath.Join(logDir, "go-test.json"),
+			combinedLogPath: filepath.Join(logDir, "combined.log"),
+			serverLogPath:   serverLogPath,
+			rerunCommand:    "go run . integration-test -dev-server",
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"TEST FAILURE REPORT",
+		"example.com/pkg / TestSuite",
+		"example.com/pkg / TestSuite/TestFailed",
+		"parent-attributed failure",
+		`go run . integration-test -dev-server -run "^TestSuite/TestFailed$"`,
+		"suite_test.go:42: boom",
+		"Lines mentioning the failed test",
+		`msg="server boom"`,
+		"Combined Go and dev server:",
+		"CI artifact: test-logs-integ-test-ubuntu-latest-stable",
+		"gh run download 12345 -n test-logs-integ-test-ubuntu-latest-stable -D .build/ci-debug",
+	} {
+		if !strings.Contains(report.String(), want) {
+			t.Fatalf("failure report missing %q:\n%s", want, report.String())
 		}
 	}
 }
@@ -194,64 +470,62 @@ func TestRunTestCmdHelperProcess(t *testing.T) {
 	case "":
 		return
 	case "pass":
-		fmt.Fprintln(os.Stdout, "stdout output")
+		writeGoTestEvent(goTestEvent{
+			Time:    time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC),
+			Action:  "output",
+			Package: "example.com/pkg",
+			Test:    "TestPassed",
+			Output:  "stdout output\n",
+		})
+		writeGoTestEvent(goTestEvent{
+			Time:    time.Date(2026, 7, 29, 12, 0, 1, 0, time.UTC),
+			Action:  "pass",
+			Package: "example.com/pkg",
+			Test:    "TestPassed",
+		})
 		fmt.Fprintln(os.Stderr, "stderr output")
 	case "fail":
-		fmt.Fprintln(os.Stdout, "=== RUN   TestFailed")
-		fmt.Fprintln(os.Stdout, "--- FAIL: TestFailed (0.00s)")
-		fmt.Fprintln(os.Stdout, "    main_test.go:10: boom")
-		fmt.Fprintln(os.Stdout, "FAIL")
-		fmt.Fprintln(os.Stdout, "FAIL\texample.com/pkg\t0.001s")
+		start := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+		writeGoTestEvent(goTestEvent{
+			Time:    start,
+			Action:  "run",
+			Package: "example.com/pkg",
+			Test:    "TestFailed",
+		})
+		for _, output := range []string{
+			"=== RUN   TestFailed\n",
+			"    main_test.go:10: boom\n",
+			"--- FAIL: TestFailed (0.00s)\n",
+		} {
+			writeGoTestEvent(goTestEvent{
+				Time:    start.Add(time.Second),
+				Action:  "output",
+				Package: "example.com/pkg",
+				Test:    "TestFailed",
+				Output:  output,
+			})
+		}
+		writeGoTestEvent(goTestEvent{
+			Time:    start.Add(2 * time.Second),
+			Action:  "fail",
+			Package: "example.com/pkg",
+			Test:    "TestFailed",
+		})
+		writeGoTestEvent(goTestEvent{
+			Time:    start.Add(2 * time.Second),
+			Action:  "output",
+			Package: "example.com/pkg",
+			Output:  "FAIL\nFAIL\texample.com/pkg\t0.001s\n",
+		})
 		os.Exit(1)
 	default:
 		t.Fatalf("unexpected helper mode")
 	}
 }
 
-func TestParseTestFailures(t *testing.T) {
-	output := strings.Join([]string{
-		"=== RUN   TestWorkflowSuite",
-		"=== RUN   TestWorkflowSuite/TestChildWorkflow",
-		"2026/05/28 19:18:39 INFO  Started Worker",
-		"    workflow_test.go:42: expected success",
-		"2026/05/28 19:18:50 INFO  Stopped Worker",
-		"--- FAIL: TestWorkflowSuite (0.01s)",
-		"    --- FAIL: TestWorkflowSuite/TestChildWorkflow (0.01s)",
-		"        workflow_test.go:42: expected success",
-		"=== RUN   TestWorkflowSuite/TestNextWorkflow",
-		"2026/05/28 19:19:01 INFO  Next test output",
-		"--- PASS: TestWorkflowSuite/TestNextWorkflow (0.01s)",
-		"FAIL",
-		"FAIL\tgo.temporal.io/sdk/internal\t0.123s",
-		"",
-	}, "\n")
-
-	rows := parseTestFailures(output)
-	if len(rows) != 1 {
-		t.Fatalf("expected 1 failure row, got %d: %#v", len(rows), rows)
-	}
-	for _, row := range rows {
-		if row.Package != "go.temporal.io/sdk/internal" {
-			t.Fatalf("expected package to be filled from FAIL line, got %#v", row)
-		}
-	}
-	if rows[0].Test != "TestWorkflowSuite/TestChildWorkflow" {
-		t.Fatalf("unexpected test: %q", rows[0].Test)
-	}
-	if !strings.Contains(rows[0].Details, "expected success") {
-		t.Fatalf("expected detail block to include failure message, got %q", rows[0].Details)
-	}
-	for _, want := range []string{
-		"=== RUN   TestWorkflowSuite/TestChildWorkflow",
-		"Started Worker",
-		"Stopped Worker",
-	} {
-		if !strings.Contains(rows[0].Details, want) {
-			t.Fatalf("expected detail block to include %q, got %q", want, rows[0].Details)
-		}
-	}
-	if strings.Contains(rows[0].Details, "Next test output") {
-		t.Fatalf("expected detail block to stop before next test, got %q", rows[0].Details)
+func writeGoTestEvent(event goTestEvent) {
+	if err := json.NewEncoder(os.Stdout).Encode(event); err != nil {
+		panic(err)
 	}
 }
 
@@ -299,13 +573,13 @@ func TestFilterParentFailureRowsUsesPackage(t *testing.T) {
 
 func TestAppendTestFailureSummary(t *testing.T) {
 	summaryPath := filepath.Join(t.TempDir(), "summary.md")
-	err := appendTestFailureSummary(summaryPath, strings.Join([]string{
-		"=== RUN   TestFailed",
-		"--- FAIL: TestFailed (0.00s)",
-		"    main_test.go:10: boom",
-		"FAIL",
-		"FAIL\texample.com/pkg\t0.001s",
-	}, "\n"))
+	err := appendTestFailureRows(summaryPath, []testFailureSummaryRow{
+		{
+			Package: "example.com/pkg",
+			Test:    "TestFailed",
+			Details: "    main_test.go:10: boom\n",
+		},
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cmd/build/main_test.go
+++ b/internal/cmd/build/main_test.go
@@ -413,7 +413,7 @@ func TestWriteStructuredTestFailureReportIncludesArtifactAndServerContext(t *tes
 	); err != nil {
 		t.Fatal(err)
 	}
-	t.Setenv("TEST_LOG_ARTIFACT_NAME", "test-logs-integ-test-ubuntu-latest-stable")
+	t.Setenv("TEST_LOG_ARTIFACT_NAME", "integ-test-ubuntu-latest-stable")
 	t.Setenv("GITHUB_RUN_ID", "12345")
 	var report bytes.Buffer
 	err := writeStructuredTestFailureReport(
@@ -456,8 +456,8 @@ func TestWriteStructuredTestFailureReportIncludesArtifactAndServerContext(t *tes
 		"Lines mentioning the failed test",
 		`msg="server boom"`,
 		"Combined Go and dev server:",
-		"CI artifact: test-logs-integ-test-ubuntu-latest-stable",
-		"gh run download 12345 -n test-logs-integ-test-ubuntu-latest-stable -D .build/ci-debug",
+		"CI artifact: integ-test-ubuntu-latest-stable",
+		"gh run download 12345 -n integ-test-ubuntu-latest-stable -D .build/ci-debug",
 	} {
 		if !strings.Contains(report.String(), want) {
 			t.Fatalf("failure report missing %q:\n%s", want, report.String())
@@ -529,30 +529,6 @@ func writeGoTestEvent(event goTestEvent) {
 	}
 }
 
-func TestRenderTestFailureSummaryEscapesHTML(t *testing.T) {
-	summary := renderTestFailureSummary([]testFailureSummaryRow{
-		{
-			Test:    "Test<Bad>",
-			Package: "go.temporal.io/sdk/test",
-			Details: "got <value> & failed",
-		},
-	})
-
-	for _, want := range []string{
-		"## Test failures",
-		"<table>",
-		"go.temporal.io/sdk/test / Test&lt;Bad&gt;",
-		"got &lt;value&gt; &amp; failed",
-	} {
-		if !strings.Contains(summary, want) {
-			t.Fatalf("summary missing %q:\n%s", want, summary)
-		}
-	}
-	if strings.Contains(summary, "Working directory") {
-		t.Fatalf("summary should not include working directory:\n%s", summary)
-	}
-}
-
 func TestFilterParentFailureRowsUsesPackage(t *testing.T) {
 	rows := filterParentFailureRows([]testFailureSummaryRow{
 		{Package: "example.com/a", Test: "TestSuite"},
@@ -568,26 +544,5 @@ func TestFilterParentFailureRowsUsesPackage(t *testing.T) {
 	}
 	if rows[1].Package != "example.com/b" || rows[1].Test != "TestSuite" {
 		t.Fatalf("expected package b parent row to be preserved, got %#v", rows[1])
-	}
-}
-
-func TestAppendTestFailureSummary(t *testing.T) {
-	summaryPath := filepath.Join(t.TempDir(), "summary.md")
-	err := appendTestFailureRows(summaryPath, []testFailureSummaryRow{
-		{
-			Package: "example.com/pkg",
-			Test:    "TestFailed",
-			Details: "    main_test.go:10: boom\n",
-		},
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	data, err := os.ReadFile(summaryPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !strings.Contains(string(data), "example.com/pkg / TestFailed") {
-		t.Fatalf("summary not written correctly:\n%s", string(data))
 	}
 }

--- a/internal/cmd/build/main_test.go
+++ b/internal/cmd/build/main_test.go
@@ -185,6 +185,8 @@ func TestGoTestJSONWriterAttributesFailedSubtestOutput(t *testing.T) {
 
 func TestRunTestCmdFailureOutput(t *testing.T) {
 	rootDir := t.TempDir()
+	summaryPath := filepath.Join(rootDir, "summary.md")
+	t.Setenv("GITHUB_STEP_SUMMARY", summaryPath)
 	b := &builder{rootDir: rootDir}
 	output, err := b.prepareTestOutput(testOutputFlags{
 		logDir:        defaultTestLogDir,
@@ -256,6 +258,57 @@ func TestRunTestCmdFailureOutput(t *testing.T) {
 	}
 	if !strings.Contains(string(combinedData), "main_test.go:10: boom") {
 		t.Fatalf("combined log missing decoded test output:\n%s", combinedData)
+	}
+	summaryData, err := os.ReadFile(summaryPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"## Test failures", "example.com/pkg / TestFailed", "main_test.go:10: boom"} {
+		if !strings.Contains(string(summaryData), want) {
+			t.Fatalf("test summary missing %q:\n%s", want, summaryData)
+		}
+	}
+}
+
+func TestRunTestCmdPassingOutput(t *testing.T) {
+	rootDir := t.TempDir()
+	summaryPath := filepath.Join(rootDir, "summary.md")
+	t.Setenv("GITHUB_STEP_SUMMARY", summaryPath)
+	b := &builder{rootDir: rootDir}
+	output, err := b.prepareTestOutput(testOutputFlags{
+		logDir:        defaultTestLogDir,
+		consoleOutput: testConsoleOutputFailures,
+	}, "unit-test.log")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	output.stdout = &stdout
+	output.stderr = &stderr
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestRunTestCmdHelperProcess$")
+	cmd.Env = append(os.Environ(), "TEMPORAL_RUN_TEST_CMD_HELPER=pass")
+	if err := b.runTestCmd(cmd, output); err != nil {
+		t.Fatal(err)
+	}
+
+	if stdout.Len() != 0 {
+		t.Fatalf("expected stdout to be suppressed, got:\n%s", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected stderr to be suppressed, got:\n%s", stderr.String())
+	}
+	logData, err := os.ReadFile(output.logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"stdout output", "stderr output"} {
+		if !strings.Contains(string(logData), want) {
+			t.Fatalf("full log missing %q:\n%s", want, logData)
+		}
+	}
+	if _, err := os.Stat(summaryPath); !os.IsNotExist(err) {
+		t.Fatalf("passing test unexpectedly wrote a job summary: %v", err)
 	}
 }
 
@@ -526,6 +579,30 @@ func TestRunTestCmdHelperProcess(t *testing.T) {
 func writeGoTestEvent(event goTestEvent) {
 	if err := json.NewEncoder(os.Stdout).Encode(event); err != nil {
 		panic(err)
+	}
+}
+
+func TestRenderTestFailureSummaryEscapesHTML(t *testing.T) {
+	summary := renderTestFailureSummary([]testFailureSummaryRow{
+		{
+			Test:    "Test<Bad>",
+			Package: "go.temporal.io/sdk/test",
+			Details: "got <value> & failed",
+		},
+	})
+
+	for _, want := range []string{
+		"## Test failures",
+		"<table>",
+		"go.temporal.io/sdk/test / Test&lt;Bad&gt;",
+		"got &lt;value&gt; &amp; failed",
+	} {
+		if !strings.Contains(summary, want) {
+			t.Fatalf("summary missing %q:\n%s", want, summary)
+		}
+	}
+	if strings.Contains(summary, "Working directory") {
+		t.Fatalf("summary should not include working directory:\n%s", summary)
 	}
 }
 

--- a/internal/cmd/build/main_test.go
+++ b/internal/cmd/build/main_test.go
@@ -458,6 +458,44 @@ func TestWriteStructuredTestFailureReportListsAllFailuresWhenDetailsAreOmitted(t
 	}
 }
 
+func TestWriteTestSetupFailureReportIncludesDevServerOutputAndLogLocations(t *testing.T) {
+	t.Setenv("GITHUB_ACTIONS", "false")
+	logDir := t.TempDir()
+	serverLogPath := filepath.Join(logDir, "dev-server.log")
+	if err := os.WriteFile(serverLogPath, []byte("server stdout\nserver stderr\nclient logger output\n"), 0666); err != nil {
+		t.Fatal(err)
+	}
+	output := testOutput{
+		logPath:         filepath.Join(logDir, "go-test.log"),
+		jsonLogPath:     filepath.Join(logDir, "go-test.json"),
+		combinedLogPath: filepath.Join(logDir, "combined.log"),
+		serverLogPath:   serverLogPath,
+		rerunCommand:    "go run . integration-test -dev-server",
+	}
+	var report bytes.Buffer
+	if err := writeTestSetupFailureReport(&report, fmt.Errorf("failed starting dev server: exit status 1"), output); err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"TEST FAILURE REPORT",
+		"Integration test setup failed before Go tests ran: failed starting dev server: exit status 1",
+		"Captured dev server output:",
+		"server stdout",
+		"server stderr",
+		"client logger output",
+		"--- Complete logs ---",
+		"Combined Go and dev server: " + output.combinedLogPath,
+		"Dev server: " + output.serverLogPath,
+	} {
+		if !strings.Contains(report.String(), want) {
+			t.Fatalf("test setup failure report missing %q:\n%s", want, report.String())
+		}
+	}
+	if strings.Contains(report.String(), "Rerun failed tests") {
+		t.Fatalf("test setup failure report offered a test rerun even though no test ran:\n%s", report.String())
+	}
+}
+
 func TestCollectServerFailureContexts(t *testing.T) {
 	start := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
 	logPath := filepath.Join(t.TempDir(), "dev-server.log")

--- a/internal/cmd/build/test_output.go
+++ b/internal/cmd/build/test_output.go
@@ -240,7 +240,7 @@ func writeStructuredTestFailureReport(
 	}
 	if output.rerunCommand != "" {
 		sb.WriteString("\nRerun from internal/cmd/build:\n")
-		for _, row := range rows {
+		for _, row := range filterParentFailureRows(rows) {
 			testPattern := "^" + regexp.QuoteMeta(row.Test) + "$"
 			fmt.Fprintf(&sb, "- %s -run %s\n", output.rerunCommand, strconv.Quote(testPattern))
 		}
@@ -304,9 +304,13 @@ func writeCompleteTestLogLocations(sb *strings.Builder, output testOutput) {
 	if artifactName := strings.TrimSpace(os.Getenv("TEST_LOG_ARTIFACT_NAME")); artifactName != "" {
 		fmt.Fprintf(sb, "- CI artifact: %s\n", artifactName)
 		if runID := strings.TrimSpace(os.Getenv("GITHUB_RUN_ID")); runID != "" {
-			command := formatShellCommand([]string{
+			args := []string{
 				"gh", "run", "download", runID, "-n", artifactName, "-D", ".build/ci-debug",
-			})
+			}
+			if repository := strings.TrimSpace(os.Getenv("GITHUB_REPOSITORY")); repository != "" {
+				args = append(args, "--repo", repository)
+			}
+			command := formatShellCommand(args)
 			fmt.Fprintf(sb, "- Download: %s\n", command)
 		}
 	}
@@ -548,11 +552,16 @@ func appendTestFailureRows(summaryPath string, rows []testFailureSummaryRow) err
 func filterParentFailureRows(rows []testFailureSummaryRow) []testFailureSummaryRow {
 	hasFailedSubtest := make(map[testFailureSummaryKey]bool, len(rows))
 	for _, row := range rows {
-		if parent, _, ok := strings.Cut(row.Test, "/"); ok {
+		for parent := row.Test; ; {
+			slash := strings.LastIndexByte(parent, '/')
+			if slash < 0 {
+				break
+			}
+			parent = parent[:slash]
 			hasFailedSubtest[testFailureSummaryKey{Package: row.Package, Test: parent}] = true
 		}
 	}
-	filtered := rows[:0]
+	filtered := make([]testFailureSummaryRow, 0, len(rows))
 	for _, row := range rows {
 		if !hasFailedSubtest[testFailureSummaryKey{Package: row.Package, Test: row.Test}] {
 			filtered = append(filtered, row)

--- a/internal/cmd/build/test_output.go
+++ b/internal/cmd/build/test_output.go
@@ -283,6 +283,24 @@ func writeStructuredTestFailureReport(
 	return writeString(w, sb.String())
 }
 
+func writeTestSetupFailureReport(w io.Writer, setupErr error, output testOutput) error {
+	var captured strings.Builder
+	fmt.Fprintf(&captured, "Integration test setup failed before Go tests ran: %v\n", setupErr)
+	if output.serverLogPath != "" {
+		serverOutput, err := os.ReadFile(output.serverLogPath)
+		switch {
+		case err != nil:
+			fmt.Fprintf(&captured, "\nUnable to read captured dev server output: %v\n", err)
+		case len(bytes.TrimSpace(serverOutput)) == 0:
+			captured.WriteString("\nNo dev server output was captured.\n")
+		default:
+			captured.WriteString("\nCaptured dev server output:\n\n")
+			captured.Write(serverOutput)
+		}
+	}
+	return writeStructuredTestFailureReport(w, nil, captured.String(), output)
+}
+
 func writeTestRerunCommands(sb *strings.Builder, rows []testFailureSummaryRow, rerunCommand string) {
 	if rerunCommand == "" {
 		return

--- a/internal/cmd/build/test_output.go
+++ b/internal/cmd/build/test_output.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"html"
 	"io"
 	"os"
 	"regexp"
@@ -15,6 +16,7 @@ import (
 	"time"
 )
 
+const githubStepSummaryMaxDetailBytes = 64 * 1024
 const testFailureSnippetMaxDetailBytes = 16 * 1024
 const testFailureSnippetMaxTotalBytes = 64 * 1024
 const testServerSnippetMaxDetailBytes = 16 * 1024
@@ -530,6 +532,19 @@ func testFailureTitle(row testFailureSummaryRow) string {
 	return row.Package + " / " + row.Test
 }
 
+func appendTestFailureRows(summaryPath string, rows []testFailureSummaryRow) error {
+	if summaryPath == "" || len(rows) == 0 {
+		return nil
+	}
+	f, err := os.OpenFile(summaryPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	_, err = f.WriteString(renderTestFailureSummary(rows))
+	return err
+}
+
 func filterParentFailureRows(rows []testFailureSummaryRow) []testFailureSummaryRow {
 	hasFailedSubtest := make(map[testFailureSummaryKey]bool, len(rows))
 	for _, row := range rows {
@@ -549,4 +564,22 @@ func filterParentFailureRows(rows []testFailureSummaryRow) []testFailureSummaryR
 type testFailureSummaryKey struct {
 	Package string
 	Test    string
+}
+
+func renderTestFailureSummary(rows []testFailureSummaryRow) string {
+	var sb strings.Builder
+	sb.WriteString("## Test failures\n\n")
+	sb.WriteString("<table>\n<tr><th>Kind</th><th>Test failure</th></tr>\n")
+	for _, row := range rows {
+		details := truncateTestFailureSnippet(row.Details, githubStepSummaryMaxDetailBytes)
+		fmt.Fprintf(
+			&sb,
+			"<tr><td>%s</td><td><details><summary>%s</summary><pre>%s</pre></details></td></tr>\n",
+			html.EscapeString("Failed"),
+			html.EscapeString(testFailureTitle(row)),
+			html.EscapeString(details),
+		)
+	}
+	sb.WriteString("</table>\n\n")
+	return sb.String()
 }

--- a/internal/cmd/build/test_output.go
+++ b/internal/cmd/build/test_output.go
@@ -220,38 +220,39 @@ func writeStructuredTestFailureReport(
 	fallback string,
 	output testOutput,
 ) error {
+	rows = collapseParentFailureRows(rows)
 	var sb strings.Builder
-	sb.WriteString("\nTEST FAILURE REPORT\n")
+	sb.WriteString("\n============================== TEST FAILURE REPORT ==============================\n")
 	if len(rows) == 0 {
+		startTestReportSection(&sb, "Command output")
 		fmt.Fprintf(
 			&sb,
-			"\nNo individual failed test was identified; showing up to %d KiB of command output:\n\n",
+			"No individual failed test was identified; showing up to %d KiB of command output:\n\n",
 			testFailureSnippetMaxTotalBytes/1024,
 		)
 		sb.WriteString(truncateTestFailureSnippet(fallback, testFailureSnippetMaxTotalBytes))
-		sb.WriteString("\n")
+		sb.WriteByte('\n')
+		endTestReportSection(&sb)
 		writeCompleteTestLogLocations(&sb, output)
+		finishTestFailureReport(&sb)
 		return writeString(w, sb.String())
 	}
 
-	fmt.Fprintf(&sb, "\nFailed tests (%d):\n", len(rows))
+	startTestReportGroup(&sb, "Failed tests")
+	fmt.Fprintf(&sb, "Failed tests (%d):\n", len(rows))
 	for _, row := range rows {
-		fmt.Fprintf(&sb, "- %s\n", testFailureTitle(row))
+		fmt.Fprintf(&sb, "\t%s\n", testFailureTitle(row))
 	}
 	if output.rerunCommand != "" {
 		sb.WriteString("\nRerun from internal/cmd/build:\n")
-		for _, row := range filterParentFailureRows(rows) {
+		for _, row := range rows {
 			testPattern := "^" + regexp.QuoteMeta(row.Test) + "$"
-			fmt.Fprintf(&sb, "- %s -run %s\n", output.rerunCommand, strconv.Quote(testPattern))
+			fmt.Fprintf(&sb, "\t%s -run %s\n", output.rerunCommand, strconv.Quote(testPattern))
 		}
 	}
+	endTestReportSection(&sb)
 
-	fmt.Fprintf(
-		&sb,
-		"\nFailed Go test output (up to %d KiB per test and %d KiB total):\n",
-		testFailureSnippetMaxDetailBytes/1024,
-		testFailureSnippetMaxTotalBytes/1024,
-	)
+	startTestReportSection(&sb, "Go test output")
 	remainingGoOutput := testFailureSnippetMaxTotalBytes
 	for i, row := range rows {
 		if remainingGoOutput <= 0 {
@@ -270,29 +271,26 @@ func writeStructuredTestFailureReport(
 		sb.WriteString("\n")
 		remainingGoOutput -= len(details)
 	}
+	endTestReportSection(&sb)
 
 	if output.serverLogPath != "" {
-		serverRows := filterParentFailureRows(rows)
-		contexts, err := collectServerFailureContexts(output.serverLogPath, serverRows)
-		fmt.Fprintf(
-			&sb,
-			"\nRelated dev server WARN/ERROR output (best effort, up to %d KiB per test and %d KiB total):\n",
-			testServerSnippetMaxDetailBytes/1024,
-			testServerSnippetMaxTotalBytes/1024,
-		)
+		startTestReportSection(&sb, "Related dev server output")
+		contexts, err := collectServerFailureContexts(output.serverLogPath, rows)
 		if err != nil {
 			fmt.Fprintf(&sb, "Unable to read dev server context: %v\n", err)
 		} else {
-			writeServerFailureContexts(&sb, serverRows, contexts, output.serverLogPath)
+			writeServerFailureContexts(&sb, rows, contexts, output.serverLogPath)
 		}
+		endTestReportSection(&sb)
 	}
 
 	writeCompleteTestLogLocations(&sb, output)
+	finishTestFailureReport(&sb)
 	return writeString(w, sb.String())
 }
 
 func writeCompleteTestLogLocations(sb *strings.Builder, output testOutput) {
-	sb.WriteString("\nComplete logs:\n")
+	startTestReportSection(sb, "Complete logs")
 	fmt.Fprintf(sb, "- Go test: %s\n", output.logPath)
 	fmt.Fprintf(sb, "- Go test JSON: %s\n", output.jsonLogPath)
 	if output.combinedLogPath != "" {
@@ -314,6 +312,29 @@ func writeCompleteTestLogLocations(sb *strings.Builder, output testOutput) {
 			fmt.Fprintf(sb, "- Download: %s\n", command)
 		}
 	}
+	endTestReportSection(sb)
+}
+
+func startTestReportSection(sb *strings.Builder, title string) {
+	startTestReportGroup(sb, title)
+	fmt.Fprintf(sb, "--- %s ---\n", title)
+}
+
+func startTestReportGroup(sb *strings.Builder, title string) {
+	sb.WriteByte('\n')
+	if os.Getenv("GITHUB_ACTIONS") == "true" {
+		fmt.Fprintf(sb, "::group::%s\n", title)
+	}
+}
+
+func endTestReportSection(sb *strings.Builder) {
+	if os.Getenv("GITHUB_ACTIONS") == "true" {
+		sb.WriteString("::endgroup::\n")
+	}
+}
+
+func finishTestFailureReport(sb *strings.Builder) {
+	sb.WriteString("\n============================ END TEST FAILURE REPORT ============================\n")
 }
 
 func writeString(w io.Writer, value string) error {
@@ -476,7 +497,7 @@ func writeServerFailureContexts(
 		remaining -= len(rendered)
 	}
 	if remaining == testServerSnippetMaxTotalBytes {
-		sb.WriteString("No dev server WARN/ERROR lines could be correlated with the failed tests.\n")
+		sb.WriteString("None.\n")
 	}
 }
 
@@ -537,6 +558,7 @@ func testFailureTitle(row testFailureSummaryRow) string {
 }
 
 func appendTestFailureRows(summaryPath string, rows []testFailureSummaryRow) error {
+	rows = collapseParentFailureRows(rows)
 	if summaryPath == "" || len(rows) == 0 {
 		return nil
 	}
@@ -549,9 +571,11 @@ func appendTestFailureRows(summaryPath string, rows []testFailureSummaryRow) err
 	return err
 }
 
-func filterParentFailureRows(rows []testFailureSummaryRow) []testFailureSummaryRow {
+func collapseParentFailureRows(rows []testFailureSummaryRow) []testFailureSummaryRow {
+	rowsByKey := make(map[testFailureSummaryKey]testFailureSummaryRow, len(rows))
 	hasFailedSubtest := make(map[testFailureSummaryKey]bool, len(rows))
 	for _, row := range rows {
+		rowsByKey[testFailureSummaryKey{Package: row.Package, Test: row.Test}] = row
 		for parent := row.Test; ; {
 			slash := strings.LastIndexByte(parent, '/')
 			if slash < 0 {
@@ -561,13 +585,53 @@ func filterParentFailureRows(rows []testFailureSummaryRow) []testFailureSummaryR
 			hasFailedSubtest[testFailureSummaryKey{Package: row.Package, Test: parent}] = true
 		}
 	}
-	filtered := make([]testFailureSummaryRow, 0, len(rows))
+	leafDescendantCount := make(map[testFailureSummaryKey]int, len(hasFailedSubtest))
 	for _, row := range rows {
-		if !hasFailedSubtest[testFailureSummaryKey{Package: row.Package, Test: row.Test}] {
-			filtered = append(filtered, row)
+		key := testFailureSummaryKey{Package: row.Package, Test: row.Test}
+		if hasFailedSubtest[key] {
+			continue
+		}
+		for parent := row.Test; ; {
+			slash := strings.LastIndexByte(parent, '/')
+			if slash < 0 {
+				break
+			}
+			parent = parent[:slash]
+			leafDescendantCount[testFailureSummaryKey{Package: row.Package, Test: parent}]++
 		}
 	}
-	return filtered
+	collapsed := make([]testFailureSummaryRow, 0, len(rows))
+	for _, row := range rows {
+		key := testFailureSummaryKey{Package: row.Package, Test: row.Test}
+		if hasFailedSubtest[key] && leafDescendantCount[key] == 1 {
+			continue
+		}
+		if !hasFailedSubtest[key] {
+			var parents []testFailureSummaryRow
+			for parent := row.Test; ; {
+				slash := strings.LastIndexByte(parent, '/')
+				if slash < 0 {
+					break
+				}
+				parent = parent[:slash]
+				parentKey := testFailureSummaryKey{Package: row.Package, Test: parent}
+				if parentRow, ok := rowsByKey[parentKey]; ok && leafDescendantCount[parentKey] == 1 {
+					parents = append(parents, parentRow)
+				}
+			}
+			var details strings.Builder
+			for i := len(parents) - 1; i >= 0; i-- {
+				if parents[i].Details != "" {
+					details.WriteString(parents[i].Details)
+					details.WriteByte('\n')
+				}
+			}
+			details.WriteString(row.Details)
+			row.Details = details.String()
+		}
+		collapsed = append(collapsed, row)
+	}
+	return collapsed
 }
 
 type testFailureSummaryKey struct {

--- a/internal/cmd/build/test_output.go
+++ b/internal/cmd/build/test_output.go
@@ -1,0 +1,585 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"html"
+	"io"
+	"os"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+const githubStepSummaryMaxDetailBytes = 64 * 1024
+const testFailureSnippetMaxDetailBytes = 16 * 1024
+const testFailureSnippetMaxTotalBytes = 64 * 1024
+const testServerSnippetMaxDetailBytes = 16 * 1024
+const testServerSnippetMaxTotalBytes = 64 * 1024
+const testServerContextPadding = 2 * time.Second
+
+type lockedWriter struct {
+	mu     sync.Mutex
+	writer io.Writer
+}
+
+func (w *lockedWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.writer.Write(p)
+}
+
+type writerFunc func([]byte) (int, error)
+
+func (f writerFunc) Write(p []byte) (int, error) {
+	return f(p)
+}
+
+type goTestEvent struct {
+	Time    time.Time
+	Action  string
+	Package string
+	Test    string
+	Output  string
+}
+
+type goTestJSONWriter struct {
+	rawWriter    io.Writer
+	outputWriter io.Writer
+	results      *goTestResults
+	pending      []byte
+}
+
+func (w *goTestJSONWriter) Write(p []byte) (int, error) {
+	n, err := w.rawWriter.Write(p)
+	if err != nil {
+		return n, err
+	}
+	if n != len(p) {
+		return n, io.ErrShortWrite
+	}
+	w.pending = append(w.pending, p...)
+	for {
+		newline := bytes.IndexByte(w.pending, '\n')
+		if newline < 0 {
+			break
+		}
+		line := append([]byte(nil), w.pending[:newline+1]...)
+		w.pending = w.pending[newline+1:]
+		if err := w.processLine(line); err != nil {
+			return len(p), err
+		}
+	}
+	return len(p), nil
+}
+
+func (w *goTestJSONWriter) Flush() error {
+	if len(w.pending) == 0 {
+		return nil
+	}
+	line := append([]byte(nil), w.pending...)
+	w.pending = nil
+	return w.processLine(line)
+}
+
+func (w *goTestJSONWriter) processLine(line []byte) error {
+	var event goTestEvent
+	if err := json.Unmarshal(bytes.TrimSpace(line), &event); err != nil {
+		if _, writeErr := w.outputWriter.Write(line); writeErr != nil {
+			return writeErr
+		}
+		_, _ = w.results.recordRawOutput(line)
+		return nil
+	}
+	w.results.recordEvent(event)
+	if event.Output != "" {
+		_, err := io.WriteString(w.outputWriter, event.Output)
+		return err
+	}
+	return nil
+}
+
+type goTestResults struct {
+	mu       sync.Mutex
+	tests    map[testFailureSummaryKey]*goTestRecord
+	fallback strings.Builder
+}
+
+type goTestRecord struct {
+	start   time.Time
+	end     time.Time
+	failed  bool
+	details strings.Builder
+}
+
+func newGoTestResults() *goTestResults {
+	return &goTestResults{tests: make(map[testFailureSummaryKey]*goTestRecord)}
+}
+
+func (r *goTestResults) recordEvent(event goTestEvent) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if event.Test == "" {
+		if event.Output != "" {
+			r.fallback.WriteString(event.Output)
+		}
+		return
+	}
+	key := testFailureSummaryKey{Package: event.Package, Test: event.Test}
+	record := r.tests[key]
+	if record == nil {
+		record = &goTestRecord{}
+		r.tests[key] = record
+	}
+	if record.start.IsZero() && !event.Time.IsZero() {
+		record.start = event.Time
+	}
+	switch event.Action {
+	case "output":
+		record.details.WriteString(event.Output)
+	case "fail":
+		record.failed = true
+		record.end = event.Time
+	case "pass", "skip":
+		delete(r.tests, key)
+	}
+}
+
+func (r *goTestResults) recordRawOutput(p []byte) (int, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.fallback.Write(p)
+}
+
+func (r *goTestResults) failures() []testFailureSummaryRow {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	rows := make([]testFailureSummaryRow, 0)
+	for key, record := range r.tests {
+		if !record.failed {
+			continue
+		}
+		details := record.details.String()
+		if strings.TrimSpace(details) == "" {
+			details = fmt.Sprintf("--- FAIL: %s", key.Test)
+		}
+		rows = append(rows, testFailureSummaryRow{
+			Test:      key.Test,
+			Package:   key.Package,
+			Details:   details,
+			StartTime: record.start,
+			EndTime:   record.end,
+		})
+	}
+	sort.SliceStable(rows, func(i, j int) bool {
+		if rows[i].Package != rows[j].Package {
+			return rows[i].Package < rows[j].Package
+		}
+		return rows[i].Test < rows[j].Test
+	})
+	return rows
+}
+
+func (r *goTestResults) fallbackOutput() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var output strings.Builder
+	output.WriteString(r.fallback.String())
+	keys := make([]testFailureSummaryKey, 0, len(r.tests))
+	for key := range r.tests {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].Package != keys[j].Package {
+			return keys[i].Package < keys[j].Package
+		}
+		return keys[i].Test < keys[j].Test
+	})
+	for _, key := range keys {
+		output.WriteString(r.tests[key].details.String())
+	}
+	return output.String()
+}
+
+type testFailureSummaryRow struct {
+	Test      string
+	Package   string
+	Details   string
+	StartTime time.Time
+	EndTime   time.Time
+}
+
+func writeStructuredTestFailureReport(
+	w io.Writer,
+	rows []testFailureSummaryRow,
+	fallback string,
+	output testOutput,
+) error {
+	var sb strings.Builder
+	sb.WriteString("\nTEST FAILURE REPORT\n")
+	if len(rows) == 0 {
+		fmt.Fprintf(
+			&sb,
+			"\nNo individual failed test was identified; showing up to %d KiB of command output:\n\n",
+			testFailureSnippetMaxTotalBytes/1024,
+		)
+		sb.WriteString(truncateTestFailureSnippet(fallback, testFailureSnippetMaxTotalBytes))
+		sb.WriteString("\n")
+		writeCompleteTestLogLocations(&sb, output)
+		return writeString(w, sb.String())
+	}
+
+	fmt.Fprintf(&sb, "\nFailed tests (%d):\n", len(rows))
+	for _, row := range rows {
+		fmt.Fprintf(&sb, "- %s\n", testFailureTitle(row))
+	}
+	if output.rerunCommand != "" {
+		sb.WriteString("\nRerun from internal/cmd/build:\n")
+		for _, row := range rows {
+			testPattern := "^" + regexp.QuoteMeta(row.Test) + "$"
+			fmt.Fprintf(&sb, "- %s -run %s\n", output.rerunCommand, strconv.Quote(testPattern))
+		}
+	}
+
+	fmt.Fprintf(
+		&sb,
+		"\nFailed Go test output (up to %d KiB per test and %d KiB total):\n",
+		testFailureSnippetMaxDetailBytes/1024,
+		testFailureSnippetMaxTotalBytes/1024,
+	)
+	remainingGoOutput := testFailureSnippetMaxTotalBytes
+	for i, row := range rows {
+		if remainingGoOutput <= 0 {
+			fmt.Fprintf(
+				&sb,
+				"\n... omitted Go output for %d additional failed tests after reaching the %d KiB total console limit; all failed tests are listed above\n",
+				len(rows)-i,
+				testFailureSnippetMaxTotalBytes/1024,
+			)
+			break
+		}
+		fmt.Fprintf(&sb, "\n--- %s ---\n", testFailureTitle(row))
+		maxDetailBytes := min(testFailureSnippetMaxDetailBytes, remainingGoOutput)
+		details := truncateTestFailureSnippet(row.Details, maxDetailBytes)
+		sb.WriteString(details)
+		sb.WriteString("\n")
+		remainingGoOutput -= len(details)
+	}
+
+	if output.serverLogPath != "" {
+		serverRows := filterParentFailureRows(rows)
+		contexts, err := collectServerFailureContexts(output.serverLogPath, serverRows)
+		fmt.Fprintf(
+			&sb,
+			"\nRelated dev server WARN/ERROR output (best effort, up to %d KiB per test and %d KiB total):\n",
+			testServerSnippetMaxDetailBytes/1024,
+			testServerSnippetMaxTotalBytes/1024,
+		)
+		if err != nil {
+			fmt.Fprintf(&sb, "Unable to read dev server context: %v\n", err)
+		} else {
+			writeServerFailureContexts(&sb, serverRows, contexts, output.serverLogPath)
+		}
+	}
+
+	writeCompleteTestLogLocations(&sb, output)
+	return writeString(w, sb.String())
+}
+
+func writeCompleteTestLogLocations(sb *strings.Builder, output testOutput) {
+	sb.WriteString("\nComplete logs:\n")
+	fmt.Fprintf(sb, "- Go test: %s\n", output.logPath)
+	fmt.Fprintf(sb, "- Go test JSON: %s\n", output.jsonLogPath)
+	if output.combinedLogPath != "" {
+		fmt.Fprintf(sb, "- Combined Go and dev server: %s\n", output.combinedLogPath)
+	}
+	if output.serverLogPath != "" {
+		fmt.Fprintf(sb, "- Dev server: %s\n", output.serverLogPath)
+	}
+	if artifactName := strings.TrimSpace(os.Getenv("TEST_LOG_ARTIFACT_NAME")); artifactName != "" {
+		fmt.Fprintf(sb, "- CI artifact: %s\n", artifactName)
+		if runID := strings.TrimSpace(os.Getenv("GITHUB_RUN_ID")); runID != "" {
+			command := formatShellCommand([]string{
+				"gh", "run", "download", runID, "-n", artifactName, "-D", ".build/ci-debug",
+			})
+			fmt.Fprintf(sb, "- Download: %s\n", command)
+		}
+	}
+}
+
+func writeString(w io.Writer, value string) error {
+	_, err := io.WriteString(w, value)
+	return err
+}
+
+type serverFailureContext struct {
+	related limitedLogCapture
+	window  limitedLogCapture
+}
+
+type limitedLogCapture struct {
+	text         strings.Builder
+	maxBytes     int
+	omittedLines int
+}
+
+func (c *limitedLogCapture) add(line string) {
+	lineBytes := len(line) + 1
+	if c.text.Len()+lineBytes > c.maxBytes {
+		c.omittedLines++
+		return
+	}
+	c.text.WriteString(line)
+	c.text.WriteByte('\n')
+}
+
+func (c *limitedLogCapture) appendTo(sb *strings.Builder, heading string) {
+	if c.text.Len() == 0 && c.omittedLines == 0 {
+		return
+	}
+	fmt.Fprintf(sb, "%s:\n", heading)
+	sb.WriteString(c.text.String())
+	if c.omittedLines > 0 {
+		fmt.Fprintf(sb, "... omitted %d additional matching server log lines\n", c.omittedLines)
+	}
+}
+
+func collectServerFailureContexts(
+	logPath string,
+	rows []testFailureSummaryRow,
+) (map[testFailureSummaryKey]*serverFailureContext, error) {
+	f, err := os.Open(logPath)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	contexts := make(map[testFailureSummaryKey]*serverFailureContext, len(rows))
+	for _, row := range rows {
+		contexts[testFailureSummaryKey{Package: row.Package, Test: row.Test}] = &serverFailureContext{
+			related: limitedLogCapture{maxBytes: testServerSnippetMaxDetailBytes},
+			window:  limitedLogCapture{maxBytes: testServerSnippetMaxDetailBytes},
+		}
+	}
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !isServerWarningOrError(line) {
+			continue
+		}
+		lineTime, hasLineTime := serverLogTime(line)
+		for _, row := range rows {
+			key := testFailureSummaryKey{Package: row.Package, Test: row.Test}
+			context := contexts[key]
+			if serverLineMatchesTest(line, row.Test) {
+				context.related.add(line)
+				continue
+			}
+			if hasLineTime && testTimeWindowContains(row, lineTime) {
+				context.window.add(line)
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return contexts, nil
+}
+
+func isServerWarningOrError(line string) bool {
+	lower := strings.ToLower(line)
+	return strings.Contains(lower, "level=warn") ||
+		strings.Contains(lower, "level=error") ||
+		strings.Contains(lower, `"level":"warn"`) ||
+		strings.Contains(lower, `"level":"error"`)
+}
+
+func serverLineMatchesTest(line, testName string) bool {
+	if strings.Contains(line, testName) {
+		return true
+	}
+	if slash := strings.LastIndexByte(testName, '/'); slash >= 0 {
+		return strings.Contains(line, testName[slash+1:])
+	}
+	return false
+}
+
+func serverLogTime(line string) (time.Time, bool) {
+	index := strings.Index(line, "time=")
+	if index < 0 {
+		return time.Time{}, false
+	}
+	value := line[index+len("time="):]
+	if space := strings.IndexByte(value, ' '); space >= 0 {
+		value = value[:space]
+	}
+	value = strings.Trim(value, `"`)
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	return parsed, err == nil
+}
+
+func testTimeWindowContains(row testFailureSummaryRow, value time.Time) bool {
+	if row.StartTime.IsZero() || row.EndTime.IsZero() {
+		return false
+	}
+	start := row.StartTime.Add(-testServerContextPadding)
+	end := row.EndTime.Add(testServerContextPadding)
+	return !value.Before(start) && !value.After(end)
+}
+
+func writeServerFailureContexts(
+	sb *strings.Builder,
+	rows []testFailureSummaryRow,
+	contexts map[testFailureSummaryKey]*serverFailureContext,
+	logPath string,
+) {
+	remaining := testServerSnippetMaxTotalBytes
+	for i, row := range rows {
+		key := testFailureSummaryKey{Package: row.Package, Test: row.Test}
+		context := contexts[key]
+		if context == nil {
+			continue
+		}
+		var details strings.Builder
+		context.related.appendTo(&details, "Lines mentioning the failed test")
+		context.window.appendTo(&details, "Other WARN/ERROR lines during the test window")
+		if details.Len() == 0 {
+			continue
+		}
+		if remaining <= 0 {
+			fmt.Fprintf(
+				sb,
+				"... omitted server context for %d additional failed tests after reaching the %d KiB total console limit\n",
+				len(rows)-i,
+				testServerSnippetMaxTotalBytes/1024,
+			)
+			return
+		}
+		fmt.Fprintf(sb, "\n--- %s ---\n", testFailureTitle(row))
+		maxDetailBytes := min(testServerSnippetMaxDetailBytes, remaining)
+		rendered := truncateServerFailureSnippet(details.String(), maxDetailBytes, logPath)
+		sb.WriteString(rendered)
+		if !strings.HasSuffix(rendered, "\n") {
+			sb.WriteByte('\n')
+		}
+		remaining -= len(rendered)
+	}
+	if remaining == testServerSnippetMaxTotalBytes {
+		sb.WriteString("No dev server WARN/ERROR lines could be correlated with the failed tests.\n")
+	}
+}
+
+func truncateServerFailureSnippet(value string, maxBytes int, logPath string) string {
+	marker := fmt.Sprintf("\n... (truncated; see complete dev server log at %s) ...\n", logPath)
+	return truncateWithMarker(value, maxBytes, marker)
+}
+
+func truncateWithMarker(value string, maxBytes int, marker string) string {
+	if len(value) <= maxBytes {
+		return value
+	}
+	if maxBytes <= len(marker) {
+		return marker[:maxBytes]
+	}
+	prefixBytes := (maxBytes - len(marker)) / 2
+	suffixBytes := maxBytes - len(marker) - prefixBytes
+	return value[:prefixBytes] + marker + value[len(value)-suffixBytes:]
+}
+
+func formatShellCommand(args []string) string {
+	quoted := make([]string, len(args))
+	for i, arg := range args {
+		if arg != "" && strings.IndexFunc(arg, shellCommandArgNeedsQuoting) < 0 {
+			quoted[i] = arg
+		} else {
+			quoted[i] = strconv.Quote(arg)
+		}
+	}
+	return strings.Join(quoted, " ")
+}
+
+func shellCommandArgNeedsQuoting(r rune) bool {
+	return !(r >= 'a' && r <= 'z') &&
+		!(r >= 'A' && r <= 'Z') &&
+		!(r >= '0' && r <= '9') &&
+		!strings.ContainsRune("-._/", r)
+}
+
+func truncateTestFailureSnippet(value string, maxBytes int) string {
+	if len(value) <= maxBytes {
+		return value
+	}
+	const marker = "\n... (truncated; see full test log) ...\n"
+	if maxBytes <= len(marker) {
+		return value[:maxBytes]
+	}
+	prefixBytes := (maxBytes - len(marker)) / 2
+	suffixBytes := maxBytes - len(marker) - prefixBytes
+	return value[:prefixBytes] + marker + value[len(value)-suffixBytes:]
+}
+
+func testFailureTitle(row testFailureSummaryRow) string {
+	if row.Package == "" {
+		return row.Test
+	}
+	return row.Package + " / " + row.Test
+}
+
+func appendTestFailureRows(summaryPath string, rows []testFailureSummaryRow) error {
+	if summaryPath == "" || len(rows) == 0 {
+		return nil
+	}
+	f, err := os.OpenFile(summaryPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	_, err = f.WriteString(renderTestFailureSummary(rows))
+	return err
+}
+
+func filterParentFailureRows(rows []testFailureSummaryRow) []testFailureSummaryRow {
+	hasFailedSubtest := make(map[testFailureSummaryKey]bool, len(rows))
+	for _, row := range rows {
+		if parent, _, ok := strings.Cut(row.Test, "/"); ok {
+			hasFailedSubtest[testFailureSummaryKey{Package: row.Package, Test: parent}] = true
+		}
+	}
+	filtered := rows[:0]
+	for _, row := range rows {
+		if !hasFailedSubtest[testFailureSummaryKey{Package: row.Package, Test: row.Test}] {
+			filtered = append(filtered, row)
+		}
+	}
+	return filtered
+}
+
+type testFailureSummaryKey struct {
+	Package string
+	Test    string
+}
+
+func renderTestFailureSummary(rows []testFailureSummaryRow) string {
+	var sb strings.Builder
+	sb.WriteString("## Test failures\n\n")
+	sb.WriteString("<table>\n<tr><th>Kind</th><th>Test failure</th></tr>\n")
+	for _, row := range rows {
+		details := truncateTestFailureSnippet(row.Details, githubStepSummaryMaxDetailBytes)
+		fmt.Fprintf(
+			&sb,
+			"<tr><td>%s</td><td><details><summary>%s</summary><pre>%s</pre></details></td></tr>\n",
+			html.EscapeString("Failed"),
+			html.EscapeString(testFailureTitle(row)),
+			html.EscapeString(details),
+		)
+	}
+	sb.WriteString("</table>\n\n")
+	return sb.String()
+}

--- a/internal/cmd/build/test_output.go
+++ b/internal/cmd/build/test_output.go
@@ -243,13 +243,6 @@ func writeStructuredTestFailureReport(
 	for _, row := range rows {
 		fmt.Fprintf(&sb, "\t%s\n", testFailureTitle(row))
 	}
-	if output.rerunCommand != "" {
-		sb.WriteString("\nRerun from internal/cmd/build:\n")
-		for _, row := range rows {
-			testPattern := "^" + regexp.QuoteMeta(row.Test) + "$"
-			fmt.Fprintf(&sb, "\t%s -run %s\n", output.rerunCommand, strconv.Quote(testPattern))
-		}
-	}
 	endTestReportSection(&sb)
 
 	startTestReportSection(&sb, "Go test output")
@@ -285,8 +278,22 @@ func writeStructuredTestFailureReport(
 	}
 
 	writeCompleteTestLogLocations(&sb, output)
+	writeTestRerunCommands(&sb, rows, output.rerunCommand)
 	finishTestFailureReport(&sb)
 	return writeString(w, sb.String())
+}
+
+func writeTestRerunCommands(sb *strings.Builder, rows []testFailureSummaryRow, rerunCommand string) {
+	if rerunCommand == "" {
+		return
+	}
+	startTestReportSection(sb, "Rerun failed tests")
+	sb.WriteString("From internal/cmd/build:\n")
+	for _, row := range rows {
+		testPattern := "^" + regexp.QuoteMeta(row.Test) + "$"
+		fmt.Fprintf(sb, "\t%s -run %s\n", rerunCommand, strconv.Quote(testPattern))
+	}
+	endTestReportSection(sb)
 }
 
 func writeCompleteTestLogLocations(sb *strings.Builder, output testOutput) {
@@ -621,8 +628,9 @@ func collapseParentFailureRows(rows []testFailureSummaryRow) []testFailureSummar
 			}
 			var details strings.Builder
 			for i := len(parents) - 1; i >= 0; i-- {
-				if parents[i].Details != "" {
-					details.WriteString(parents[i].Details)
+				parentDetails := withoutTestHarnessOutput(parents[i])
+				if parentDetails != "" {
+					details.WriteString(parentDetails)
 					details.WriteByte('\n')
 				}
 			}
@@ -632,6 +640,22 @@ func collapseParentFailureRows(rows []testFailureSummaryRow) []testFailureSummar
 		collapsed = append(collapsed, row)
 	}
 	return collapsed
+}
+
+func withoutTestHarnessOutput(row testFailureSummaryRow) string {
+	var details strings.Builder
+	for line := range strings.SplitSeq(row.Details, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "=== RUN   "+row.Test ||
+			(strings.HasPrefix(trimmed, "--- FAIL: "+row.Test+" (") && strings.HasSuffix(trimmed, ")")) {
+			continue
+		}
+		if details.Len() > 0 {
+			details.WriteByte('\n')
+		}
+		details.WriteString(line)
+	}
+	return strings.TrimSpace(details.String())
 }
 
 type testFailureSummaryKey struct {

--- a/internal/cmd/build/test_output.go
+++ b/internal/cmd/build/test_output.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"html"
 	"io"
 	"os"
 	"regexp"
@@ -16,7 +15,6 @@ import (
 	"time"
 )
 
-const githubStepSummaryMaxDetailBytes = 64 * 1024
 const testFailureSnippetMaxDetailBytes = 16 * 1024
 const testFailureSnippetMaxTotalBytes = 64 * 1024
 const testServerSnippetMaxDetailBytes = 16 * 1024
@@ -532,19 +530,6 @@ func testFailureTitle(row testFailureSummaryRow) string {
 	return row.Package + " / " + row.Test
 }
 
-func appendTestFailureRows(summaryPath string, rows []testFailureSummaryRow) error {
-	if summaryPath == "" || len(rows) == 0 {
-		return nil
-	}
-	f, err := os.OpenFile(summaryPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-	_, err = f.WriteString(renderTestFailureSummary(rows))
-	return err
-}
-
 func filterParentFailureRows(rows []testFailureSummaryRow) []testFailureSummaryRow {
 	hasFailedSubtest := make(map[testFailureSummaryKey]bool, len(rows))
 	for _, row := range rows {
@@ -564,22 +549,4 @@ func filterParentFailureRows(rows []testFailureSummaryRow) []testFailureSummaryR
 type testFailureSummaryKey struct {
 	Package string
 	Test    string
-}
-
-func renderTestFailureSummary(rows []testFailureSummaryRow) string {
-	var sb strings.Builder
-	sb.WriteString("## Test failures\n\n")
-	sb.WriteString("<table>\n<tr><th>Kind</th><th>Test failure</th></tr>\n")
-	for _, row := range rows {
-		details := truncateTestFailureSnippet(row.Details, githubStepSummaryMaxDetailBytes)
-		fmt.Fprintf(
-			&sb,
-			"<tr><td>%s</td><td><details><summary>%s</summary><pre>%s</pre></details></td></tr>\n",
-			html.EscapeString("Failed"),
-			html.EscapeString(testFailureTitle(row)),
-			html.EscapeString(details),
-		)
-	}
-	sb.WriteString("</table>\n\n")
-	return sb.String()
 }

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -309,7 +309,6 @@ func (ts *IntegrationTestSuite) TestBasic() {
 	// We cannot check PollActivityTaskQueue metric because eager activities
 	// affect poll count
 	ts.assertMetricCountAtLeast("temporal_long_request", 3, "operation", "PollWorkflowTaskQueue")
-	ts.Fail("intentional failure to demonstrate CI test output")
 }
 
 func (ts *IntegrationTestSuite) TestPreferredVersionProvider() {

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -133,6 +133,7 @@ func (ts *IntegrationTestSuite) TearDownSuite() {
 }
 
 func (ts *IntegrationTestSuite) SetupTest() {
+	ts.Assertions = require.New(ts.T())
 	ts.metricsHandler = metrics.NewCapturingHandler()
 	var metricsHandler client.MetricsHandler = ts.metricsHandler
 	// Use Tally handler for Tally test

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -308,6 +308,7 @@ func (ts *IntegrationTestSuite) TestBasic() {
 	// We cannot check PollActivityTaskQueue metric because eager activities
 	// affect poll count
 	ts.assertMetricCountAtLeast("temporal_long_request", 3, "operation", "PollWorkflowTaskQueue")
+	ts.Fail("intentional failure to demonstrate CI test output")
 }
 
 func (ts *IntegrationTestSuite) TestPreferredVersionProvider() {


### PR DESCRIPTION


## What was changed
Only print tests run and test failure logs. 

Publish full logs as CI artifacts, so you can still view full logs if needed. 

• We added two flags to both unit-test and integration-test:

  - -console-output failures|full
      - failures is the default. Test and dev-server output is captured during execution. If tests fail, the console
        shows every failed test name, bounded Go failure snippets, relevant dev-server WARN/ERROR context, rerun
        commands, and artifact paths.

      - full streams all Go test and dev-server output live, matching the old verbose behavior. Full logs are still saved
        to files.

  - -log-dir <directory>
      - Defaults to .build/test-logs, relative to the repository root.
      - Changes where all generated log files are written.
      - Absolute paths are also accepted.

Unit test output goes from ~7600 to ~40 lines
Integ test output goes from ~6000 to ~60 lines

## Why?
Inspired by https://github.com/temporalio/sdk-typescript/pull/2270, we never care about all of the lot spew for passing tests, only for the failures. So let's make only-failure output by default, while maintaining access to full logs with files if someone actually cares

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to the build/CI test harness and documentation; production SDK runtime behavior is unaffected aside from optional dev-server logging during integration tests.
> 
> **Overview**
> **Default test runs are much quieter:** the internal build tool now writes full Go test and dev-server output to `.build/test-logs` (configurable via `-log-dir`) and only prints failure-focused reports unless you pass `-console-output full`.
> 
> **Failure reporting is richer:** `go test -json` drives structured failure extraction, GitHub job summaries, bounded console snippets, related dev-server WARN/ERROR lines, per-test rerun commands, and setup-failure handling when the embedded dev server fails to start. Integration tests also route dev-server stdout/stderr and client logger output into those logs.
> 
> **CI publishes full logs:** unit, integration, docker-compose, and cloud jobs set `TEST_LOG_ARTIFACT_NAME`, upload `.build/test-logs` as artifacts (14-day retention), and add a download link to the step summary on failure; docker-compose additionally captures compose logs into the artifact.
> 
> README documents `-console-output` and `-log-dir`. A small integration test change sets `require.New` on the suite assertions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9caed4c61b1f79cbcc4b3fe008c652c657b7195. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->