### PR TITLE
Add envconfig support to integration test harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,10 +266,10 @@ jobs:
     if: ${{ github.event.pull_request.head.repo.full_name == '' || github.event.pull_request.head.repo.full_name == 'temporalio/sdk-go' }}
     runs-on: ubuntu-latest
     env:
-      SERVICE_ADDR: sdk-ci.a2dd6.tmprl.cloud:7233
+      TEMPORAL_ADDRESS: sdk-ci.a2dd6.tmprl.cloud:7233
       TEMPORAL_NAMESPACE: sdk-ci.a2dd6
-      TEMPORAL_CLIENT_CERT: ${{ secrets.TEMPORAL_CLIENT_CERT }}
-      TEMPORAL_CLIENT_KEY: ${{ secrets.TEMPORAL_CLIENT_KEY }}
+      TEMPORAL_TLS_CLIENT_CERT_DATA: ${{ secrets.TEMPORAL_CLIENT_CERT }}
+      TEMPORAL_TLS_CLIENT_KEY_DATA: ${{ secrets.TEMPORAL_CLIENT_KEY }}
       GODEBUG: ${{ matrix.fips && 'fips140=on' || '' }}
 
     steps:
@@ -282,7 +282,7 @@ jobs:
       - name: Selected integration tests against cloud
         # Keep this list intentionally small. Add cloud-safe tests here when
         # they cover behavior that cannot be validated against the local dev server.
