### PR TITLE
Add CI job for contrib/googleadk tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,6 +255,31 @@ jobs:
         env:
           ARTIFACT_URL: ${{ steps.upload-test-logs.outputs.artifact-url }}
 
+  # contrib modules are independent Go modules that the root-module jobs above
+  # do not compile or test. Runs the googleadk module's full test suite; its
+  # integration tests boot a local dev server via testsuite.StartDevServer.
+  googleadk-test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+      statuses: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          submodules: recursive
+
+      - name: Setup Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version: stable
+          cache-dependency-path: contrib/googleadk/go.sum
+
+      - name: Test googleadk
+        run: go test -count 1 -race -timeout 10m ./...
+        working-directory: ./contrib/googleadk
+
   cloud-test:
     strategy:
       matrix:


### PR DESCRIPTION
## What was changed

New `googleadk-test` CI job running `go test -count 1 -race -timeout 10m ./...` in `./contrib/googleadk`, using the same pinned actions/permissions as the existing jobs and caching keyed on the module's own `go.sum`.

## Why

No CI job tests `contrib/googleadk` today — `check`/`unit-test`/`integ-test*` all drive `internal/cmd/build`, which never crosses module boundaries — so regressions in the module could merge with green CI. The job needs no secrets: the gemini e2e tests stub the HTTP backend, and the integration tests boot a dev server via `testsuite.StartDevServer` (skipping cleanly if unavailable).

The other `contrib/*` modules are equally uncovered; this PR intentionally adds only googleadk, leaving a contrib-wide matrix as future work.

## How was it tested

Exact CI command run locally with API-key env vars unset (`ok ... 17.885s`, dev-server and gemini tests PASS rather than SKIP); `actionlint` clean; this PR's own CI run demonstrates the job end to end.