### PR TITLE
Add optional retry policy to RemotePayloadCodec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,8 @@ to docs, or any other relevant information.
 
 - Improved the performance of yield-heavy workloads by eliminating unnecessary computation and heap allocations.
 - Replaced the internal `OnceCell` implementation with `sync.OnceValue` for lazy workflow run ID lookup.
+- Added optional `RetryPolicy` field to `RemotePayloadCodecOptions` for configuring
+  exponential-backoff retries on transient HTTP failures. Retries are disabled by default.
 
 ### Fixed
 

--- a/converter/codec.go
+++ b/converter/codec.go
@@ -3,13 +3,16 @@ package converter
 import (
 	"bytes"
 	"compress/zlib"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	commonpb "go.temporal.io/api/common/v1"
+	"go.temporal.io/sdk/internal/common/backoff"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 )
@@ -353,12 +356,59 @@ func NewPayloadCodecHTTPHandler(e ...PayloadCodec) http.Handler {
 	return &codecHTTPHandler{codecs: e}
 }
 
+// RemotePayloadCodecRetryPolicy configures retry behavior for
+// RemotePayloadCodec HTTP calls. When set on RemotePayloadCodecOptions,
+// transient failures are retried with exponential backoff. Retries consume
+// the Workflow Task timeout budget, so keep MaxAttempts and Expiration bounded.
+type RemotePayloadCodecRetryPolicy struct {
+	// InitialInterval is the delay before the first retry.
+	// Required; must be positive.
+	InitialInterval time.Duration
+
+	// MaximumInterval caps the delay between retries. Zero means unlimited.
+	MaximumInterval time.Duration
+
+	// BackoffCoefficient is the multiplier applied to the interval after each
+	// retry. Defaults to 2.0 when zero.
+	BackoffCoefficient float64
+
+	// MaxAttempts is the maximum number of attempts (including the initial
+	// call). For example, 3 means one initial call plus two retries.
+	// Zero means unlimited attempts (bounded only by Expiration or context).
+	MaxAttempts int
+
+	// Expiration is the total time allowed for all attempts. Zero means no
+	// expiration limit (bounded only by MaxAttempts or context).
+	Expiration time.Duration
+
+	// IsRetryableError is an optional predicate that decides whether a given
+	// error should be retried. When nil, all errors are considered retryable.
+	// HTTP responses with non-200 status codes are wrapped in
+	// *RemotePayloadCodecHTTPError before being passed to this function.
+	IsRetryableError func(error) bool
+}
+
+// RemotePayloadCodecHTTPError is returned when the remote codec endpoint
+// responds with a non-200 status code.
+type RemotePayloadCodecHTTPError struct {
+	StatusCode int
+	Status     string
+	Body       string
+}
+
+func (e *RemotePayloadCodecHTTPError) Error() string {
+	return fmt.Sprintf("%s: %s", e.Status, e.Body)
+}
+
 // RemotePayloadCodecOptions are options for RemotePayloadCodec.
 // Client is optional.
 type RemotePayloadCodecOptions struct {
 	Endpoint      string
 	ModifyRequest func(*http.Request) error
 	Client        http.Client
+	// RetryPolicy configures optional retry behavior for HTTP calls.
+	// When nil (the default), no retries are attempted.
+	RetryPolicy *RemotePayloadCodecRetryPolicy
 }
 
 type remotePayloadCodec struct {
@@ -386,44 +436,83 @@ func (pc *remotePayloadCodec) encodeOrDecode(endpoint string, payloads []*common
 		return payloads, fmt.Errorf("unable to marshal payloads: %w", err)
 	}
 
-	req, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewReader(requestPayloads))
-	if err != nil {
-		return payloads, fmt.Errorf("unable to build request: %w", err)
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-
-	if pc.options.ModifyRequest != nil {
-		err = pc.options.ModifyRequest(req)
+	var result []*commonpb.Payload
+	doRequest := func() error {
+		req, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewReader(requestPayloads))
 		if err != nil {
-			return payloads, err
+			return fmt.Errorf("unable to build request: %w", err)
+		}
+
+		req.Header.Set("Content-Type", "application/json")
+
+		if pc.options.ModifyRequest != nil {
+			if err = pc.options.ModifyRequest(req); err != nil {
+				return err
+			}
+		}
+
+		response, err := pc.options.Client.Do(req)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = response.Body.Close() }()
+
+		if response.StatusCode == 200 {
+			bs, err := io.ReadAll(response.Body)
+			if err != nil {
+				return fmt.Errorf("failed to read response body: %w", err)
+			}
+			var resultPayloads commonpb.Payloads
+			err = protojson.Unmarshal(bs, &resultPayloads)
+			if err != nil {
+				return fmt.Errorf("unable to unmarshal payloads: %w", err)
+			}
+			if len(payloads) != len(resultPayloads.Payloads) {
+				return fmt.Errorf("received %d payloads from remote codec, expected %d", len(resultPayloads.Payloads), len(payloads))
+			}
+			result = resultPayloads.Payloads
+			return nil
+		}
+
+		message, _ := io.ReadAll(response.Body)
+		return &RemotePayloadCodecHTTPError{
+			StatusCode: response.StatusCode,
+			Status:     http.StatusText(response.StatusCode),
+			Body:       string(message),
 		}
 	}
 
