### PR TITLE
Fix Pending Activity cancellation is not removed after completion when using a custom Activity ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ to docs, or any other relevant information.
 
 ## [Unreleased]
 
+### Fixed
+
+- Prevent workflow task failures when an activity with a custom ID completes while its cancellation
+  command is pending.
 
 ## [1.46.0] - 2026-07-28
 

--- a/internal/internal_command_state_machine.go
+++ b/internal/internal_command_state_machine.go
@@ -1137,7 +1137,7 @@ func (h *commandsHelper) handleActivityTaskClosed(activityID string, scheduledEv
 	command := h.getCommand(makeCommandID(commandTypeActivity, activityID))
 	// If, for whatever reason, we were going to send an activity cancel request, don't do that anymore
 	// since we already know the activity is resolved.
-	possibleCancelID := makeCommandID(commandTypeRequestCancelActivityTask, activityID)
+	possibleCancelID := makeCommandID(commandTypeRequestCancelActivityTask, strconv.FormatInt(scheduledEventID, 10))
 	h.removeCancelOfResolvedCommand(possibleCancelID)
 	command.handleCompletionEvent()
 	delete(h.scheduledEventIDToActivityID, scheduledEventID)

--- a/internal/internal_command_state_machine_test.go
+++ b/internal/internal_command_state_machine_test.go
@@ -252,6 +252,29 @@ func Test_ActivityStateMachine_CompletedAfterCancel(t *testing.T) {
 	require.Equal(t, 0, len(h.getCommands(false)))
 }
 
+func Test_ActivityStateMachine_CompletionRemovesPendingCancelWithCustomActivityID(t *testing.T) {
+	t.Parallel()
+	activityID := "custom-activity-id"
+	attributes := &commandpb.ScheduleActivityTaskCommandAttributes{
+		ActivityId: activityID,
+	}
+	h := newCommandsHelper()
+	h.setCurrentWorkflowTaskStartedEventID(3)
+
+	// Schedule the activity in one workflow task.
+	scheduleID := h.getNextID()
+	d := h.scheduleActivityTask(scheduleID, attributes, nil)
+	require.Len(t, h.getCommands(true), 1)
+	h.handleActivityTaskScheduled(activityID, scheduleID)
+	require.Equal(t, commandStateInitiated, d.getState())
+
+	// Queue cancellation, then resolve the activity before the next workflow task starts.
+	h.requestCancelActivityTask(activityID)
+	h.handleActivityTaskClosed(activityID, scheduleID)
+
+	require.Empty(t, h.getCommands(false))
+}
+
 func Test_ActivityStateMachine_CancelInitiated_After_CanceledBeforeSent(t *testing.T) {
 	t.Parallel()
 	activityID := "test-activity-1"

--- a/test/replaytests/cancel-activity-completion-before-workflow-task-started.json
+++ b/test/replaytests/cancel-activity-completion-before-workflow-task-started.json
@@ -1,0 +1,194 @@
+{
+  "events": [
+    {
+      "eventId": "1",
+      "eventTime": "2026-07-30T09:31:08.315536125Z",
+      "eventType": "WorkflowExecutionStarted",
+      "taskId": "1",
+      "workflowExecutionStartedEventAttributes": {
+        "workflowType": {
+          "name": "CancelActivityCompletionBeforeWorkflowTaskStarted"
+        },
+        "taskQueue": {
+          "name": "replay-test",
+          "kind": "Normal"
+        },
+        "workflowExecutionTimeout": "0s",
+        "workflowRunTimeout": "0s",
+        "workflowTaskTimeout": "10s",
+        "originalExecutionRunId": "019fb25d-049b-782a-9796-2fca5d96ee0e",
+        "identity": "replay-test",
+        "firstExecutionRunId": "019fb25d-049b-782a-9796-2fca5d96ee0e",
+        "attempt": 1,
+        "firstWorkflowTaskBackoff": "0s",
+        "header": {}
+      }
+    },
+    {
+      "eventId": "2",
+      "eventTime": "2026-07-30T09:31:08.340919073Z",
+      "eventType": "WorkflowTaskScheduled",
+      "taskId": "2",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "replay-test",
+          "kind": "Normal"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "3",
+      "eventTime": "2026-07-30T09:31:08.351929366Z",
+      "eventType": "WorkflowTaskStarted",
+      "taskId": "3",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "2",
+        "identity": "replay-test",
+        "requestId": "00000000-0000-0000-0000-000000000003",
+        "historySizeBytes": "500"
+      }
+    },
+    {
+      "eventId": "4",
+      "eventTime": "2026-07-30T09:31:08.367429716Z",
+      "eventType": "WorkflowTaskCompleted",
+      "taskId": "4",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "2",
+        "startedEventId": "3",
+        "identity": "replay-test",
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "5",
+      "eventTime": "2026-07-30T09:31:08.367490254Z",
+      "eventType": "ActivityTaskScheduled",
+      "taskId": "5",
+      "activityTaskScheduledEventAttributes": {
+        "activityId": "custom-activity-id",
+        "activityType": {
+          "name": "helloworldActivity"
+        },
+        "taskQueue": {
+          "name": "replay-test",
+          "kind": "Normal"
+        },
+        "header": {},
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "IndvcmxkIg=="
+            }
+          ]
+        },
+        "scheduleToCloseTimeout": "0s",
+        "scheduleToStartTimeout": "60s",
+        "startToCloseTimeout": "60s",
+        "heartbeatTimeout": "20s",
+        "workflowTaskCompletedEventId": "4",
+        "retryPolicy": {
+          "initialInterval": "1s",
+          "backoffCoefficient": 2,
+          "maximumInterval": "100s"
+        }
+      }
+    },
+    {
+      "eventId": "6",
+      "eventTime": "2026-07-30T09:31:08.367543849Z",
+      "eventType": "ActivityTaskStarted",
+      "taskId": "6",
+      "activityTaskStartedEventAttributes": {
+        "scheduledEventId": "5",
+        "identity": "replay-test",
+        "requestId": "00000000-0000-0000-0000-000000000006",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "7",
+      "eventTime": "2026-07-30T09:31:10.837866966Z",
+      "eventType": "WorkflowExecutionCancelRequested",
+      "taskId": "7",
+      "workflowExecutionCancelRequestedEventAttributes": {
+        "identity": "replay-test"
+      }
+    },
+    {
+      "eventId": "8",
+      "eventTime": "2026-07-30T09:31:10.837875154Z",
+      "eventType": "WorkflowTaskScheduled",
+      "taskId": "8",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "replay-test",
+          "kind": "Normal"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "9",
+      "eventTime": "2026-07-30T09:31:10.847626093Z",
+      "eventType": "ActivityTaskCompleted",
+      "taskId": "9",
+      "activityTaskCompletedEventAttributes": {
+        "result": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "IkhlbGxvIHdvcmxkISI="
+            }
+          ]
+        },
+        "scheduledEventId": "5",
+        "startedEventId": "6",
+        "identity": "replay-test"
+      }
+    },
+    {
+      "eventId": "10",
+      "eventTime": "2026-07-30T09:31:10.859659419Z",
+      "eventType": "WorkflowTaskStarted",
+      "taskId": "10",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "8",
+        "identity": "replay-test",
+        "requestId": "00000000-0000-0000-0000-000000000010",
+        "historySizeBytes": "1500"
+      }
+    },
+    {
+      "eventId": "11",
+      "eventTime": "2026-07-30T09:31:10.876650965Z",
+      "eventType": "WorkflowTaskCompleted",
+      "taskId": "11",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "8",
+        "startedEventId": "10",
+        "identity": "replay-test",
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "12",
+      "eventTime": "2026-07-30T09:31:10.876668368Z",
+      "eventType": "WorkflowExecutionCanceled",
+      "taskId": "12",
+      "workflowExecutionCanceledEventAttributes": {
+        "workflowTaskCompletedEventId": "11"
+      }
+    }
+  ]
+}

