### PR TITLE
Honor equals function in test env MutableSideEffect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ to docs, or any other relevant information.
 
 - Prevent workflow task failures when an activity with a custom ID completes while its cancellation
   command is pending.
+- `TestWorkflowEnvironment.MutableSideEffect` now honors the provided equals function and only
+  updates the recorded value when it changes, matching the real worker. Previously it ignored
+  equals and returned a freshly computed value on every call.
 
 ## [1.46.0] - 2026-07-28
 

--- a/internal/internal_event_handlers.go
+++ b/internal/internal_event_handlers.go
@@ -1164,13 +1164,24 @@ func (wc *workflowEnvironmentImpl) MutableSideEffect(id string, f func() interfa
 }
 
 func (wc *workflowEnvironmentImpl) isEqualValue(newValue interface{}, encodedOldValue *commonpb.Payloads, equals func(a, b interface{}) bool) bool {
+	return isEqualMutableSideEffectValue(wc.GetDataConverter(), newValue, encodedOldValue, equals)
+}
+
+// isEqualMutableSideEffectValue reports whether newValue is equal to the
+// previously recorded (encoded) value for a MutableSideEffect, using the
+// user-supplied equals function. It is shared by the real worker and the test
+// environment so both honor equals identically. A nil newValue is compared by
+// its encoded form to avoid invoking equals with a nil.
+func isEqualMutableSideEffectValue(dc converter.DataConverter, newValue interface{}, encodedOldValue *commonpb.Payloads, equals func(a, b interface{}) bool) bool {
 	if newValue == nil {
-		// new value is nil
-		newEncodedValue := wc.encodeValue(nil)
+		newEncodedValue, err := dc.ToPayloads(nil)
+		if err != nil {
+			panic(err)
+		}
 		return proto.Equal(newEncodedValue, encodedOldValue)
 	}
 
-	oldValue := decodeValue(newEncodedValue(encodedOldValue, wc.GetDataConverter()), newValue)
+	oldValue := decodeValue(newEncodedValue(encodedOldValue, dc), newValue)
 	return equals(newValue, oldValue)
 }
 