-	response, err := pc.options.Client.Do(req)
+	if pc.options.RetryPolicy == nil {
+		if err := doRequest(); err != nil {
+			return payloads, err
+		}
+		return result, nil
+	}
+
+	policy := pc.buildRetryPolicy()
+	err = backoff.Retry(context.Background(), doRequest, policy, pc.options.RetryPolicy.IsRetryableError)
 	if err != nil {
 		return payloads, err
 	}
-	defer func() { _ = response.Body.Close() }()
+	return result, nil
+}
 
-	if response.StatusCode == 200 {
-		bs, err := io.ReadAll(response.Body)
-		if err != nil {
-			return payloads, fmt.Errorf("failed to read response body: %w", err)
-		}
-		var resultPayloads commonpb.Payloads
-		err = protojson.Unmarshal(bs, &resultPayloads)
-		if err != nil {
-			return payloads, fmt.Errorf("unable to unmarshal payloads: %w", err)
-		}
-		if len(payloads) != len(resultPayloads.Payloads) {
-			return payloads, fmt.Errorf("received %d payloads from remote codec, expected %d", len(resultPayloads.Payloads), len(payloads))
-		}
-		return resultPayloads.Payloads, nil
+func (pc *remotePayloadCodec) buildRetryPolicy() *backoff.ExponentialRetryPolicy {
+	rp := pc.options.RetryPolicy
+	policy := backoff.NewExponentialRetryPolicy(rp.InitialInterval)
+	if rp.BackoffCoefficient != 0 {
+		policy.SetBackoffCoefficient(rp.BackoffCoefficient)
 	}
-
-	message, _ := io.ReadAll(response.Body)
-	return payloads, fmt.Errorf("%s: %s", http.StatusText(response.StatusCode), message)
+	if rp.MaximumInterval != 0 {
+		policy.SetMaximumInterval(rp.MaximumInterval)
+	}
+	if rp.MaxAttempts != 0 {
+		policy.SetMaximumAttempts(rp.MaxAttempts)
+	}
+	if rp.Expiration != 0 {
+		policy.SetExpirationInterval(rp.Expiration)
+	}
+	return policy
 }
 
 // Fields Endpoint, ModifyRequest, Client of RemotePayloadCodecOptions are also
@@ -445,7 +534,11 @@ type remoteDataConverter struct {
 // encoding/decoding on the payload via the remote endpoint.
 func NewRemoteDataConverter(parent DataConverter, options RemoteDataConverterOptions) DataConverter {
 	options.Endpoint = strings.TrimSuffix(options.Endpoint, "/")
-	payloadCodec := NewRemotePayloadCodec(RemotePayloadCodecOptions(options))
+	payloadCodec := NewRemotePayloadCodec(RemotePayloadCodecOptions{
+		Endpoint:      options.Endpoint,
+		ModifyRequest: options.ModifyRequest,
+		Client:        options.Client,
+	})
 	return &remoteDataConverter{parent, payloadCodec}
 }
 

--- a/converter/codec_test.go
+++ b/converter/codec_test.go
@@ -3,12 +3,15 @@ package converter
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	commonpb "go.temporal.io/api/common/v1"
@@ -354,4 +357,156 @@ func TestCodecDataConverter_ToPayload_EncodeError(t *testing.T) {
 	require.EqualError(err, "some encode error")
 	// Also assert that the original payload is returned on error.
 	require.True(proto.Equal(originalPayload, payload))
+}
+
+func TestRemotePayloadCodecNoRetry(t *testing.T) {
+	var attempts atomic.Int32
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts.Add(1)
+		http.Error(w, "server error", http.StatusInternalServerError)
+	})
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	codec := NewRemotePayloadCodec(RemotePayloadCodecOptions{
+		Endpoint: server.URL,
+	})
+
+	defaultConv := GetDefaultDataConverter()
+	payloads, _ := defaultConv.ToPayloads("test")
+
+	_, err := codec.Encode(payloads.Payloads)
+	require.Error(t, err)
+	require.Equal(t, int32(1), attempts.Load())
+}
+
+func TestRemotePayloadCodecRetryOnTransientError(t *testing.T) {
+	var attempts atomic.Int32
+	codec := NewZlibCodec(ZlibCodecOptions{AlwaysEncode: true})
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := attempts.Add(1)
+		if n < 3 {
+			http.Error(w, "server error", http.StatusInternalServerError)
+			return
+		}
+		NewPayloadCodecHTTPHandler(codec).ServeHTTP(w, r)
+	})
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	remoteCodec := NewRemotePayloadCodec(RemotePayloadCodecOptions{
+		Endpoint: server.URL,
+		RetryPolicy: &RemotePayloadCodecRetryPolicy{
+			InitialInterval: 10 * time.Millisecond,
+			MaxAttempts:     5,
+		},
+	})
+
+	defaultConv := GetDefaultDataConverter()
+	payloads, _ := defaultConv.ToPayloads("test")
+
+	encoded, err := remoteCodec.Encode(payloads.Payloads)
+	require.NoError(t, err)
+	require.Equal(t, int32(3), attempts.Load())
+
+	localEncoded, err := codec.Encode(payloads.Payloads)
+	require.NoError(t, err)
+	require.Len(t, encoded, len(localEncoded))
+}
+
+func TestRemotePayloadCodecRetryExhausted(t *testing.T) {
+	var attempts atomic.Int32
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts.Add(1)
+		http.Error(w, "always fails", http.StatusServiceUnavailable)
+	})
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	codec := NewRemotePayloadCodec(RemotePayloadCodecOptions{
+		Endpoint: server.URL,
+		RetryPolicy: &RemotePayloadCodecRetryPolicy{
+			InitialInterval: 10 * time.Millisecond,
+			MaxAttempts:     3,
+		},
+	})
+
+	defaultConv := GetDefaultDataConverter()
+	payloads, _ := defaultConv.ToPayloads("test")
+
+	_, err := codec.Encode(payloads.Payloads)
+	require.Error(t, err)
+	var httpErr *RemotePayloadCodecHTTPError
+	require.True(t, errors.As(err, &httpErr))
+	require.Equal(t, http.StatusServiceUnavailable, httpErr.StatusCode)
+	require.Equal(t, int32(3), attempts.Load())
+}
+
+func TestRemotePayloadCodecRetryIsRetryableFilter(t *testing.T) {
+	var attempts atomic.Int32
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts.Add(1)
+		http.Error(w, "bad request", http.StatusBadRequest)
+	})
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	codec := NewRemotePayloadCodec(RemotePayloadCodecOptions{
+		Endpoint: server.URL,
+		RetryPolicy: &RemotePayloadCodecRetryPolicy{
+			InitialInterval: 10 * time.Millisecond,
+			MaxAttempts:     5,
+			IsRetryableError: func(err error) bool {
+				var httpErr *RemotePayloadCodecHTTPError
+				if errors.As(err, &httpErr) {
+					return httpErr.StatusCode >= 500
+				}
+				return true
+			},
+		},
+	})
+
+	defaultConv := GetDefaultDataConverter()
+	payloads, _ := defaultConv.ToPayloads("test")
+
+	_, err := codec.Encode(payloads.Payloads)
+	require.Error(t, err)
+	require.Equal(t, int32(1), attempts.Load())
+}
+
+func TestRemotePayloadCodecRetryTransportError(t *testing.T) {
+	var attempts atomic.Int32
+	codec := NewZlibCodec(ZlibCodecOptions{AlwaysEncode: true})
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := attempts.Add(1)
+		if n == 1 {
+			hj, ok := w.(http.Hijacker)
+			if !ok {
+				http.Error(w, "hijack not supported", http.StatusInternalServerError)
+				return
+			}
+			conn, _, _ := hj.Hijack()
+			conn.Close()
+			return
+		}
+		NewPayloadCodecHTTPHandler(codec).ServeHTTP(w, r)
+	})
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	remoteCodec := NewRemotePayloadCodec(RemotePayloadCodecOptions{
+		Endpoint: server.URL,
+		RetryPolicy: &RemotePayloadCodecRetryPolicy{
+			InitialInterval: 10 * time.Millisecond,
+			MaxAttempts:     3,
+		},
+	})
+
+	defaultConv := GetDefaultDataConverter()
+	payloads, _ := defaultConv.ToPayloads("test")
+
+	encoded, err := remoteCodec.Encode(payloads.Payloads)
+	require.NoError(t, err)
+	require.Equal(t, int32(2), attempts.Load())
+	require.NotNil(t, encoded)
 }