--- a/test/replaytests/replay_test.go
+++ b/test/replaytests/replay_test.go
@@ -387,6 +387,17 @@ func (s *replayTestSuite) TestCancelOrder() {
 	s.NoError(err)
 }
 
+func (s *replayTestSuite) TestCancelActivityCompletionBeforeWorkflowTaskStarted() {
+	replayer := worker.NewWorkflowReplayer()
+	replayer.RegisterWorkflow(CancelActivityCompletionBeforeWorkflowTaskStarted)
+
+	err := replayer.ReplayWorkflowHistoryFromJSONFile(
+		ilog.NewDefaultLogger(),
+		"cancel-activity-completion-before-workflow-task-started.json",
+	)
+	s.NoError(err)
+}
+
 func (s *replayTestSuite) TestChildWorkflowCancelWithUpdate() {
 	// Test that update requests are still replayed successfully
 	// when commands are generated before the update requests are handled

--- a/test/replaytests/workflows.go
+++ b/test/replaytests/workflows.go
@@ -461,6 +461,16 @@ func CancelOrderSelectWorkflow(ctx workflow.Context) error {
 	return err
 }
 
+func CancelActivityCompletionBeforeWorkflowTaskStarted(ctx workflow.Context) error {
+	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		ActivityID:             "custom-activity-id",
+		ScheduleToStartTimeout: time.Minute,
+		StartToCloseTimeout:    time.Minute,
+		HeartbeatTimeout:       20 * time.Second,
+	})
+	return workflow.ExecuteActivity(ctx, helloworldActivity, "world").Get(ctx, nil)
+}
+
 func ChildWorkflowCancelWithUpdate(ctx workflow.Context) error {
 	if err := workflow.SetUpdateHandler(ctx, "update",
 		func(ctx workflow.Context) error {


### PR DESCRIPTION


<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

When an Activity completes before a pending cancellation command is sent, the Go SDK should remove the cancellation command regardless of whether the Activity uses a custom Activity ID. The Workflow Task should complete without sending RequestCancelActivityTask for an already-completed Activity.

## Why?

The Server reject the cancel command causing the workflow to get stuck.

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-go/issues/2512

2. How was this tested:
Unit tests, and replay tests

3. Any docs updates needed?
No
