### PR TITLE
Expose First Execution Run on WorkflowRun

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ to docs, or any other relevant information.
 ### Added
 
 - Added `client.Options.SdkName` and `client.Options.SdkVersion` to override the SDK name and version reported in worker heartbeats.
+- Added `client.WorkflowRun.GetFirstExecutionRunID` to expose the first execution run ID returned by the server when starting a workflow.
 
 ### Changed
 

--- a/client/client.go
+++ b/client/client.go
@@ -1133,9 +1133,10 @@ type (
 		//  - serviceerror.Unavailable
 		//  - serviceerror.WorkflowExecutionAlreadyStarted, when WorkflowExecutionErrorWhenAlreadyStarted is specified
 		//
-		// WorkflowRun has 3 methods:
-		//  - GetWorkflowID() string: which return the started workflow ID
+		// WorkflowRun provides:
+		//  - GetID() string: which returns the started workflow ID
 		//  - GetRunID() string: which return the first started workflow run ID (please see below)
+		//  - GetFirstExecutionRunID() string: which returns the first execution run ID in the workflow chain
 		//  - Get(ctx context.Context, valuePtr interface{}) error: which will fill the workflow
 		//    execution result to valuePtr, if workflow execution is a success, or return corresponding
 		//    error. This is a blocking API.
@@ -1154,8 +1155,10 @@ type (
 		//  - workflow ID of the workflow.
 		//  - runID can be default(empty string). if empty string then it will pick the last running execution of that workflow ID.
 		//
-		// WorkflowRun has 2 methods:
+		// WorkflowRun provides:
+		//  - GetID() string: which returns the workflow ID
 		//  - GetRunID() string: which return the first started workflow run ID (please see below)
+		//  - GetFirstExecutionRunID() string: which is empty for handles returned by GetWorkflow
 		//  - Get(ctx context.Context, valuePtr interface{}) error: which will fill the workflow
 		//    execution result to valuePtr, if workflow execution is a success, or return corresponding
 		//    error. This is a blocking API.

--- a/internal/client.go
+++ b/internal/client.go
@@ -97,9 +97,10 @@ type (
 		// The current timeout resolution implementation is in seconds and uses math.Ceil(d.Seconds()) as the duration. But is
 		// subjected to change in the future.
 		//
-		// WorkflowRun has three methods:
+		// WorkflowRun provides:
 		//  - GetID() string: which return workflow ID (which is same as StartWorkflowOptions.ID if provided)
 		//  - GetRunID() string: which return the first started workflow run ID (please see below)
+		//  - GetFirstExecutionRunID() string: which returns the first execution run ID in the workflow chain
 		//  - Get(ctx context.Context, valuePtr interface{}) error: which will fill the workflow
 		//    execution result to valuePtr, if workflow execution is a success, or return corresponding
 		//    error. This is a blocking API.
@@ -118,9 +119,10 @@ type (
 		//  - workflow ID of the workflow.
 		//  - runID can be default(empty string). if empty string then it will pick the last running execution of that workflow ID.
 		//
-		// WorkflowRun has three methods:
+		// WorkflowRun provides:
 		//  - GetID() string: which return workflow ID (which is same as StartWorkflowOptions.ID if provided)
 		//  - GetRunID() string: which return the first started workflow run ID (please see below)
+		//  - GetFirstExecutionRunID() string: which is empty for handles returned by GetWorkflow
 		//  - Get(ctx context.Context, valuePtr interface{}) error: which will fill the workflow
 		//    execution result to valuePtr, if workflow execution is a success, or return corresponding
 		//    error. This is a blocking API.

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -124,6 +124,11 @@ type (
 		// called if there was a later run for this run.
 		GetRunID() string
 
+		// GetFirstExecutionRunID returns the run ID of the first execution in the
+		// workflow execution chain. The value may be empty if the server did not
+		// return it, such as when using GetWorkflow or an older server version.
+		GetFirstExecutionRunID() string
+
 		// Get will fill the workflow execution result to valuePtr, if workflow
 		// execution is a success, or return corresponding error. If valuePtr is
 		// nil, valuePtr will be ignored and only the corresponding error of the
@@ -169,7 +174,7 @@ type (
 	workflowRunImpl struct {
 		workflowType          string
 		workflowID            string
-		firstRunID            string
+		firstExecutionRunID   string
 		currentRunID          func() string
 		iterFn                func(ctx context.Context, runID string) HistoryEventIterator
 		dataConverter         converter.DataConverter
@@ -283,7 +288,6 @@ func (wc *WorkflowClient) GetWorkflow(ctx context.Context, workflowID string, ru
 	}
 	return &workflowRunImpl{
 		workflowID:            workflowID,
-		firstRunID:            runID,
 		currentRunID:          currentRunID,
 		iterFn:                iterFn,
 		dataConverter:         converter.WithDataConverterSerializationContext(wc.dataConverter, gwCtx),
@@ -1889,6 +1893,10 @@ func (workflowRun *workflowRunImpl) GetRunID() string {
 	return workflowRun.currentRunID()
 }
 
+func (workflowRun *workflowRunImpl) GetFirstExecutionRunID() string {
+	return workflowRun.firstExecutionRunID
+}
+
 func (workflowRun *workflowRunImpl) GetID() string {
 	return workflowRun.workflowID
 }
@@ -2187,7 +2195,7 @@ func (w *workflowClientInterceptor) ExecuteWorkflow(
 		defaultGrpcRetryParameters(ctx))
 	defer cancel()
 
-	var runID string
+	var runID, firstExecutionRunID string
 	response, err := w.client.workflowService.StartWorkflowExecution(grpcCtx, startRequest)
 
 	eagerWorkflowTask := response.GetEagerWorkflowTask()
@@ -2200,10 +2208,12 @@ func (w *workflowClientInterceptor) ExecuteWorkflow(
 	// Allow already-started error
 	if e, ok := err.(*serviceerror.WorkflowExecutionAlreadyStarted); ok && !in.Options.WorkflowExecutionErrorWhenAlreadyStarted {
 		runID = e.RunId
+		firstExecutionRunID = e.FirstExecutionRunId
 	} else if err != nil {
 		return nil, err
 	} else {
-		runID = response.RunId
+		runID = response.GetRunId()
+		firstExecutionRunID = response.GetFirstExecutionRunId()
 	}
 
 	if responseInfo := in.Options.responseInfo; responseInfo != nil {
@@ -2224,7 +2234,7 @@ func (w *workflowClientInterceptor) ExecuteWorkflow(
 	return &workflowRunImpl{
 		workflowType:          in.WorkflowType,
 		workflowID:            workflowID,
-		firstRunID:            runID,
+		firstExecutionRunID:   firstExecutionRunID,
 		currentRunID:          func() string { return runID },
 		iterFn:                iterFn,
 		dataConverter:         converter.WithDataConverterSerializationContext(w.client.dataConverter, wfCtx),
@@ -2282,14 +2292,14 @@ func (w *workflowClientInterceptor) UpdateWithStartWorkflow(
 	onStart := func(startResp *workflowservice.StartWorkflowExecutionResponse) {
 		runID := startResp.RunId
 		startOp.set(&workflowRunImpl{
-			workflowType:     startOp.input.WorkflowType,
-			workflowID:       startOp.input.Options.ID,
-			firstRunID:       runID,
-			currentRunID:     func() string { return runID },
-			iterFn:           iterFn,
-			dataConverter:    converter.WithDataConverterSerializationContext(w.client.dataConverter, startWfCtx),
-			failureConverter: converter.WithFailureConverterSerializationContext(w.client.failureConverter, startWfCtx),
-			registry:         w.client.registry,
+			workflowType:        startOp.input.WorkflowType,
+			workflowID:          startOp.input.Options.ID,
+			firstExecutionRunID: startResp.GetFirstExecutionRunId(),
+			currentRunID:        func() string { return runID },
+			iterFn:              iterFn,
+			dataConverter:       converter.WithDataConverterSerializationContext(w.client.dataConverter, startWfCtx),
+			failureConverter:    converter.WithFailureConverterSerializationContext(w.client.failureConverter, startWfCtx),
+			registry:            w.client.registry,
 		}, nil)
 	}
 
@@ -2636,7 +2646,7 @@ func (w *workflowClientInterceptor) SignalWithStartWorkflow(
 	return &workflowRunImpl{
 		workflowType:          in.WorkflowType,
 		workflowID:            in.Options.ID,
-		firstRunID:            runID,
+		firstExecutionRunID:   response.GetFirstExecutionRunId(),
 		currentRunID:          func() string { return runID },
 		iterFn:                iterFn,
 		dataConverter:         converter.WithDataConverterSerializationContext(w.client.dataConverter, swsCtx),

--- a/internal/internal_workflow_client_test.go
+++ b/internal/internal_workflow_client_test.go
@@ -363,8 +363,10 @@ func (s *workflowRunSuite) TearDownTest() {
 }
 
 func (s *workflowRunSuite) TestExecuteWorkflow_NoDup_Success() {
+	firstExecutionRunID := "first-execution-run-id"
 	createResponse := &workflowservice.StartWorkflowExecutionResponse{
-		RunId: runID,
+		RunId:               runID,
+		FirstExecutionRunId: firstExecutionRunID,
 	}
 	s.workflowServiceClient.EXPECT().StartWorkflowExecution(gomock.Any(), gomock.Any()).Return(createResponse, nil).Times(1)
 
@@ -401,6 +403,7 @@ func (s *workflowRunSuite) TestExecuteWorkflow_NoDup_Success() {
 	s.Nil(err)
 	s.Equal(workflowRun.GetID(), workflowID)
 	s.Equal(workflowRun.GetRunID(), runID)
+	s.Equal(firstExecutionRunID, workflowRun.GetFirstExecutionRunID())
 	decodedResult := time.Minute
 	err = workflowRun.Get(context.Background(), &decodedResult)
 	s.Nil(err)
@@ -525,8 +528,11 @@ func (s *workflowRunSuite) TestExecuteWorkflowWorkflowExecutionAlreadyStartedErr
 }
 
 func (s *workflowRunSuite) alreadyStartedErrTest(dc converter.DataConverter, rawHistory bool) {
+	firstExecutionRunID := "first-execution-run-id"
 	s.workflowServiceClient.EXPECT().StartWorkflowExecution(gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(nil, serviceerror.NewWorkflowExecutionAlreadyStarted("Already Started", "", runID)).Times(1)
+		Return(nil, serviceerror.NewWorkflowExecutionAlreadyStartedWithFirstExecutionRunId(
+			"Already Started", "", runID, firstExecutionRunID,
+		)).Times(1)
 
 	eventType := enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED
 	workflowResult := time.Hour * 59
@@ -587,6 +593,7 @@ func (s *workflowRunSuite) alreadyStartedErrTest(dc converter.DataConverter, raw
 	s.Nil(err)
 	s.Equal(workflowRun.GetID(), workflowID)
 	s.Equal(workflowRun.GetRunID(), runID)
+	s.Equal(firstExecutionRunID, workflowRun.GetFirstExecutionRunID())
 	decodedResult := time.Minute
 	err = workflowRun.Get(context.Background(), &decodedResult)
 	s.Nil(err)
@@ -734,6 +741,7 @@ func (s *workflowRunSuite) TestExecuteWorkflow_NoDup_Canceled() {
 	s.Nil(err)
 	s.Equal(workflowRun.GetID(), workflowID)
 	s.Equal(workflowRun.GetRunID(), runID)
+	s.Empty(workflowRun.GetFirstExecutionRunID())
 	decodedResult := time.Minute
 
 	err = workflowRun.Get(context.Background(), &decodedResult)
@@ -989,6 +997,7 @@ func (s *workflowRunSuite) TestGetWorkflow() {
 	)
 	s.Equal(workflowRun.GetID(), workflowID)
 	s.Equal(workflowRun.GetRunID(), runID)
+	s.Empty(workflowRun.GetFirstExecutionRunID())
 	decodedResult := time.Minute
 	err := workflowRun.Get(context.Background(), &decodedResult)
 	s.Nil(err)
@@ -1023,6 +1032,7 @@ func (s *workflowRunSuite) TestGetWorkflowNoExtantWorkflowAndNoRunId() {
 }
 
 func (s *workflowRunSuite) TestExecuteWorkflowWithUpdate_Retry() {
+	firstExecutionRunID := "FIRST_EXECUTION_RUN_ID"
 	s.workflowServiceClient.EXPECT().
 		ExecuteMultiOperation(gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(&workflowservice.ExecuteMultiOperationResponse{
@@ -1041,7 +1051,8 @@ func (s *workflowRunSuite) TestExecuteWorkflowWithUpdate_Retry() {
 				{
 					Response: &workflowservice.ExecuteMultiOperationResponse_Response_StartWorkflow{
 						StartWorkflow: &workflowservice.StartWorkflowExecutionResponse{
-							RunId: "RUN_ID",
+							RunId:               "RUN_ID",
+							FirstExecutionRunId: firstExecutionRunID,
 						},
 					},
 				},
@@ -1075,6 +1086,9 @@ func (s *workflowRunSuite) TestExecuteWorkflowWithUpdate_Retry() {
 		},
 	)
 	s.NoError(err)
+	workflowRun, err := startOp.Get(context.Background())
+	s.NoError(err)
+	s.Equal(firstExecutionRunID, workflowRun.GetFirstExecutionRunID())
 }
 
 func (s *workflowRunSuite) TestExecuteWorkflowWithUpdate_DefaultTimeout() {
@@ -1454,6 +1468,7 @@ func TestLoadCapabilitiesNonUnknownMethodUnimplementedFails(t *testing.T) {
 }
 
 func (s *workflowClientTestSuite) TestSignalWithStartWorkflow() {
+	firstExecutionRunID := "first-execution-run-id"
 	signalName := "my signal"
 	signalInput := []byte("my signal input")
 	options := StartWorkflowOptions{
@@ -1464,7 +1479,8 @@ func (s *workflowClientTestSuite) TestSignalWithStartWorkflow() {
 	}
 
 	startResponse := &workflowservice.SignalWithStartWorkflowExecutionResponse{
-		RunId: runID,
+		RunId:               runID,
+		FirstExecutionRunId: firstExecutionRunID,
 	}
 	s.service.EXPECT().SignalWithStartWorkflowExecution(gomock.Any(), gomock.Any(), gomock.Any()).Return(startResponse, nil).Times(2)
 
@@ -1472,12 +1488,14 @@ func (s *workflowClientTestSuite) TestSignalWithStartWorkflow() {
 		options, workflowType)
 	s.Nil(err)
 	s.Equal(startResponse.GetRunId(), resp.GetRunID())
+	s.Equal(firstExecutionRunID, resp.GetFirstExecutionRunID())
 
 	options.ID = ""
 	resp, err = s.client.SignalWithStartWorkflow(context.Background(), "", signalName, signalInput,
 		options, workflowType)
 	s.Nil(err)
 	s.Equal(startResponse.GetRunId(), resp.GetRunID())
+	s.Equal(firstExecutionRunID, resp.GetFirstExecutionRunID())
 }
 
 func (s *workflowClientTestSuite) TestSignalWithStartWorkflowWithContextAwareDataConverter() {

--- a/internal/nexus_operations.go
+++ b/internal/nexus_operations.go
@@ -1006,6 +1006,11 @@ func (t *testEnvWorkflowRunForNexusOperations) GetRunID() string {
 	return t.RunID
 }
 
+// GetFirstExecutionRunID implements WorkflowRun.
+func (t *testEnvWorkflowRunForNexusOperations) GetFirstExecutionRunID() string {
+	return t.RunID
+}
+
 // GetWithOptions implements WorkflowRun.
 func (t *testEnvWorkflowRunForNexusOperations) GetWithOptions(ctx context.Context, valuePtr interface{}, options WorkflowRunGetOptions) error {
 	panic("not implemented in the test environment")

--- a/mocks/WorkflowRun.go
+++ b/mocks/WorkflowRun.go
@@ -53,6 +53,24 @@ func (_m *WorkflowRun) GetID() string {
 	return r0
 }
 
+// GetFirstExecutionRunID provides a mock function with given fields:
+func (_m *WorkflowRun) GetFirstExecutionRunID() string {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetFirstExecutionRunID")
+	}
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
 // GetRunID provides a mock function with given fields:
 func (_m *WorkflowRun) GetRunID() string {
 	ret := _m.Called()

--- a/mocks/mock_test.go
+++ b/mocks/mock_test.go
@@ -17,6 +17,7 @@ import (
 func Test_MockClient(t *testing.T) {
 	testWorkflowID := "test-workflowid"
 	testRunID := "test-runid"
+	testFirstExecutionRunID := "test-first-execution-runid"
 	testWorkflowName := "workflow"
 	testWorkflowInput := "input"
 	mockClient := &Client{}
@@ -24,6 +25,7 @@ func Test_MockClient(t *testing.T) {
 	mockWorkflowRun := &WorkflowRun{}
 	mockWorkflowRun.On("GetID").Return(testWorkflowID).Times(4)
 	mockWorkflowRun.On("GetRunID").Return(testRunID).Times(4)
+	mockWorkflowRun.On("GetFirstExecutionRunID").Return(testFirstExecutionRunID).Times(4)
 	mockWorkflowRun.On("Get", mock.Anything, mock.Anything).Return(nil).Times(2)
 
 	mockClient.On("ExecuteWorkflow", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(mockWorkflowRun, nil).Once()
@@ -32,6 +34,7 @@ func Test_MockClient(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, testWorkflowID, wr.GetID())
 	require.Equal(t, testRunID, wr.GetRunID())
+	require.Equal(t, testFirstExecutionRunID, wr.GetFirstExecutionRunID())
 	require.NoError(t, mockWorkflowRun.Get(context.Background(), &testWorkflowID))
 
 	mockClient.On("SignalWithStartWorkflow", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(mockWorkflowRun, nil).Once()
@@ -40,6 +43,7 @@ func Test_MockClient(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, testWorkflowID, wr.GetID())
 	require.Equal(t, testRunID, wr.GetRunID())
+	require.Equal(t, testFirstExecutionRunID, wr.GetFirstExecutionRunID())
 
 	mockClient.On("CancelWorkflow", mock.Anything, testWorkflowID, testRunID).Return(nil).Once()
 	err = mockClient.CancelWorkflow(context.Background(), testWorkflowID, testRunID)
@@ -47,12 +51,14 @@ func Test_MockClient(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, testWorkflowID, wr.GetID())
 	require.Equal(t, testRunID, wr.GetRunID())
+	require.Equal(t, testFirstExecutionRunID, wr.GetFirstExecutionRunID())
 
 	mockClient.On("GetWorkflow", mock.Anything, testWorkflowID, testRunID).Return(mockWorkflowRun).Once()
 	wr = mockClient.GetWorkflow(context.Background(), testWorkflowID, testRunID)
 	mockClient.AssertExpectations(t)
 	require.Equal(t, testWorkflowID, wr.GetID())
 	require.Equal(t, testRunID, wr.GetRunID())
+	require.Equal(t, testFirstExecutionRunID, wr.GetFirstExecutionRunID())
 	require.NoError(t, wr.Get(context.Background(), &testWorkflowID))
 
 	mockHistoryIter := &HistoryEventIterator{}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Expose First Execution Run on WorkflowRun

## Why?
So users can properly target entity workflows.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API and field population on start paths; no change to cancel/terminate or GetRunID semantics beyond documented empty values for GetWorkflow.
> 
> **Overview**
> Adds **`client.WorkflowRun.GetFirstExecutionRunID()`**, returning the first execution run ID in a workflow chain from the server when a workflow is started (including **already-started** handling and **update-with-start**, **signal-with-start** paths).
> 
> **`GetWorkflow`** handles still return an **empty** first-execution run ID; **`GetRunID()`** behavior is unchanged. Internal `workflowRunImpl` now stores `firstExecutionRunID` separately from the current run ID instead of conflating them on start.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18f0ad0c9908125173778f22c730cc3ff9791008. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->