### PR TITLE
Refactor integration test client creation

### DIFF
--- a/test/external_storage_test.go
+++ b/test/external_storage_test.go
@@ -19,7 +19,6 @@ import (
 	"go.temporal.io/sdk/activity"
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/converter"
-	ilog "go.temporal.io/sdk/internal/log"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/worker"
 	"go.temporal.io/sdk/workflow"
@@ -166,16 +165,12 @@ func (s *ExternalStorageTestSuite) SetupTest() {
 	s.taskQueueName = taskQueuePrefix + "-ext-" + s.T().Name()
 	s.driver = newMemDriver("test")
 	var err error
-	s.client, err = client.Dial(client.Options{
-		HostPort:  s.config.ServiceAddr,
-		Namespace: s.config.Namespace,
-		Logger:    ilog.NewDefaultLogger(),
-		ExternalStorage: converter.ExternalStorage{
+	s.client, err = s.newDefaultClient(func(options *client.Options) {
+		options.WorkerHeartbeatInterval = -1
+		options.ExternalStorage = converter.ExternalStorage{
 			Drivers:              []converter.StorageDriver{s.driver},
 			PayloadSizeThreshold: extStoreThreshold,
-		},
-		ConnectionOptions:       client.ConnectionOptions{TLS: s.config.TLS},
-		WorkerHeartbeatInterval: -1,
+		}
 	})
 	s.NoError(err)
 	s.worker = worker.New(s.client, s.taskQueueName, worker.Options{
@@ -406,17 +401,13 @@ func (s *ExternalStorageTestSuite) TestDriverSelector() {
 
 	var err error
 	s.client.Close()
-	s.client, err = client.Dial(client.Options{
-		HostPort:  s.config.ServiceAddr,
-		Namespace: s.config.Namespace,
-		Logger:    ilog.NewDefaultLogger(),
-		ExternalStorage: converter.ExternalStorage{
+	s.client, err = s.newDefaultClient(func(options *client.Options) {
+		options.WorkerHeartbeatInterval = -1
+		options.ExternalStorage = converter.ExternalStorage{
 			Drivers:              []converter.StorageDriver{d1, d2},
 			DriverSelector:       selector,
 			PayloadSizeThreshold: extStoreThreshold,
-		},
-		ConnectionOptions:       client.ConnectionOptions{TLS: s.config.TLS},
-		WorkerHeartbeatInterval: -1,
+		}
 	})
 	s.NoError(err)
 	// Re-create worker bound to the new client.
@@ -497,12 +488,8 @@ func (s *ExternalStorageTestSuite) TestRetrieveFailure() {
 func (s *ExternalStorageTestSuite) TestWorkerWithoutExternalStorageFails() {
 	// Build a client and worker with no ExternalStorage. s.client still has the
 	// driver, so it can store the oversized input; the worker below cannot retrieve it.
-	noStorageClient, err := client.Dial(client.Options{
-		HostPort:                s.config.ServiceAddr,
-		Namespace:               s.config.Namespace,
-		Logger:                  ilog.NewDefaultLogger(),
-		ConnectionOptions:       client.ConnectionOptions{TLS: s.config.TLS},
-		WorkerHeartbeatInterval: -1,
+	noStorageClient, err := s.newDefaultClient(func(options *client.Options) {
+		options.WorkerHeartbeatInterval = -1
 	})
 	s.NoError(err)
 	defer noStorageClient.Close()
@@ -583,16 +570,12 @@ func (s *ExternalStorageTestSuite) TestNoStorageWhenBelowThreshold() {
 func (s *ExternalStorageTestSuite) TestDriverPanicOnRetrieve() {
 	pd := &panicMemDriver{memStorageDriver: newMemDriver("test"), panicOnRetrieve: true}
 
-	c, err := client.Dial(client.Options{
-		HostPort:  s.config.ServiceAddr,
-		Namespace: s.config.Namespace,
-		Logger:    ilog.NewDefaultLogger(),
-		ExternalStorage: converter.ExternalStorage{
+	c, err := s.newDefaultClient(func(options *client.Options) {
+		options.WorkerHeartbeatInterval = -1
+		options.ExternalStorage = converter.ExternalStorage{
 			Drivers:              []converter.StorageDriver{pd},
 			PayloadSizeThreshold: extStoreThreshold,
-		},
-		ConnectionOptions:       client.ConnectionOptions{TLS: s.config.TLS},
-		WorkerHeartbeatInterval: -1,
+		}
 	})
 	s.NoError(err)
 	defer c.Close()
@@ -632,16 +615,12 @@ func extStorePanicOnStoreWorkflow(_ workflow.Context) (string, error) {
 func (s *ExternalStorageTestSuite) TestDriverPanicOnStore() {
 	pd := &panicMemDriver{memStorageDriver: newMemDriver("test"), panicOnStore: true}
 
-	c, err := client.Dial(client.Options{
-		HostPort:  s.config.ServiceAddr,
-		Namespace: s.config.Namespace,
-		Logger:    ilog.NewDefaultLogger(),
-		ExternalStorage: converter.ExternalStorage{
+	c, err := s.newDefaultClient(func(options *client.Options) {
+		options.WorkerHeartbeatInterval = -1
+		options.ExternalStorage = converter.ExternalStorage{
 			Drivers:              []converter.StorageDriver{pd},
 			PayloadSizeThreshold: extStoreThreshold,
-		},
-		ConnectionOptions:       client.ConnectionOptions{TLS: s.config.TLS},
-		WorkerHeartbeatInterval: -1,
+		}
 	})
 	s.NoError(err)
 	defer c.Close()

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -175,22 +175,18 @@ func (ts *IntegrationTestSuite) SetupTest() {
 
 	var err error
 	trafficController := test.NewSimpleTrafficController()
-	ts.client, err = client.Dial(client.Options{
-		HostPort:  ts.config.ServiceAddr,
-		Namespace: ts.config.Namespace,
-		Logger:    ilog.NewDefaultLogger(),
-		ContextPropagators: []workflow.ContextPropagator{
+	ts.client, err = ts.newDefaultClient(func(options *client.Options) {
+		options.WorkerHeartbeatInterval = -1
+		options.ContextPropagators = []workflow.ContextPropagator{
 			NewKeysPropagator([]string{testContextKey1}),
 			NewKeysPropagator([]string{testContextKey2}),
-		},
-		MetricsHandler:          metricsHandler,
-		TrafficController:       trafficController,
-		Interceptors:            clientInterceptors,
-		ConnectionOptions:       client.ConnectionOptions{TLS: ts.config.TLS},
-		WorkerHeartbeatInterval: -1,
-		PayloadLimits: client.PayloadLimitOptions{
+		}
+		options.MetricsHandler = metricsHandler
+		options.TrafficController = trafficController
+		options.Interceptors = clientInterceptors
+		options.PayloadLimits = client.PayloadLimitOptions{
 			PayloadSizeWarning: 128,
-		},
+		}
 	})
 	ts.NoError(err)
 
@@ -5226,30 +5222,25 @@ func (ts *IntegrationTestSuite) testWorkerFatalError(useWorkerRun bool) {
 	// Allow the worker to fail faster so the test does not take 2 minutes.
 	internal.SetRetryLongPollGracePeriod(5 * time.Second)
 	// Make a new client that will fail a poll with a namespace not found
-	c, err := client.Dial(client.Options{
-		HostPort:  ts.config.ServiceAddr,
-		Namespace: ts.config.Namespace,
-		ConnectionOptions: client.ConnectionOptions{
-			TLS: ts.config.TLS,
-			DialOptions: []grpc.DialOption{
-				grpc.WithUnaryInterceptor(func(
-					ctx context.Context,
-					method string,
-					req interface{},
-					reply interface{},
-					cc *grpc.ClientConn,
-					invoker grpc.UnaryInvoker,
-					opts ...grpc.CallOption,
-				) error {
-					if method == "/temporal.api.workflowservice.v1.WorkflowService/PollWorkflowTaskQueue" {
-						// We sleep a bit to let all internal workers start
-						time.Sleep(1 * time.Second)
-						return serviceerror.NewNamespaceNotFound(ts.config.Namespace)
-					}
-					return invoker(ctx, method, req, reply, cc, opts...)
-				}),
-			},
-		},
+	c, err := ts.newDefaultClient(func(options *client.Options) {
+		options.ConnectionOptions.DialOptions = []grpc.DialOption{
+			grpc.WithUnaryInterceptor(func(
+				ctx context.Context,
+				method string,
+				req interface{},
+				reply interface{},
+				cc *grpc.ClientConn,
+				invoker grpc.UnaryInvoker,
+				opts ...grpc.CallOption,
+			) error {
+				if method == "/temporal.api.workflowservice.v1.WorkflowService/PollWorkflowTaskQueue" {
+					// We sleep a bit to let all internal workers start
+					time.Sleep(1 * time.Second)
+					return serviceerror.NewNamespaceNotFound(ts.config.Namespace)
+				}
+				return invoker(ctx, method, req, reply, cc, opts...)
+			}),
+		}
 	})
 	ts.NoError(err)
 	defer c.Close()
@@ -7149,13 +7140,7 @@ func (ts *IntegrationTestSuite) TestScheduleUpdateWorkflowActionMemo() {
 func (ts *IntegrationTestSuite) TestNoVersioningBehaviorPanics() {
 	seriesName := "deploy-test-" + uuid.NewString()
 
-	c, err := client.Dial(client.Options{
-		HostPort:  ts.config.ServiceAddr,
-		Namespace: ts.config.Namespace,
-		ConnectionOptions: client.ConnectionOptions{
-			TLS: ts.config.TLS,
-		},
-	})
+	c, err := ts.newDefaultClient()
 	ts.NoError(err)
 	defer c.Close()
 
@@ -7187,29 +7172,24 @@ func (ts *IntegrationTestSuite) TestNoVersioningBehaviorPanics() {
 
 func (ts *IntegrationTestSuite) TestSendsCorrectMeteringData() {
 	nonfirstLAAttemptCounts := make([]uint32, 0)
-	c, err := client.Dial(client.Options{
-		HostPort:  ts.config.ServiceAddr,
-		Namespace: ts.config.Namespace,
-		ConnectionOptions: client.ConnectionOptions{
-			TLS: ts.config.TLS,
-			DialOptions: []grpc.DialOption{
-				grpc.WithUnaryInterceptor(func(
-					ctx context.Context,
-					method string,
-					req interface{},
-					reply interface{},
-					cc *grpc.ClientConn,
-					invoker grpc.UnaryInvoker,
-					opts ...grpc.CallOption,
-				) error {
-					if method == "/temporal.api.workflowservice.v1.WorkflowService/RespondWorkflowTaskCompleted" {
-						asReq := req.(*workflowservice.RespondWorkflowTaskCompletedRequest)
-						nonfirstLAAttemptCounts = append(nonfirstLAAttemptCounts, asReq.MeteringMetadata.NonfirstLocalActivityExecutionAttempts)
-					}
-					return invoker(ctx, method, req, reply, cc, opts...)
-				}),
-			},
-		},
+	c, err := ts.newDefaultClient(func(options *client.Options) {
+		options.ConnectionOptions.DialOptions = []grpc.DialOption{
+			grpc.WithUnaryInterceptor(func(
+				ctx context.Context,
+				method string,
+				req interface{},
+				reply interface{},
+				cc *grpc.ClientConn,
+				invoker grpc.UnaryInvoker,
+				opts ...grpc.CallOption,
+			) error {
+				if method == "/temporal.api.workflowservice.v1.WorkflowService/RespondWorkflowTaskCompleted" {
+					asReq := req.(*workflowservice.RespondWorkflowTaskCompletedRequest)
+					nonfirstLAAttemptCounts = append(nonfirstLAAttemptCounts, asReq.MeteringMetadata.NonfirstLocalActivityExecutionAttempts)
+				}
+				return invoker(ctx, method, req, reply, cc, opts...)
+			}),
+		}
 	})
 	ts.NoError(err)
 	defer c.Close()
@@ -7897,12 +7877,8 @@ func (ts *IntegrationTestSuite) TestRawValueQueryMetadata() {
 		converter.NewJSONPayloadConverter(),
 	)
 	zlibConv := converter.NewCodecDataConverter(dc, converter.NewZlibCodec(converter.ZlibCodecOptions{}))
-	c, err := client.Dial(client.Options{
-		HostPort:          ts.config.ServiceAddr,
-		Namespace:         ts.config.Namespace,
-		Logger:            ilog.NewDefaultLogger(),
-		ConnectionOptions: client.ConnectionOptions{TLS: ts.config.TLS},
-		DataConverter:     zlibConv,
+	c, err := ts.newDefaultClient(func(options *client.Options) {
+		options.DataConverter = zlibConv
 	})
 	defer c.Close()
 	ts.NoError(err)
@@ -7998,12 +7974,9 @@ func (ts *IntegrationTestSuite) TestActivityFailureMetric_BenignHandling() {
 
 	// Configure client/worker with logger, capture logs
 	logger := ilog.NewMemoryLogger()
-	c, err := client.Dial(client.Options{
-		HostPort:          ts.config.ServiceAddr,
-		Namespace:         ts.config.Namespace,
-		Logger:            logger,
-		ConnectionOptions: client.ConnectionOptions{TLS: ts.config.TLS},
-		MetricsHandler:    ts.metricsHandler,
+	c, err := ts.newDefaultClient(func(options *client.Options) {
+		options.Logger = logger
+		options.MetricsHandler = ts.metricsHandler
 	})
 	ts.NoError(err)
 	defer c.Close()
@@ -8830,12 +8803,16 @@ func (ts *IntegrationTestSuite) TestClientPlugin() {
 
 	// Failing dial first
 	plugin := &clientPluginForTest{ts: ts, failNew: true}
-	_, err := client.Dial(client.Options{Namespace: ts.config.Namespace, Plugins: []client.Plugin{plugin}})
+	_, err := ts.newDefaultClient(func(options *client.Options) {
+		options.Plugins = []client.Plugin{plugin}
+	})
 	ts.ErrorContains(err, "intentional client error")
 
 	// Now succeed dial and run simple workflow
 	plugin = &clientPluginForTest{ts: ts}
-	cl, err := client.Dial(client.Options{Namespace: ts.config.Namespace, Plugins: []client.Plugin{plugin}})
+	cl, err := ts.newDefaultClient(func(options *client.Options) {
+		options.Plugins = []client.Plugin{plugin}
+	})
 	ts.NoError(err)
 	defer cl.Close()
 	wrk := worker.New(cl, ts.taskQueueName, worker.Options{})
@@ -9109,7 +9086,9 @@ func (ts *IntegrationTestSuite) TestSimplePlugin() {
 	ts.NoError(err)
 
 	// Just run a simple workflow and stop worker
-	cl, err := client.Dial(client.Options{Namespace: ts.config.Namespace, Plugins: []client.Plugin{plugin}})
+	cl, err := ts.newDefaultClient(func(options *client.Options) {
+		options.Plugins = []client.Plugin{plugin}
+	})
 	ts.NoError(err)
 	defer cl.Close()
 	wrk := worker.New(cl, ts.taskQueueName, worker.Options{})
@@ -9159,7 +9138,9 @@ func (ts *IntegrationTestSuite) TestSimplePluginDoNothing() {
 	// Just run a simple workflow with a do-nothing plugin and make sure it works as normal
 	plugin, err := temporal.NewSimplePlugin(temporal.SimplePluginOptions{Name: "simple-plugin"})
 	ts.NoError(err)
-	cl, err := client.Dial(client.Options{Namespace: ts.config.Namespace, Plugins: []client.Plugin{plugin}})
+	cl, err := ts.newDefaultClient(func(options *client.Options) {
+		options.Plugins = []client.Plugin{plugin}
+	})
 	ts.NoError(err)
 	defer cl.Close()
 	wrk := worker.New(cl, ts.taskQueueName, worker.Options{})
@@ -9490,11 +9471,8 @@ func (ts *IntegrationTestSuite) TestSessionCancelNDE() {
 		poison:        poison,
 	}
 
-	cl, err := client.Dial(client.Options{
-		HostPort:          ts.config.ServiceAddr,
-		Namespace:         ts.config.Namespace,
-		DataConverter:     dc,
-		ConnectionOptions: client.ConnectionOptions{TLS: ts.config.TLS},
+	cl, err := ts.newDefaultClient(func(options *client.Options) {
+		options.DataConverter = dc
 	})
 	ts.NoError(err)
 	defer cl.Close()
@@ -9614,12 +9592,9 @@ func (ts *IntegrationTestSuite) TestPayloadSizeWarningDefaultSize() {
 	defer cancel()
 
 	logger := ilog.NewMemoryLogger()
-	client, err := client.Dial(client.Options{
-		HostPort:          ts.config.ServiceAddr,
-		Namespace:         ts.config.Namespace,
-		Logger:            logger,
-		ConnectionOptions: client.ConnectionOptions{TLS: ts.config.TLS},
-		MetricsHandler:    ts.metricsHandler,
+	client, err := ts.newDefaultClient(func(options *client.Options) {
+		options.Logger = logger
+		options.MetricsHandler = ts.metricsHandler
 	})
 	ts.NoError(err)
 	defer client.Close()

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -2,6 +2,7 @@ package test_test
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"flag"
 	"fmt"
@@ -8792,9 +8793,12 @@ func (c *clientPluginForTest) NewClient(
 	if c.failNew {
 		return fmt.Errorf("intentional client error")
 	}
-	// Confirm the configuration was respected
-	c.ts.Equal(c.ts.config.ServiceAddr, options.ClientOptions.HostPort)
-	c.ts.True(c.ts.config.TLS == options.ClientOptions.ConnectionOptions.TLS)
+	if options.ClientOptions.HostPort != c.ts.config.ServiceAddr {
+		return fmt.Errorf("plugin did not configure host port: got %q, want %q", options.ClientOptions.HostPort, c.ts.config.ServiceAddr)
+	}
+	if options.ClientOptions.ConnectionOptions.TLS != c.ts.config.TLS {
+		return fmt.Errorf("plugin did not configure TLS")
+	}
 	c.ts.Len(options.ClientOptions.Interceptors, 1)
 	return next(ctx, options)
 }
@@ -8810,10 +8814,14 @@ func (ts *IntegrationTestSuite) TestClientPlugin() {
 	})
 	ts.ErrorContains(err, "intentional client error")
 
-	// Now succeed dial and run simple workflow. Use client.Dial because
-	// newDefaultClient populates HostPort/TLS values.
+	// Now succeed dial and run simple workflow
 	plugin = &clientPluginForTest{ts: ts}
-	cl, err := client.Dial(client.Options{Namespace: ts.config.Namespace, Plugins: []client.Plugin{plugin}})
+	cl, err := ts.newDefaultClient(func(options *client.Options) {
+		// Set garbage values to ensure plugin overwrites them
+		options.HostPort = "127.0.0.1:1"
+		options.ConnectionOptions.TLS = &tls.Config{ServerName: "plugin-must-overwrite.invalid"}
+		options.Plugins = []client.Plugin{plugin}
+	})
 	ts.NoError(err)
 	defer cl.Close()
 	wrk := worker.New(cl, ts.taskQueueName, worker.Options{})

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -8792,7 +8792,9 @@ func (c *clientPluginForTest) NewClient(
 	if c.failNew {
 		return fmt.Errorf("intentional client error")
 	}
-	// Confirm our interceptor was set
+	// Confirm the configuration was respected
+	c.ts.Equal(c.ts.config.ServiceAddr, options.ClientOptions.HostPort)
+	c.ts.True(c.ts.config.TLS == options.ClientOptions.ConnectionOptions.TLS)
 	c.ts.Len(options.ClientOptions.Interceptors, 1)
 	return next(ctx, options)
 }
@@ -8808,11 +8810,10 @@ func (ts *IntegrationTestSuite) TestClientPlugin() {
 	})
 	ts.ErrorContains(err, "intentional client error")
 
-	// Now succeed dial and run simple workflow
+	// Now succeed dial and run simple workflow. Use client.Dial because
+	// newDefaultClient populates HostPort/TLS values.
 	plugin = &clientPluginForTest{ts: ts}
-	cl, err := ts.newDefaultClient(func(options *client.Options) {
-		options.Plugins = []client.Plugin{plugin}
-	})
+	cl, err := client.Dial(client.Options{Namespace: ts.config.Namespace, Plugins: []client.Plugin{plugin}})
 	ts.NoError(err)
 	defer cl.Close()
 	wrk := worker.New(cl, ts.taskQueueName, worker.Options{})

--- a/test/serialization_context_test.go
+++ b/test/serialization_context_test.go
@@ -11,7 +11,6 @@ import (
 
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/converter"
-	ilog "go.temporal.io/sdk/internal/log"
 	"go.temporal.io/sdk/worker"
 	"go.temporal.io/sdk/workflow"
 )
@@ -101,12 +100,8 @@ func intTestCombinedWorkflow(ctx workflow.Context, input string) (string, error)
 func (ts *IntegrationTestSuite) newSerCtxClientAndWorker(taskQueue string) (client.Client, worker.Worker) {
 	codecDC := converter.NewCodecDataConverter(converter.GetDefaultDataConverter(), &intTestSigningCodec{})
 
-	c, err := client.Dial(client.Options{
-		HostPort:          ts.config.ServiceAddr,
-		Namespace:         ts.config.Namespace,
-		Logger:            ilog.NewDefaultLogger(),
-		DataConverter:     codecDC,
-		ConnectionOptions: client.ConnectionOptions{TLS: ts.config.TLS},
+	c, err := ts.newDefaultClient(func(options *client.Options) {
+		options.DataConverter = codecDC
 	})
 	ts.NoError(err)
 

--- a/test/test_utils_test.go
+++ b/test/test_utils_test.go
@@ -238,30 +238,39 @@ func (ts *ConfigAndClientSuiteBase) InitConfigAndNamespace() error {
 	return nil
 }
 
+// InitClient initializes ts.client according to ts.config with the same
+// defaults as newIntegrationTestClient.
 func (ts *ConfigAndClientSuiteBase) InitClient(clientOpts ...ConfigureClientOptions) error {
 	var err error
 	if ts.client != nil {
 		return nil
 	}
-	ts.client, err = ts.newClient(clientOpts...)
+	ts.client, err = ts.newIntegrationTestClient(clientOpts...)
 	return err
 }
 
-func (ts *ConfigAndClientSuiteBase) newClient(clientOpts ...ConfigureClientOptions) (client.Client, error) {
+// newIntegrationTestClient creates a client according to ts.config with heartbeats disabled
+// and an extended GetSystemInfoTimeout.
+func (ts *ConfigAndClientSuiteBase) newIntegrationTestClient(clientOpts ...ConfigureClientOptions) (client.Client, error) {
+	return ts.newDefaultClient(func(options *client.Options) {
+		options.ConnectionOptions.GetSystemInfoTimeout = ctxTimeout
+		options.WorkerHeartbeatInterval = -1
+		for _, opt := range clientOpts {
+			opt(options)
+		}
+	})
+}
+
+// newDefaultClient creates a client according to ts.config with SDK defaults.
+func (ts *ConfigAndClientSuiteBase) newDefaultClient(clientOpts ...ConfigureClientOptions) (client.Client, error) {
 	options := client.Options{
-		HostPort:  ts.config.ServiceAddr,
-		Namespace: ts.config.Namespace,
-		ConnectionOptions: client.ConnectionOptions{
-			TLS:                  ts.config.TLS,
-			GetSystemInfoTimeout: ctxTimeout,
-		},
-		WorkerHeartbeatInterval: -1,
+		HostPort:          ts.config.ServiceAddr,
+		Namespace:         ts.config.Namespace,
+		ConnectionOptions: client.ConnectionOptions{TLS: ts.config.TLS},
+		Logger:            ilog.NewDefaultLogger(),
 	}
 	for _, opt := range clientOpts {
 		opt(&options)
-	}
-	if options.Logger == nil {
-		options.Logger = ilog.NewDefaultLogger()
 	}
 	return client.Dial(options)
 }
@@ -319,7 +328,7 @@ func (ts *ConfigAndClientSuiteBase) ensureSearchAttributes() error {
 	// We have to create a client specifically for this call and close it after
 	// this call because it may not get closed externally and can trip the
 	// goroutine leak detector.
-	client, err := ts.newClient()
+	client, err := ts.newIntegrationTestClient()
 	if err != nil {
 		return fmt.Errorf("unable to create client: %w", err)
 	}

--- a/test/worker_deployment_test.go
+++ b/test/worker_deployment_test.go
@@ -1413,7 +1413,7 @@ func (ts *WorkerDeploymentTestSuite) TestDeleteDeployment() {
 	worker1.Stop()
 	ts.client.Close()
 
-	client2, err := ts.newClient()
+	client2, err := ts.newIntegrationTestClient()
 	ts.NoError(err)
 	ts.client = client2
 

--- a/test/worker_heartbeat_test.go
+++ b/test/worker_heartbeat_test.go
@@ -22,7 +22,6 @@ import (
 	"go.temporal.io/sdk/contrib/sysinfo"
 	"go.temporal.io/sdk/converter"
 	"go.temporal.io/sdk/internal"
-	ilog "go.temporal.io/sdk/internal/log"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/worker"
 	"go.temporal.io/sdk/workflow"
@@ -47,13 +46,10 @@ func (ts *WorkerHeartbeatTestSuite) SetupSuite() {
 
 	var err error
 	// Create a client with heartbeating enabled
-	ts.client, err = client.Dial(client.Options{
-		HostPort:                ts.config.ServiceAddr,
-		Namespace:               ts.config.Namespace,
-		Logger:                  ilog.NewDefaultLogger(),
-		WorkerHeartbeatInterval: 1 * time.Second,
-		ConnectionOptions:       client.ConnectionOptions{TLS: ts.config.TLS, GetSystemInfoTimeout: ctxTimeout},
-		Identity:                "WorkerHeartbeatTest",
+	ts.client, err = ts.newDefaultClient(func(options *client.Options) {
+		options.ConnectionOptions.GetSystemInfoTimeout = ctxTimeout
+		options.WorkerHeartbeatInterval = time.Second
+		options.Identity = "WorkerHeartbeatTest"
 	})
 	ts.NoError(err)
 }
@@ -308,12 +304,9 @@ func (ts *WorkerHeartbeatTestSuite) TestWorkerHeartbeatDisabled() {
 	ctx := context.Background()
 
 	// Create a separate client with heartbeating disabled
-	clientNoHeartbeat, err := client.Dial(client.Options{
-		HostPort:                ts.config.ServiceAddr,
-		Namespace:               ts.config.Namespace,
-		Logger:                  ilog.NewDefaultLogger(),
-		WorkerHeartbeatInterval: -1,
-		ConnectionOptions:       client.ConnectionOptions{TLS: ts.config.TLS, GetSystemInfoTimeout: ctxTimeout},
+	clientNoHeartbeat, err := ts.newDefaultClient(func(options *client.Options) {
+		options.ConnectionOptions.GetSystemInfoTimeout = ctxTimeout
+		options.WorkerHeartbeatInterval = -1
 	})
 	ts.NoError(err)
 	defer clientNoHeartbeat.Close()
@@ -967,14 +960,11 @@ func (ts *WorkerHeartbeatTestSuite) TestWorkerHeartbeatPlugins() {
 	ts.NoError(err)
 
 	// Create a new client with the plugin
-	pluginClient, err := client.Dial(client.Options{
-		HostPort:                ts.config.ServiceAddr,
-		Namespace:               ts.config.Namespace,
-		Logger:                  ilog.NewDefaultLogger(),
-		WorkerHeartbeatInterval: 1 * time.Second,
-		ConnectionOptions:       client.ConnectionOptions{TLS: ts.config.TLS, GetSystemInfoTimeout: ctxTimeout},
-		Identity:                "PluginTest",
-		Plugins:                 []client.Plugin{clientPlugin},
+	pluginClient, err := ts.newDefaultClient(func(options *client.Options) {
+		options.ConnectionOptions.GetSystemInfoTimeout = ctxTimeout
+		options.WorkerHeartbeatInterval = time.Second
+		options.Identity = "PluginTest"
+		options.Plugins = []client.Plugin{clientPlugin}
 	})
 	ts.NoError(err)
 	defer pluginClient.Close()
@@ -1029,45 +1019,39 @@ func (ts *WorkerHeartbeatTestSuite) TestWorkerPollCompleteOnShutdown() {
 		pollErrors  []error
 	)
 
-	c, err := client.Dial(client.Options{
-		HostPort:                ts.config.ServiceAddr,
-		Namespace:               ts.config.Namespace,
-		Logger:                  ilog.NewDefaultLogger(),
-		WorkerHeartbeatInterval: 1 * time.Second,
-		ConnectionOptions: client.ConnectionOptions{
-			TLS:                  ts.config.TLS,
-			GetSystemInfoTimeout: ctxTimeout,
-			DialOptions: []grpc.DialOption{
-				grpc.WithUnaryInterceptor(func(
-					ctx context.Context,
-					method string,
-					req any,
-					reply any,
-					cc *grpc.ClientConn,
-					invoker grpc.UnaryInvoker,
-					opts ...grpc.CallOption,
-				) error {
-					if strings.HasSuffix(method, "/ShutdownWorker") {
-						mu.Lock()
-						shutdownReq = req.(*workflowservice.ShutdownWorkerRequest)
-						mu.Unlock()
-					}
+	c, err := ts.newDefaultClient(func(options *client.Options) {
+		options.ConnectionOptions.GetSystemInfoTimeout = ctxTimeout
+		options.WorkerHeartbeatInterval = time.Second
+		options.ConnectionOptions.DialOptions = []grpc.DialOption{
+			grpc.WithUnaryInterceptor(func(
+				ctx context.Context,
+				method string,
+				req any,
+				reply any,
+				cc *grpc.ClientConn,
+				invoker grpc.UnaryInvoker,
+				opts ...grpc.CallOption,
+			) error {
+				if strings.HasSuffix(method, "/ShutdownWorker") {
+					mu.Lock()
+					shutdownReq = req.(*workflowservice.ShutdownWorkerRequest)
+					mu.Unlock()
+				}
 
-					err := invoker(ctx, method, req, reply, cc, opts...)
+				err := invoker(ctx, method, req, reply, cc, opts...)
 
-					isPoll := strings.HasSuffix(method, "/PollWorkflowTaskQueue") ||
-						strings.HasSuffix(method, "/PollActivityTaskQueue") ||
-						strings.HasSuffix(method, "/PollNexusTaskQueue")
-					if isPoll && err != nil {
-						mu.Lock()
-						pollErrors = append(pollErrors, err)
-						mu.Unlock()
-					}
+				isPoll := strings.HasSuffix(method, "/PollWorkflowTaskQueue") ||
+					strings.HasSuffix(method, "/PollActivityTaskQueue") ||
+					strings.HasSuffix(method, "/PollNexusTaskQueue")
+				if isPoll && err != nil {
+					mu.Lock()
+					pollErrors = append(pollErrors, err)
+					mu.Unlock()
+				}
 
-					return err
-				}),
-			},
-		},
+				return err
+			}),
+		}
 	})
 	ts.NoError(err)
 	defer c.Close()
@@ -1146,17 +1130,14 @@ func (ts *WorkerHeartbeatTestSuite) TestWorkerHeartbeatStorageDrivers() {
 	drivers := []converter.StorageDriver{driver1, driver2, driver3}
 
 	// Create a client with external storage configured
-	storageClient, err := client.Dial(client.Options{
-		HostPort:  ts.config.ServiceAddr,
-		Namespace: ts.config.Namespace,
-		Logger:    ilog.NewDefaultLogger(),
-		ExternalStorage: converter.ExternalStorage{
+	storageClient, err := ts.newDefaultClient(func(options *client.Options) {
+		options.ConnectionOptions.GetSystemInfoTimeout = ctxTimeout
+		options.ExternalStorage = converter.ExternalStorage{
 			Drivers:        drivers,
 			DriverSelector: &roundRobinSelector{drivers: drivers},
-		},
-		WorkerHeartbeatInterval: 1 * time.Second,
-		ConnectionOptions:       client.ConnectionOptions{TLS: ts.config.TLS, GetSystemInfoTimeout: ctxTimeout},
-		Identity:                "StorageDriverTest",
+		}
+		options.WorkerHeartbeatInterval = time.Second
+		options.Identity = "StorageDriverTest"
 	})
 	ts.NoError(err)
 	defer storageClient.Close()


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Replaced `client.Dial` in integration tests with calls to `ConfigAndClientSuiteBase.newDefaultClient` and `ConfigAndClientSuiteBase.newIntegrationTestClient`.

## Why?
<!-- Tell your future self why have you made these changes -->
Ensure all clients use the configured connection info instead of local defaults. Useful for cloud CI.


## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here --> nothing

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Re-ran existing tests and confirmed they still work.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
No.