### PR DESCRIPTION
## Summary

- Adds `RemotePayloadCodecRetryPolicy` struct and optional `RetryPolicy` field to `RemotePayloadCodecOptions`
- When set, transient HTTP failures (transport errors, 5xx responses) are retried with exponential backoff
- When nil (default), behavior is unchanged — exactly one HTTP request per encode/decode
- HTTP errors wrapped in `RemotePayloadCodecHTTPError` for status-code-based filtering via `IsRetryableError`
- Fixes backward-compat `RemoteDataConverterOptions` → `RemotePayloadCodecOptions` conversion (field-by-field instead of struct cast)

Configurable knobs: `InitialInterval`, `MaximumInterval`, `BackoffCoefficient`, `MaxAttempts`, `Expiration`, `IsRetryableError`.

Closes #2507

## Test plan

- [x] `TestRemotePayloadCodecNoRetry` — no retry policy → single attempt on failure
- [x] `TestRemotePayloadCodecRetryOnTransientError` — server fails twice then succeeds → retried and succeeds on 3rd attempt
- [x] `TestRemotePayloadCodecRetryExhausted` — all attempts fail → returns last error after max attempts
- [x] `TestRemotePayloadCodecRetryIsRetryableFilter` — 400 error with 5xx-only filter → not retried (single attempt)
- [x] `TestRemotePayloadCodecRetryTransportError` — TCP connection reset → retried and succeeds on 2nd attempt
- [x] All existing converter tests pass unchanged