### PR TITLE
fix: add TMPRL1105 prefix to extstore error

### DIFF
--- a/internal/extstore/internal_extstore.go
+++ b/internal/extstore/internal_extstore.go
@@ -226,7 +226,7 @@ func (v *externalRetrievalVisitor) Visit(ctx *proxy.VisitPayloadsContext, payloa
 		// No storage drivers configured at all — fail immediately with a clear error
 		// rather than passing through an unresolved reference.
 		if len(v.params.driverMap) == 0 {
-			return nil, fmt.Errorf("externally stored payload encountered but no storage driver is configured")
+			return nil, fmt.Errorf("[TMPRL1105] Externally stored payload encountered but no storage driver is configured")
 		}
 
 		ref, err := payloadToStorageReference(p)

--- a/test/external_storage_test.go
+++ b/test/external_storage_test.go
@@ -542,7 +542,7 @@ func (s *ExternalStorageTestSuite) TestWorkerWithoutExternalStorageFails() {
 		return false
 	}, 10*time.Second, 200*time.Millisecond, "expected a WorkflowTaskFailed event")
 
-	s.Contains(failureMsg, "externally stored payload encountered but no storage driver is configured")
+	s.Contains(failureMsg, "[TMPRL1105] Externally stored payload encountered but no storage driver is configured")
 	s.NoError(s.client.TerminateWorkflow(ctx, wfID, "", "test complete"))
 }
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Add TMPRL1105 to the error that is returned when we detect storage references but external storage is not configured.

## Why?

Consistency with other SDKs and drive customers to the https://github.com/temporalio/rules/blob/main/rules/TMPRL1105.md