-        run: 'go run . integration-test -p 1 -packages . -run "TestIntegrationSuite/(TestBasic|TestShutdownDuringActiveTimerActivityWorkflows)$"'
+        run: 'go run . integration-test -envconfig -p 1 -packages . -run "TestIntegrationSuite/(TestBasic|TestShutdownDuringActiveTimerActivityWorkflows)$"'
         working-directory: ./internal/cmd/build
         env:
           TEST_LOG_ARTIFACT_NAME: ${{ github.job }}-${{ matrix.go-version }}-fips-${{ matrix.fips }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ to docs, or any other relevant information.
 
 ### Added
 
+- Added `-envconfig` support to the integration test harness, allowing integration tests to use
+  standard client settings from `contrib/envconfig`.
 - Added `client.Options.SdkName` and `client.Options.SdkVersion` to override the SDK name and version reported in worker heartbeats.
 - Added `client.Client.CancelWorkflowWithOptions` and `client.Client.TerminateWorkflowWithOptions` to target a workflow execution chain by its first execution run ID. Cancellation options can also specify a reason.
 - Added experimental `workflow.GetRandomStream` for named deterministic pseudorandom values in workflows.

--- a/internal/cmd/build/main.go
+++ b/internal/cmd/build/main.go
@@ -104,10 +104,14 @@ func (b *builder) integrationTest() error {
 	pFlag := flagSet.String("p", "", "Passed to go test as -p")
 	packagesFlag := flagSet.String("packages", "./...", "Packages passed to go test")
 	devServerFlag := flagSet.Bool("dev-server", false, "Use an embedded dev server")
+	envConfigFlag := flagSet.Bool("envconfig", false, "Load test server client options from envconfig")
 	coverageFileFlag := flagSet.String("coverage-file", "", "If set, enables coverage output to this filename")
 	testOutputFlags := addTestOutputFlags(flagSet)
 	if err := flagSet.Parse(os.Args[2:]); err != nil {
 		return fmt.Errorf("failed parsing flags: %w", err)
+	}
+	if *devServerFlag && *envConfigFlag {
+		return fmt.Errorf("-dev-server and -envconfig cannot be used together")
 	}
 	testOutput, err := b.prepareTestOutput(*testOutputFlags, "go-test.log")
 	if err != nil {
@@ -131,6 +135,9 @@ func (b *builder) integrationTest() error {
 	rerunArgs := []string{"go", "run", ".", "integration-test"}
 	if *devServerFlag {
 		rerunArgs = append(rerunArgs, "-dev-server")
+	}
+	if *envConfigFlag {
+		rerunArgs = append(rerunArgs, "-envconfig")
 	}
 	if *pFlag != "" {
 		rerunArgs = append(rerunArgs, "-p", *pFlag)
@@ -259,6 +266,9 @@ func (b *builder) integrationTest() error {
 	if *devServerFlag {
 		args = append(args, "--", "-using-cli-dev-server")
 		env = append(env, "TEMPORAL_NAMESPACE=integration-test-namespace")
+	}
+	if *envConfigFlag {
+		env = append(env, "TEMPORAL_TEST_ENV_CONFIG_SERVER=true")
 	}
 	// Must run in test dir
 	cmd := b.cmdFromRoot(args...)

--- a/test/envconfig_test.go
+++ b/test/envconfig_test.go
@@ -63,10 +63,10 @@ func TestNewConfigEnvConfigServerCallbacksOverlay(t *testing.T) {
 	require.Equal(t, "envconfig-authority", options.ConnectionOptions.Authority)
 }
 
-func TestNewConfigLegacyServerPreservesPrecedence(t *testing.T) {
+func TestNewConfigHarnessEnvironmentOverridesCallbacks(t *testing.T) {
 	t.Setenv("TEMPORAL_TEST_ENV_CONFIG_SERVER", "false")
-	t.Setenv("SERVICE_ADDR", "legacy.example:7233")
-	t.Setenv("TEMPORAL_NAMESPACE", "legacy-namespace")
+	t.Setenv("SERVICE_ADDR", "environment.example:7233")
+	t.Setenv("TEMPORAL_NAMESPACE", "environment-namespace")
 	t.Setenv("TEMPORAL_CLIENT_CERT", "")
 	t.Setenv("TEMPORAL_CLIENT_KEY", "")
 	t.Setenv("TEMPORAL_ADDRESS", "ignored-envconfig.example:7233")
@@ -77,8 +77,8 @@ func TestNewConfigLegacyServerPreservesPrecedence(t *testing.T) {
 		WithNamespace("callback-namespace"),
 	)
 
-	require.Equal(t, "legacy.example:7233", config.ServiceAddr)
-	require.Equal(t, "legacy-namespace", config.Namespace)
+	require.Equal(t, "environment.example:7233", config.ServiceAddr)
+	require.Equal(t, "environment-namespace", config.Namespace)
 	require.False(t, config.ShouldRegisterNamespace)
 	require.Equal(t, config.ServiceAddr, options.HostPort)
 	require.Equal(t, config.Namespace, options.Namespace)

--- a/test/envconfig_test.go
+++ b/test/envconfig_test.go
@@ -1,0 +1,62 @@
+package test_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewConfigEnvConfigServer(t *testing.T) {
+	t.Setenv("TEMPORAL_TEST_ENV_CONFIG_SERVER", "true")
+	t.Setenv("TEMPORAL_ADDRESS", "envconfig.example:7233")
+	t.Setenv("TEMPORAL_NAMESPACE", "envconfig-namespace")
+	t.Setenv("TEMPORAL_API_KEY", "envconfig-api-key")
+	t.Setenv("TEMPORAL_TLS", "false")
+	t.Setenv("TEMPORAL_GRPC_META_TEST_HEADER", "envconfig-test")
+	t.Setenv("TEMPORAL_CLIENT_AUTHORITY", "envconfig-authority")
+
+	config := NewConfig()
+
+	require.Equal(t, "envconfig.example:7233", config.ServiceAddr)
+	require.Equal(t, "envconfig-namespace", config.Namespace)
+	require.False(t, config.ShouldRegisterNamespace)
+	require.Equal(t, "envconfig.example:7233", config.clientOptions.HostPort)
+	require.Equal(t, "envconfig-namespace", config.clientOptions.Namespace)
+	require.NotNil(t, config.clientOptions.Credentials)
+	require.True(t, config.clientOptions.ConnectionOptions.TLSDisabled)
+	require.Nil(t, config.clientOptions.ConnectionOptions.TLS)
+	require.Equal(t, "envconfig-authority", config.clientOptions.ConnectionOptions.Authority)
+
+	require.NotNil(t, config.clientOptions.HeadersProvider)
+	headers, err := config.clientOptions.HeadersProvider.GetHeaders(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "envconfig-test", headers["test-header"])
+}
+
+func TestNewConfigEnvConfigServerCallbackServer(t *testing.T) {
+	t.Setenv("TEMPORAL_TEST_ENV_CONFIG_SERVER", "true")
+	t.Setenv("TEMPORAL_ADDRESS", "envconfig.example:7233")
+	t.Setenv("TEMPORAL_NAMESPACE", "envconfig-namespace")
+	t.Setenv("TEMPORAL_API_KEY", "envconfig-api-key")
+	t.Setenv("TEMPORAL_TLS", "true")
+	t.Setenv("TEMPORAL_GRPC_META_TEST_HEADER", "envconfig-test")
+	t.Setenv("TEMPORAL_CLIENT_AUTHORITY", "envconfig-authority")
+
+	config := NewConfig(
+		WithServiceAddr("127.0.0.1:7234"),
+		WithNamespace("dedicated-test-namespace"),
+	)
+
+	require.Equal(t, "127.0.0.1:7234", config.ServiceAddr)
+	require.Equal(t, "dedicated-test-namespace", config.Namespace)
+	require.True(t, config.ShouldRegisterNamespace)
+	require.Nil(t, config.TLS)
+	require.Equal(t, config.ServiceAddr, config.clientOptions.HostPort)
+	require.Equal(t, config.Namespace, config.clientOptions.Namespace)
+	require.Nil(t, config.clientOptions.Credentials)
+	require.Nil(t, config.clientOptions.HeadersProvider)
+	require.Nil(t, config.clientOptions.ConnectionOptions.TLS)
+	require.False(t, config.clientOptions.ConnectionOptions.TLSDisabled)
+	require.Empty(t, config.clientOptions.ConnectionOptions.Authority)
+}

--- a/test/envconfig_test.go
+++ b/test/envconfig_test.go
@@ -2,9 +2,11 @@ package test_test
 
 import (
 	"context"
+	"crypto/tls"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/client"
 )
 
 func TestNewConfigEnvConfigServer(t *testing.T) {
@@ -82,4 +84,35 @@ func TestNewConfigLegacyServerPreservesPrecedence(t *testing.T) {
 	require.Equal(t, config.Namespace, options.Namespace)
 	require.Nil(t, options.Credentials)
 	require.Nil(t, options.HeadersProvider)
+}
+
+func TestConfigAndClientSuiteBaseClientOptionsLayering(t *testing.T) {
+	baseTLS := &tls.Config{ServerName: "base.example"}
+	configTLS := &tls.Config{ServerName: "config.example"}
+	ts := ConfigAndClientSuiteBase{
+		config: Config{
+			ServiceAddr: "config.example:7233",
+			Namespace:   "config-namespace",
+			TLS:         configTLS,
+		},
+		baseClientOptions: client.Options{
+			HostPort:  "base.example:7233",
+			Namespace: "base-namespace",
+			ConnectionOptions: client.ConnectionOptions{
+				TLS:       baseTLS,
+				Authority: "base-authority",
+			},
+		},
+	}
+
+	options := ts.newClientOptions(func(options *client.Options) {
+		options.Namespace = "client-override-namespace"
+	})
+
+	require.Equal(t, ts.config.ServiceAddr, options.HostPort)
+	require.Equal(t, "client-override-namespace", options.Namespace)
+	require.Same(t, configTLS, options.ConnectionOptions.TLS)
+	require.Equal(t, "base-authority", options.ConnectionOptions.Authority)
+	require.NotNil(t, options.Logger)
+	require.Equal(t, "base-namespace", ts.baseClientOptions.Namespace)
 }

--- a/test/envconfig_test.go
+++ b/test/envconfig_test.go
@@ -9,7 +9,7 @@ import (
 	"go.temporal.io/sdk/client"
 )
 
-func TestNewConfigEnvConfigServer(t *testing.T) {
+func TestEnvironmentFromEnvConfig(t *testing.T) {
 	t.Setenv("TEMPORAL_TEST_ENV_CONFIG_SERVER", "true")
 	t.Setenv("TEMPORAL_ADDRESS", "envconfig.example:7233")
 	t.Setenv("TEMPORAL_NAMESPACE", "envconfig-namespace")
@@ -18,7 +18,9 @@ func TestNewConfigEnvConfigServer(t *testing.T) {
 	t.Setenv("TEMPORAL_GRPC_META_TEST_HEADER", "envconfig-test")
 	t.Setenv("TEMPORAL_CLIENT_AUTHORITY", "envconfig-authority")
 
-	config, options := newConfigAndClientOptions()
+	environment := newTestEnvironment()
+	config := environment.config
+	options := environment.clientOptions
 
 	require.Equal(t, "envconfig.example:7233", config.ServiceAddr)
 	require.Equal(t, "envconfig-namespace", config.Namespace)
@@ -36,7 +38,7 @@ func TestNewConfigEnvConfigServer(t *testing.T) {
 	require.Equal(t, "envconfig-test", headers["test-header"])
 }
 
-func TestNewConfigEnvConfigServerCallbacksOverlay(t *testing.T) {
+func TestEnvironmentFromEnvConfigCallbacksOverlay(t *testing.T) {
 	t.Setenv("TEMPORAL_TEST_ENV_CONFIG_SERVER", "true")
 	t.Setenv("TEMPORAL_ADDRESS", "envconfig.example:7233")
 	t.Setenv("TEMPORAL_NAMESPACE", "envconfig-namespace")
@@ -45,10 +47,12 @@ func TestNewConfigEnvConfigServerCallbacksOverlay(t *testing.T) {
 	t.Setenv("TEMPORAL_GRPC_META_TEST_HEADER", "envconfig-test")
 	t.Setenv("TEMPORAL_CLIENT_AUTHORITY", "envconfig-authority")
 
-	config, options := newConfigAndClientOptions(
+	environment := newTestEnvironment(
 		WithServiceAddr("127.0.0.1:7234"),
 		WithNamespace("dedicated-test-namespace"),
 	)
+	config := environment.config
+	options := environment.clientOptions
 
 	require.Equal(t, "127.0.0.1:7234", config.ServiceAddr)
 	require.Equal(t, "dedicated-test-namespace", config.Namespace)
@@ -63,7 +67,7 @@ func TestNewConfigEnvConfigServerCallbacksOverlay(t *testing.T) {
 	require.Equal(t, "envconfig-authority", options.ConnectionOptions.Authority)
 }
 
-func TestNewConfigHarnessEnvironmentOverridesCallbacks(t *testing.T) {
+func TestEnvironmentFromConfigHarnessEnvironmentOverridesCallbacks(t *testing.T) {
 	t.Setenv("TEMPORAL_TEST_ENV_CONFIG_SERVER", "false")
 	t.Setenv("SERVICE_ADDR", "environment.example:7233")
 	t.Setenv("TEMPORAL_NAMESPACE", "environment-namespace")
@@ -72,10 +76,12 @@ func TestNewConfigHarnessEnvironmentOverridesCallbacks(t *testing.T) {
 	t.Setenv("TEMPORAL_ADDRESS", "ignored-envconfig.example:7233")
 	t.Setenv("TEMPORAL_API_KEY", "ignored-envconfig-api-key")
 
-	config, options := newConfigAndClientOptions(
+	environment := newTestEnvironment(
 		WithServiceAddr("callback.example:7233"),
 		WithNamespace("callback-namespace"),
 	)
+	config := environment.config
+	options := environment.clientOptions
 
 	require.Equal(t, "environment.example:7233", config.ServiceAddr)
 	require.Equal(t, "environment-namespace", config.Namespace)
@@ -86,33 +92,21 @@ func TestNewConfigHarnessEnvironmentOverridesCallbacks(t *testing.T) {
 	require.Nil(t, options.HeadersProvider)
 }
 
-func TestConfigAndClientSuiteBaseClientOptionsLayering(t *testing.T) {
-	baseTLS := &tls.Config{ServerName: "base.example"}
+func TestEnvironmentClientOptions(t *testing.T) {
 	configTLS := &tls.Config{ServerName: "config.example"}
-	ts := ConfigAndClientSuiteBase{
-		config: Config{
-			ServiceAddr: "config.example:7233",
-			Namespace:   "config-namespace",
-			TLS:         configTLS,
-		},
-		baseClientOptions: client.Options{
-			HostPort:  "base.example:7233",
-			Namespace: "base-namespace",
-			ConnectionOptions: client.ConnectionOptions{
-				TLS:       baseTLS,
-				Authority: "base-authority",
-			},
-		},
-	}
+	environment := newTestEnvironmentFromConfig(Config{
+		ServiceAddr: "config.example:7233",
+		Namespace:   "config-namespace",
+		TLS:         configTLS,
+	})
 
-	options := ts.newClientOptions(func(options *client.Options) {
+	options := environment.newClientOptions(func(options *client.Options) {
 		options.Namespace = "client-override-namespace"
 	})
 
-	require.Equal(t, ts.config.ServiceAddr, options.HostPort)
+	require.Equal(t, environment.config.ServiceAddr, options.HostPort)
 	require.Equal(t, "client-override-namespace", options.Namespace)
 	require.Same(t, configTLS, options.ConnectionOptions.TLS)
-	require.Equal(t, "base-authority", options.ConnectionOptions.Authority)
 	require.NotNil(t, options.Logger)
-	require.Equal(t, "base-namespace", ts.baseClientOptions.Namespace)
+	require.Equal(t, "config-namespace", environment.clientOptions.Namespace)
 }

--- a/test/envconfig_test.go
+++ b/test/envconfig_test.go
@@ -9,7 +9,7 @@ import (
 	"go.temporal.io/sdk/client"
 )
 
-func TestEnvironmentFromEnvConfig(t *testing.T) {
+func TestConfigAndClientSuiteBaseFromEnvConfig(t *testing.T) {
 	t.Setenv("TEMPORAL_TEST_ENV_CONFIG_SERVER", "true")
 	t.Setenv("TEMPORAL_ADDRESS", "envconfig.example:7233")
 	t.Setenv("TEMPORAL_NAMESPACE", "envconfig-namespace")
@@ -18,10 +18,11 @@ func TestEnvironmentFromEnvConfig(t *testing.T) {
 	t.Setenv("TEMPORAL_GRPC_META_TEST_HEADER", "envconfig-test")
 	t.Setenv("TEMPORAL_CLIENT_AUTHORITY", "envconfig-authority")
 
-	environment := newTestEnvironment()
-	config := environment.config
-	require.NotNil(t, environment.envConfigClientOptions)
-	options := *environment.envConfigClientOptions
+	testSuite := ConfigAndClientSuiteBase{}
+	testSuite.initConfig()
+	config := testSuite.config
+	require.NotNil(t, testSuite.envConfigClientOptions)
+	options := *testSuite.envConfigClientOptions
 
 	require.Equal(t, "envconfig.example:7233", config.ServiceAddr)
 	require.Equal(t, "envconfig-namespace", config.Namespace)
@@ -39,7 +40,7 @@ func TestEnvironmentFromEnvConfig(t *testing.T) {
 	require.Equal(t, "envconfig-test", headers["test-header"])
 }
 
-func TestEnvironmentFromEnvConfigClientOptionsOverlay(t *testing.T) {
+func TestConfigAndClientSuiteBaseEnvConfigClientOptionsOverlay(t *testing.T) {
 	t.Setenv("TEMPORAL_TEST_ENV_CONFIG_SERVER", "true")
 	t.Setenv("TEMPORAL_ADDRESS", "envconfig.example:7233")
 	t.Setenv("TEMPORAL_NAMESPACE", "envconfig-namespace")
@@ -48,10 +49,11 @@ func TestEnvironmentFromEnvConfigClientOptionsOverlay(t *testing.T) {
 	t.Setenv("TEMPORAL_GRPC_META_TEST_HEADER", "envconfig-test")
 	t.Setenv("TEMPORAL_CLIENT_AUTHORITY", "envconfig-authority")
 
-	environment := newTestEnvironment()
-	config := environment.config
-	require.NotNil(t, environment.envConfigClientOptions)
-	options := environment.newClientOptions(func(options *client.Options) {
+	testSuite := ConfigAndClientSuiteBase{}
+	testSuite.initConfig()
+	config := testSuite.config
+	require.NotNil(t, testSuite.envConfigClientOptions)
+	options := testSuite.newDefaultClientOptions(func(options *client.Options) {
 		options.Namespace = "client-override-namespace"
 	})
 
@@ -66,10 +68,10 @@ func TestEnvironmentFromEnvConfigClientOptionsOverlay(t *testing.T) {
 	require.NotNil(t, options.ConnectionOptions.TLS)
 	require.False(t, options.ConnectionOptions.TLSDisabled)
 	require.Equal(t, "envconfig-authority", options.ConnectionOptions.Authority)
-	require.Equal(t, "envconfig-namespace", environment.envConfigClientOptions.Namespace)
+	require.Equal(t, "envconfig-namespace", testSuite.envConfigClientOptions.Namespace)
 }
 
-func TestEnvironmentFromConfigHarnessEnvironmentOverridesCallbacks(t *testing.T) {
+func TestConfigAndClientSuiteBaseHarnessEnvironmentOverridesCallbacks(t *testing.T) {
 	t.Setenv("TEMPORAL_TEST_ENV_CONFIG_SERVER", "false")
 	t.Setenv("SERVICE_ADDR", "environment.example:7233")
 	t.Setenv("TEMPORAL_NAMESPACE", "environment-namespace")
@@ -78,14 +80,16 @@ func TestEnvironmentFromConfigHarnessEnvironmentOverridesCallbacks(t *testing.T)
 	t.Setenv("TEMPORAL_ADDRESS", "ignored-envconfig.example:7233")
 	t.Setenv("TEMPORAL_API_KEY", "ignored-envconfig-api-key")
 
-	environment := newTestEnvironmentFromConfig(NewConfig(
-		WithServiceAddr("callback.example:7233"),
-		WithNamespace("callback-namespace"),
-	))
-	config := environment.config
-	options := environment.newClientOptions()
+	testSuite := ConfigAndClientSuiteBase{
+		config: NewConfig(
+			WithServiceAddr("callback.example:7233"),
+			WithNamespace("callback-namespace"),
+		),
+	}
+	config := testSuite.config
+	options := testSuite.newDefaultClientOptions()
 
-	require.Nil(t, environment.envConfigClientOptions)
+	require.Nil(t, testSuite.envConfigClientOptions)
 	require.Equal(t, "environment.example:7233", config.ServiceAddr)
 	require.Equal(t, "environment-namespace", config.Namespace)
 	require.False(t, config.ShouldRegisterNamespace)
@@ -95,26 +99,28 @@ func TestEnvironmentFromConfigHarnessEnvironmentOverridesCallbacks(t *testing.T)
 	require.Nil(t, options.HeadersProvider)
 }
 
-func TestEnvironmentClientOptions(t *testing.T) {
+func TestConfigAndClientSuiteBaseClientOptions(t *testing.T) {
 	configTLS := &tls.Config{ServerName: "config.example"}
-	environment := newTestEnvironmentFromConfig(Config{
-		ServiceAddr: "config.example:7233",
-		Namespace:   "config-namespace",
-		TLS:         configTLS,
-	})
-	require.Nil(t, environment.envConfigClientOptions)
+	testSuite := ConfigAndClientSuiteBase{
+		config: Config{
+			ServiceAddr: "config.example:7233",
+			Namespace:   "config-namespace",
+			TLS:         configTLS,
+		},
+	}
+	require.Nil(t, testSuite.envConfigClientOptions)
 
-	environment.config.Namespace = "updated-config-namespace"
-	baseOptions := environment.newClientOptions()
+	testSuite.config.Namespace = "updated-config-namespace"
+	baseOptions := testSuite.newDefaultClientOptions()
 	require.Equal(t, "updated-config-namespace", baseOptions.Namespace)
 
-	options := environment.newClientOptions(func(options *client.Options) {
+	options := testSuite.newDefaultClientOptions(func(options *client.Options) {
 		options.Namespace = "client-override-namespace"
 	})
 
-	require.Equal(t, environment.config.ServiceAddr, options.HostPort)
+	require.Equal(t, testSuite.config.ServiceAddr, options.HostPort)
 	require.Equal(t, "client-override-namespace", options.Namespace)
 	require.Same(t, configTLS, options.ConnectionOptions.TLS)
 	require.NotNil(t, options.Logger)
-	require.Equal(t, "updated-config-namespace", environment.config.Namespace)
+	require.Equal(t, "updated-config-namespace", testSuite.config.Namespace)
 }

--- a/test/envconfig_test.go
+++ b/test/envconfig_test.go
@@ -16,25 +16,25 @@ func TestNewConfigEnvConfigServer(t *testing.T) {
 	t.Setenv("TEMPORAL_GRPC_META_TEST_HEADER", "envconfig-test")
 	t.Setenv("TEMPORAL_CLIENT_AUTHORITY", "envconfig-authority")
 
-	config := NewConfig()
+	config, options := newConfigAndClientOptions()
 
 	require.Equal(t, "envconfig.example:7233", config.ServiceAddr)
 	require.Equal(t, "envconfig-namespace", config.Namespace)
 	require.False(t, config.ShouldRegisterNamespace)
-	require.Equal(t, "envconfig.example:7233", config.clientOptions.HostPort)
-	require.Equal(t, "envconfig-namespace", config.clientOptions.Namespace)
-	require.NotNil(t, config.clientOptions.Credentials)
-	require.True(t, config.clientOptions.ConnectionOptions.TLSDisabled)
-	require.Nil(t, config.clientOptions.ConnectionOptions.TLS)
-	require.Equal(t, "envconfig-authority", config.clientOptions.ConnectionOptions.Authority)
+	require.Equal(t, "envconfig.example:7233", options.HostPort)
+	require.Equal(t, "envconfig-namespace", options.Namespace)
+	require.NotNil(t, options.Credentials)
+	require.True(t, options.ConnectionOptions.TLSDisabled)
+	require.Nil(t, options.ConnectionOptions.TLS)
+	require.Equal(t, "envconfig-authority", options.ConnectionOptions.Authority)
 
-	require.NotNil(t, config.clientOptions.HeadersProvider)
-	headers, err := config.clientOptions.HeadersProvider.GetHeaders(context.Background())
+	require.NotNil(t, options.HeadersProvider)
+	headers, err := options.HeadersProvider.GetHeaders(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, "envconfig-test", headers["test-header"])
 }
 
-func TestNewConfigEnvConfigServerCallbackServer(t *testing.T) {
+func TestNewConfigEnvConfigServerCallbacksOverlay(t *testing.T) {
 	t.Setenv("TEMPORAL_TEST_ENV_CONFIG_SERVER", "true")
 	t.Setenv("TEMPORAL_ADDRESS", "envconfig.example:7233")
 	t.Setenv("TEMPORAL_NAMESPACE", "envconfig-namespace")
@@ -43,20 +43,43 @@ func TestNewConfigEnvConfigServerCallbackServer(t *testing.T) {
 	t.Setenv("TEMPORAL_GRPC_META_TEST_HEADER", "envconfig-test")
 	t.Setenv("TEMPORAL_CLIENT_AUTHORITY", "envconfig-authority")
 
-	config := NewConfig(
+	config, options := newConfigAndClientOptions(
 		WithServiceAddr("127.0.0.1:7234"),
 		WithNamespace("dedicated-test-namespace"),
 	)
 
 	require.Equal(t, "127.0.0.1:7234", config.ServiceAddr)
 	require.Equal(t, "dedicated-test-namespace", config.Namespace)
-	require.True(t, config.ShouldRegisterNamespace)
-	require.Nil(t, config.TLS)
-	require.Equal(t, config.ServiceAddr, config.clientOptions.HostPort)
-	require.Equal(t, config.Namespace, config.clientOptions.Namespace)
-	require.Nil(t, config.clientOptions.Credentials)
-	require.Nil(t, config.clientOptions.HeadersProvider)
-	require.Nil(t, config.clientOptions.ConnectionOptions.TLS)
-	require.False(t, config.clientOptions.ConnectionOptions.TLSDisabled)
-	require.Empty(t, config.clientOptions.ConnectionOptions.Authority)
+	require.False(t, config.ShouldRegisterNamespace)
+	require.NotNil(t, config.TLS)
+	require.Equal(t, config.ServiceAddr, options.HostPort)
+	require.Equal(t, config.Namespace, options.Namespace)
+	require.NotNil(t, options.Credentials)
+	require.NotNil(t, options.HeadersProvider)
+	require.NotNil(t, options.ConnectionOptions.TLS)
+	require.False(t, options.ConnectionOptions.TLSDisabled)
+	require.Equal(t, "envconfig-authority", options.ConnectionOptions.Authority)
+}
+
+func TestNewConfigLegacyServerPreservesPrecedence(t *testing.T) {
+	t.Setenv("TEMPORAL_TEST_ENV_CONFIG_SERVER", "false")
+	t.Setenv("SERVICE_ADDR", "legacy.example:7233")
+	t.Setenv("TEMPORAL_NAMESPACE", "legacy-namespace")
+	t.Setenv("TEMPORAL_CLIENT_CERT", "")
+	t.Setenv("TEMPORAL_CLIENT_KEY", "")
+	t.Setenv("TEMPORAL_ADDRESS", "ignored-envconfig.example:7233")
+	t.Setenv("TEMPORAL_API_KEY", "ignored-envconfig-api-key")
+
+	config, options := newConfigAndClientOptions(
+		WithServiceAddr("callback.example:7233"),
+		WithNamespace("callback-namespace"),
+	)
+
+	require.Equal(t, "legacy.example:7233", config.ServiceAddr)
+	require.Equal(t, "legacy-namespace", config.Namespace)
+	require.False(t, config.ShouldRegisterNamespace)
+	require.Equal(t, config.ServiceAddr, options.HostPort)
+	require.Equal(t, config.Namespace, options.Namespace)
+	require.Nil(t, options.Credentials)
+	require.Nil(t, options.HeadersProvider)
 }

--- a/test/envconfig_test.go
+++ b/test/envconfig_test.go
@@ -20,7 +20,8 @@ func TestEnvironmentFromEnvConfig(t *testing.T) {
 
 	environment := newTestEnvironment()
 	config := environment.config
-	options := environment.clientOptions
+	require.NotNil(t, environment.envConfigClientOptions)
+	options := *environment.envConfigClientOptions
 
 	require.Equal(t, "envconfig.example:7233", config.ServiceAddr)
 	require.Equal(t, "envconfig-namespace", config.Namespace)
@@ -38,7 +39,7 @@ func TestEnvironmentFromEnvConfig(t *testing.T) {
 	require.Equal(t, "envconfig-test", headers["test-header"])
 }
 
-func TestEnvironmentFromEnvConfigCallbacksOverlay(t *testing.T) {
+func TestEnvironmentFromEnvConfigClientOptionsOverlay(t *testing.T) {
 	t.Setenv("TEMPORAL_TEST_ENV_CONFIG_SERVER", "true")
 	t.Setenv("TEMPORAL_ADDRESS", "envconfig.example:7233")
 	t.Setenv("TEMPORAL_NAMESPACE", "envconfig-namespace")
@@ -47,24 +48,25 @@ func TestEnvironmentFromEnvConfigCallbacksOverlay(t *testing.T) {
 	t.Setenv("TEMPORAL_GRPC_META_TEST_HEADER", "envconfig-test")
 	t.Setenv("TEMPORAL_CLIENT_AUTHORITY", "envconfig-authority")
 
-	environment := newTestEnvironment(
-		WithServiceAddr("127.0.0.1:7234"),
-		WithNamespace("dedicated-test-namespace"),
-	)
+	environment := newTestEnvironment()
 	config := environment.config
-	options := environment.clientOptions
+	require.NotNil(t, environment.envConfigClientOptions)
+	options := environment.newClientOptions(func(options *client.Options) {
+		options.Namespace = "client-override-namespace"
+	})
 
-	require.Equal(t, "127.0.0.1:7234", config.ServiceAddr)
-	require.Equal(t, "dedicated-test-namespace", config.Namespace)
+	require.Equal(t, "envconfig.example:7233", config.ServiceAddr)
+	require.Equal(t, "envconfig-namespace", config.Namespace)
 	require.False(t, config.ShouldRegisterNamespace)
 	require.NotNil(t, config.TLS)
 	require.Equal(t, config.ServiceAddr, options.HostPort)
-	require.Equal(t, config.Namespace, options.Namespace)
+	require.Equal(t, "client-override-namespace", options.Namespace)
 	require.NotNil(t, options.Credentials)
 	require.NotNil(t, options.HeadersProvider)
 	require.NotNil(t, options.ConnectionOptions.TLS)
 	require.False(t, options.ConnectionOptions.TLSDisabled)
 	require.Equal(t, "envconfig-authority", options.ConnectionOptions.Authority)
+	require.Equal(t, "envconfig-namespace", environment.envConfigClientOptions.Namespace)
 }
 
 func TestEnvironmentFromConfigHarnessEnvironmentOverridesCallbacks(t *testing.T) {
@@ -76,13 +78,14 @@ func TestEnvironmentFromConfigHarnessEnvironmentOverridesCallbacks(t *testing.T)
 	t.Setenv("TEMPORAL_ADDRESS", "ignored-envconfig.example:7233")
 	t.Setenv("TEMPORAL_API_KEY", "ignored-envconfig-api-key")
 
-	environment := newTestEnvironment(
+	environment := newTestEnvironmentFromConfig(NewConfig(
 		WithServiceAddr("callback.example:7233"),
 		WithNamespace("callback-namespace"),
-	)
+	))
 	config := environment.config
-	options := environment.clientOptions
+	options := environment.newClientOptions()
 
+	require.Nil(t, environment.envConfigClientOptions)
 	require.Equal(t, "environment.example:7233", config.ServiceAddr)
 	require.Equal(t, "environment-namespace", config.Namespace)
 	require.False(t, config.ShouldRegisterNamespace)
@@ -99,6 +102,11 @@ func TestEnvironmentClientOptions(t *testing.T) {
 		Namespace:   "config-namespace",
 		TLS:         configTLS,
 	})
+	require.Nil(t, environment.envConfigClientOptions)
+
+	environment.config.Namespace = "updated-config-namespace"
+	baseOptions := environment.newClientOptions()
+	require.Equal(t, "updated-config-namespace", baseOptions.Namespace)
 
 	options := environment.newClientOptions(func(options *client.Options) {
 		options.Namespace = "client-override-namespace"
@@ -108,5 +116,5 @@ func TestEnvironmentClientOptions(t *testing.T) {
 	require.Equal(t, "client-override-namespace", options.Namespace)
 	require.Same(t, configTLS, options.ConnectionOptions.TLS)
 	require.NotNil(t, options.Logger)
-	require.Equal(t, "config-namespace", environment.clientOptions.Namespace)
+	require.Equal(t, "updated-config-namespace", environment.config.Namespace)
 }

--- a/test/external_storage_nexus_test.go
+++ b/test/external_storage_nexus_test.go
@@ -16,7 +16,6 @@ import (
 
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/converter"
-	ilog "go.temporal.io/sdk/internal/log"
 	"go.temporal.io/sdk/worker"
 	"go.temporal.io/sdk/workflow"
 )
@@ -102,17 +101,15 @@ func (d *transientFailDriver) attempts() (store, retrieve int) {
 // Nexus endpoint targeting a fresh task queue, returning the client, task queue, and
 // endpoint name.
 func newNexusExtStoreClient(t *testing.T, ctx context.Context, driver converter.StorageDriver) (client.Client, string, string) {
-	config := NewConfig()
+	clientBase := ConfigAndClientSuiteBase{}
+	clientBase.initConfig()
+	config := clientBase.config
 	require.NoError(t, WaitForTCP(time.Minute, config.ServiceAddr))
-	c, err := client.DialContext(ctx, client.Options{
-		HostPort:          config.ServiceAddr,
-		Namespace:         config.Namespace,
-		Logger:            ilog.NewDefaultLogger(),
-		ConnectionOptions: client.ConnectionOptions{TLS: config.TLS},
-		ExternalStorage: converter.ExternalStorage{
+	c, err := clientBase.newDefaultClientContext(ctx, func(options *client.Options) {
+		options.ExternalStorage = converter.ExternalStorage{
 			Drivers:              []converter.StorageDriver{driver},
 			PayloadSizeThreshold: extStoreThreshold,
-		},
+		}
 	})
 	require.NoError(t, err)
 

--- a/test/go.mod
+++ b/test/go.mod
@@ -15,6 +15,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.43.0
 	go.temporal.io/api v1.63.4
 	go.temporal.io/sdk v1.46.0
+	go.temporal.io/sdk/contrib/envconfig v0.0.0-00010101000000-000000000000
 	go.temporal.io/sdk/contrib/opentelemetry v0.0.0-00010101000000-000000000000
 	go.temporal.io/sdk/contrib/opentracing v0.0.0-00010101000000-000000000000
 	go.temporal.io/sdk/contrib/sysinfo v0.0.0-00010101000000-000000000000
@@ -25,6 +26,7 @@ require (
 )
 
 require (
+	github.com/BurntSushi/toml v1.4.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cilium/ebpf v0.11.0 // indirect
 	github.com/containerd/cgroups/v3 v3.0.3 // indirect
@@ -68,6 +70,7 @@ require (
 
 replace (
 	go.temporal.io/sdk => ../
+	go.temporal.io/sdk/contrib/envconfig => ../contrib/envconfig
 	go.temporal.io/sdk/contrib/opentelemetry => ../contrib/opentelemetry
 	go.temporal.io/sdk/contrib/opentracing => ../contrib/opentracing
 	go.temporal.io/sdk/contrib/sysinfo => ../contrib/sysinfo

--- a/test/go.sum
+++ b/test/go.sum
@@ -1,4 +1,6 @@
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+github.com/BurntSushi/toml v1.4.0 h1:kuoIxZQy2WRRk1pttg9asf+WVv6tWQuBNVmK8+nqPr0=
+github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=

--- a/test/nexus_test.go
+++ b/test/nexus_test.go
@@ -74,18 +74,17 @@ func newTestContext(t *testing.T, ctx context.Context, optionFuncs ...testContex
 		opt(options)
 	}
 
-	config := NewConfig()
+	clientBase := ConfigAndClientSuiteBase{}
+	clientBase.initConfig()
+	config := clientBase.config
 	require.NoError(t, WaitForTCP(time.Minute, config.ServiceAddr))
 
 	metricsHandler := metrics.NewCapturingHandler()
 	logger := ilog.NewMemoryLogger()
-	c, err := client.DialContext(ctx, client.Options{
-		HostPort:          config.ServiceAddr,
-		Namespace:         config.Namespace,
-		Logger:            logger,
-		ConnectionOptions: client.ConnectionOptions{TLS: config.TLS},
-		MetricsHandler:    metricsHandler,
-		Interceptors:      options.clientInterceptors,
+	c, err := clientBase.newDefaultClientContext(ctx, func(clientOptions *client.Options) {
+		clientOptions.Logger = logger
+		clientOptions.MetricsHandler = metricsHandler
+		clientOptions.Interceptors = options.clientInterceptors
 	})
 	require.NoError(t, err)
 

--- a/test/payload_limits_test.go
+++ b/test/payload_limits_test.go
@@ -45,11 +45,11 @@ const payloadWarningMessage = "[TMPRL1103] Attempted to upload payloads with siz
 
 func (ts *PayloadLimitsTestSuite) SetupSuite() {
 	ts.Assertions = require.New(ts.T())
-	ts.testEnvironment = newTestEnvironmentFromConfig(NewConfig(
+	ts.config = NewConfig(
 		WithNamespace("payload-limits-namespace"),
 		WithServiceAddr("127.0.0.1:7234"),
 		WithServiceHTTPAddr("127.0.0.1:7244"),
-	))
+	)
 
 	_, httpPort, err := net.SplitHostPort(ts.config.ServiceHTTPAddr)
 	ts.NoError(err)

--- a/test/payload_limits_test.go
+++ b/test/payload_limits_test.go
@@ -45,11 +45,11 @@ const payloadWarningMessage = "[TMPRL1103] Attempted to upload payloads with siz
 
 func (ts *PayloadLimitsTestSuite) SetupSuite() {
 	ts.Assertions = require.New(ts.T())
-	ts.config = NewConfig(
+	ts.testEnvironment = newTestEnvironmentFromConfig(NewConfig(
 		WithNamespace("payload-limits-namespace"),
 		WithServiceAddr("127.0.0.1:7234"),
 		WithServiceHTTPAddr("127.0.0.1:7244"),
-	)
+	))
 
 	_, httpPort, err := net.SplitHostPort(ts.config.ServiceHTTPAddr)
 	ts.NoError(err)

--- a/test/test_utils_test.go
+++ b/test/test_utils_test.go
@@ -38,25 +38,15 @@ type (
 		TLS                     *tls.Config
 	}
 	// context.WithValue need this type instead of basic type string to avoid lint error
-	contextKey string
-	// testEnvironment configures one test server target. Its invariants are:
-	//   - When envConfigClientOptions is nil, config is the source for clients.
-	//   - When envConfigClientOptions is non-nil, it is the only source for clients.
-	//     config is a read-only projection used by test setup and lifecycle logic;
-	//     the two representations are not synchronized after construction.
-	//   - Per-client configuration is applied to a value copy of the selected
-	//     source; callbacks must not mutate reference-valued members inherited
-	//     from it.
-	testEnvironment struct {
-		config                 Config
-		envConfigClientOptions *client.Options
-	}
-	// ConfigAndClientSuiteBase owns a resolved test environment and any shared
-	// client created from that environment.
+	contextKey               string
 	ConfigAndClientSuiteBase struct {
-		testEnvironment
-		client        client.Client
-		taskQueueName string
+		config Config
+		// When set, envConfigClientOptions is the authoritative source for clients.
+		// config is only its initial projection for test setup and lifecycle logic.
+		// Later changes to config do not affect clients in this mode.
+		envConfigClientOptions *client.Options
+		client                 client.Client
+		taskQueueName          string
 	}
 	ConfigureConfigCallback func(*Config)
 	ConfigureClientOptions  func(*client.Options)
@@ -73,23 +63,15 @@ func NewConfig(configCallbacks ...ConfigureConfigCallback) Config {
 	return cfg
 }
 
-func newTestEnvironment() testEnvironment {
+func (ts *ConfigAndClientSuiteBase) initConfig() {
 	if envConfigEnabled() {
-		return newEnvConfigTestEnvironment()
+		options := loadEnvConfigClientOptions()
+		ts.config = newConfigFromClientOptions(options)
+		ts.envConfigClientOptions = &options
+		return
 	}
-	return newTestEnvironmentFromConfig(NewConfig())
-}
-
-func newTestEnvironmentFromConfig(cfg Config) testEnvironment {
-	return testEnvironment{config: cfg}
-}
-
-func newEnvConfigTestEnvironment() testEnvironment {
-	options := loadEnvConfigClientOptions()
-	return testEnvironment{
-		config:                 newConfigFromClientOptions(options),
-		envConfigClientOptions: &options,
-	}
+	ts.config = NewConfig()
+	ts.envConfigClientOptions = nil
 }
 
 func newDefaultConfig() Config {
@@ -310,7 +292,7 @@ func (s *keysPropagator) ExtractToWorkflow(ctx workflow.Context, reader workflow
 }
 
 func (ts *ConfigAndClientSuiteBase) InitConfigAndNamespace() error {
-	ts.testEnvironment = newTestEnvironment()
+	ts.initConfig()
 	var err error
 	err = WaitForTCP(time.Minute, ts.config.ServiceAddr)
 	if err != nil {

--- a/test/test_utils_test.go
+++ b/test/test_utils_test.go
@@ -19,6 +19,7 @@ import (
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/contrib/envconfig"
 	"go.temporal.io/sdk/converter"
 	ilog "go.temporal.io/sdk/internal/log"
 	"go.temporal.io/sdk/worker"
@@ -35,6 +36,7 @@ type (
 		Namespace               string
 		ShouldRegisterNamespace bool
 		TLS                     *tls.Config
+		clientOptions           client.Options
 	}
 	// context.WithValue need this type instead of basic type string to avoid lint error
 	contextKey               string
@@ -62,8 +64,40 @@ func NewConfig(configCallbacks ...ConfigureConfigCallback) Config {
 	for _, configure := range configCallbacks {
 		configure(&cfg)
 	}
-	if addr := getEnvServiceAddr(); addr != "" {
-		cfg.ServiceAddr = addr
+	useEnvConfig := getEnvConfigServer() && len(configCallbacks) == 0
+	callbackServer := getEnvConfigServer() && len(configCallbacks) > 0
+	if useEnvConfig {
+		options, err := envconfig.LoadDefaultClientOptions()
+		if err != nil {
+			panic(fmt.Sprintf("Failed loading envconfig: %v", err))
+		}
+		if options.HostPort == "" {
+			options.HostPort = client.DefaultHostPort
+		}
+		if options.Namespace == "" {
+			options.Namespace = client.DefaultNamespace
+		}
+		cfg.ServiceAddr = options.HostPort
+		cfg.Namespace = options.Namespace
+		cfg.ShouldRegisterNamespace = false
+		cfg.TLS = options.ConnectionOptions.TLS
+		cfg.clientOptions = options
+	} else if !callbackServer {
+		if addr := getEnvServiceAddr(); addr != "" {
+			cfg.ServiceAddr = addr
+		}
+		if os.Getenv("TEMPORAL_NAMESPACE") != "" {
+			cfg.Namespace = os.Getenv("TEMPORAL_NAMESPACE")
+			cfg.ShouldRegisterNamespace = false
+		}
+		if os.Getenv("TEMPORAL_CLIENT_CERT") != "" || os.Getenv("TEMPORAL_CLIENT_KEY") != "" {
+			log.Print("Using custom client certificate")
+			cert, err := tls.X509KeyPair([]byte(os.Getenv("TEMPORAL_CLIENT_CERT")), []byte(os.Getenv("TEMPORAL_CLIENT_KEY")))
+			if err != nil {
+				panic(fmt.Sprintf("Failed loading client cert: %v", err))
+			}
+			cfg.TLS = &tls.Config{Certificates: []tls.Certificate{cert}}
+		}
 	}
 	if addr := strings.TrimSpace(os.Getenv("SERVICE_HTTP_ADDR")); addr != "" {
 		cfg.ServiceHTTPAddr = addr
@@ -79,17 +113,14 @@ func NewConfig(configCallbacks ...ConfigureConfigCallback) Config {
 	if debug := getDebug(); debug != "" {
 		cfg.Debug = debug == "true"
 	}
-	if os.Getenv("TEMPORAL_NAMESPACE") != "" {
-		cfg.Namespace = os.Getenv("TEMPORAL_NAMESPACE")
-		cfg.ShouldRegisterNamespace = false
-	}
-	if os.Getenv("TEMPORAL_CLIENT_CERT") != "" || os.Getenv("TEMPORAL_CLIENT_KEY") != "" {
-		log.Print("Using custom client certificate")
-		cert, err := tls.X509KeyPair([]byte(os.Getenv("TEMPORAL_CLIENT_CERT")), []byte(os.Getenv("TEMPORAL_CLIENT_KEY")))
-		if err != nil {
-			panic(fmt.Sprintf("Failed loading client cert: %v", err))
+	if !useEnvConfig {
+		cfg.clientOptions = client.Options{
+			HostPort:  cfg.ServiceAddr,
+			Namespace: cfg.Namespace,
+			ConnectionOptions: client.ConnectionOptions{
+				TLS: cfg.TLS,
+			},
 		}
-		cfg.TLS = &tls.Config{Certificates: []tls.Certificate{cert}}
 	}
 	return cfg
 }
@@ -116,6 +147,10 @@ func getEnvCacheSize() string {
 
 func getDebug() string {
 	return strings.ToLower(strings.TrimSpace(os.Getenv("DEBUG")))
+}
+
+func getEnvConfigServer() bool {
+	return strings.EqualFold(strings.TrimSpace(os.Getenv("TEMPORAL_TEST_ENV_CONFIG_SERVER")), "true")
 }
 
 // WaitForTCP waits until target tcp address is available.
@@ -263,11 +298,11 @@ func (ts *ConfigAndClientSuiteBase) newIntegrationTestClient(clientOpts ...Confi
 
 // newDefaultClient creates a client according to ts.config with SDK defaults.
 func (ts *ConfigAndClientSuiteBase) newDefaultClient(clientOpts ...ConfigureClientOptions) (client.Client, error) {
-	options := client.Options{
-		HostPort:          ts.config.ServiceAddr,
-		Namespace:         ts.config.Namespace,
-		ConnectionOptions: client.ConnectionOptions{TLS: ts.config.TLS},
-		Logger:            ilog.NewDefaultLogger(),
+	options := ts.config.clientOptions
+	options.HostPort = ts.config.ServiceAddr
+	options.Namespace = ts.config.Namespace
+	if options.Logger == nil {
+		options.Logger = ilog.NewDefaultLogger()
 	}
 	for _, opt := range clientOpts {
 		opt(&options)

--- a/test/test_utils_test.go
+++ b/test/test_utils_test.go
@@ -36,13 +36,13 @@ type (
 		Namespace               string
 		ShouldRegisterNamespace bool
 		TLS                     *tls.Config
-		clientOptions           client.Options
 	}
 	// context.WithValue need this type instead of basic type string to avoid lint error
 	contextKey               string
 	ConfigAndClientSuiteBase struct {
 		config        Config
 		client        client.Client
+		clientOptions client.Options
 		taskQueueName string
 	}
 	ConfigureConfigCallback func(*Config)
@@ -54,6 +54,11 @@ var taskQueuePrefix = "tq-" + uuid.NewString()
 
 // NewConfig creates new Config instance
 func NewConfig(configCallbacks ...ConfigureConfigCallback) Config {
+	cfg, _ := newConfigAndClientOptions(configCallbacks...)
+	return cfg
+}
+
+func newConfigAndClientOptions(configCallbacks ...ConfigureConfigCallback) (Config, client.Options) {
 	cfg := Config{
 		ServiceAddr:             client.DefaultHostPort,
 		ServiceHTTPAddr:         "localhost:7243",
@@ -61,13 +66,11 @@ func NewConfig(configCallbacks ...ConfigureConfigCallback) Config {
 		Namespace:               "integration-test-namespace",
 		ShouldRegisterNamespace: true,
 	}
-	for _, configure := range configCallbacks {
-		configure(&cfg)
-	}
-	useEnvConfig := getEnvConfigServer() && len(configCallbacks) == 0
-	callbackServer := getEnvConfigServer() && len(configCallbacks) > 0
+	var options client.Options
+	useEnvConfig := getEnvConfigServer()
 	if useEnvConfig {
-		options, err := envconfig.LoadDefaultClientOptions()
+		var err error
+		options, err = envconfig.LoadDefaultClientOptions()
 		if err != nil {
 			panic(fmt.Sprintf("Failed loading envconfig: %v", err))
 		}
@@ -81,22 +84,15 @@ func NewConfig(configCallbacks ...ConfigureConfigCallback) Config {
 		cfg.Namespace = options.Namespace
 		cfg.ShouldRegisterNamespace = false
 		cfg.TLS = options.ConnectionOptions.TLS
-		cfg.clientOptions = options
-	} else if !callbackServer {
+		for _, configure := range configCallbacks {
+			configure(&cfg)
+		}
+	} else {
+		for _, configure := range configCallbacks {
+			configure(&cfg)
+		}
 		if addr := getEnvServiceAddr(); addr != "" {
 			cfg.ServiceAddr = addr
-		}
-		if os.Getenv("TEMPORAL_NAMESPACE") != "" {
-			cfg.Namespace = os.Getenv("TEMPORAL_NAMESPACE")
-			cfg.ShouldRegisterNamespace = false
-		}
-		if os.Getenv("TEMPORAL_CLIENT_CERT") != "" || os.Getenv("TEMPORAL_CLIENT_KEY") != "" {
-			log.Print("Using custom client certificate")
-			cert, err := tls.X509KeyPair([]byte(os.Getenv("TEMPORAL_CLIENT_CERT")), []byte(os.Getenv("TEMPORAL_CLIENT_KEY")))
-			if err != nil {
-				panic(fmt.Sprintf("Failed loading client cert: %v", err))
-			}
-			cfg.TLS = &tls.Config{Certificates: []tls.Certificate{cert}}
 		}
 	}
 	if addr := strings.TrimSpace(os.Getenv("SERVICE_HTTP_ADDR")); addr != "" {
@@ -114,15 +110,23 @@ func NewConfig(configCallbacks ...ConfigureConfigCallback) Config {
 		cfg.Debug = debug == "true"
 	}
 	if !useEnvConfig {
-		cfg.clientOptions = client.Options{
-			HostPort:  cfg.ServiceAddr,
-			Namespace: cfg.Namespace,
-			ConnectionOptions: client.ConnectionOptions{
-				TLS: cfg.TLS,
-			},
+		if os.Getenv("TEMPORAL_NAMESPACE") != "" {
+			cfg.Namespace = os.Getenv("TEMPORAL_NAMESPACE")
+			cfg.ShouldRegisterNamespace = false
+		}
+		if os.Getenv("TEMPORAL_CLIENT_CERT") != "" || os.Getenv("TEMPORAL_CLIENT_KEY") != "" {
+			log.Print("Using custom client certificate")
+			cert, err := tls.X509KeyPair([]byte(os.Getenv("TEMPORAL_CLIENT_CERT")), []byte(os.Getenv("TEMPORAL_CLIENT_KEY")))
+			if err != nil {
+				panic(fmt.Sprintf("Failed loading client cert: %v", err))
+			}
+			cfg.TLS = &tls.Config{Certificates: []tls.Certificate{cert}}
 		}
 	}
-	return cfg
+	options.HostPort = cfg.ServiceAddr
+	options.Namespace = cfg.Namespace
+	options.ConnectionOptions.TLS = cfg.TLS
+	return cfg, options
 }
 
 func WithNamespace(ns string) ConfigureConfigCallback {
@@ -257,7 +261,7 @@ func (s *keysPropagator) ExtractToWorkflow(ctx workflow.Context, reader workflow
 }
 
 func (ts *ConfigAndClientSuiteBase) InitConfigAndNamespace() error {
-	ts.config = NewConfig()
+	ts.config, ts.clientOptions = newConfigAndClientOptions()
 	var err error
 	err = WaitForTCP(time.Minute, ts.config.ServiceAddr)
 	if err != nil {
@@ -298,9 +302,10 @@ func (ts *ConfigAndClientSuiteBase) newIntegrationTestClient(clientOpts ...Confi
 
 // newDefaultClient creates a client according to ts.config with SDK defaults.
 func (ts *ConfigAndClientSuiteBase) newDefaultClient(clientOpts ...ConfigureClientOptions) (client.Client, error) {
-	options := ts.config.clientOptions
+	options := ts.clientOptions
 	options.HostPort = ts.config.ServiceAddr
 	options.Namespace = ts.config.Namespace
+	options.ConnectionOptions.TLS = ts.config.TLS
 	if options.Logger == nil {
 		options.Logger = ilog.NewDefaultLogger()
 	}

--- a/test/test_utils_test.go
+++ b/test/test_utils_test.go
@@ -39,18 +39,17 @@ type (
 	}
 	// context.WithValue need this type instead of basic type string to avoid lint error
 	contextKey string
-	// testEnvironment is the immutable, resolved configuration for one test
-	// server target. Its invariants are:
-	//   - config and clientOptions describe the same address, namespace, and TLS
-	//     configuration at construction time.
-	//   - clientOptions is the source for every client created by the environment.
-	//   - per-client configuration is applied to a value copy of clientOptions;
-	//     callbacks must not mutate reference-valued members inherited from it.
-	//
-	// Neither config nor clientOptions should be mutated after construction.
+	// testEnvironment configures one test server target. Its invariants are:
+	//   - When envConfigClientOptions is nil, config is the source for clients.
+	//   - When envConfigClientOptions is non-nil, it is the only source for clients.
+	//     config is a read-only projection used by test setup and lifecycle logic;
+	//     the two representations are not synchronized after construction.
+	//   - Per-client configuration is applied to a value copy of the selected
+	//     source; callbacks must not mutate reference-valued members inherited
+	//     from it.
 	testEnvironment struct {
-		config        Config
-		clientOptions client.Options
+		config                 Config
+		envConfigClientOptions *client.Options
 	}
 	// ConfigAndClientSuiteBase owns a resolved test environment and any shared
 	// client created from that environment.
@@ -74,24 +73,23 @@ func NewConfig(configCallbacks ...ConfigureConfigCallback) Config {
 	return cfg
 }
 
-func newTestEnvironment(configCallbacks ...ConfigureConfigCallback) testEnvironment {
+func newTestEnvironment() testEnvironment {
 	if envConfigEnabled() {
-		return newEnvConfigTestEnvironment(configCallbacks...)
+		return newEnvConfigTestEnvironment()
 	}
-	return newTestEnvironmentFromConfig(NewConfig(configCallbacks...))
+	return newTestEnvironmentFromConfig(NewConfig())
 }
 
 func newTestEnvironmentFromConfig(cfg Config) testEnvironment {
-	return testEnvironment{config: cfg, clientOptions: cfg.toClientOptions()}
+	return testEnvironment{config: cfg}
 }
 
-func newEnvConfigTestEnvironment(configCallbacks ...ConfigureConfigCallback) testEnvironment {
-	cfg := newDefaultConfig()
-	options := loadEnvConfigClientOptions(&cfg)
-	applyConfigCallbacks(&cfg, configCallbacks)
-	applySharedConfig(&cfg)
-	applyConfigToClientOptions(cfg, &options)
-	return testEnvironment{config: cfg, clientOptions: options}
+func newEnvConfigTestEnvironment() testEnvironment {
+	options := loadEnvConfigClientOptions()
+	return testEnvironment{
+		config:                 newConfigFromClientOptions(options),
+		envConfigClientOptions: &options,
+	}
 }
 
 func newDefaultConfig() Config {
@@ -123,7 +121,7 @@ func applyHarnessEnvironmentOverrides(cfg *Config) {
 	}
 }
 
-func loadEnvConfigClientOptions(cfg *Config) client.Options {
+func loadEnvConfigClientOptions() client.Options {
 	options, err := envconfig.LoadDefaultClientOptions()
 	if err != nil {
 		panic(fmt.Sprintf("Failed loading envconfig: %v", err))
@@ -134,11 +132,17 @@ func loadEnvConfigClientOptions(cfg *Config) client.Options {
 	if options.Namespace == "" {
 		options.Namespace = client.DefaultNamespace
 	}
+	return options
+}
+
+func newConfigFromClientOptions(options client.Options) Config {
+	cfg := newDefaultConfig()
 	cfg.ServiceAddr = options.HostPort
 	cfg.Namespace = options.Namespace
 	cfg.ShouldRegisterNamespace = false
 	cfg.TLS = options.ConnectionOptions.TLS
-	return options
+	applySharedConfig(&cfg)
+	return cfg
 }
 
 func applyConfigCallbacks(cfg *Config, configCallbacks []ConfigureConfigCallback) {
@@ -162,12 +166,6 @@ func applySharedConfig(cfg *Config) {
 	if debug := getDebug(); debug != "" {
 		cfg.Debug = debug == "true"
 	}
-}
-
-func applyConfigToClientOptions(cfg Config, options *client.Options) {
-	options.HostPort = cfg.ServiceAddr
-	options.Namespace = cfg.Namespace
-	options.ConnectionOptions.TLS = cfg.TLS
 }
 
 func (cfg Config) toClientOptions() client.Options {
@@ -357,7 +355,12 @@ func (ts *ConfigAndClientSuiteBase) newDefaultClient(clientOpts ...ConfigureClie
 }
 
 func (ts *ConfigAndClientSuiteBase) newDefaultClientOptions(clientOpts ...ConfigureClientOptions) client.Options {
-	options := ts.testEnvironment.clientOptions
+	var options client.Options
+	if ts.envConfigClientOptions == nil {
+		options = ts.config.toClientOptions()
+	} else {
+		options = *ts.envConfigClientOptions
+	}
 	if options.Logger == nil {
 		options.Logger = ilog.NewDefaultLogger()
 	}

--- a/test/test_utils_test.go
+++ b/test/test_utils_test.go
@@ -39,17 +39,25 @@ type (
 	}
 	// context.WithValue need this type instead of basic type string to avoid lint error
 	contextKey string
-	// ConfigAndClientSuiteBase stores the resolved test configuration and the
-	// base options used to create clients for a suite.
+	// testEnvironment is the immutable, resolved configuration for one test
+	// server target. Its invariants are:
+	//   - config and clientOptions describe the same address, namespace, and TLS
+	//     configuration at construction time.
+	//   - clientOptions is the source for every client created by the environment.
+	//   - per-client configuration is applied to a value copy of clientOptions;
+	//     callbacks must not mutate reference-valued members inherited from it.
+	//
+	// Neither config nor clientOptions should be mutated after construction.
+	testEnvironment struct {
+		config        Config
+		clientOptions client.Options
+	}
+	// ConfigAndClientSuiteBase owns a resolved test environment and any shared
+	// client created from that environment.
 	ConfigAndClientSuiteBase struct {
-		config Config
-		client client.Client
-		// baseClientOptions contains the resolved options inherited by clients
-		// created through newDefaultClient. Config is reapplied for the overlapping
-		// address, namespace, and TLS fields. Per-client modifiers may
-		// intentionally override those values.
-		baseClientOptions client.Options
-		taskQueueName     string
+		testEnvironment
+		client        client.Client
+		taskQueueName string
 	}
 	ConfigureConfigCallback func(*Config)
 	ConfigureClientOptions  func(*client.Options)
@@ -60,23 +68,30 @@ var taskQueuePrefix = "tq-" + uuid.NewString()
 
 // NewConfig creates new Config instance
 func NewConfig(configCallbacks ...ConfigureConfigCallback) Config {
-	cfg, _ := newConfigAndClientOptions(configCallbacks...)
+	cfg := newDefaultConfig()
+	applyConfigCallbacks(&cfg, configCallbacks)
+	applyHarnessEnvironmentOverrides(&cfg)
 	return cfg
 }
 
-func newConfigAndClientOptions(configCallbacks ...ConfigureConfigCallback) (Config, client.Options) {
-	cfg := newDefaultConfig()
-	var options client.Options
+func newTestEnvironment(configCallbacks ...ConfigureConfigCallback) testEnvironment {
 	if envConfigEnabled() {
-		options = loadEnvConfigClientOptions(&cfg)
-		applyConfigCallbacks(&cfg, configCallbacks)
-	} else {
-		applyConfigCallbacks(&cfg, configCallbacks)
-		applyHarnessEnvironmentOverrides(&cfg)
+		return newEnvConfigTestEnvironment(configCallbacks...)
 	}
+	return newTestEnvironmentFromConfig(NewConfig(configCallbacks...))
+}
+
+func newTestEnvironmentFromConfig(cfg Config) testEnvironment {
+	return testEnvironment{config: cfg, clientOptions: cfg.toClientOptions()}
+}
+
+func newEnvConfigTestEnvironment(configCallbacks ...ConfigureConfigCallback) testEnvironment {
+	cfg := newDefaultConfig()
+	options := loadEnvConfigClientOptions(&cfg)
+	applyConfigCallbacks(&cfg, configCallbacks)
 	applySharedConfig(&cfg)
 	applyConfigToClientOptions(cfg, &options)
-	return cfg, options
+	return testEnvironment{config: cfg, clientOptions: options}
 }
 
 func newDefaultConfig() Config {
@@ -93,6 +108,7 @@ func applyHarnessEnvironmentOverrides(cfg *Config) {
 	if addr := getEnvServiceAddr(); addr != "" {
 		cfg.ServiceAddr = addr
 	}
+	applySharedConfig(cfg)
 	if os.Getenv("TEMPORAL_NAMESPACE") != "" {
 		cfg.Namespace = os.Getenv("TEMPORAL_NAMESPACE")
 		cfg.ShouldRegisterNamespace = false
@@ -152,6 +168,16 @@ func applyConfigToClientOptions(cfg Config, options *client.Options) {
 	options.HostPort = cfg.ServiceAddr
 	options.Namespace = cfg.Namespace
 	options.ConnectionOptions.TLS = cfg.TLS
+}
+
+func (cfg Config) toClientOptions() client.Options {
+	return client.Options{
+		HostPort:  cfg.ServiceAddr,
+		Namespace: cfg.Namespace,
+		ConnectionOptions: client.ConnectionOptions{
+			TLS: cfg.TLS,
+		},
+	}
 }
 
 func WithNamespace(ns string) ConfigureConfigCallback {
@@ -286,7 +312,7 @@ func (s *keysPropagator) ExtractToWorkflow(ctx workflow.Context, reader workflow
 }
 
 func (ts *ConfigAndClientSuiteBase) InitConfigAndNamespace() error {
-	ts.config, ts.baseClientOptions = newConfigAndClientOptions()
+	ts.testEnvironment = newTestEnvironment()
 	var err error
 	err = WaitForTCP(time.Minute, ts.config.ServiceAddr)
 	if err != nil {
@@ -331,10 +357,7 @@ func (ts *ConfigAndClientSuiteBase) newDefaultClient(clientOpts ...ConfigureClie
 }
 
 func (ts *ConfigAndClientSuiteBase) newDefaultClientOptions(clientOpts ...ConfigureClientOptions) client.Options {
-	options := ts.baseClientOptions
-	options.HostPort = ts.config.ServiceAddr
-	options.Namespace = ts.config.Namespace
-	options.ConnectionOptions.TLS = ts.config.TLS
+	options := ts.testEnvironment.clientOptions
 	if options.Logger == nil {
 		options.Logger = ilog.NewDefaultLogger()
 	}

--- a/test/test_utils_test.go
+++ b/test/test_utils_test.go
@@ -336,6 +336,15 @@ func (ts *ConfigAndClientSuiteBase) newDefaultClient(clientOpts ...ConfigureClie
 	return client.Dial(ts.newDefaultClientOptions(clientOpts...))
 }
 
+// newDefaultClientContext creates a client according to ts.config with SDK defaults,
+// using ctx while dialing.
+func (ts *ConfigAndClientSuiteBase) newDefaultClientContext(
+	ctx context.Context,
+	clientOpts ...ConfigureClientOptions,
+) (client.Client, error) {
+	return client.DialContext(ctx, ts.newDefaultClientOptions(clientOpts...))
+}
+
 func (ts *ConfigAndClientSuiteBase) newDefaultClientOptions(clientOpts ...ConfigureClientOptions) client.Options {
 	var options client.Options
 	if ts.envConfigClientOptions == nil {

--- a/test/test_utils_test.go
+++ b/test/test_utils_test.go
@@ -38,16 +38,28 @@ type (
 		TLS                     *tls.Config
 	}
 	// context.WithValue need this type instead of basic type string to avoid lint error
-	contextKey               string
+	contextKey       string
+	clientConfigMode int
+	// ConfigAndClientSuiteBase stores the resolved test configuration and the
+	// base options used to create clients for a suite.
 	ConfigAndClientSuiteBase struct {
-		config        Config
-		client        client.Client
-		clientOptions client.Options
-		taskQueueName string
+		config Config
+		client client.Client
+		// baseClientOptions contains the resolved options inherited by clients
+		// created through newDefaultClient. Config is reapplied for the overlapping
+		// address, namespace, and TLS fields. Per-client modifiers may
+		// intentionally override those values.
+		baseClientOptions client.Options
+		taskQueueName     string
 	}
 	ConfigureConfigCallback func(*Config)
 	ConfigureClientOptions  func(*client.Options)
 	ConfigureWorkerOptions  func(*worker.Options)
+)
+
+const (
+	clientConfigModeLegacy clientConfigMode = iota
+	clientConfigModeEnvConfig
 )
 
 var taskQueuePrefix = "tq-" + uuid.NewString()
@@ -59,42 +71,76 @@ func NewConfig(configCallbacks ...ConfigureConfigCallback) Config {
 }
 
 func newConfigAndClientOptions(configCallbacks ...ConfigureConfigCallback) (Config, client.Options) {
-	cfg := Config{
+	cfg := newDefaultConfig()
+	var options client.Options
+	switch getClientConfigMode() {
+	case clientConfigModeLegacy:
+		resolveLegacyConfig(&cfg, configCallbacks...)
+	case clientConfigModeEnvConfig:
+		options = resolveEnvConfigClientConfig(&cfg, configCallbacks...)
+	default:
+		panic("unknown client config mode")
+	}
+	applySharedConfig(&cfg)
+	applyConfigToClientOptions(cfg, &options)
+	return cfg, options
+}
+
+func newDefaultConfig() Config {
+	return Config{
 		ServiceAddr:             client.DefaultHostPort,
 		ServiceHTTPAddr:         "localhost:7243",
 		maxWorkflowCacheSize:    10000,
 		Namespace:               "integration-test-namespace",
 		ShouldRegisterNamespace: true,
 	}
-	var options client.Options
-	useEnvConfig := getEnvConfigServer()
-	if useEnvConfig {
-		var err error
-		options, err = envconfig.LoadDefaultClientOptions()
-		if err != nil {
-			panic(fmt.Sprintf("Failed loading envconfig: %v", err))
-		}
-		if options.HostPort == "" {
-			options.HostPort = client.DefaultHostPort
-		}
-		if options.Namespace == "" {
-			options.Namespace = client.DefaultNamespace
-		}
-		cfg.ServiceAddr = options.HostPort
-		cfg.Namespace = options.Namespace
-		cfg.ShouldRegisterNamespace = false
-		cfg.TLS = options.ConnectionOptions.TLS
-		for _, configure := range configCallbacks {
-			configure(&cfg)
-		}
-	} else {
-		for _, configure := range configCallbacks {
-			configure(&cfg)
-		}
-		if addr := getEnvServiceAddr(); addr != "" {
-			cfg.ServiceAddr = addr
-		}
+}
+
+func resolveLegacyConfig(cfg *Config, configCallbacks ...ConfigureConfigCallback) {
+	applyConfigCallbacks(cfg, configCallbacks)
+	if addr := getEnvServiceAddr(); addr != "" {
+		cfg.ServiceAddr = addr
 	}
+	if os.Getenv("TEMPORAL_NAMESPACE") != "" {
+		cfg.Namespace = os.Getenv("TEMPORAL_NAMESPACE")
+		cfg.ShouldRegisterNamespace = false
+	}
+	if os.Getenv("TEMPORAL_CLIENT_CERT") != "" || os.Getenv("TEMPORAL_CLIENT_KEY") != "" {
+		log.Print("Using custom client certificate")
+		cert, err := tls.X509KeyPair([]byte(os.Getenv("TEMPORAL_CLIENT_CERT")), []byte(os.Getenv("TEMPORAL_CLIENT_KEY")))
+		if err != nil {
+			panic(fmt.Sprintf("Failed loading client cert: %v", err))
+		}
+		cfg.TLS = &tls.Config{Certificates: []tls.Certificate{cert}}
+	}
+}
+
+func resolveEnvConfigClientConfig(cfg *Config, configCallbacks ...ConfigureConfigCallback) client.Options {
+	options, err := envconfig.LoadDefaultClientOptions()
+	if err != nil {
+		panic(fmt.Sprintf("Failed loading envconfig: %v", err))
+	}
+	if options.HostPort == "" {
+		options.HostPort = client.DefaultHostPort
+	}
+	if options.Namespace == "" {
+		options.Namespace = client.DefaultNamespace
+	}
+	cfg.ServiceAddr = options.HostPort
+	cfg.Namespace = options.Namespace
+	cfg.ShouldRegisterNamespace = false
+	cfg.TLS = options.ConnectionOptions.TLS
+	applyConfigCallbacks(cfg, configCallbacks)
+	return options
+}
+
+func applyConfigCallbacks(cfg *Config, configCallbacks []ConfigureConfigCallback) {
+	for _, configure := range configCallbacks {
+		configure(cfg)
+	}
+}
+
+func applySharedConfig(cfg *Config) {
 	if addr := strings.TrimSpace(os.Getenv("SERVICE_HTTP_ADDR")); addr != "" {
 		cfg.ServiceHTTPAddr = addr
 	}
@@ -109,24 +155,12 @@ func newConfigAndClientOptions(configCallbacks ...ConfigureConfigCallback) (Conf
 	if debug := getDebug(); debug != "" {
 		cfg.Debug = debug == "true"
 	}
-	if !useEnvConfig {
-		if os.Getenv("TEMPORAL_NAMESPACE") != "" {
-			cfg.Namespace = os.Getenv("TEMPORAL_NAMESPACE")
-			cfg.ShouldRegisterNamespace = false
-		}
-		if os.Getenv("TEMPORAL_CLIENT_CERT") != "" || os.Getenv("TEMPORAL_CLIENT_KEY") != "" {
-			log.Print("Using custom client certificate")
-			cert, err := tls.X509KeyPair([]byte(os.Getenv("TEMPORAL_CLIENT_CERT")), []byte(os.Getenv("TEMPORAL_CLIENT_KEY")))
-			if err != nil {
-				panic(fmt.Sprintf("Failed loading client cert: %v", err))
-			}
-			cfg.TLS = &tls.Config{Certificates: []tls.Certificate{cert}}
-		}
-	}
+}
+
+func applyConfigToClientOptions(cfg Config, options *client.Options) {
 	options.HostPort = cfg.ServiceAddr
 	options.Namespace = cfg.Namespace
 	options.ConnectionOptions.TLS = cfg.TLS
-	return cfg, options
 }
 
 func WithNamespace(ns string) ConfigureConfigCallback {
@@ -153,8 +187,11 @@ func getDebug() string {
 	return strings.ToLower(strings.TrimSpace(os.Getenv("DEBUG")))
 }
 
-func getEnvConfigServer() bool {
-	return strings.EqualFold(strings.TrimSpace(os.Getenv("TEMPORAL_TEST_ENV_CONFIG_SERVER")), "true")
+func getClientConfigMode() clientConfigMode {
+	if strings.EqualFold(strings.TrimSpace(os.Getenv("TEMPORAL_TEST_ENV_CONFIG_SERVER")), "true") {
+		return clientConfigModeEnvConfig
+	}
+	return clientConfigModeLegacy
 }
 
 // WaitForTCP waits until target tcp address is available.
@@ -261,7 +298,7 @@ func (s *keysPropagator) ExtractToWorkflow(ctx workflow.Context, reader workflow
 }
 
 func (ts *ConfigAndClientSuiteBase) InitConfigAndNamespace() error {
-	ts.config, ts.clientOptions = newConfigAndClientOptions()
+	ts.config, ts.baseClientOptions = newConfigAndClientOptions()
 	var err error
 	err = WaitForTCP(time.Minute, ts.config.ServiceAddr)
 	if err != nil {
@@ -302,7 +339,11 @@ func (ts *ConfigAndClientSuiteBase) newIntegrationTestClient(clientOpts ...Confi
 
 // newDefaultClient creates a client according to ts.config with SDK defaults.
 func (ts *ConfigAndClientSuiteBase) newDefaultClient(clientOpts ...ConfigureClientOptions) (client.Client, error) {
-	options := ts.clientOptions
+	return client.Dial(ts.newDefaultClientOptions(clientOpts...))
+}
+
+func (ts *ConfigAndClientSuiteBase) newDefaultClientOptions(clientOpts ...ConfigureClientOptions) client.Options {
+	options := ts.baseClientOptions
 	options.HostPort = ts.config.ServiceAddr
 	options.Namespace = ts.config.Namespace
 	options.ConnectionOptions.TLS = ts.config.TLS
@@ -312,7 +353,7 @@ func (ts *ConfigAndClientSuiteBase) newDefaultClient(clientOpts ...ConfigureClie
 	for _, opt := range clientOpts {
 		opt(&options)
 	}
-	return client.Dial(options)
+	return options
 }
 
 func SimplestWorkflow(_ workflow.Context) error {

--- a/test/test_utils_test.go
+++ b/test/test_utils_test.go
@@ -38,8 +38,7 @@ type (
 		TLS                     *tls.Config
 	}
 	// context.WithValue need this type instead of basic type string to avoid lint error
-	contextKey       string
-	clientConfigMode int
+	contextKey string
 	// ConfigAndClientSuiteBase stores the resolved test configuration and the
 	// base options used to create clients for a suite.
 	ConfigAndClientSuiteBase struct {
@@ -57,11 +56,6 @@ type (
 	ConfigureWorkerOptions  func(*worker.Options)
 )
 
-const (
-	clientConfigModeLegacy clientConfigMode = iota
-	clientConfigModeEnvConfig
-)
-
 var taskQueuePrefix = "tq-" + uuid.NewString()
 
 // NewConfig creates new Config instance
@@ -73,13 +67,12 @@ func NewConfig(configCallbacks ...ConfigureConfigCallback) Config {
 func newConfigAndClientOptions(configCallbacks ...ConfigureConfigCallback) (Config, client.Options) {
 	cfg := newDefaultConfig()
 	var options client.Options
-	switch getClientConfigMode() {
-	case clientConfigModeLegacy:
-		resolveLegacyConfig(&cfg, configCallbacks...)
-	case clientConfigModeEnvConfig:
-		options = resolveEnvConfigClientConfig(&cfg, configCallbacks...)
-	default:
-		panic("unknown client config mode")
+	if envConfigEnabled() {
+		options = loadEnvConfigClientOptions(&cfg)
+		applyConfigCallbacks(&cfg, configCallbacks)
+	} else {
+		applyConfigCallbacks(&cfg, configCallbacks)
+		applyHarnessEnvironmentOverrides(&cfg)
 	}
 	applySharedConfig(&cfg)
 	applyConfigToClientOptions(cfg, &options)
@@ -96,8 +89,7 @@ func newDefaultConfig() Config {
 	}
 }
 
-func resolveLegacyConfig(cfg *Config, configCallbacks ...ConfigureConfigCallback) {
-	applyConfigCallbacks(cfg, configCallbacks)
+func applyHarnessEnvironmentOverrides(cfg *Config) {
 	if addr := getEnvServiceAddr(); addr != "" {
 		cfg.ServiceAddr = addr
 	}
@@ -115,7 +107,7 @@ func resolveLegacyConfig(cfg *Config, configCallbacks ...ConfigureConfigCallback
 	}
 }
 
-func resolveEnvConfigClientConfig(cfg *Config, configCallbacks ...ConfigureConfigCallback) client.Options {
+func loadEnvConfigClientOptions(cfg *Config) client.Options {
 	options, err := envconfig.LoadDefaultClientOptions()
 	if err != nil {
 		panic(fmt.Sprintf("Failed loading envconfig: %v", err))
@@ -130,7 +122,6 @@ func resolveEnvConfigClientConfig(cfg *Config, configCallbacks ...ConfigureConfi
 	cfg.Namespace = options.Namespace
 	cfg.ShouldRegisterNamespace = false
 	cfg.TLS = options.ConnectionOptions.TLS
-	applyConfigCallbacks(cfg, configCallbacks)
 	return options
 }
 
@@ -187,11 +178,8 @@ func getDebug() string {
 	return strings.ToLower(strings.TrimSpace(os.Getenv("DEBUG")))
 }
 
-func getClientConfigMode() clientConfigMode {
-	if strings.EqualFold(strings.TrimSpace(os.Getenv("TEMPORAL_TEST_ENV_CONFIG_SERVER")), "true") {
-		return clientConfigModeEnvConfig
-	}
-	return clientConfigModeLegacy
+func envConfigEnabled() bool {
+	return strings.EqualFold(strings.TrimSpace(os.Getenv("TEMPORAL_TEST_ENV_CONFIG_SERVER")), "true")
 }
 
 // WaitForTCP waits until target tcp address is available.


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Add `-envconfig` flag to integration test suite, which enables connection through `contrib/envconfig`.

In the existing harness path, `Config` remains the source for clients. Existing configuration callbacks work as before. In `envconfig` mode, the loaded `client.Options` are the sole client source, so API keys, TLS settings, gRPC metadata, and authority are preserved; `Config` is only a lifecycle projection used by existing test setup.

The existing two-test Temporal Cloud job now uses this path with the standard `envconfig` certificate-data variables.

## Why?
<!-- Tell your future self why have you made these changes -->

Add `envconfig` backed harness to the integration test suite, allowing tests to run against arbitrary server environments.

## Checklist
<!--- add/delete as needed --->

1. Part of temporalio/features#851.

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

- `go test -run '^TestConfigAndClientSuiteBase' -count=1 .`
- `go test -run '^$' ./...`
- `go run . integration-test -envconfig -packages . -run '^TestConfigAndClientSuiteBaseFromEnvConfig$'`
- `go run . integration-test -dev-server -p 1 -packages . -run 'TestIntegrationSuite/TestBasic$'`
- Verified that combining `-dev-server` and `-envconfig` fails with a clear error.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

No. This changes internal SDK integration-test infrastructure and its existing Cloud CI job.