--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -234,6 +234,11 @@ type (
 		changeVersions map[string]Version
 		openSessions   map[string]*SessionInfo
 
+		// mutableSideEffect holds the last recorded value per MutableSideEffect id
+		// so the test environment can honor the user-supplied equals function the
+		// same way the real worker does (only update when the value changed).
+		mutableSideEffect map[string]*commonpb.Payloads
+
 		workflowCancelHandler func()
 		signalHandler         func(name string, input *commonpb.Payloads, header *commonpb.Header) error
 		queryHandler          func(string, *commonpb.Payloads, *commonpb.Header) (*commonpb.Payloads, error)
@@ -330,8 +335,9 @@ func newTestWorkflowEnvironmentImpl(s *WorkflowTestSuite, parentRegistry *regist
 		},
 		registry: r,
 
-		changeVersions: make(map[string]Version),
-		openSessions:   make(map[string]*SessionInfo),
+		changeVersions:    make(map[string]Version),
+		openSessions:      make(map[string]*SessionInfo),
+		mutableSideEffect: make(map[string]*commonpb.Payloads),
 
 		doneChannel:                 make(chan struct{}),
 		workerStopChannel:           make(chan struct{}),
@@ -3244,10 +3250,24 @@ func (env *testWorkflowEnvironmentImpl) UpsertMemo(memoMap map[string]interface{
 	return err
 }
 
-func (env *testWorkflowEnvironmentImpl) MutableSideEffect(id string, f func() interface{}, _ func(a, b interface{}) bool, _ string) converter.EncodedValue {
+func (env *testWorkflowEnvironmentImpl) MutableSideEffect(id string, f func() interface{}, equals func(a, b interface{}) bool, _ string) converter.EncodedValue {
 	mockMethod := mockMethodForMutableSideEffect
 	if _, ok := env.expectedWorkflowMockCalls[mockMethod]; !ok {
-		return newEncodedValue(env.encodeValue(f()), env.GetDataConverter())
+		// Mirror the real worker's semantics: only record a new value when the
+		// user-supplied equals function reports that the value changed; otherwise
+		// return the previously recorded value.
+		if oldValue, ok := env.mutableSideEffect[id]; ok {
+			newValue := f()
+			if isEqualMutableSideEffectValue(env.GetDataConverter(), newValue, oldValue, equals) {
+				return newEncodedValue(oldValue, env.GetDataConverter())
+			}
+			encoded := env.encodeValue(newValue)
+			env.mutableSideEffect[id] = encoded
+			return newEncodedValue(encoded, env.GetDataConverter())
+		}
+		encoded := env.encodeValue(f())
+		env.mutableSideEffect[id] = encoded
+		return newEncodedValue(encoded, env.GetDataConverter())
 	}
 
 	mockRet := env.workflowMock.MethodCalled(mockMethod, id)

--- a/internal/internal_workflow_testsuite_test.go
+++ b/internal/internal_workflow_testsuite_test.go
@@ -826,8 +826,14 @@ func (s *WorkflowTestSuiteUnitTest) Test_MutableSideEffect_HonorsEqualsFunc() {
 			func(ctx Context) interface{} { return 10 }, neverEqual))
 		changedSecond := get(MutableSideEffect(ctx, "changed",
 			func(ctx Context) interface{} { return 20 }, neverEqual))
+		// The previous call must have stored 20 as the new baseline. With equals
+		// true, this returns that stored baseline (20), not the newly computed 30.
+		// An implementation that returns the changed value but forgets to store it
+		// would keep a stale baseline (10) and return 10 here.
+		changedThird := get(MutableSideEffect(ctx, "changed",
+			func(ctx Context) interface{} { return 30 }, alwaysEqual))
 
-		return []int{pinnedFirst, pinnedSecond, changedFirst, changedSecond}, nil
+		return []int{pinnedFirst, pinnedSecond, changedFirst, changedSecond, changedThird}, nil
 	}
 
 	env := s.NewTestWorkflowEnvironment()
@@ -837,7 +843,7 @@ func (s *WorkflowTestSuiteUnitTest) Test_MutableSideEffect_HonorsEqualsFunc() {
 	s.NoError(env.GetWorkflowError())
 	var result []int
 	s.NoError(env.GetWorkflowResult(&result))
-	s.Equal([]int{1, 1, 10, 20}, result)
+	s.Equal([]int{1, 1, 10, 20, 20}, result)
 }
 
 func (s *WorkflowTestSuiteUnitTest) Test_LongRunningSideEffect() {

--- a/internal/internal_workflow_testsuite_test.go
+++ b/internal/internal_workflow_testsuite_test.go
@@ -801,6 +801,45 @@ func (s *WorkflowTestSuiteUnitTest) Test_OnMutableSideEffect() {
 	env.AssertExpectations(s.T())
 }
 
+func (s *WorkflowTestSuiteUnitTest) Test_MutableSideEffect_HonorsEqualsFunc() {
+	// The test environment must honor the user-supplied equals function the same
+	// way the real worker does: a new value is only recorded when equals reports
+	// a change. See https://github.com/temporalio/sdk-go/issues/2109.
+	workflowFn := func(ctx Context) ([]int, error) {
+		var alwaysEqual = func(a, b interface{}) bool { return true }
+		var neverEqual = func(a, b interface{}) bool { return false }
+
+		get := func(v converter.EncodedValue) int {
+			var out int
+			s.NoError(v.Get(&out))
+			return out
+		}
+
+		// equals always true: value stays pinned to the first (1), not 2.
+		pinnedFirst := get(MutableSideEffect(ctx, "pinned",
+			func(ctx Context) interface{} { return 1 }, alwaysEqual))
+		pinnedSecond := get(MutableSideEffect(ctx, "pinned",
+			func(ctx Context) interface{} { return 2 }, alwaysEqual))
+
+		// equals always false: value updates on every call.
+		changedFirst := get(MutableSideEffect(ctx, "changed",
+			func(ctx Context) interface{} { return 10 }, neverEqual))
+		changedSecond := get(MutableSideEffect(ctx, "changed",
+			func(ctx Context) interface{} { return 20 }, neverEqual))
+
+		return []int{pinnedFirst, pinnedSecond, changedFirst, changedSecond}, nil
+	}
+
+	env := s.NewTestWorkflowEnvironment()
+	env.ExecuteWorkflow(workflowFn)
+
+	s.True(env.IsWorkflowCompleted())
+	s.NoError(env.GetWorkflowError())
+	var result []int
+	s.NoError(env.GetWorkflowResult(&result))
+	s.Equal([]int{1, 1, 10, 20}, result)
+}
+
 func (s *WorkflowTestSuiteUnitTest) Test_LongRunningSideEffect() {
 	workflowFn := func(ctx Context) error {
 		// Sleep for 2 seconds would trigger deadlock detection timeout if we wouldn't override it below.


### PR DESCRIPTION
## What

`TestWorkflowEnvironment.MutableSideEffect` ignored the user-supplied `equals`
function and kept no per-id state, so it returned `f()` on every call. A real
worker only records/returns a new value when `equals(new, old)` reports a
change; otherwise it returns the previously recorded value. As a result,
workflows that use `MutableSideEffect` (for example, to read dynamically
changing config) behave differently under test than in production.

Fixes #2109 (reproduced on current `main`; reported against v1.26.0).

## Change

- Track the last recorded value per id in the test environment and honor
  `equals`: the first value is recorded, and on a later call the new value is
  only recorded/returned when `equals` reports a change.
- Extract the comparison into a shared helper `isEqualMutableSideEffectValue`;
  the production `isEqualValue` now delegates to it, so the test environment and
  the real worker use identical semantics and cannot drift again.
- The mock path (`OnMutableSideEffect`) is unchanged.

## Testing

- Added `Test_MutableSideEffect_HonorsEqualsFunc`: equals-true pins the value to
  the first result, equals-false updates on each call, and distinct ids are
  independent.
- `go test ./internal -run TestUnitTestSuite` passes; production
  `Test_MutatingFunctionsInMutableSideEffect` and `...InSideEffect` pass;
  `go vet ./internal` and `gofmt` are clean.
