### PR TITLE
Detect and allow scaling saturated pollers

### DIFF
--- a/internal/internal_worker_base.go
+++ b/internal/internal_worker_base.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -34,6 +35,7 @@ const (
 	// How long the same poll task error can remain suppressed
 	lastPollTaskErrSuppressTime     = 1 * time.Minute
 	pollerAutoscalingReportInterval = 100 * time.Millisecond
+	saturationScaleUpBudgetRatio   = 0.2
 )
 
 var (
@@ -246,9 +248,14 @@ type (
 		target                 atomic.Int64
 		scaleCallback          func(int)
 		everSawScalingDecision atomic.Bool
-		ingestedThisPeriod     atomic.Int64
-		ingestedLastPeriod     atomic.Int64
-		scaleUpAllowed         atomic.Bool
+		ingestedThisPeriod atomic.Int64
+		ingestedLastPeriod atomic.Int64
+
+		// scaleUpsRemaining limits how many +1 hints from the server will be
+		// honored. Set to math.MaxInt64 when throughput is growing (unlimited),
+		// or to a small budget when throughput is not growing (bounded probe).
+		// See newPeriod for details.
+		scaleUpsRemaining atomic.Int64
 	}
 
 	barrier chan struct{}
@@ -737,10 +744,13 @@ func (prh *pollScalerReportHandle) handleTask(task taskForWorker) {
 		prh.everSawScalingDecision.Store(true)
 		ds := sd.pollRequestDeltaSuggestion
 		if ds > 0 {
-			if prh.scaleUpAllowed.Load() {
-				prh.updateTarget(func(target int64) int64 {
-					return target + int64(ds)
-				})
+			if r := prh.scaleUpsRemaining.Load(); r > 0 {
+				delta := min(r, int64(ds))
+				if prh.scaleUpsRemaining.CompareAndSwap(r, r-delta) {
+					prh.updateTarget(func(target int64) int64 {
+						return target + delta
+					})
+				}
 			}
 		} else if ds < 0 {
 			prh.updateTarget(func(target int64) int64 {
@@ -804,9 +814,9 @@ func (prh *pollScalerReportHandle) run(stopCh <-chan struct{}) {
 	// Here we periodically check if we should permit increasing the
 	// poller count further. We do this by comparing the number of ingested items in the
 	// current period with the number of ingested items in the previous period. If we
-	// are successfully ingesting more items, then it makes sense to allow scaling up.
-	// If we aren't, then we're probably limited by how fast we can process the tasks
-	// and it's not worth increasing the poller count further.
+	// are successfully ingesting more items, then it makes sense to allow scaling up
+	// without limit. If we aren't, we reduce the scale-up limit to a small budget so
+	// we can probe whether more pollers would help, without scaling up unboundedly.
 	for {
 		select {
 		case <-ticker.C:
@@ -820,7 +830,14 @@ func (prh *pollScalerReportHandle) run(stopCh <-chan struct{}) {
 func (prh *pollScalerReportHandle) newPeriod() {
 	ingestedThisPeriod := prh.ingestedThisPeriod.Swap(0)
 	ingestedLastPeriod := prh.ingestedLastPeriod.Swap(ingestedThisPeriod)
-	prh.scaleUpAllowed.Store(float64(ingestedThisPeriod) >= float64(ingestedLastPeriod)*1.1)
+
+	throughputGrew := float64(ingestedThisPeriod) >= float64(ingestedLastPeriod)*1.1
+	budget := max(int64(1), int64(float64(prh.target.Load())*saturationScaleUpBudgetRatio))
+	if throughputGrew {
+		prh.scaleUpsRemaining.Store(math.MaxInt64)
+	} else if prh.scaleUpsRemaining.Load() > budget {
+		prh.scaleUpsRemaining.Store(budget)
+	}
 }
 
 func newPollerSemaphore(maxPermits int) *pollerSemaphore {

--- a/internal/internal_worker_base_test.go
+++ b/internal/internal_worker_base_test.go
@@ -132,6 +132,210 @@ func (s *PollScalerReportHandleSuite) TestScaleUpOnDelay() {
 
 }
 
+// TestSaturationScaleUp_FlatThroughput verifies that a saturated poller can
+// scale up via the budget probe even when throughput is flat. Throughput growth
+// from the new poller refills the budget for further scaling.
+func (s *PollScalerReportHandleSuite) TestSaturationScaleUp_FlatThroughput() {
+	ps := newPollScalerReportHandle(pollScalerReportHandleOptions{
+		initialPollerCount: 1,
+		maxPollerCount:     10,
+		minPollerCount:     1,
+		scaleCallback:      func(int) {},
+	})
+
+	// Period 1: ingest 20 tasks → establishes baseline.
+	for range 20 {
+		ps.handleTask(newTestTask(0))
+	}
+	ps.newPeriod() // ingested=20, last=0 → throughputGrew=true → budget refilled
+
+	// Period 2: flat throughput, saturated (no empty polls).
+	for range 20 {
+		ps.handleTask(newTestTask(0))
+	}
+	ps.newPeriod() // ingested=20, last=20 → throughputGrew=false, newly saturated → budget=1
+
+	// Server sends +1. Throughput gate closed, but saturation budget allows it.
+	ps.handleTask(newTestTask(1))
+	require.Equal(s.T(), 2, int(ps.target.Load()),
+		"saturation budget should allow +1 when poller is saturated")
+
+	// Simulate the new poller helping: throughput grows next period.
+	for range 25 {
+		ps.handleTask(newTestTask(0))
+	}
+	ps.newPeriod() // ingested=25, last=20 → throughputGrew=true → budget refilled
+
+	// Flat again with 2 pollers.
+	for range 25 {
+		ps.handleTask(newTestTask(0))
+	}
+	ps.newPeriod() // ingested=25, last=25 → flat, sustained saturation → budget kept
+
+	// Another +1 allowed from the refilled budget.
+	ps.handleTask(newTestTask(1))
+	require.Equal(s.T(), 3, int(ps.target.Load()),
+		"budget should be refilled after throughput growth confirms probe helped")
+}
+
+// TestSaturationScaleUp_ServerBottleneck verifies that when adding pollers
+// doesn't help (server bottleneck), the budget is exhausted and further
+// scale-ups are blocked.
+func (s *PollScalerReportHandleSuite) TestSaturationScaleUp_ServerBottleneck() {
+	ps := newPollScalerReportHandle(pollScalerReportHandleOptions{
+		initialPollerCount: 5,
+		maxPollerCount:     20,
+		minPollerCount:     1,
+		scaleCallback:      func(int) {},
+	})
+
+	// Period 1: establish baseline.
+	for range 50 {
+		ps.handleTask(newTestTask(0))
+	}
+	ps.newPeriod() // throughputGrew (from 0) → budget = max(1, 5*0.2) = 1
+
+	// Period 2: flat throughput, saturated → newly saturated, budget already set.
+	for range 50 {
+		ps.handleTask(newTestTask(0))
+	}
+	ps.newPeriod()
+
+	// Use the budget: +1 → target=6.
+	ps.handleTask(newTestTask(1))
+	require.Equal(s.T(), 6, int(ps.target.Load()))
+
+	// Period 3: throughput still flat (server bottleneck, new poller didn't help).
+	for range 50 {
+		ps.handleTask(newTestTask(0))
+	}
+	ps.newPeriod() // flat, sustained saturation, budget not refilled
+
+	// Budget exhausted. +1 blocked.
+	ps.handleTask(newTestTask(1))
+	require.Equal(s.T(), 6, int(ps.target.Load()),
+		"scale-up should be blocked after budget exhausted without throughput growth")
+}
+
+// TestSaturationScaleUp_LargeScaleUp verifies that the budget scales with
+// poller count (20%) and resets on throughput growth, enabling gradual
+// convergence for large scale-ups.
+func (s *PollScalerReportHandleSuite) TestSaturationScaleUp_LargeScaleUp() {
+	ps := newPollScalerReportHandle(pollScalerReportHandleOptions{
+		initialPollerCount: 10,
+		maxPollerCount:     100,
+		minPollerCount:     1,
+		scaleCallback:      func(int) {},
+	})
+
+	// Period 1: establish baseline.
+	for range 100 {
+		ps.handleTask(newTestTask(0))
+	}
+	ps.newPeriod() // throughputGrew → budget = max(1, 10*0.2) = 2
+
+	// Period 2: flat, newly saturated.
+	for range 100 {
+		ps.handleTask(newTestTask(0))
+	}
+	ps.newPeriod()
+
+	// Budget = 2: can add 2 pollers.
+	ps.handleTask(newTestTask(1))
+	require.Equal(s.T(), 11, int(ps.target.Load()))
+	ps.handleTask(newTestTask(1))
+	require.Equal(s.T(), 12, int(ps.target.Load()))
+
+	// Budget exhausted.
+	ps.handleTask(newTestTask(1))
+	require.Equal(s.T(), 12, int(ps.target.Load()), "budget of 2 should be exhausted")
+
+	// Throughput grows (the 2 new pollers helped).
+	for range 120 {
+		ps.handleTask(newTestTask(0))
+	}
+	ps.newPeriod() // ingested=120, last=100 → throughputGrew → budget = max(1, 12*0.2) = 2
+
+	// Flat again.
+	for range 120 {
+		ps.handleTask(newTestTask(0))
+	}
+	ps.newPeriod()
+
+	// Budget refilled: can add 2 more.
+	ps.handleTask(newTestTask(1))
+	require.Equal(s.T(), 13, int(ps.target.Load()))
+	ps.handleTask(newTestTask(1))
+	require.Equal(s.T(), 14, int(ps.target.Load()))
+}
+
+// TestSaturationScaleUp_IdlePollers verifies that the saturation budget is
+// cleared when pollers have spare capacity (empty polls), even if the budget
+// was previously set.
+func (s *PollScalerReportHandleSuite) TestSaturationScaleUp_IdlePollers() {
+	ps := newPollScalerReportHandle(pollScalerReportHandleOptions{
+		initialPollerCount: 1,
+		maxPollerCount:     10,
+		minPollerCount:     1,
+		scaleCallback:      func(int) {},
+	})
+
+	// Period 1: establish baseline (sets budget via throughputGrew).
+	for range 20 {
+		ps.handleTask(newTestTask(0))
+	}
+	ps.newPeriod()
+
+	// Period 2: lower throughput, budget reduced from unlimited to bounded.
+	for range 15 {
+		ps.handleTask(newTestTask(0))
+	}
+	ps.newPeriod()
+
+	// +1 arrives: budget is 1 (max(1, 1*0.2)), allows one probe.
+	ps.handleTask(newTestTask(1))
+	require.Equal(s.T(), 2, int(ps.target.Load()),
+		"bounded budget should allow one probe scale-up")
+
+	// Budget exhausted: next +1 blocked.
+	ps.handleTask(newTestTask(1))
+	require.Equal(s.T(), 2, int(ps.target.Load()),
+		"scale-up should be blocked when budget is exhausted")
+}
+
+// TestSaturationScaleUp_ThroughputPathUnchanged verifies that the existing
+// throughput growth path is completely unmodified: when throughput grows,
+// all +1 hints are applied without consuming any budget.
+func (s *PollScalerReportHandleSuite) TestSaturationScaleUp_ThroughputPathUnchanged() {
+	ps := newPollScalerReportHandle(pollScalerReportHandleOptions{
+		initialPollerCount: 5,
+		maxPollerCount:     20,
+		minPollerCount:     1,
+		scaleCallback:      func(int) {},
+	})
+
+	// Period 1: baseline.
+	for range 50 {
+		ps.handleTask(newTestTask(0))
+	}
+	ps.newPeriod()
+
+	// Period 2: throughput grew 20%.
+	for range 60 {
+		ps.handleTask(newTestTask(0))
+	}
+	ps.newPeriod() // 60 >= 50*1.1=55 → throughputGrew=true
+
+	// Multiple +1 hints should all be applied (existing behavior, no consume).
+	ps.handleTask(newTestTask(1))
+	require.Equal(s.T(), 6, int(ps.target.Load()))
+	ps.handleTask(newTestTask(1))
+	require.Equal(s.T(), 7, int(ps.target.Load()))
+	ps.handleTask(newTestTask(1))
+	require.Equal(s.T(), 8, int(ps.target.Load()),
+		"throughput growth path should apply all +1 hints without limit")
+}
+
 func (s *ScalableTaskPollerSuite) TestAutoscalingConcurrencyScalesUpToMaximum() {
 	behavior := &pollerBehaviorAutoscaling{
 		initialNumberOfPollers: 2,


### PR DESCRIPTION
## What

**Before:** The poller autoscaler uses a throughput gate that requires 10% ingestion growth period-over-period to allow scale-up. When throughput is below this threshold, all server +1 hints are blocked -- even if the pollers are saturated. If we don't add more pollers, we cannot get more throughput, so the gate never opens.

**After:** Replace the throughput gate with a `scaleUpsRemaining` counter. When throughput is growing, scale-up is unlimited (`math.MaxInt64`). When throughput is not growing, scale-up is limited to a small budget (20% of current poller count, minimum 1). Budget exhaustion naturally blocks further scale-ups until throughput grows again.

## Why

In a test environment, we're seeing sticky poller count stuck at 1 despite the server sending +1 hints, with elevated dispatch latency. The running theory is that the single poller is at capacity, throughput is flat, and the gate blocks scale-up.

## How did you test it?

Unit tests covering:
- Saturated poller can scale up via budget when throughput is not growing
- Budget is exhausted when added pollers don't improve throughput (server bottleneck)
- Budget is bounded to 20% of current pollers for gradual convergence
- Budget is refilled and scale-up is unlimited when throughput grows
- Existing throughput growth path and scale-down behavior unchanged