### PR TITLE
Fix double sending link on SAA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ to docs, or any other relevant information.
 
 ## [Unreleased]
 
+### Added
+
+- Nexus operation link propagation for stand-alone activities. When a Nexus operation handler uses
+  `client.ExecuteActivity`, inbound Nexus request links are forwarded to the activity and the
+  activity link returned by the server is propagated back to the Nexus operation caller.
 
 ## [1.46.0] - 2026-07-28
 

--- a/internal/internal_activity_client.go
+++ b/internal/internal_activity_client.go
@@ -599,7 +599,8 @@ func (w *workflowClientInterceptor) ExecuteActivity(
 			request.Links = links
 		}
 	}
-	if _, ok := NexusOperationContextFromGoContext(ctx); ok {
+	if _, ok := NexusOperationContextFromGoContext(ctx); ok &&
+		(len(request.GetCompletionCallbacks()) > 0 || len(request.GetLinks()) > 0) {
 		request.OnConflictOptions = &commonpb.OnConflictOptions{
 			AttachRequestId:           request.GetRequestId() != "",
 			AttachCompletionCallbacks: len(request.GetCompletionCallbacks()) > 0,

--- a/internal/internal_activity_client.go
+++ b/internal/internal_activity_client.go
@@ -113,27 +113,12 @@ type (
 		// StartDelay - Time to wait before dispatching the activity. This delay is not applied to retry attempts.
 		StartDelay time.Duration
 
-		// responseInfo holds the response Link populated by the server when the activity is started.
-		// Only settable by the SDK - e.g. [temporalnexus.temporalOperation].
-		responseInfo *startActivityResponseInfo
 		// requestID is the request ID used to dedup retried starts.
 		// Only settable by the SDK - e.g. [temporalnexus.temporalOperation].
 		requestID string
 		// callbacks is the set of completion callbacks the server should invoke when the activity
 		// reaches a terminal state. Only settable by the SDK - e.g. [temporalnexus.temporalOperation].
 		callbacks []*commonpb.Callback
-		// links to be associated with the activity. Only settable by the SDK - e.g. [temporalnexus.temporalOperation].
-		links []*commonpb.Link
-		// onConflictOptions configures behavior when ActivityIdConflictPolicy is USE_EXISTING and an
-		// activity with the same ID is already running. Only settable by the SDK - e.g. [temporalnexus.temporalOperation].
-		onConflictOptions *OnConflictOptions
-	}
-
-	// startActivityResponseInfo can be populated by the SDK to receive additional fields from the
-	// StartActivityExecution response. Only settable by the SDK.
-	startActivityResponseInfo struct {
-		// Link to the started activity event.
-		Link *commonpb.Link
 	}
 
 	// ClientGetActivityHandleOptions contains input for GetActivityHandle call.
@@ -605,6 +590,22 @@ func (w *workflowClientInterceptor) ExecuteActivity(
 	if err = in.Options.validateAndSetInRequest(request, dataConverter); err != nil {
 		return nil, err
 	}
+	// When invoked from inside a Nexus operation handler, attach the operation's inbound caller
+	// links to the start request so the backing activity links back to the caller. Async
+	// Nexus-backed activities carry these on the completion callback instead, so skip when a
+	// callback is already present to avoid duplicating them.
+	if len(request.CompletionCallbacks) == 0 {
+		if links, ok := ctx.Value(NexusOperationRequestLinksKey).([]*commonpb.Link); ok {
+			request.Links = links
+		}
+	}
+	if _, ok := NexusOperationContextFromGoContext(ctx); ok {
+		request.OnConflictOptions = &commonpb.OnConflictOptions{
+			AttachRequestId:           request.GetRequestId() != "",
+			AttachCompletionCallbacks: len(request.GetCompletionCallbacks()) > 0,
+			AttachLinks:               len(request.GetLinks()) > 0,
+		}
+	}
 	if request.Input, err = encodeArgs(dataConverter, in.Args); err != nil {
 		return nil, err
 	}
@@ -632,8 +633,8 @@ func (w *workflowClientInterceptor) ExecuteActivity(
 	} else {
 		runID = resp.RunId
 	}
-	if in.Options.responseInfo != nil {
-		in.Options.responseInfo.Link = resp.Link
+	if nctx, ok := NexusOperationContextFromGoContext(ctx); ok {
+		nctx.AddResponseLink(resp.GetLink())
 	}
 
 	return &clientActivityHandleImpl{
@@ -685,14 +686,6 @@ func (options *ClientStartActivityOptions) validateAndSetInRequest(request *work
 		request.RequestId = options.requestID
 	}
 	request.CompletionCallbacks = options.callbacks
-	request.Links = options.links
-	if options.onConflictOptions != nil {
-		request.OnConflictOptions = &commonpb.OnConflictOptions{
-			AttachRequestId:           options.onConflictOptions.AttachRequestID,
-			AttachCompletionCallbacks: options.onConflictOptions.AttachCompletionCallbacks,
-			AttachLinks:               options.onConflictOptions.AttachLinks,
-		}
-	}
 	return nil
 }
 
@@ -706,43 +699,6 @@ func SetRequestIDOnStartActivityOptions(opts *ClientStartActivityOptions, reques
 // ClientStartActivityOptions. Callbacks are purposefully not exposed to users for the time being.
 func SetCallbacksOnStartActivityOptions(opts *ClientStartActivityOptions, callbacks []*commonpb.Callback) {
 	opts.callbacks = callbacks
-}
-
-// SetLinksOnStartActivityOptions is an internal-only method for setting links on
-// ClientStartActivityOptions. Links are purposefully not exposed to users for the time being.
-func SetLinksOnStartActivityOptions(opts *ClientStartActivityOptions, links []*commonpb.Link) {
-	opts.links = links
-}
-
-// SetOnConflictOptionsOnStartActivityOptions is an internal-only method for setting on-conflict
-// options on ClientStartActivityOptions. Used to ensure that when an activity with the same ID is
-// already running and the conflict policy is USE_EXISTING, the caller's request ID, callback, and
-// links are attached to the existing activity.
-func SetOnConflictOptionsOnStartActivityOptions(opts *ClientStartActivityOptions) {
-	opts.onConflictOptions = &OnConflictOptions{
-		AttachRequestID:           true,
-		AttachCompletionCallbacks: true,
-		AttachLinks:               true,
-	}
-}
-
-// SetResponseInfoOnStartActivityOptions is an internal-only method for setting a response info
-// pointer on ClientStartActivityOptions. The returned pointer is populated by ExecuteActivity with
-// the start response's Link.
-func SetResponseInfoOnStartActivityOptions(opts *ClientStartActivityOptions) *startActivityResponseInfo {
-	if opts.responseInfo == nil {
-		opts.responseInfo = &startActivityResponseInfo{}
-	}
-	return opts.responseInfo
-}
-
-// GetResponseLinkFromStartActivityResponseInfo returns the activity start Link captured from the
-// server response, or nil if none was captured.
-func GetResponseLinkFromStartActivityResponseInfo(info *startActivityResponseInfo) *commonpb.Link {
-	if info == nil {
-		return nil
-	}
-	return info.Link
 }
 
 func (w *workflowClientInterceptor) GetActivityHandle(

--- a/internal/internal_activity_client_test.go
+++ b/internal/internal_activity_client_test.go
@@ -80,7 +80,7 @@ func TestExecuteActivityFromLinklessNexusRequestOmitsOnConflictOptions(t *testin
 			return &workflowservice.StartActivityExecutionResponse{RunId: "run-id"}, nil
 		})
 
-	ctx := context.WithValue(context.Background(), nexusOperationContextKey, &NexusOperationContext{})
+	ctx := context.WithValue(t.Context(), nexusOperationContextKey, &NexusOperationContext{})
 	_, err := client.ExecuteActivity(ctx, ClientStartActivityOptions{
 		ID:                     "activity-id",
 		TaskQueue:              "task-queue",

--- a/internal/internal_activity_client_test.go
+++ b/internal/internal_activity_client_test.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/api/workflowservicemock/v1"
 )
 
 // headerCheckInterceptor is a ClientInterceptor that verifies the header is
@@ -62,4 +65,29 @@ func TestExecuteActivityHeaderAvailableToInterceptors(t *testing.T) {
 	require.ErrorContains(t, err, "short-circuit")
 	require.True(t, interceptor.headerWasPresent,
 		"Header should be set on context before interceptor chain runs")
+}
+
+func TestExecuteActivityFromLinklessNexusRequestOmitsOnConflictOptions(t *testing.T) {
+	service := workflowservicemock.NewMockWorkflowServiceClient(gomock.NewController(t))
+	client := NewServiceClient(service, nil, ClientOptions{})
+	client.capabilities = &workflowservice.GetSystemInfoResponse_Capabilities{}
+
+	var request *workflowservice.StartActivityExecutionRequest
+	service.EXPECT().
+		StartActivityExecution(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, req *workflowservice.StartActivityExecutionRequest, _ ...interface{}) (*workflowservice.StartActivityExecutionResponse, error) {
+			request = req
+			return &workflowservice.StartActivityExecutionResponse{RunId: "run-id"}, nil
+		})
+
+	ctx := context.WithValue(context.Background(), nexusOperationContextKey, &NexusOperationContext{})
+	_, err := client.ExecuteActivity(ctx, ClientStartActivityOptions{
+		ID:                     "activity-id",
+		TaskQueue:              "task-queue",
+		ScheduleToCloseTimeout: time.Minute,
+	}, "activity")
+	require.NoError(t, err)
+	require.Empty(t, request.GetLinks())
+	require.Empty(t, request.GetCompletionCallbacks())
+	require.Nil(t, request.GetOnConflictOptions())
 }

--- a/internal/nexus_operations.go
+++ b/internal/nexus_operations.go
@@ -845,18 +845,6 @@ func (t *testSuiteClientForNexusOperations) ExecuteActivity(ctx context.Context,
 	activityID := options.ID
 	runID := uuid.NewString()
 
-	if options.responseInfo != nil {
-		options.responseInfo.Link = &commonpb.Link{
-			Variant: &commonpb.Link_Activity_{
-				Activity: &commonpb.Link_Activity{
-					Namespace:  t.env.workflowInfo.Namespace,
-					ActivityId: activityID,
-					RunId:      runID,
-				},
-			},
-		}
-	}
-
 	params := ExecuteActivityParams{
 		ExecuteActivityOptions: ExecuteActivityOptions{
 			ActivityID:             activityID,

--- a/temporalnexus/temporal_operation.go
+++ b/temporalnexus/temporal_operation.go
@@ -455,11 +455,6 @@ func startActivity[R any](
 		})
 	}
 
-	// Duplicated in links to be compatible with older servers that don't read links from callbacks.
-	internal.SetLinksOnStartActivityOptions(&activityOpts, links)
-	internal.SetOnConflictOptionsOnStartActivityOptions(&activityOpts)
-	responseInfo := internal.SetResponseInfoOnStartActivityOptions(&activityOpts)
-
 	handle, err := c.ExecuteActivity(ctx, activityOpts, activityType, args...)
 	if err != nil {
 		return TemporalOperationResult[R]{}, err
@@ -469,15 +464,6 @@ func startActivity[R any](
 		return TemporalOperationResult[R]{}, err
 	}
 
-	activityLink := internal.GetResponseLinkFromStartActivityResponseInfo(responseInfo).GetActivity()
-	if activityLink == nil {
-		activityLink = &commonpb.Link_Activity{
-			Namespace:  nctx.Namespace,
-			ActivityId: handle.GetID(),
-			RunId:      handle.GetRunID(),
-		}
-	}
-	nexus.AddHandlerLinks(ctx, ConvertLinkActivityToNexusLink(activityLink))
 	return NewAsyncResult[R](encodedToken), nil
 }
 

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -270,7 +270,8 @@ func (ts *IntegrationTestSuite) SetupTest() {
 	ts.worker = worker.New(ts.client, ts.taskQueueName, options)
 	ts.workerStopped = false
 	ts.registerWorkflowsAndActivities(ts.worker)
-	if strings.Contains(ts.T().Name(), "TestExecuteNexusOperationSuite") {
+	if strings.Contains(ts.T().Name(), "TestExecuteNexusOperationSuite") ||
+		strings.Contains(ts.T().Name(), "TestStandaloneActivityStartLinks") {
 		ts.registerStandaloneNexusOperations(ts.worker)
 	}
 	if strings.Contains(ts.T().Name(), "NoWorker") {
@@ -3299,6 +3300,95 @@ func (ts *IntegrationTestSuite) TestStandaloneActivityTracing() {
 	ts.Equal("RunActivity:tracingTestStandaloneActivity", runActivitySpan.Name())
 	ts.Equal(startActivitySpan.SpanContext().SpanID(), runActivitySpan.Parent().SpanID())
 	ts.Equal(startActivitySpan.SpanContext().TraceID(), runActivitySpan.SpanContext().TraceID())
+}
+
+// TestStandaloneActivityStartLinks verifies that a stand-alone activity started from a stand-alone
+// Nexus operation handler carries a link back to the Nexus operation on its start request.
+func (ts *IntegrationTestSuite) TestStandaloneActivityStartLinks() {
+	if os.Getenv("DISABLE_STANDALONE_ACTIVITY_TESTS") != "" {
+		ts.T().SkipNow()
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	endpoint := "standalone-activity-links-ep-" + uuid.NewString()
+	createResp, err := ts.client.OperatorService().CreateNexusEndpoint(ctx, &operatorservice.CreateNexusEndpointRequest{
+		Spec: &nexuspb.EndpointSpec{
+			Name: endpoint,
+			Target: &nexuspb.EndpointTarget{
+				Variant: &nexuspb.EndpointTarget_Worker_{
+					Worker: &nexuspb.EndpointTarget_Worker{
+						Namespace: ts.config.Namespace,
+						TaskQueue: ts.taskQueueName,
+					},
+				},
+			},
+		},
+	})
+	ts.NoError(err)
+	defer func() {
+		_, _ = ts.client.OperatorService().DeleteNexusEndpoint(ctx, &operatorservice.DeleteNexusEndpointRequest{
+			Id:      createResp.Endpoint.Id,
+			Version: createResp.Endpoint.Version,
+		})
+	}()
+
+	nexusClient, err := ts.client.NewNexusClient(client.NexusClientOptions{
+		Endpoint: endpoint,
+		Service:  "test-standalone-service",
+	})
+	ts.NoError(err)
+
+	activityID := "standalone-link-" + uuid.NewString()
+	operationID := "standalone-link-op-" + uuid.NewString()
+	var operationHandle client.NexusOperationHandle
+	require.Eventually(ts.T(), func() bool {
+		operationHandle, err = nexusClient.ExecuteOperation(ctx, "start-standalone-activity", activityID, client.StartNexusOperationOptions{
+			ID:                     operationID,
+			ScheduleToCloseTimeout: 30 * time.Second,
+		})
+		return err == nil
+	}, 10*time.Second, 100*time.Millisecond, "timed out waiting for endpoint to propagate")
+
+	var startedActivityID string
+	ts.NoError(operationHandle.Get(ctx, &startedActivityID))
+	ts.Equal(activityID, startedActivityID)
+
+	activityHandle := ts.client.GetActivityHandle(client.GetActivityHandleOptions{
+		ActivityID: startedActivityID,
+	})
+	var result string
+	ts.NoError(activityHandle.Get(ctx, &result))
+	ts.Equal(activityID, result)
+
+	descResp, err := ts.client.WorkflowService().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+		Namespace:  ts.config.Namespace,
+		ActivityId: activityID,
+	})
+	ts.NoError(err)
+	var nexusOperationLink *commonpb.Link_NexusOperation
+	for _, link := range descResp.GetInfo().GetLinks() {
+		if nexusOp := link.GetNexusOperation(); nexusOp != nil {
+			nexusOperationLink = nexusOp
+		}
+	}
+	ts.Require().NotNil(nexusOperationLink, "activity must link back to the Nexus operation that started it")
+	ts.Equal(ts.config.Namespace, nexusOperationLink.GetNamespace())
+	ts.Equal(operationHandle.GetID(), nexusOperationLink.GetOperationId())
+	ts.Equal(operationHandle.GetRunID(), nexusOperationLink.GetRunId())
+
+	operationDescription, err := operationHandle.Describe(ctx, client.DescribeNexusOperationOptions{})
+	ts.NoError(err)
+	var activityLink *commonpb.Link_Activity
+	for _, link := range operationDescription.RawInfo.GetLinks() {
+		if activity := link.GetActivity(); activity != nil {
+			activityLink = activity
+		}
+	}
+	ts.Require().NotNil(activityLink, "Nexus operation must link to the activity started by its handler")
+	ts.Equal(ts.config.Namespace, activityLink.GetNamespace())
+	ts.Equal(activityHandle.GetID(), activityLink.GetActivityId())
+	ts.Equal(descResp.GetInfo().GetRunId(), activityLink.GetRunId())
 }
 
 func (ts *IntegrationTestSuite) TestOpenTelemetryTracing() {
@@ -7521,7 +7611,21 @@ func (ts *IntegrationTestSuite) registerStandaloneNexusOperations(w worker.Worke
 			return input, nil
 		},
 	)
-	ts.NoError(service.Register(syncOp, asyncOp, asyncEchoOp, linkEchoOp, signalEchoOp))
+	startStandaloneActivityOp := nexus.NewSyncOperation(
+		"start-standalone-activity",
+		func(ctx context.Context, activityID string, _ nexus.StartOperationOptions) (string, error) {
+			handle, err := temporalnexus.GetClient(ctx).ExecuteActivity(ctx, client.StartActivityOptions{
+				ID:                     activityID,
+				TaskQueue:              temporalnexus.GetOperationInfo(ctx).TaskQueue,
+				ScheduleToCloseTimeout: 30 * time.Second,
+			}, "EchoString", activityID)
+			if err != nil {
+				return "", err
+			}
+			return handle.GetID(), nil
+		},
+	)
+	ts.NoError(service.Register(syncOp, asyncOp, asyncEchoOp, linkEchoOp, signalEchoOp, startStandaloneActivityOp))
 	w.RegisterNexusService(service)
 }
 
@@ -10191,57 +10295,6 @@ func (ts *IntegrationTestSuite) TestActivityBackedNexusOperationSuite() {
 	retrySucceedActivityInput := "retry-succeed-act-" + uuid.NewString()
 	retryExhaustActivityInput := "retry-exhaust-act-" + uuid.NewString()
 
-	callerNexusStartedLinks := func(run client.WorkflowRun) []*commonpb.Link {
-		iter := ts.client.GetWorkflowHistory(ctx, run.GetID(), run.GetRunID(), false, enumspb.HISTORY_EVENT_FILTER_TYPE_ALL_EVENT)
-		for iter.HasNext() {
-			e, err := iter.Next()
-			ts.NoError(err)
-			if e.GetEventType() == enumspb.EVENT_TYPE_NEXUS_OPERATION_STARTED {
-				return e.GetLinks()
-			}
-		}
-		return nil
-	}
-
-	// verifyActivityLinks asserts forward (caller NexusOperationStarted -> activity) and
-	// backward (activity execution info -> caller workflow event) link plumbing.
-	//
-	// NEXUS-400: server does not currently emit Link_Activity on NexusOperationStarted nor
-	// Link_WorkflowEvent on the backing activity's execution info for activity-backed Nexus
-	// operations. Body commented out until the server fix lands; the helper stays in place
-	// so callers compile and the test table is unchanged.
-	verifyActivityLinks := func(activityID string) func(run client.WorkflowRun) {
-		_ = callerNexusStartedLinks
-		_ = activityID
-		return func(run client.WorkflowRun) {
-			// var fwd *commonpb.Link_Activity
-			// for _, link := range callerNexusStartedLinks(run) {
-			// 	if a := link.GetActivity(); a != nil {
-			// 		fwd = a
-			// 	}
-			// }
-			// ts.NotNil(fwd, "caller's NexusOperationStarted should have a Link_Activity")
-			// if fwd != nil {
-			// 	ts.Equal(activityID, fwd.GetActivityId())
-			// }
-			//
-			// handle := ts.client.GetActivityHandle(client.GetActivityHandleOptions{ActivityID: activityID})
-			// desc, err := handle.Describe(ctx, client.DescribeActivityOptions{})
-			// ts.NoError(err)
-			// var back *commonpb.Link_WorkflowEvent
-			// for _, link := range desc.RawExecutionInfo.GetLinks() {
-			// 	if w := link.GetWorkflowEvent(); w != nil {
-			// 		back = w
-			// 	}
-			// }
-			// ts.NotNil(back, "activity should have a Link_WorkflowEvent back to caller")
-			// if back != nil {
-			// 	ts.Equal(run.GetID(), back.GetWorkflowId())
-			// }
-			_ = run
-		}
-	}
-
 	// verifyActivityFinalStatus polls the activity's Describe until it reports the expected
 	// terminal status, asserting that server-side propagation of the Nexus operation outcome
 	// (cancellation, failure, timeout) actually reaches the backing activity.
@@ -10293,19 +10346,18 @@ func (ts *IntegrationTestSuite) TestActivityBackedNexusOperationSuite() {
 		expected string
 		verify   func(run client.WorkflowRun)
 	}{
-		{"Async with StartActivity", ts.workflows.TemporalOpAsyncActivityCaller, typedActivityInput, typedActivityInput, verifyActivityLinks("act-" + typedActivityInput)},
-		{"Async with StartUntypedActivity", ts.workflows.TemporalOpAsyncUntypedActivityCaller, untypedActivityInput, untypedActivityInput, verifyActivityLinks("act-untyped-" + untypedActivityInput)},
+		{"Async with StartActivity", ts.workflows.TemporalOpAsyncActivityCaller, typedActivityInput, typedActivityInput, nil},
+		{"Async with StartUntypedActivity", ts.workflows.TemporalOpAsyncUntypedActivityCaller, untypedActivityInput, untypedActivityInput, nil},
 		// Regression: activities registered with a custom name via activity.RegisterOptions.Name
 		// must be resolved through the worker's registry when scheduled via
 		// temporalnexus.StartActivity — otherwise the raw Go function name is sent and the
 		// activity fails as unregistered.
-		{"Async with StartActivity resolves worker-registered activity alias", ts.workflows.TemporalOpRenamedActivityCaller, renamedActivityInput, "renamed:" + renamedActivityInput, verifyActivityLinks("renamed-act-" + renamedActivityInput)},
+		{"Async with StartActivity resolves worker-registered activity alias", ts.workflows.TemporalOpRenamedActivityCaller, renamedActivityInput, "renamed:" + renamedActivityInput, nil},
 		{
 			"Cancel activity execution",
 			ts.workflows.TemporalOpCancelActivityCaller,
 			cancelActivityInput, "",
 			composeVerify(
-				verifyActivityLinks("cancel-act-"+cancelActivityInput),
 				verifyActivityFinalStatus("cancel-act-"+cancelActivityInput, enumspb.ACTIVITY_EXECUTION_STATUS_CANCELED),
 			),
 		},
@@ -10315,7 +10367,6 @@ func (ts *IntegrationTestSuite) TestActivityBackedNexusOperationSuite() {
 			failureActivityInput,
 			"application:NexusActivityTestFailureType:activity failed: " + failureActivityInput,
 			composeVerify(
-				verifyActivityLinks("failing-act-"+failureActivityInput),
 				verifyActivityFinalStatus("failing-act-"+failureActivityInput, enumspb.ACTIVITY_EXECUTION_STATUS_FAILED),
 			),
 		},
@@ -10325,7 +10376,6 @@ func (ts *IntegrationTestSuite) TestActivityBackedNexusOperationSuite() {
 			timeoutActivityInput,
 			"timeout:StartToClose",
 			composeVerify(
-				verifyActivityLinks("timeout-act-"+timeoutActivityInput),
 				verifyActivityFinalStatus("timeout-act-"+timeoutActivityInput, enumspb.ACTIVITY_EXECUTION_STATUS_TIMED_OUT),
 			),
 		},
@@ -10335,7 +10385,6 @@ func (ts *IntegrationTestSuite) TestActivityBackedNexusOperationSuite() {
 			stcTimeoutActivityInput,
 			"timeout:ScheduleToClose",
 			composeVerify(
-				verifyActivityLinks("schedule-to-close-act-"+stcTimeoutActivityInput),
 				verifyActivityFinalStatus("schedule-to-close-act-"+stcTimeoutActivityInput, enumspb.ACTIVITY_EXECUTION_STATUS_TIMED_OUT),
 			),
 		},
@@ -10345,7 +10394,6 @@ func (ts *IntegrationTestSuite) TestActivityBackedNexusOperationSuite() {
 			heartbeatTimeoutActivityInput,
 			"timeout:Heartbeat",
 			composeVerify(
-				verifyActivityLinks("heartbeat-act-"+heartbeatTimeoutActivityInput),
 				verifyActivityFinalStatus("heartbeat-act-"+heartbeatTimeoutActivityInput, enumspb.ACTIVITY_EXECUTION_STATUS_TIMED_OUT),
 			),
 		},
@@ -10355,7 +10403,6 @@ func (ts *IntegrationTestSuite) TestActivityBackedNexusOperationSuite() {
 			retrySucceedActivityInput,
 			retrySucceedActivityInput,
 			composeVerify(
-				verifyActivityLinks("retry-succeed-act-"+retrySucceedActivityInput),
 				verifyActivityFinalStatus("retry-succeed-act-"+retrySucceedActivityInput, enumspb.ACTIVITY_EXECUTION_STATUS_COMPLETED),
 				verifyActivityAttemptAtLeast("retry-succeed-act-"+retrySucceedActivityInput, 3),
 			),
@@ -10366,7 +10413,6 @@ func (ts *IntegrationTestSuite) TestActivityBackedNexusOperationSuite() {
 			retryExhaustActivityInput,
 			"application:NexusActivityRetryTestFailureType:attempt 2 failed; will succeed on 999",
 			composeVerify(
-				verifyActivityLinks("retry-exhaust-act-"+retryExhaustActivityInput),
 				verifyActivityFinalStatus("retry-exhaust-act-"+retryExhaustActivityInput, enumspb.ACTIVITY_EXECUTION_STATUS_FAILED),
 				verifyActivityAttemptAtLeast("retry-exhaust-act-"+retryExhaustActivityInput, 2),
 			),
@@ -10460,31 +10506,23 @@ func (ts *IntegrationTestSuite) TestActivityBackedNexusOperationSuite() {
 		ts.Len(descResp.GetCallbacks(), 2,
 			"both callers must have attached callbacks to the same activity")
 
-		// Both callers' NexusOperationStarted events must carry a Link_Activity pointing at the
-		// shared activity (forward link from caller -> activity).
-		//
-		// NEXUS-400: server does not currently emit Link_Activity on NexusOperationStarted for
-		// activity-backed Nexus operations. Commented out until the server fix lands.
-		_ = activityID
-		// for _, run := range []client.WorkflowRun{runA, runB} {
-		// 	iter := ts.client.GetWorkflowHistory(ctx, run.GetID(), run.GetRunID(), false, enumspb.HISTORY_EVENT_FILTER_TYPE_ALL_EVENT)
-		// 	var fwd *commonpb.Link_Activity
-		// 	for iter.HasNext() {
-		// 		e, err := iter.Next()
-		// 		ts.NoError(err)
-		// 		if e.GetEventType() == enumspb.EVENT_TYPE_NEXUS_OPERATION_STARTED {
-		// 			for _, link := range e.GetLinks() {
-		// 				if a := link.GetActivity(); a != nil {
-		// 					fwd = a
-		// 				}
-		// 			}
-		// 		}
-		// 	}
-		// 	ts.NotNil(fwd, "caller %s should have a Link_Activity on NexusOperationStarted", run.GetID())
-		// 	if fwd != nil {
-		// 		ts.Equal(activityID, fwd.GetActivityId())
-		// 	}
-		// }
+		// StartActivity attaches the caller's link to the completion callback (not the start
+		// request). The server stores each callback on the activity, so both callbacks must carry
+		// a workflow-event link back to their respective caller.
+		gotCallerLinkIDs := map[string]bool{}
+		for _, cb := range descResp.GetCallbacks() {
+			links := cb.GetInfo().GetCallback().GetLinks()
+			ts.Len(links, 1, "each callback must carry exactly one caller link")
+			for _, link := range links {
+				we := link.GetWorkflowEvent()
+				ts.NotNil(we, "callback link must be a Link_WorkflowEvent pointing at the caller")
+				if we != nil {
+					gotCallerLinkIDs[we.GetWorkflowId()] = true
+				}
+			}
+		}
+		ts.Equal(map[string]bool{runA.GetID(): true, runB.GetID(): true}, gotCallerLinkIDs,
+			"both callbacks must link back to their caller workflows")
 	})
 
 	// Caller workflow terminated mid-operation: the backing activity terminates its own


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Fix double sending link on SAA + Nexus. Previously if a Standalone Activity was started by a Nexus Operation handler we attached the link to the callback and the request

## Why?
<!-- Tell your future self why have you made these changes -->
Previously I based the SAA code on the Workflow code that has some legacy behaviour for old server that we don't need to handle for SAA.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Nexus–activity linking and start-request shaping on the client `ExecuteActivity` path, which affects correlation and idempotent conflict attachment but not auth or data handling.
> 
> **Overview**
> Fixes **duplicate link attachment** when a Nexus operation handler starts a **standalone activity** via `client.ExecuteActivity`. Caller inbound links are now added on the **start request only when there is no completion callback** (async activity-backed Nexus ops keep links on the callback). **OnConflictOptions** for attaching request ID, callbacks, and links is set only inside a Nexus operation context when those fields are actually present.
> 
> **Response link propagation** moves into `ExecuteActivity`: the server’s activity start link is recorded on the Nexus operation context via `AddResponseLink`, replacing the removed `ClientStartActivityOptions` / `temporalnexus` helpers that duplicated links on both the request and callback paths.
> 
> Adds **`TestStandaloneActivityStartLinks`** (bidirectional Nexus↔activity links) and a unit test that a linkless Nexus `ExecuteActivity` does not send **OnConflictOptions**. Integration tests drop stubbed NEXUS-400 link checks and assert **workflow-event links on shared-activity callbacks** instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2298c341a56d2c55c5847f7edddd7c019741f64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->