### PR TITLE
Use synctest for tests

### DIFF
--- a/contrib/aws/lambdaworker/runworker_test.go
+++ b/contrib/aws/lambdaworker/runworker_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/aws/aws-lambda-go/lambda"
@@ -532,26 +533,28 @@ func TestRunWorkerInternal_OnShutdownRunsAfterWorkerStop(t *testing.T) {
 }
 
 func TestRunWorkerInternal_TightDeadlineReturnsError(t *testing.T) {
-	deps, w, c := newTestDeps()
+	synctest.Test(t, func(t *testing.T) {
+		deps, w, c := newTestDeps()
 
-	// 2s deadline with 1500ms buffer → ~500ms workTime (≤ 1s), error.
-	deps.startLambda = func(handler interface{}, options ...lambda.Option) {
-		if h, ok := handler.(func(context.Context) error); ok {
-			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-			defer cancel()
-			handlerErr := h(ctx)
-			assert.ErrorContains(t, handlerErr,
-				"almost no time for work")
+		// 2s deadline with 1500ms buffer → ~500ms workTime (≤ 1s), error.
+		deps.startLambda = func(handler interface{}, options ...lambda.Option) {
+			if h, ok := handler.(func(context.Context) error); ok {
+				ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+				defer cancel()
+				handlerErr := h(ctx)
+				assert.ErrorContains(t, handlerErr,
+					"almost no time for work")
+			}
 		}
-	}
 
-	err := runWorkerInternal(testVersion, func(ctx *Options) error {
-		ctx.ShutdownDeadlineBuffer = 1500 * time.Millisecond
-		return nil
-	}, deps)
-	require.NoError(t, err)
-	w.AssertExpectations(t)
-	c.AssertExpectations(t)
+		err := runWorkerInternal(testVersion, func(ctx *Options) error {
+			ctx.ShutdownDeadlineBuffer = 1500 * time.Millisecond
+			return nil
+		}, deps)
+		require.NoError(t, err)
+		w.AssertExpectations(t)
+		c.AssertExpectations(t)
+	})
 }
 
 type capturingLogger struct {
@@ -569,37 +572,39 @@ func (l *capturingLogger) Error(msg string, _ ...interface{}) {
 }
 
 func TestRunWorkerInternal_TightDeadlineLogsWarning(t *testing.T) {
-	deps, w, c := newTestDeps()
-	logger := &capturingLogger{}
-	deps.loadConfig = func() (client.Options, error) {
-		return client.Options{Logger: logger}, nil
-	}
-
-	// Use a small custom buffer so workTime lands in the warning band
-	// (> 1s but < 5s) without a long wait. 2s deadline, 500ms buffer → ~1.5s
-	// work time.
-	deps.startLambda = func(handler interface{}, options ...lambda.Option) {
-		if h, ok := handler.(func(context.Context) error); ok {
-			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-			defer cancel()
-			_ = h(ctx)
+	synctest.Test(t, func(t *testing.T) {
+		deps, w, c := newTestDeps()
+		logger := &capturingLogger{}
+		deps.loadConfig = func() (client.Options, error) {
+			return client.Options{Logger: logger}, nil
 		}
-	}
 
-	w.On("Start").Return(nil).Once()
-	w.On("Stop").Once()
-	c.On("Close").Once()
+		// Use a small custom buffer so workTime lands in the warning band
+		// (> 1s but < 5s) without a long wait. 2s deadline, 500ms buffer → ~1.5s
+		// work time.
+		deps.startLambda = func(handler interface{}, options ...lambda.Option) {
+			if h, ok := handler.(func(context.Context) error); ok {
+				ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+				defer cancel()
+				_ = h(ctx)
+			}
+		}
 
-	err := runWorkerInternal(testVersion, func(ctx *Options) error {
-		ctx.ShutdownDeadlineBuffer = 500 * time.Millisecond
-		return nil
-	}, deps)
+		w.On("Start").Return(nil).Once()
+		w.On("Stop").Once()
+		c.On("Close").Once()
 
-	require.NoError(t, err)
-	require.Len(t, logger.warns, 1)
-	assert.Contains(t, logger.warns[0], "less than 5s for work")
-	w.AssertExpectations(t)
-	c.AssertExpectations(t)
+		err := runWorkerInternal(testVersion, func(ctx *Options) error {
+			ctx.ShutdownDeadlineBuffer = 500 * time.Millisecond
+			return nil
+		}, deps)
+
+		require.NoError(t, err)
+		require.Len(t, logger.warns, 1)
+		assert.Contains(t, logger.warns[0], "less than 5s for work")
+		w.AssertExpectations(t)
+		c.AssertExpectations(t)
+	})
 }
 
 func TestRunWorkerInternal_PerInvocationLifecycle(t *testing.T) {

--- a/contrib/workflowstreams/client_test.go
+++ b/contrib/workflowstreams/client_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/require"
@@ -125,18 +126,19 @@ func TestSequenceAdvancesAcrossFlushes(t *testing.T) {
 }
 
 func TestMaxBatchSizeTriggersFlush(t *testing.T) {
-	fc := &fakeClient{}
-	// Long interval so only the size threshold can trigger a flush.
-	c := NewClient(fc, "wf-1", Options{BatchInterval: time.Hour, MaxBatchSize: 2})
+	synctest.Test(t, func(t *testing.T) {
+		fc := &fakeClient{}
+		// Long interval so only the size threshold can trigger a flush.
+		c := NewClient(fc, "wf-1", Options{BatchInterval: time.Hour, MaxBatchSize: 2})
 
-	c.Topic("t").Publish("a", false)
-	c.Topic("t").Publish("b", false) // reaches MaxBatchSize → flush
+		c.Topic("t").Publish("a", false)
+		c.Topic("t").Publish("b", false) // reaches MaxBatchSize → flush
 
-	require.Eventually(t, func() bool {
-		return len(fc.recorded()) == 1
-	}, time.Second, 5*time.Millisecond)
+		synctest.Wait()
+		require.Len(t, fc.recorded(), 1)
 
-	require.NoError(t, c.Close(context.Background()))
+		require.NoError(t, c.Close(context.Background()))
+	})
 }
 
 func TestCloseDrainsBuffer(t *testing.T) {
@@ -152,36 +154,35 @@ func TestCloseDrainsBuffer(t *testing.T) {
 }
 
 func TestForceFlush(t *testing.T) {
-	fc := &fakeClient{}
-	c := NewClient(fc, "wf-1", Options{BatchInterval: time.Hour})
+	synctest.Test(t, func(t *testing.T) {
+		fc := &fakeClient{}
+		c := NewClient(fc, "wf-1", Options{BatchInterval: time.Hour})
 
-	c.Topic("t").Publish("a", true) // forceFlush
+		c.Topic("t").Publish("a", true) // forceFlush
 
-	require.Eventually(t, func() bool {
-		return len(fc.recorded()) == 1
-	}, time.Second, 5*time.Millisecond)
+		synctest.Wait()
+		require.Len(t, fc.recorded(), 1)
 
-	require.NoError(t, c.Close(context.Background()))
+		require.NoError(t, c.Close(context.Background()))
+	})
 }
 
 func TestFlushTimeoutAfterMaxRetryDuration(t *testing.T) {
-	const retryWindow = time.Millisecond
-	fc := &fakeClient{signalErr: errors.New("boom")}
-	c := NewClient(fc, "wf-1", Options{BatchInterval: time.Hour, MaxRetryDuration: retryWindow})
+	synctest.Test(t, func(t *testing.T) {
+		const retryWindow = time.Millisecond
+		fc := &fakeClient{signalErr: errors.New("boom")}
+		c := NewClient(fc, "wf-1", Options{BatchInterval: time.Hour, MaxRetryDuration: retryWindow})
 
-	c.Topic("t").Publish("a", false)
+		c.Topic("t").Publish("a", false)
 
-	// The first flush sets pending and fails to send (transient "boom").
-	require.Error(t, c.Flush(context.Background()))
+		// The first flush sets pending and fails to send (transient "boom").
+		require.Error(t, c.Flush(context.Background()))
 
-	// Wait past the retry window with ample margin for coarse OS timer
-	// granularity (notably on Windows, where sub-tick durations can read as
-	// zero). The next flush sees the window exceeded and returns
-	// FlushTimeoutError.
-	time.Sleep(50 * time.Millisecond)
+		time.Sleep(retryWindow + time.Nanosecond)
 
-	var fte *FlushTimeoutError
-	require.ErrorAs(t, c.Flush(context.Background()), &fte)
+		var fte *FlushTimeoutError
+		require.ErrorAs(t, c.Flush(context.Background()), &fte)
 
-	require.NoError(t, c.Close(context.Background()))
+		require.NoError(t, c.Close(context.Background()))
+	})
 }

--- a/contrib/workflowstreams/subscribe_test.go
+++ b/contrib/workflowstreams/subscribe_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/require"
@@ -238,32 +239,34 @@ func TestSubscribeContinueAsNewRetries(t *testing.T) {
 }
 
 func TestSubscribeRetriesWhileDraining(t *testing.T) {
-	// While the workflow is detaching for continue-as-new, the poll validator
-	// rejects with ErrTypeStreamDraining. Subscribe must back off and retry
-	// rather than surface the rejection; the next poll then lands on the
-	// successor run.
-	draining := temporal.NewApplicationError("workflow is draining", ErrTypeStreamDraining)
-	fc := &fakeSubClient{steps: []pollStep{
-		{runID: "R1", getErr: draining},
-		{runID: "R2", result: PollResult{Items: []WireItem{wireItem(t, "evt", "after-can", 1)}, NextOffset: 2, MoreReady: true}},
-	}}
-	c := newSubClient(fc)
+	synctest.Test(t, func(t *testing.T) {
+		// While the workflow is detaching for continue-as-new, the poll validator
+		// rejects with ErrTypeStreamDraining. Subscribe must back off and retry
+		// rather than surface the rejection; the next poll then lands on the
+		// successor run.
+		draining := temporal.NewApplicationError("workflow is draining", ErrTypeStreamDraining)
+		fc := &fakeSubClient{steps: []pollStep{
+			{runID: "R1", getErr: draining},
+			{runID: "R2", result: PollResult{Items: []WireItem{wireItem(t, "evt", "after-can", 1)}, NextOffset: 2, MoreReady: true}},
+		}}
+		c := newSubClient(fc)
 
-	var got []string
-	var gotErr error
-	for item, err := range c.Subscribe(context.Background(), SubscribeOptions{PollCooldown: time.Millisecond}) {
-		if err != nil {
-			gotErr = err
+		var got []string
+		var gotErr error
+		for item, err := range c.Subscribe(context.Background(), SubscribeOptions{PollCooldown: time.Millisecond}) {
+			if err != nil {
+				gotErr = err
+				break
+			}
+			got = append(got, decodeItem(t, item.Data))
 			break
 		}
-		got = append(got, decodeItem(t, item.Data))
-		break
-	}
 
-	require.NoError(t, gotErr, "a draining rejection must not surface as an error")
-	require.Equal(t, []string{"after-can"}, got)
-	require.GreaterOrEqual(t, len(fc.recordedPolls()), 2, "the poll is retried after the draining rejection")
-	require.Empty(t, fc.recordedDescribeRuns(), "a draining rejection is retried without describing the workflow")
+		require.NoError(t, gotErr, "a draining rejection must not surface as an error")
+		require.Equal(t, []string{"after-can"}, got)
+		require.GreaterOrEqual(t, len(fc.recordedPolls()), 2, "the poll is retried after the draining rejection")
+		require.Empty(t, fc.recordedDescribeRuns(), "a draining rejection is retried without describing the workflow")
+	})
 }
 
 func TestSubscribeSurfacesNonTerminalError(t *testing.T) {
@@ -306,42 +309,47 @@ func TestSubscribeContextCanceledBeforePolling(t *testing.T) {
 }
 
 func TestSubscribeCooldownCanceledByContext(t *testing.T) {
-	// First poll succeeds with no items and MoreReady=false, so the loop enters
-	// the cooldown wait. A long cooldown plus a canceled context proves the wait
-	// is interruptible rather than blocking for the full PollCooldown.
-	fc := &fakeSubClient{steps: []pollStep{
-		{result: PollResult{Items: nil, NextOffset: 1, MoreReady: false}},
-	}}
-	c := newSubClient(fc)
+	synctest.Test(t, func(t *testing.T) {
+		// First poll succeeds with no items and MoreReady=false, so the loop enters
+		// the cooldown wait. A long cooldown plus a canceled context proves the wait
+		// is interruptible rather than blocking for the full PollCooldown.
+		const cancelAfter = 20 * time.Millisecond
+		fc := &fakeSubClient{steps: []pollStep{
+			{result: PollResult{Items: nil, NextOffset: 1, MoreReady: false}},
+		}}
+		c := newSubClient(fc)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	go func() {
-		time.Sleep(20 * time.Millisecond)
-		cancel()
-	}()
+		ctx, cancel := context.WithCancel(context.Background())
+		go func() {
+			time.Sleep(cancelAfter)
+			cancel()
+		}()
 
-	start := time.Now()
-	var gotErr error
-	for _, err := range c.Subscribe(ctx, SubscribeOptions{PollCooldown: time.Hour}) {
-		gotErr = err
-	}
-	require.ErrorIs(t, gotErr, context.Canceled)
-	require.Less(t, time.Since(start), 5*time.Second, "cooldown wait should be interrupted by context cancellation")
+		start := time.Now()
+		var gotErr error
+		for _, err := range c.Subscribe(ctx, SubscribeOptions{PollCooldown: time.Hour}) {
+			gotErr = err
+		}
+		require.ErrorIs(t, gotErr, context.Canceled)
+		require.Equal(t, cancelAfter, time.Since(start))
+	})
 }
 
 func TestSubscribeCooldownAppliedWhenNotMoreReady(t *testing.T) {
-	const cooldown = 60 * time.Millisecond
-	fc := &fakeSubClient{steps: []pollStep{
-		{result: PollResult{Items: nil, NextOffset: 1, MoreReady: false}}, // triggers cooldown
-		{result: PollResult{Items: []WireItem{wireItem(t, "evt", "a", 1)}, NextOffset: 2, MoreReady: true}},
-	}}
-	c := newSubClient(fc)
+	synctest.Test(t, func(t *testing.T) {
+		const cooldown = 60 * time.Millisecond
+		fc := &fakeSubClient{steps: []pollStep{
+			{result: PollResult{Items: nil, NextOffset: 1, MoreReady: false}}, // triggers cooldown
+			{result: PollResult{Items: []WireItem{wireItem(t, "evt", "a", 1)}, NextOffset: 2, MoreReady: true}},
+		}}
+		c := newSubClient(fc)
 
-	start := time.Now()
-	for item, err := range c.Subscribe(context.Background(), SubscribeOptions{PollCooldown: cooldown}) {
-		require.NoError(t, err)
-		require.Equal(t, "a", decodeItem(t, item.Data))
-		break
-	}
-	require.GreaterOrEqual(t, time.Since(start), cooldown/2, "a cooldown is applied between polls when MoreReady is false")
+		start := time.Now()
+		for item, err := range c.Subscribe(context.Background(), SubscribeOptions{PollCooldown: cooldown}) {
+			require.NoError(t, err)
+			require.Equal(t, "a", decodeItem(t, item.Data))
+			break
+		}
+		require.Equal(t, cooldown, time.Since(start))
+	})
 }

--- a/internal/common/backoff/retry_test.go
+++ b/internal/common/backoff/retry_test.go
@@ -3,6 +3,7 @@ package backoff
 import (
 	"context"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -40,27 +41,32 @@ func TestRetrySuccess(t *testing.T) {
 
 func TestNoRetryAfterContextDone(t *testing.T) {
 	t.Parallel()
-	retryCounter := 0
-	op := func() error {
-		retryCounter++
+	synctest.Test(t, func(t *testing.T) {
+		retryCounter := 0
+		op := func() error {
+			retryCounter++
 
-		if retryCounter == 5 {
-			return nil
+			if retryCounter == 5 {
+				return nil
+			}
+
+			return &someError{}
 		}
 
-		return &someError{}
-	}
+		policy := NewExponentialRetryPolicy(10 * time.Millisecond)
+		policy.SetMaximumInterval(50 * time.Millisecond)
+		policy.SetMaximumAttempts(10)
 
-	policy := NewExponentialRetryPolicy(10 * time.Millisecond)
-	policy.SetMaximumInterval(50 * time.Millisecond)
-	policy.SetMaximumAttempts(10)
+		const timeout = 50 * time.Millisecond
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		defer cancel()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
-	defer cancel()
-
-	err := Retry(ctx, op, policy, nil)
-	assert.Error(t, err)
-	assert.True(t, retryCounter >= 2, "retryCounter should be at least 2 but was %d", retryCounter) // verify that we did retry
+		start := time.Now()
+		err := Retry(ctx, op, policy, nil)
+		assert.Error(t, err)
+		assert.Equal(t, 3, retryCounter)
+		assert.Equal(t, timeout, time.Since(start))
+	})
 }
 
 func TestRetryFailed(t *testing.T) {

--- a/internal/common/cache/lru_test.go
+++ b/internal/common/cache/lru_test.go
@@ -3,6 +3,7 @@ package cache
 import (
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -43,14 +44,19 @@ func TestLRU(t *testing.T) {
 }
 
 func TestLRUWithTTL(t *testing.T) {
-	cache := New(5, &Options{
-		TTL: time.Millisecond * 100,
+	synctest.Test(t, func(t *testing.T) {
+		const ttl = 100 * time.Millisecond
+		cache := New(5, &Options{
+			TTL: ttl,
+		})
+		cache.Put("A", "foo")
+		assert.Equal(t, "foo", cache.Get("A"))
+		time.Sleep(ttl)
+		assert.Equal(t, "foo", cache.Get("A"))
+		time.Sleep(time.Nanosecond)
+		assert.Nil(t, cache.Get("A"))
+		assert.Equal(t, 0, cache.Size())
 	})
-	cache.Put("A", "foo")
-	assert.Equal(t, "foo", cache.Get("A"))
-	time.Sleep(time.Millisecond * 300)
-	assert.Nil(t, cache.Get("A"))
-	assert.Equal(t, 0, cache.Size())
 }
 
 func TestLRUCacheConcurrentAccess(t *testing.T) {
@@ -88,76 +94,64 @@ func TestLRUCacheConcurrentAccess(t *testing.T) {
 }
 
 func TestRemoveFunc(t *testing.T) {
-	ch := make(chan bool)
-	cache := New(5, &Options{
-		RemovedFunc: func(i interface{}) {
-			_, ok := i.(*testing.T)
-			assert.True(t, ok)
-			ch <- true
-		},
+	synctest.Test(t, func(t *testing.T) {
+		removed := false
+		cache := New(5, &Options{
+			RemovedFunc: func(i interface{}) {
+				_, ok := i.(*testing.T)
+				assert.True(t, ok)
+				removed = true
+			},
+		})
+
+		cache.Put("testing", t)
+		cache.Delete("testing")
+		assert.Nil(t, cache.Get("testing"))
+		synctest.Wait()
+		assert.True(t, removed)
 	})
-
-	cache.Put("testing", t)
-	cache.Delete("testing")
-	assert.Nil(t, cache.Get("testing"))
-
-	timeout := time.NewTimer(time.Millisecond * 300)
-	select {
-	case b := <-ch:
-		assert.True(t, b)
-	case <-timeout.C:
-		t.Error("RemovedFunc did not send true on channel ch")
-	}
 }
 
 func TestRemovedFuncWithTTL(t *testing.T) {
-	ch := make(chan bool)
-	cache := New(5, &Options{
-		TTL: time.Millisecond * 50,
-		RemovedFunc: func(i interface{}) {
-			_, ok := i.(*testing.T)
-			assert.True(t, ok)
-			ch <- true
-		},
+	synctest.Test(t, func(t *testing.T) {
+		removed := false
+		cache := New(5, &Options{
+			TTL: time.Millisecond * 50,
+			RemovedFunc: func(i interface{}) {
+				_, ok := i.(*testing.T)
+				assert.True(t, ok)
+				removed = true
+			},
+		})
+
+		cache.Put("A", t)
+		assert.Equal(t, t, cache.Get("A"))
+		time.Sleep(time.Millisecond * 100)
+		assert.Nil(t, cache.Get("A"))
+		synctest.Wait()
+		assert.True(t, removed)
 	})
-
-	cache.Put("A", t)
-	assert.Equal(t, t, cache.Get("A"))
-	time.Sleep(time.Millisecond * 100)
-	assert.Nil(t, cache.Get("A"))
-
-	timeout := time.NewTimer(time.Millisecond * 300)
-	select {
-	case b := <-ch:
-		assert.True(t, b)
-	case <-timeout.C:
-		t.Error("RemovedFunc did not send true on channel ch")
-	}
 }
 
 func TestClear(t *testing.T) {
-	ch := make(chan bool)
-	cache := New(5, &Options{
-		TTL: time.Millisecond * 50,
-		RemovedFunc: func(i interface{}) {
-			_, ok := i.(*testing.T)
-			assert.True(t, ok)
-			ch <- true
-		},
+	synctest.Test(t, func(t *testing.T) {
+		removed := false
+		cache := New(5, &Options{
+			TTL: time.Millisecond * 50,
+			RemovedFunc: func(i interface{}) {
+				_, ok := i.(*testing.T)
+				assert.True(t, ok)
+				removed = true
+			},
+		})
+
+		cache.Put("A", t)
+		assert.Equal(t, t, cache.Get("A"))
+		cache.Clear()
+		assert.Nil(t, cache.Get("A"))
+		synctest.Wait()
+		assert.True(t, removed)
 	})
-
-	cache.Put("A", t)
-	assert.Equal(t, t, cache.Get("A"))
-	cache.Clear()
-	assert.Nil(t, cache.Get("A"))
-
-	timeout := time.NewTimer(time.Millisecond * 300)
-	select {
-	case b := <-ch:
-		assert.True(t, b)
-	case <-timeout.C:
-		t.Error("Clear did not send true on channel ch")
-	}
 }
 
 func TestLRUMax(t *testing.T) {

--- a/internal/extstore/extstore_test.go
+++ b/internal/extstore/extstore_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/google/uuid"
@@ -601,22 +602,24 @@ func TestStoreVisitor_CancelOnError(t *testing.T) {
 }
 
 func TestStoreVisitor_Callback(t *testing.T) {
-	driver := newTestDriver("d")
-	driver.storeDelay = time.Millisecond
-	params, err := ExternalStorageToParams(ExternalStorage{
-		Drivers:              []StorageDriver{driver},
-		PayloadSizeThreshold: 1,
-	})
-	require.NoError(t, err)
-	visitor := NewExternalStorageVisitor(params)
+	synctest.Test(t, func(t *testing.T) {
+		driver := newTestDriver("d")
+		driver.storeDelay = time.Millisecond
+		params, err := ExternalStorageToParams(ExternalStorage{
+			Drivers:              []StorageDriver{driver},
+			PayloadSizeThreshold: 1,
+		})
+		require.NoError(t, err)
+		visitor := NewExternalStorageVisitor(params)
 
-	cb := &testCallback{}
-	ctx := WithStorageOperationCallback(context.Background(), cb)
-	_, err = visitPayloads(ctx, visitor, []*commonpb.Payload{makePayload(t, "x"), makePayload(t, "y")})
-	require.NoError(t, err)
-	require.Equal(t, 2, cb.count)
-	require.Greater(t, cb.size, int64(0))
-	require.Greater(t, cb.duration, time.Duration(0))
+		cb := &testCallback{}
+		ctx := WithStorageOperationCallback(context.Background(), cb)
+		_, err = visitPayloads(ctx, visitor, []*commonpb.Payload{makePayload(t, "x"), makePayload(t, "y")})
+		require.NoError(t, err)
+		require.Equal(t, 2, cb.count)
+		require.Greater(t, cb.size, int64(0))
+		require.Equal(t, time.Millisecond, cb.duration)
+	})
 }
 
 func TestStoreVisitor_Callback_ExternalCountOnly(t *testing.T) {
@@ -858,24 +861,26 @@ func TestRetrievalVisitor_WrongPayloadCount(t *testing.T) {
 }
 
 func TestRetrievalVisitor_Callback(t *testing.T) {
-	driver := newTestDriver("d")
-	driver.retrieveDelay = time.Millisecond
-	params, err := ExternalStorageToParams(ExternalStorage{
-		Drivers:              []StorageDriver{driver},
-		PayloadSizeThreshold: 1,
+	synctest.Test(t, func(t *testing.T) {
+		driver := newTestDriver("d")
+		driver.retrieveDelay = time.Millisecond
+		params, err := ExternalStorageToParams(ExternalStorage{
+			Drivers:              []StorageDriver{driver},
+			PayloadSizeThreshold: 1,
+		})
+		require.NoError(t, err)
+		storeVisitor := NewExternalStorageVisitor(params)
+		retrieveVisitor := NewExternalRetrievalVisitor(params)
+
+		refs, err := visitPayloads(context.Background(), storeVisitor, []*commonpb.Payload{makePayload(t, "x")})
+		require.NoError(t, err)
+
+		cb := &testCallback{}
+		ctx := WithStorageOperationCallback(context.Background(), cb)
+		_, err = visitPayloads(ctx, retrieveVisitor, refs)
+		require.NoError(t, err)
+		require.Equal(t, time.Millisecond, cb.duration)
 	})
-	require.NoError(t, err)
-	storeVisitor := NewExternalStorageVisitor(params)
-	retrieveVisitor := NewExternalRetrievalVisitor(params)
-
-	refs, err := visitPayloads(context.Background(), storeVisitor, []*commonpb.Payload{makePayload(t, "x")})
-	require.NoError(t, err)
-
-	cb := &testCallback{}
-	ctx := WithStorageOperationCallback(context.Background(), cb)
-	_, err = visitPayloads(ctx, retrieveVisitor, refs)
-	require.NoError(t, err)
-	require.Greater(t, cb.duration, time.Duration(0))
 }
 
 func TestRetrievalVisitor_Callback_ExternalCountOnly(t *testing.T) {

--- a/internal/internal_coroutines_test.go
+++ b/internal/internal_coroutines_test.go
@@ -7,8 +7,8 @@ import (
 	"strconv"
 	"strings"
 	"sync/atomic"
-
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -52,23 +52,26 @@ func TestDispatcher(t *testing.T) {
 }
 
 func TestDispatcherDeferClose(t *testing.T) {
-	var value atomic.Bool
-	d := createNewDispatcher(func(ctx Context) {
-		// Block all coroutines on this channel
-		c1 := NewChannel(ctx)
-		defer func() {
-			value.Store(true)
-		}()
-		c1.Receive(ctx, nil)
+	synctest.Test(t, func(t *testing.T) {
+		var value atomic.Bool
+		d := createNewDispatcher(func(ctx Context) {
+			// Block all coroutines on this channel
+			c1 := NewChannel(ctx)
+			defer func() {
+				value.Store(true)
+			}()
+			c1.Receive(ctx, nil)
+		})
+		defer d.Close()
+		require.Equal(t, false, value.Load())
+		requireNoExecuteErr(t, d.ExecuteUntilAllBlocked(defaultDeadlockDetectionTimeout))
+		// Closing the dispatcher will cause the blocked goroutine to stop executing, but defers
+		// will still run.
+		d.Close()
+		require.True(t, d.IsClosed())
+		synctest.Wait()
+		require.True(t, value.Load())
 	})
-	defer d.Close()
-	require.Equal(t, false, value.Load())
-	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked(defaultDeadlockDetectionTimeout))
-	// Closing the dispatcher will cause the blocked goroutine to stop executing, but defers
-	// will still run.
-	d.Close()
-	require.True(t, d.IsClosed())
-	require.Eventually(t, value.Load, time.Second, 10*time.Millisecond)
 }
 
 func TestDispatcherDeadlockedDefer(t *testing.T) {
@@ -93,34 +96,35 @@ func TestDispatcherDeadlockedDefer(t *testing.T) {
 }
 
 func TestDispatcherDeferCloseRace(t *testing.T) {
-	var value atomic.Int32
-	var d dispatcher
-	d = createNewDispatcher(func(ctx Context) {
-		// Block all coroutines on this channel
-		c1 := NewChannel(ctx)
-		for i := 0; i < 100; i++ {
-			index := i
-			id := "coroutine_" + strconv.Itoa(index)
-			d.NewCoroutine(ctx, id, false, func(ctx Context) {
-				defer func() {
-					value.Store(int32(index))
-				}()
-				c1.Receive(ctx, nil)
-			})
-		}
-		c1.Receive(ctx, nil)
-	})
-	defer d.Close()
+	synctest.Test(t, func(t *testing.T) {
+		var value atomic.Int32
+		var d dispatcher
+		d = createNewDispatcher(func(ctx Context) {
+			// Block all coroutines on this channel
+			c1 := NewChannel(ctx)
+			for i := 0; i < 100; i++ {
+				index := i
+				id := "coroutine_" + strconv.Itoa(index)
+				d.NewCoroutine(ctx, id, false, func(ctx Context) {
+					defer func() {
+						value.Store(int32(index))
+					}()
+					c1.Receive(ctx, nil)
+				})
+			}
+			c1.Receive(ctx, nil)
+		})
+		defer d.Close()
 
-	require.Equal(t, int32(0), value.Load())
-	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked(defaultDeadlockDetectionTimeout))
-	// Closing the dispatcher will cause the blocked coroutine to stop executing, but defers
-	// will still run.
-	d.Close()
-	require.True(t, d.IsClosed())
-	require.Eventually(t, func() bool {
-		return value.Load() == int32(99)
-	}, time.Second, 10*time.Millisecond)
+		require.Equal(t, int32(0), value.Load())
+		requireNoExecuteErr(t, d.ExecuteUntilAllBlocked(defaultDeadlockDetectionTimeout))
+		// Closing the dispatcher will cause the blocked coroutine to stop executing, but defers
+		// will still run.
+		d.Close()
+		require.True(t, d.IsClosed())
+		synctest.Wait()
+		require.Equal(t, int32(99), value.Load())
+	})
 }
 
 func TestNonBlockingChildren(t *testing.T) {

--- a/internal/internal_eager_activity_test.go
+++ b/internal/internal_eager_activity_test.go
@@ -3,7 +3,7 @@ package internal
 import (
 	"sync/atomic"
 	"testing"
-	"time"
+	"testing/synctest"
 
 	"github.com/stretchr/testify/require"
 	commandpb "go.temporal.io/api/command/v1"
@@ -98,108 +98,109 @@ func TestEagerActivityMaxPerTask(t *testing.T) {
 }
 
 func TestEagerActivityCounts(t *testing.T) {
-	// We'll create an eager activity executor with 3 max eager concurrent and 5
-	// max concurrent
-	exec := newEagerActivityExecutor(eagerActivityExecutorOptions{taskQueue: "task-queue1",
-		maxConcurrent: 3,
-		maxPerTask:    defaultMaxEagerActivityReservationsPerWorkflowTask})
-	tuner, err := NewFixedSizeTuner(FixedSizeTunerOptions{
-		NumWorkflowSlots:      defaultMaxConcurrentTaskExecutionSize,
-		NumActivitySlots:      5,
-		NumLocalActivitySlots: defaultMaxConcurrentLocalActivityExecutionSize})
-	require.NoError(t, err)
-	activityWorker := newActivityWorker(nil,
-		workerExecutionParameters{TaskQueue: "task-queue1", Tuner: tuner}, nil, newRegistry(), nil)
-	activityWorker.worker.isWorkerStarted = true
-	go activityWorker.worker.runEagerTaskDispatcher()
+	synctest.Test(t, func(t *testing.T) {
+		// We'll create an eager activity executor with 3 max eager concurrent and 5
+		// max concurrent
+		exec := newEagerActivityExecutor(eagerActivityExecutorOptions{taskQueue: "task-queue1",
+			maxConcurrent: 3,
+			maxPerTask:    defaultMaxEagerActivityReservationsPerWorkflowTask})
+		tuner, err := NewFixedSizeTuner(FixedSizeTunerOptions{
+			NumWorkflowSlots:      defaultMaxConcurrentTaskExecutionSize,
+			NumActivitySlots:      5,
+			NumLocalActivitySlots: defaultMaxConcurrentLocalActivityExecutionSize})
+		require.NoError(t, err)
+		activityWorker := newActivityWorker(nil,
+			workerExecutionParameters{TaskQueue: "task-queue1", Tuner: tuner}, nil, newRegistry(), nil)
+		activityWorker.worker.isWorkerStarted = true
+		activityWorker.worker.stopWG.Add(1)
+		go activityWorker.worker.runEagerTaskDispatcher()
+		defer close(activityWorker.worker.stopCh)
 
-	exec.activityWorker = activityWorker.worker
-	// Replace task processor
-	taskProcessor := newWaitingTaskProcessor()
-	activityWorker.worker.options.taskProcessor = taskProcessor
+		exec.activityWorker = activityWorker.worker
+		// Replace task processor
+		taskProcessor := newWaitingTaskProcessor()
+		activityWorker.worker.options.taskProcessor = taskProcessor
 
-	// Request 2 commands on wrong task queue then 5 commands on proper task queue
-	// but have 2nd request disabled
-	req := &workflowservice.RespondWorkflowTaskCompletedRequest{}
-	addScheduleTaskCommand(req, "task-queue2")
-	addScheduleTaskCommand(req, "task-queue2")
-	addScheduleTaskCommand(req, "task-queue1")
-	addScheduleTaskCommand(req, "task-queue1").RequestEagerExecution = false
-	addScheduleTaskCommand(req, "task-queue1")
-	addScheduleTaskCommand(req, "task-queue1")
-	addScheduleTaskCommand(req, "task-queue1")
+		// Request 2 commands on wrong task queue then 5 commands on proper task queue
+		// but have 2nd request disabled
+		req := &workflowservice.RespondWorkflowTaskCompletedRequest{}
+		addScheduleTaskCommand(req, "task-queue2")
+		addScheduleTaskCommand(req, "task-queue2")
+		addScheduleTaskCommand(req, "task-queue1")
+		addScheduleTaskCommand(req, "task-queue1").RequestEagerExecution = false
+		addScheduleTaskCommand(req, "task-queue1")
+		addScheduleTaskCommand(req, "task-queue1")
+		addScheduleTaskCommand(req, "task-queue1")
 
-	// Apply to request and confirm only the proper 3 remain as true
-	reservedPermits := exec.applyToRequest(req)
-	require.Equal(t, 3, len(reservedPermits))
-	require.False(t, req.Commands[0].GetScheduleActivityTaskCommandAttributes().RequestEagerExecution)
-	require.False(t, req.Commands[1].GetScheduleActivityTaskCommandAttributes().RequestEagerExecution)
-	require.True(t, req.Commands[2].GetScheduleActivityTaskCommandAttributes().RequestEagerExecution)
-	require.False(t, req.Commands[3].GetScheduleActivityTaskCommandAttributes().RequestEagerExecution)
-	require.True(t, req.Commands[4].GetScheduleActivityTaskCommandAttributes().RequestEagerExecution)
-	require.True(t, req.Commands[5].GetScheduleActivityTaskCommandAttributes().RequestEagerExecution)
-	require.False(t, req.Commands[6].GetScheduleActivityTaskCommandAttributes().RequestEagerExecution)
+		// Apply to request and confirm only the proper 3 remain as true
+		reservedPermits := exec.applyToRequest(req)
+		require.Equal(t, 3, len(reservedPermits))
+		require.False(t, req.Commands[0].GetScheduleActivityTaskCommandAttributes().RequestEagerExecution)
+		require.False(t, req.Commands[1].GetScheduleActivityTaskCommandAttributes().RequestEagerExecution)
+		require.True(t, req.Commands[2].GetScheduleActivityTaskCommandAttributes().RequestEagerExecution)
+		require.False(t, req.Commands[3].GetScheduleActivityTaskCommandAttributes().RequestEagerExecution)
+		require.True(t, req.Commands[4].GetScheduleActivityTaskCommandAttributes().RequestEagerExecution)
+		require.True(t, req.Commands[5].GetScheduleActivityTaskCommandAttributes().RequestEagerExecution)
+		require.False(t, req.Commands[6].GetScheduleActivityTaskCommandAttributes().RequestEagerExecution)
 
-	// Confirm counts
-	tss := activityWorker.worker.slotSupplier
-	require.Equal(t, int32(3), tss.issuedSlotsAtomic.Load())
-	// None are used at this point
-	require.Equal(t, 0, len(tss.usedSlots))
+		// Confirm counts
+		tss := activityWorker.worker.slotSupplier
+		require.Equal(t, int32(3), tss.issuedSlotsAtomic.Load())
+		// None are used at this point
+		require.Equal(t, 0, len(tss.usedSlots))
 
-	// Pretend server only returned 2 eager activities
-	resp := &workflowservice.RespondWorkflowTaskCompletedResponse{
-		ActivityTasks: []*workflowservice.PollActivityTaskQueueResponse{
-			{ActivityId: "activity1"},
-			{ActivityId: "activity2"},
-		},
-	}
-	exec.handleResponse(resp, reservedPermits)
-
-	// Wait a bit until both tasks running
-	require.Eventually(t, func() bool {
-		return atomic.LoadInt32(&taskProcessor.numWaiting) == 2
-	}, 2*time.Second, 100*time.Millisecond)
-
-	// Confirm counts
-	require.Equal(t, int32(2), tss.issuedSlotsAtomic.Load())
-	// Both are used
-	require.Equal(t, 2, len(tss.usedSlots))
-
-	// Try a request with two more eager and confirm only room for one
-	req = &workflowservice.RespondWorkflowTaskCompletedRequest{}
-	addScheduleTaskCommand(req, "task-queue1")
-	addScheduleTaskCommand(req, "task-queue1")
-	require.Equal(t, 1, len(exec.applyToRequest(req)))
-	require.True(t, req.Commands[0].GetScheduleActivityTaskCommandAttributes().RequestEagerExecution)
-	require.False(t, req.Commands[1].GetScheduleActivityTaskCommandAttributes().RequestEagerExecution)
-	require.Equal(t, int32(3), tss.issuedSlotsAtomic.Load())
-
-	// Resolve that saying none came back
-	exec.handleResponse(nil, []*SlotPermit{{}})
-	require.Equal(t, int32(2), tss.issuedSlotsAtomic.Load())
-
-	// Now take all remaining slots from the activity side and confirm we can't
-	// reserve any eager
-	for {
-		permit := tss.TryReserveSlot(&slotReservationData{taskQueue: "task-queue1"})
-		if permit == nil {
-			break
+		// Pretend server only returned 2 eager activities
+		resp := &workflowservice.RespondWorkflowTaskCompletedResponse{
+			ActivityTasks: []*workflowservice.PollActivityTaskQueueResponse{
+				{ActivityId: "activity1"},
+				{ActivityId: "activity2"},
+			},
 		}
-	}
+		exec.handleResponse(resp, reservedPermits)
 
-	req = &workflowservice.RespondWorkflowTaskCompletedRequest{}
-	addScheduleTaskCommand(req, "task-queue1")
-	require.Empty(t, exec.applyToRequest(req))
-	require.False(t, req.Commands[0].GetScheduleActivityTaskCommandAttributes().RequestEagerExecution)
-	require.Equal(t, int32(5), tss.issuedSlotsAtomic.Load())
+		synctest.Wait()
+		require.Equal(t, int32(2), atomic.LoadInt32(&taskProcessor.numWaiting))
 
-	// Complete eager two and confirm those are released. The three we took by hand from the
-	// slot supplier won't be released since no one but this test knows about them.
-	taskProcessor.completeCh <- struct{}{}
-	taskProcessor.completeCh <- struct{}{}
-	require.Eventually(t, func() bool {
-		return int32(3) == tss.issuedSlotsAtomic.Load()
-	}, 2*time.Second, 100*time.Millisecond)
+		// Confirm counts
+		require.Equal(t, int32(2), tss.issuedSlotsAtomic.Load())
+		// Both are used
+		require.Equal(t, 2, len(tss.usedSlots))
+
+		// Try a request with two more eager and confirm only room for one
+		req = &workflowservice.RespondWorkflowTaskCompletedRequest{}
+		addScheduleTaskCommand(req, "task-queue1")
+		addScheduleTaskCommand(req, "task-queue1")
+		require.Equal(t, 1, len(exec.applyToRequest(req)))
+		require.True(t, req.Commands[0].GetScheduleActivityTaskCommandAttributes().RequestEagerExecution)
+		require.False(t, req.Commands[1].GetScheduleActivityTaskCommandAttributes().RequestEagerExecution)
+		require.Equal(t, int32(3), tss.issuedSlotsAtomic.Load())
+
+		// Resolve that saying none came back
+		exec.handleResponse(nil, []*SlotPermit{{}})
+		require.Equal(t, int32(2), tss.issuedSlotsAtomic.Load())
+
+		// Now take all remaining slots from the activity side and confirm we can't
+		// reserve any eager
+		for {
+			permit := tss.TryReserveSlot(&slotReservationData{taskQueue: "task-queue1"})
+			if permit == nil {
+				break
+			}
+		}
+
+		req = &workflowservice.RespondWorkflowTaskCompletedRequest{}
+		addScheduleTaskCommand(req, "task-queue1")
+		require.Empty(t, exec.applyToRequest(req))
+		require.False(t, req.Commands[0].GetScheduleActivityTaskCommandAttributes().RequestEagerExecution)
+		require.Equal(t, int32(5), tss.issuedSlotsAtomic.Load())
+
+		// Complete eager two and confirm those are released. The three we took by hand from the
+		// slot supplier won't be released since no one but this test knows about them.
+		taskProcessor.completeCh <- struct{}{}
+		taskProcessor.completeCh <- struct{}{}
+		synctest.Wait()
+		require.Equal(t, int32(3), tss.issuedSlotsAtomic.Load())
+	})
 }
 
 func addScheduleTaskCommand(

--- a/internal/internal_task_handlers_test.go
+++ b/internal/internal_task_handlers_test.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/golang/mock/gomock"
@@ -1783,89 +1784,90 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_Message_Admitted_Paged() {
 }
 
 func (t *TaskHandlersTestSuite) TestLocalActivityRetry_Workflow() {
-	backoffInterval := 10 * time.Millisecond
-	workflowComplete := false
-	var laFailures atomic.Uint64
+	synctest.Test(t.T(), func(_ *testing.T) {
+		backoffInterval := 10 * time.Millisecond
+		workflowComplete := false
+		var laFailures atomic.Uint64
 
-	retryLocalActivityWorkflowFunc := func(ctx Context, input []byte) error {
-		ao := LocalActivityOptions{
-			ScheduleToCloseTimeout: time.Minute,
-			RetryPolicy: &RetryPolicy{
-				InitialInterval:    backoffInterval,
-				BackoffCoefficient: 1.1,
-				MaximumInterval:    time.Minute,
-				MaximumAttempts:    5,
+		retryLocalActivityWorkflowFunc := func(ctx Context, input []byte) error {
+			ao := LocalActivityOptions{
+				ScheduleToCloseTimeout: time.Minute,
+				RetryPolicy: &RetryPolicy{
+					InitialInterval:    backoffInterval,
+					BackoffCoefficient: 1.1,
+					MaximumInterval:    time.Minute,
+					MaximumAttempts:    5,
+				},
+			}
+			ctx = WithLocalActivityOptions(ctx, ao)
+
+			err := ExecuteLocalActivity(ctx, func() error {
+				if laFailures.Load() > 2 {
+					return nil
+				}
+				laFailures.Add(1)
+				return errors.New("fail number " + strconv.Itoa(int(laFailures.Load())))
+			}).Get(ctx, nil)
+			workflowComplete = true
+			return err
+		}
+		t.registry.RegisterWorkflowWithOptions(
+			retryLocalActivityWorkflowFunc,
+			RegisterWorkflowOptions{Name: "RetryLocalActivityWorkflow"},
+		)
+
+		workflowTaskStartedEvent := createTestEventWorkflowTaskStarted(3)
+		now := time.Now()
+		onesec := 5 * time.Second
+		workflowTaskStartedEvent.EventTime = timestamppb.New(now)
+		testEvents := []*historypb.HistoryEvent{
+			createTestEventWorkflowExecutionStarted(1, &historypb.WorkflowExecutionStartedEventAttributes{
+				WorkflowTaskTimeout: durationpb.New(onesec),
+				TaskQueue:           &taskqueuepb.TaskQueue{Name: testWorkflowTaskTaskqueue},
 			},
+			),
+			createTestEventWorkflowTaskScheduled(2, &historypb.WorkflowTaskScheduledEventAttributes{}),
+			workflowTaskStartedEvent,
 		}
-		ctx = WithLocalActivityOptions(ctx, ao)
 
-		err := ExecuteLocalActivity(ctx, func() error {
-			if laFailures.Load() > 2 {
-				return nil
+		task := createWorkflowTask(testEvents, 0, "RetryLocalActivityWorkflow")
+		stopCh := make(chan struct{})
+		params := t.getTestWorkerExecutionParams()
+		params.WorkerStopChannel = stopCh
+		defer close(stopCh)
+
+		taskHandler := newWorkflowTaskHandler(params, nil, t.registry)
+		laStopCh := make(chan struct{})
+		defer close(laStopCh)
+		laTunnel := newLocalActivityTunnel(laStopCh)
+		taskHandlerImpl, ok := taskHandler.(*workflowTaskHandlerImpl)
+		t.True(ok)
+		taskHandlerImpl.laTunnel = laTunnel
+
+		laTaskPoller := newLocalActivityPoller(params, laTunnel, nil, nil, stopCh)
+		go func() {
+			for {
+				task, _ := laTaskPoller.PollTask()
+				if task == nil {
+					return
+				}
+				_ = laTaskPoller.ProcessTask(task)
 			}
-			laFailures.Add(1)
-			return errors.New("fail number " + strconv.Itoa(int(laFailures.Load())))
-		}).Get(ctx, nil)
-		workflowComplete = true
-		return err
-	}
-	t.registry.RegisterWorkflowWithOptions(
-		retryLocalActivityWorkflowFunc,
-		RegisterWorkflowOptions{Name: "RetryLocalActivityWorkflow"},
-	)
+		}()
 
-	workflowTaskStartedEvent := createTestEventWorkflowTaskStarted(3)
-	now := time.Now()
-	onesec := 5 * time.Second
-	workflowTaskStartedEvent.EventTime = timestamppb.New(now)
-	testEvents := []*historypb.HistoryEvent{
-		createTestEventWorkflowExecutionStarted(1, &historypb.WorkflowExecutionStartedEventAttributes{
-			WorkflowTaskTimeout: durationpb.New(onesec),
-			TaskQueue:           &taskqueuepb.TaskQueue{Name: testWorkflowTaskTaskqueue},
-		},
-		),
-		createTestEventWorkflowTaskScheduled(2, &historypb.WorkflowTaskScheduledEventAttributes{}),
-		workflowTaskStartedEvent,
-	}
-
-	task := createWorkflowTask(testEvents, 0, "RetryLocalActivityWorkflow")
-	stopCh := make(chan struct{})
-	params := t.getTestWorkerExecutionParams()
-	params.WorkerStopChannel = stopCh
-	defer close(stopCh)
-
-	taskHandler := newWorkflowTaskHandler(params, nil, t.registry)
-	laStopCh := make(chan struct{})
-	defer close(laStopCh)
-	laTunnel := newLocalActivityTunnel(laStopCh)
-	taskHandlerImpl, ok := taskHandler.(*workflowTaskHandlerImpl)
-	t.True(ok)
-	taskHandlerImpl.laTunnel = laTunnel
-
-	laTaskPoller := newLocalActivityPoller(params, laTunnel, nil, nil, stopCh)
-	go func() {
-		for {
-			task, _ := laTaskPoller.PollTask()
-			if task == nil {
-				return
-			}
-			_ = laTaskPoller.ProcessTask(task)
-		}
-	}()
-
-	laResultCh := make(chan *localActivityResult)
-	laRetryCh := make(chan *localActivityTask)
-	wftask := workflowTask{task: task, laResultCh: laResultCh, laRetryCh: laRetryCh}
-	wfctx := t.mustWorkflowContextImpl(&wftask, taskHandler)
-	response, err := taskHandler.ProcessWorkflowTask(&wftask, wfctx, nil)
-	t.NotNil(response)
-	t.NoError(err)
-	asWFTComplete := response.rawRequest.(*workflowservice.RespondWorkflowTaskCompletedRequest)
-	// There should be no non-first LA attempts since all the retries happen in one WFT
-	t.Equal(uint32(0), asWFTComplete.MeteringMetadata.NonfirstLocalActivityExecutionAttempts)
-	// wait long enough for wf to complete
-	time.Sleep(backoffInterval * 3)
-	t.True(workflowComplete)
+		laResultCh := make(chan *localActivityResult)
+		laRetryCh := make(chan *localActivityTask)
+		wftask := workflowTask{task: task, laResultCh: laResultCh, laRetryCh: laRetryCh}
+		wfctx := t.mustWorkflowContextImpl(&wftask, taskHandler)
+		response, err := taskHandler.ProcessWorkflowTask(&wftask, wfctx, nil)
+		t.NotNil(response)
+		t.NoError(err)
+		asWFTComplete := response.rawRequest.(*workflowservice.RespondWorkflowTaskCompletedRequest)
+		// There should be no non-first LA attempts since all the retries happen in one WFT
+		t.Equal(uint32(0), asWFTComplete.MeteringMetadata.NonfirstLocalActivityExecutionAttempts)
+		synctest.Wait()
+		t.True(workflowComplete)
+	})
 }
 
 func (t *TaskHandlersTestSuite) TestLocalActivityRetry_WorkflowTaskHeartbeatFail() {

--- a/internal/internal_worker_base_test.go
+++ b/internal/internal_worker_base_test.go
@@ -381,126 +381,126 @@ func (s *ScalableTaskPollerSuite) TestAutoscalingConcurrencyScalesUpToMaximum() 
 }
 
 func (s *ScalableTaskPollerSuite) TestAutoscalingScalesDownToMinimum() {
-	behavior := &pollerBehaviorAutoscaling{
-		initialNumberOfPollers: 2,
-		maximumNumberOfPollers: 3,
-		minimumNumberOfPollers: 1,
-	}
+	synctest.Test(s.T(), func(t *testing.T) {
+		behavior := &pollerBehaviorAutoscaling{
+			initialNumberOfPollers: 2,
+			maximumNumberOfPollers: 3,
+			minimumNumberOfPollers: 1,
+		}
 
-	blockingPoller := newBlockingProbeTaskPoller()
-	poller := newScalableTaskPoller(blockingPoller, ilog.NewNopLogger(), behavior, "", nil)
+		blockingPoller := newBlockingProbeTaskPoller()
+		poller := newScalableTaskPoller(blockingPoller, ilog.NewNopLogger(), behavior, "", nil)
 
-	bw := newBaseWorker(baseWorkerOptions{
-		slotSupplier:     &testSlotSupplier{},
-		maxTaskPerSecond: 1000,
-		taskPollers:      []scalableTaskPoller{poller},
-		taskProcessor:    noopTaskProcessor{},
-		workerType:       "AutoscalingTest",
-		logger:           ilog.NewNopLogger(),
-		stopTimeout:      time.Second,
-		metricsHandler:   metrics.NopHandler,
+		bw := newBaseWorker(baseWorkerOptions{
+			slotSupplier:     &testSlotSupplier{},
+			maxTaskPerSecond: 1000,
+			taskPollers:      []scalableTaskPoller{poller},
+			taskProcessor:    noopTaskProcessor{},
+			workerType:       "AutoscalingTest",
+			logger:           ilog.NewNopLogger(),
+			stopTimeout:      time.Second,
+			metricsHandler:   metrics.NopHandler,
+		})
+
+		bw.Start()
+		defer func() {
+			blockingPoller.Allow(readAutoscalingPollerState(poller.autoscalingRunner))
+			blockingPoller.Close()
+			bw.Stop()
+		}()
+
+		assertAutoscalingPollerState(t, poller.autoscalingRunner, 2, "expected initial concurrency")
+
+		poller.pollerAutoscaler.updateTarget(func(target int64) int64 { return 1 })
+		blockingPoller.Allow(2)
+
+		assertAutoscalingPollerState(t, poller.autoscalingRunner, 1, "expected concurrency to reduce to minimum")
+
+		for range 5 {
+			assert.Equal(t, int64(1), poller.pollerAutoscaler.target.Load(), "should not scale target below minimum")
+			blockingPoller.Allow(1)
+			assertAutoscalingPollerState(t, poller.autoscalingRunner, 1, "expected concurrency to recover to minimum")
+		}
 	})
-
-	bw.Start()
-	defer func() {
-		blockingPoller.Allow(readAutoscalingPollerState(poller.autoscalingRunner))
-		blockingPoller.Close()
-		bw.Stop()
-	}()
-
-	eventuallyAutoscalingPollerState(s.T(), poller.autoscalingRunner, 2, "expected initial concurrency")
-
-	poller.pollerAutoscaler.updateTarget(func(target int64) int64 { return 1 })
-	blockingPoller.Allow(2)
-
-	eventuallyAutoscalingPollerState(s.T(), poller.autoscalingRunner, 1, "expected concurrency to reduce to minimum")
-
-	for range 5 {
-		assert.Equal(s.T(), int64(1), poller.pollerAutoscaler.target.Load(), "should not scale target below minimum")
-		blockingPoller.Allow(1)
-		eventuallyAutoscalingPollerState(s.T(), poller.autoscalingRunner, 1, "expected concurrency to recover to minimum")
-	}
 }
 
 func (s *ScalableTaskPollerSuite) TestAutoscalingDoesNotHoldSlotWhileWaitingForPollCapacity() {
-	behavior := &pollerBehaviorAutoscaling{
-		initialNumberOfPollers: 1,
-		maximumNumberOfPollers: 2,
-		minimumNumberOfPollers: 1,
-	}
+	synctest.Test(s.T(), func(t *testing.T) {
+		behavior := &pollerBehaviorAutoscaling{
+			initialNumberOfPollers: 1,
+			maximumNumberOfPollers: 2,
+			minimumNumberOfPollers: 1,
+		}
 
-	blockingPoller := newBlockingProbeTaskPoller()
-	poller := newScalableTaskPoller(blockingPoller, ilog.NewNopLogger(), behavior, "", nil)
-	slotSupplier := newLimitedSlotSupplier(2)
+		blockingPoller := newBlockingProbeTaskPoller()
+		poller := newScalableTaskPoller(blockingPoller, ilog.NewNopLogger(), behavior, "", nil)
+		slotSupplier := newLimitedSlotSupplier(2)
 
-	bw := newBaseWorker(baseWorkerOptions{
-		slotSupplier:     slotSupplier,
-		maxTaskPerSecond: 1000,
-		taskPollers:      []scalableTaskPoller{poller},
-		taskProcessor:    noopTaskProcessor{},
-		workerType:       "AutoscalingSlotCapacityTest",
-		logger:           ilog.NewNopLogger(),
-		stopTimeout:      time.Second,
-		metricsHandler:   metrics.NopHandler,
+		bw := newBaseWorker(baseWorkerOptions{
+			slotSupplier:     slotSupplier,
+			maxTaskPerSecond: 1000,
+			taskPollers:      []scalableTaskPoller{poller},
+			taskProcessor:    noopTaskProcessor{},
+			workerType:       "AutoscalingSlotCapacityTest",
+			logger:           ilog.NewNopLogger(),
+			stopTimeout:      time.Second,
+			metricsHandler:   metrics.NopHandler,
+		})
+
+		bw.Start()
+		defer func() {
+			blockingPoller.Allow(readAutoscalingPollerState(poller.autoscalingRunner))
+			blockingPoller.Close()
+			bw.Stop()
+		}()
+
+		assertAutoscalingPollerState(t, poller.autoscalingRunner, 1, "expected initial poller to start")
+		require.Equal(t, int32(1), slotSupplier.reserves.Load(),
+			"autoscaling poller should not reserve another slot while blocked by its target")
+
+		permit := slotSupplier.TryReserveSlot(nil)
+		require.NotNil(t, permit, "unused slot should remain available while autoscaling target is full")
+		slotSupplier.ReleaseSlot(nil)
 	})
-
-	bw.Start()
-	defer func() {
-		blockingPoller.Allow(readAutoscalingPollerState(poller.autoscalingRunner))
-		blockingPoller.Close()
-		bw.Stop()
-	}()
-
-	eventuallyAutoscalingPollerState(s.T(), poller.autoscalingRunner, 1, "expected initial poller to start")
-
-	require.Never(s.T(), func() bool {
-		return slotSupplier.reserves.Load() > 1
-	}, 200*time.Millisecond, 10*time.Millisecond,
-		"autoscaling poller should not reserve another slot while blocked by its target")
-
-	permit := slotSupplier.TryReserveSlot(nil)
-	require.NotNil(s.T(), permit, "unused slot should remain available while autoscaling target is full")
-	slotSupplier.ReleaseSlot(nil)
 }
 
 func (s *ScalableTaskPollerSuite) TestAutoscalingBalancerDoesNotHoldSlotsWhileBlocked() {
-	behavior := &pollerBehaviorAutoscaling{
-		initialNumberOfPollers: 2,
-		maximumNumberOfPollers: 2,
-		minimumNumberOfPollers: 1,
-	}
+	synctest.Test(s.T(), func(t *testing.T) {
+		behavior := &pollerBehaviorAutoscaling{
+			initialNumberOfPollers: 2,
+			maximumNumberOfPollers: 2,
+			minimumNumberOfPollers: 1,
+		}
 
-	blockingPoller := newBlockingProbeTaskPoller()
-	poller := newScalableTaskPoller(blockingPoller, ilog.NewNopLogger(), behavior, "a", nil)
-	slotSupplier := newLimitedSlotSupplier(2)
+		blockingPoller := newBlockingProbeTaskPoller()
+		poller := newScalableTaskPoller(blockingPoller, ilog.NewNopLogger(), behavior, "a", nil)
+		slotSupplier := newLimitedSlotSupplier(2)
 
-	bw := newBaseWorker(baseWorkerOptions{
-		slotSupplier:     slotSupplier,
-		maxTaskPerSecond: 1000,
-		taskPollers: []scalableTaskPoller{
-			poller,
-			{taskPollerType: "b"},
-		},
-		taskProcessor:  noopTaskProcessor{},
-		workerType:     "AutoscalingBalancerTest",
-		logger:         ilog.NewNopLogger(),
-		stopTimeout:    time.Second,
-		metricsHandler: metrics.NopHandler,
+		bw := newBaseWorker(baseWorkerOptions{
+			slotSupplier:     slotSupplier,
+			maxTaskPerSecond: 1000,
+			taskPollers: []scalableTaskPoller{
+				poller,
+				{taskPollerType: "b"},
+			},
+			taskProcessor:  noopTaskProcessor{},
+			workerType:     "AutoscalingBalancerTest",
+			logger:         ilog.NewNopLogger(),
+			stopTimeout:    time.Second,
+			metricsHandler: metrics.NopHandler,
+		})
+
+		bw.Start()
+		defer func() {
+			blockingPoller.Allow(readAutoscalingPollerState(poller.autoscalingRunner))
+			blockingPoller.Close()
+			bw.Stop()
+		}()
+
+		assertAutoscalingPollerState(t, poller.autoscalingRunner, 1, "expected first poller to start")
+		require.Equal(t, int32(1), slotSupplier.reserves.Load(),
+			"autoscaling poller should not reserve another slot while blocked by poller balancer")
 	})
-
-	bw.Start()
-	defer func() {
-		blockingPoller.Allow(readAutoscalingPollerState(poller.autoscalingRunner))
-		blockingPoller.Close()
-		bw.Stop()
-	}()
-
-	eventuallyAutoscalingPollerState(s.T(), poller.autoscalingRunner, 1, "expected first poller to start")
-
-	require.Never(s.T(), func() bool {
-		return slotSupplier.reserves.Load() > 1
-	}, 200*time.Millisecond, 10*time.Millisecond,
-		"autoscaling poller should not reserve another slot while blocked by poller balancer")
 }
 
 type blockingProbeTaskPoller struct {
@@ -546,6 +546,11 @@ func eventuallyAutoscalingPollerState(t *testing.T, runner *autoscalingTaskPolle
 	require.Eventually(t, func() bool {
 		return readAutoscalingPollerState(runner) == expectedActive
 	}, time.Second, 10*time.Millisecond, msg)
+}
+
+func assertAutoscalingPollerState(t *testing.T, runner *autoscalingTaskPollerRunner, expectedActive int, msg string) {
+	synctest.Wait()
+	require.Equal(t, expectedActive, readAutoscalingPollerState(runner), msg)
 }
 
 func readAutoscalingPollerState(runner *autoscalingTaskPollerRunner) int {
@@ -658,136 +663,142 @@ func (noopTaskProcessor) ProcessTask(any) error { return nil }
 // poller receives a task during shutdown, the task is still dispatched and
 // processed rather than silently dropped.
 func TestTaskNotDroppedDuringShutdown(t *testing.T) {
-	taskProcessed := make(chan struct{}, 1)
-	pollStarted := make(chan struct{}, 1)
+	synctest.Test(t, func(t *testing.T) {
+		taskProcessed := make(chan struct{}, 1)
+		pollStarted := make(chan struct{}, 1)
 
-	// A poller that blocks until returnTask is closed, then returns a task
-	// exactly once. Subsequent polls return nil so the poller can exit.
-	tp := &shutdownTaskPoller{
-		pollStarted: pollStarted,
-		returnTask:  make(chan struct{}),
-		task:        &testTask{},
-	}
+		// A poller that blocks until returnTask is closed, then returns a task
+		// exactly once. Subsequent polls return nil so the poller can exit.
+		tp := &shutdownTaskPoller{
+			pollStarted: pollStarted,
+			returnTask:  make(chan struct{}),
+			task:        &testTask{},
+		}
 
-	processor := &recordingTaskProcessor{
-		processed: taskProcessed,
-	}
-	workerPollCompleteOnShutdown := &atomic.Bool{}
-	workerPollCompleteOnShutdown.Store(true)
+		processor := &recordingTaskProcessor{
+			processed: taskProcessed,
+		}
+		workerPollCompleteOnShutdown := &atomic.Bool{}
+		workerPollCompleteOnShutdown.Store(true)
 
-	bw := newBaseWorker(baseWorkerOptions{
-		slotSupplier:     &testSlotSupplier{},
-		maxTaskPerSecond: 1000,
-		taskPollers: []scalableTaskPoller{
-			{taskPollerType: "test", pollerCount: 1, taskPoller: tp},
-		},
-		taskProcessor:                processor,
-		workerType:                   "ShutdownTest",
-		logger:                       ilog.NewNopLogger(),
-		stopTimeout:                  5 * time.Second,
-		metricsHandler:               metrics.NopHandler,
-		workerPollCompleteOnShutdown: workerPollCompleteOnShutdown,
+		bw := newBaseWorker(baseWorkerOptions{
+			slotSupplier:     &testSlotSupplier{},
+			maxTaskPerSecond: 1000,
+			taskPollers: []scalableTaskPoller{
+				{taskPollerType: "test", pollerCount: 1, taskPoller: tp},
+			},
+			taskProcessor:                processor,
+			workerType:                   "ShutdownTest",
+			logger:                       ilog.NewNopLogger(),
+			stopTimeout:                  5 * time.Second,
+			metricsHandler:               metrics.NopHandler,
+			workerPollCompleteOnShutdown: workerPollCompleteOnShutdown,
+		})
+
+		bw.Start()
+
+		// Wait for the poller to be actively polling.
+		<-pollStarted
+
+		// AggregatedWorker.Stop sets noRepoll before stopping base workers.
+		bw.noRepoll.Store(true)
+
+		// Stop exercises the base worker shutdown path: close(stopCh),
+		// poll-side limiter cancellation, and awaitWaitGroup.
+		stopDone := make(chan struct{})
+		go func() {
+			bw.Stop()
+			close(stopDone)
+		}()
+
+		<-bw.stopCh
+
+		// Release the poller after shutdown has started so the task is polled
+		// during shutdown. The poller returns a task and then nil on subsequent
+		// polls, allowing it to exit via noRepoll/stopCh during Stop().
+		close(tp.returnTask)
+		synctest.Wait()
+
+		select {
+		case <-taskProcessed:
+			// Success: the task was dispatched and processed during shutdown
+		default:
+			t.Fatal("task polled during shutdown was not processed (dropped)")
+		}
+
+		select {
+		case <-stopDone:
+			// Stop completed cleanly
+		default:
+			t.Fatal("Stop() did not return after the poller completed")
+		}
 	})
-
-	bw.Start()
-
-	// Wait for the poller to be actively polling.
-	<-pollStarted
-
-	// AggregatedWorker.Stop sets noRepoll before stopping base workers.
-	bw.noRepoll.Store(true)
-
-	// Stop exercises the base worker shutdown path: close(stopCh),
-	// poll-side limiter cancellation, and awaitWaitGroup.
-	stopDone := make(chan struct{})
-	go func() {
-		bw.Stop()
-		close(stopDone)
-	}()
-
-	<-bw.stopCh
-
-	// Release the poller after shutdown has started so the task is polled
-	// during shutdown. The poller returns a task and then nil on subsequent
-	// polls, allowing it to exit via noRepoll/stopCh during Stop().
-	close(tp.returnTask)
-
-	select {
-	case <-taskProcessed:
-		// Success: the task was dispatched and processed during shutdown
-	case <-time.After(5 * time.Second):
-		t.Fatal("task polled during shutdown was not processed (dropped)")
-	}
-
-	select {
-	case <-stopDone:
-		// Stop completed cleanly
-	case <-time.After(5 * time.Second):
-		t.Fatal("Stop() did not return in time")
-	}
 }
 
 func TestAutoscalingTaskNotDroppedDuringShutdown(t *testing.T) {
-	taskProcessed := make(chan struct{}, 1)
-	pollStarted := make(chan struct{}, 1)
-	tp := &shutdownTaskPoller{
-		pollStarted: pollStarted,
-		returnTask:  make(chan struct{}),
-		task:        &testTask{},
-	}
-	processor := &recordingTaskProcessor{
-		processed: taskProcessed,
-	}
-	workerPollCompleteOnShutdown := &atomic.Bool{}
-	workerPollCompleteOnShutdown.Store(true)
-	poller := newScalableTaskPoller(
-		tp,
-		ilog.NewNopLogger(),
-		&pollerBehaviorAutoscaling{
-			initialNumberOfPollers: 1,
-			maximumNumberOfPollers: 2,
-			minimumNumberOfPollers: 1,
-		},
-		"test",
-		&atomic.Bool{},
-	)
+	synctest.Test(t, func(t *testing.T) {
+		taskProcessed := make(chan struct{}, 1)
+		pollStarted := make(chan struct{}, 1)
+		tp := &shutdownTaskPoller{
+			pollStarted: pollStarted,
+			returnTask:  make(chan struct{}),
+			task:        &testTask{},
+		}
+		processor := &recordingTaskProcessor{
+			processed: taskProcessed,
+		}
+		workerPollCompleteOnShutdown := &atomic.Bool{}
+		workerPollCompleteOnShutdown.Store(true)
+		poller := newScalableTaskPoller(
+			tp,
+			ilog.NewNopLogger(),
+			&pollerBehaviorAutoscaling{
+				initialNumberOfPollers: 1,
+				maximumNumberOfPollers: 2,
+				minimumNumberOfPollers: 1,
+			},
+			"test",
+			&atomic.Bool{},
+		)
 
-	bw := newBaseWorker(baseWorkerOptions{
-		slotSupplier:                 &testSlotSupplier{},
-		maxTaskPerSecond:             1000,
-		taskPollers:                  []scalableTaskPoller{poller},
-		taskProcessor:                processor,
-		workerType:                   "AutoscalingShutdownTest",
-		logger:                       ilog.NewNopLogger(),
-		stopTimeout:                  5 * time.Second,
-		metricsHandler:               metrics.NopHandler,
-		workerPollCompleteOnShutdown: workerPollCompleteOnShutdown,
+		bw := newBaseWorker(baseWorkerOptions{
+			slotSupplier:                 &testSlotSupplier{},
+			maxTaskPerSecond:             1000,
+			taskPollers:                  []scalableTaskPoller{poller},
+			taskProcessor:                processor,
+			workerType:                   "AutoscalingShutdownTest",
+			logger:                       ilog.NewNopLogger(),
+			stopTimeout:                  5 * time.Second,
+			metricsHandler:               metrics.NopHandler,
+			workerPollCompleteOnShutdown: workerPollCompleteOnShutdown,
+		})
+
+		bw.Start()
+		<-pollStarted
+		bw.noRepoll.Store(true)
+
+		stopDone := make(chan struct{})
+		go func() {
+			bw.Stop()
+			close(stopDone)
+		}()
+
+		<-bw.stopCh
+		close(tp.returnTask)
+		synctest.Wait()
+
+		select {
+		case <-taskProcessed:
+		default:
+			t.Fatal("task polled during autoscaling shutdown was not processed")
+		}
+
+		select {
+		case <-stopDone:
+		default:
+			t.Fatal("Stop() did not return after the poller completed")
+		}
 	})
-
-	bw.Start()
-	<-pollStarted
-	bw.noRepoll.Store(true)
-
-	stopDone := make(chan struct{})
-	go func() {
-		bw.Stop()
-		close(stopDone)
-	}()
-
-	<-bw.stopCh
-	close(tp.returnTask)
-
-	select {
-	case <-taskProcessed:
-	case <-time.After(5 * time.Second):
-		t.Fatal("task polled during autoscaling shutdown was not processed")
-	}
-
-	select {
-	case <-stopDone:
-	case <-time.After(5 * time.Second):
-		t.Fatal("Stop() did not return in time")
-	}
 }
 
 // effectivelyBlockedDispatchRate lets the first task consume the limiter's
@@ -796,117 +807,126 @@ func TestAutoscalingTaskNotDroppedDuringShutdown(t *testing.T) {
 const effectivelyBlockedDispatchRate = 0.001
 
 func TestTaskDrainDuringShutdownRespectsDispatchRate(t *testing.T) {
-	taskProcessed := make(chan struct{}, 2)
-	workerPollCompleteOnShutdown := &atomic.Bool{}
-	workerPollCompleteOnShutdown.Store(true)
+	synctest.Test(t, func(t *testing.T) {
+		taskProcessed := make(chan struct{}, 2)
+		workerPollCompleteOnShutdown := &atomic.Bool{}
+		workerPollCompleteOnShutdown.Store(true)
 
-	bw := newBaseWorker(baseWorkerOptions{
-		slotSupplier:                 &testSlotSupplier{},
-		maxTaskPerSecond:             effectivelyBlockedDispatchRate,
-		taskPollers:                  []scalableTaskPoller{},
-		taskProcessor:                &recordingTaskProcessor{processed: taskProcessed},
-		workerType:                   "ShutdownRateLimitTest",
-		logger:                       ilog.NewNopLogger(),
-		stopTimeout:                  5 * time.Second,
-		metricsHandler:               metrics.NopHandler,
-		workerPollCompleteOnShutdown: workerPollCompleteOnShutdown,
-	})
+		bw := newBaseWorker(baseWorkerOptions{
+			slotSupplier:                 &testSlotSupplier{},
+			maxTaskPerSecond:             effectivelyBlockedDispatchRate,
+			taskPollers:                  []scalableTaskPoller{},
+			taskProcessor:                &recordingTaskProcessor{processed: taskProcessed},
+			workerType:                   "ShutdownRateLimitTest",
+			logger:                       ilog.NewNopLogger(),
+			stopTimeout:                  5 * time.Second,
+			metricsHandler:               metrics.NopHandler,
+			workerPollCompleteOnShutdown: workerPollCompleteOnShutdown,
+		})
 
-	bw.stopWG.Add(1)
-	go bw.runTaskDispatcher()
-	bw.taskQueueCh <- &polledTask{task: &testTask{}, permit: &SlotPermit{}}
-
-	select {
-	case <-taskProcessed:
-	case <-time.After(time.Second):
-		t.Fatal("first task polled during shutdown was not processed")
-	}
-
-	secondSent := make(chan struct{})
-	go func() {
+		bw.stopWG.Add(1)
+		go bw.runTaskDispatcher()
 		bw.taskQueueCh <- &polledTask{task: &testTask{}, permit: &SlotPermit{}}
-		close(secondSent)
-	}()
-	select {
-	case <-secondSent:
-	case <-time.After(time.Second):
-		t.Fatal("dispatcher did not receive the second task")
-	}
+		synctest.Wait()
 
-	select {
-	case <-taskProcessed:
-		t.Fatal("second task should not bypass the dispatch rate during shutdown drain")
-	case <-time.After(200 * time.Millisecond):
-	}
+		select {
+		case <-taskProcessed:
+		default:
+			t.Fatal("first task polled during shutdown was not processed")
+		}
 
-	bw.taskLimiterContextCancel()
-	close(bw.taskQueueCh)
+		secondSent := make(chan struct{})
+		go func() {
+			bw.taskQueueCh <- &polledTask{task: &testTask{}, permit: &SlotPermit{}}
+			close(secondSent)
+		}()
+		synctest.Wait()
+		select {
+		case <-secondSent:
+		default:
+			t.Fatal("dispatcher did not receive the second task")
+		}
 
-	require.True(t, awaitWaitGroup(&bw.stopWG, time.Second),
-		"dispatcher and processed tasks should finish after taskQueueCh closes")
+		time.Sleep(200 * time.Millisecond)
+		synctest.Wait()
+		select {
+		case <-taskProcessed:
+			t.Fatal("second task should not bypass the dispatch rate during shutdown drain")
+		default:
+		}
+
+		bw.taskLimiterContextCancel()
+		close(bw.taskQueueCh)
+		synctest.Wait()
+		bw.stopWG.Wait()
+	})
 }
 
 func TestTaskDrainAfterDispatchLimiterCancelReleasesUnprocessedTasks(t *testing.T) {
-	taskProcessed := make(chan struct{}, 3)
-	workerPollCompleteOnShutdown := &atomic.Bool{}
-	workerPollCompleteOnShutdown.Store(true)
-	slotSupplier := &CountingSlotSupplier{}
+	synctest.Test(t, func(t *testing.T) {
+		taskProcessed := make(chan struct{}, 3)
+		workerPollCompleteOnShutdown := &atomic.Bool{}
+		workerPollCompleteOnShutdown.Store(true)
+		slotSupplier := &CountingSlotSupplier{}
 
-	bw := newBaseWorker(baseWorkerOptions{
-		slotSupplier:                 slotSupplier,
-		maxTaskPerSecond:             effectivelyBlockedDispatchRate,
-		taskPollers:                  []scalableTaskPoller{},
-		taskProcessor:                &recordingTaskProcessor{processed: taskProcessed},
-		workerType:                   "ShutdownTimeoutDrainTest",
-		logger:                       ilog.NewNopLogger(),
-		stopTimeout:                  5 * time.Second,
-		metricsHandler:               metrics.NopHandler,
-		workerPollCompleteOnShutdown: workerPollCompleteOnShutdown,
+		bw := newBaseWorker(baseWorkerOptions{
+			slotSupplier:                 slotSupplier,
+			maxTaskPerSecond:             effectivelyBlockedDispatchRate,
+			taskPollers:                  []scalableTaskPoller{},
+			taskProcessor:                &recordingTaskProcessor{processed: taskProcessed},
+			workerType:                   "ShutdownTimeoutDrainTest",
+			logger:                       ilog.NewNopLogger(),
+			stopTimeout:                  5 * time.Second,
+			metricsHandler:               metrics.NopHandler,
+			workerPollCompleteOnShutdown: workerPollCompleteOnShutdown,
+		})
+
+		bw.stopWG.Add(1)
+		go bw.runTaskDispatcher()
+		bw.taskQueueCh <- &polledTask{task: &testTask{}, permit: &SlotPermit{}}
+		synctest.Wait()
+
+		select {
+		case <-taskProcessed:
+		default:
+			t.Fatal("first task polled during shutdown was not processed")
+		}
+
+		secondSent := make(chan struct{})
+		go func() {
+			bw.taskQueueCh <- &polledTask{task: &testTask{}, permit: &SlotPermit{}}
+			close(secondSent)
+		}()
+		synctest.Wait()
+		select {
+		case <-secondSent:
+		default:
+			t.Fatal("dispatcher did not receive the second task")
+		}
+
+		thirdSent := make(chan struct{})
+		go func() {
+			bw.taskQueueCh <- &polledTask{task: &testTask{}, permit: &SlotPermit{}}
+			close(thirdSent)
+		}()
+
+		bw.taskLimiterContextCancel()
+		synctest.Wait()
+		select {
+		case <-thirdSent:
+		default:
+			t.Fatal("dispatcher did not keep receiving after dispatch limiter cancellation")
+		}
+		close(bw.taskQueueCh)
+		synctest.Wait()
+		bw.stopWG.Wait()
+		require.Empty(t, taskProcessed,
+			"only the task dispatched before dispatch limiter cancellation should be processed")
+		require.Equal(t, int32(1), slotSupplier.uses.Load(),
+			"only the processed task should mark its slot used")
+		require.Equal(t, int32(3), slotSupplier.releases.Load(),
+			"processed and discarded tasks should all release their slots")
 	})
-
-	bw.stopWG.Add(1)
-	go bw.runTaskDispatcher()
-	bw.taskQueueCh <- &polledTask{task: &testTask{}, permit: &SlotPermit{}}
-
-	select {
-	case <-taskProcessed:
-	case <-time.After(time.Second):
-		t.Fatal("first task polled during shutdown was not processed")
-	}
-
-	secondSent := make(chan struct{})
-	go func() {
-		bw.taskQueueCh <- &polledTask{task: &testTask{}, permit: &SlotPermit{}}
-		close(secondSent)
-	}()
-	select {
-	case <-secondSent:
-	case <-time.After(time.Second):
-		t.Fatal("dispatcher did not receive the second task")
-	}
-
-	thirdSent := make(chan struct{})
-	go func() {
-		bw.taskQueueCh <- &polledTask{task: &testTask{}, permit: &SlotPermit{}}
-		close(thirdSent)
-	}()
-
-	bw.taskLimiterContextCancel()
-	select {
-	case <-thirdSent:
-	case <-time.After(time.Second):
-		t.Fatal("dispatcher did not keep receiving after dispatch limiter cancellation")
-	}
-	close(bw.taskQueueCh)
-
-	require.True(t, awaitWaitGroup(&bw.stopWG, time.Second),
-		"dispatcher should keep receiving and releasing tasks after dispatch limiter cancellation so pollers can exit")
-	require.Empty(t, taskProcessed,
-		"only the task dispatched before dispatch limiter cancellation should be processed")
-	require.Equal(t, int32(1), slotSupplier.uses.Load(),
-		"only the processed task should mark its slot used")
-	require.Equal(t, int32(3), slotSupplier.releases.Load(),
-		"processed and discarded tasks should all release their slots")
 }
 
 func TestTaskNotProcessedDuringLegacyShutdown(t *testing.T) {
@@ -925,61 +945,70 @@ func TestTaskNotProcessedDuringLegacyShutdown(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			taskProcessed := make(chan struct{}, 1)
-			pollStarted := make(chan struct{}, 1)
+			synctest.Test(t, func(t *testing.T) {
+				taskProcessed := make(chan struct{}, 1)
+				pollStarted := make(chan struct{}, 1)
 
-			// This poller simulates a poll returning a task after shutdown has
-			// already started. Legacy shutdown should not dispatch that task.
-			tp := &shutdownTaskPoller{
-				pollStarted: pollStarted,
-				returnTask:  make(chan struct{}),
-				task:        &testTask{},
-			}
+				// This poller simulates a poll returning a task after shutdown has
+				// already started. Legacy shutdown should not dispatch that task.
+				tp := &shutdownTaskPoller{
+					pollStarted: pollStarted,
+					returnTask:  make(chan struct{}),
+					task:        &testTask{},
+				}
 
-			bw := newBaseWorker(baseWorkerOptions{
-				slotSupplier:     &testSlotSupplier{},
-				maxTaskPerSecond: 1000,
-				taskPollers: []scalableTaskPoller{
-					{taskPollerType: "test", pollerCount: 1, taskPoller: tp},
-				},
-				taskProcessor:                &recordingTaskProcessor{processed: taskProcessed},
-				workerType:                   "LegacyShutdownTest",
-				logger:                       ilog.NewNopLogger(),
-				stopTimeout:                  5 * time.Second,
-				metricsHandler:               metrics.NopHandler,
-				workerPollCompleteOnShutdown: tt.workerPollCompleteOnShutdown,
+				bw := newBaseWorker(baseWorkerOptions{
+					slotSupplier:     &testSlotSupplier{},
+					maxTaskPerSecond: 1000,
+					taskPollers: []scalableTaskPoller{
+						{taskPollerType: "test", pollerCount: 1, taskPoller: tp},
+					},
+					taskProcessor:                &recordingTaskProcessor{processed: taskProcessed},
+					workerType:                   "LegacyShutdownTest",
+					logger:                       ilog.NewNopLogger(),
+					stopTimeout:                  5 * time.Second,
+					metricsHandler:               metrics.NopHandler,
+					workerPollCompleteOnShutdown: tt.workerPollCompleteOnShutdown,
+				})
+
+				bw.Start()
+				synctest.Wait()
+				select {
+				case <-pollStarted:
+				default:
+					t.Fatal("poller did not start before the system became quiescent")
+				}
+
+				// AggregatedWorker.Stop sets noRepoll before stopping base workers.
+				bw.noRepoll.Store(true)
+
+				stopDone := make(chan struct{})
+				go func() {
+					bw.Stop()
+					close(stopDone)
+				}()
+
+				synctest.Wait()
+				select {
+				case <-bw.stopCh:
+				default:
+					t.Fatal("shutdown did not start")
+				}
+				close(tp.returnTask)
+				synctest.Wait()
+
+				select {
+				case <-stopDone:
+				default:
+					t.Fatal("Stop() did not return after the poller completed")
+				}
+
+				select {
+				case <-taskProcessed:
+					t.Fatal("task polled during legacy shutdown was processed")
+				default:
+				}
 			})
-
-			bw.Start()
-			select {
-			case <-pollStarted:
-			case <-time.After(5 * time.Second):
-				t.Fatal("poller did not start in time")
-			}
-
-			// AggregatedWorker.Stop sets noRepoll before stopping base workers.
-			bw.noRepoll.Store(true)
-
-			stopDone := make(chan struct{})
-			go func() {
-				bw.Stop()
-				close(stopDone)
-			}()
-
-			<-bw.stopCh
-			close(tp.returnTask)
-
-			select {
-			case <-stopDone:
-			case <-time.After(5 * time.Second):
-				t.Fatal("Stop() did not return in time")
-			}
-
-			select {
-			case <-taskProcessed:
-				t.Fatal("task polled during legacy shutdown was processed")
-			default:
-			}
 		})
 	}
 }
@@ -1232,37 +1261,34 @@ func TestPollerBalancerReturnsNilWhenOwnCountZero(t *testing.T) {
 // behavior: balance() blocks when another poller type has no active pollers, and
 // unblocks once that type starts a poller.
 func TestPollerBalancerBlocksWhenOtherTypeHasNoPollers(t *testing.T) {
-	pb := &pollerBalancer{
-		pollerCount:   make(map[string]int),
-		pollerBarrier: make(map[string]barrier),
-	}
-	pb.registerPollerType("sticky")
-	pb.registerPollerType("non-sticky")
+	synctest.Test(t, func(t *testing.T) {
+		pb := &pollerBalancer{
+			pollerCount:   make(map[string]int),
+			pollerBarrier: make(map[string]barrier),
+		}
+		pb.registerPollerType("sticky")
+		pb.registerPollerType("non-sticky")
 
-	// sticky has 1 poller, non-sticky has 0 — balance("sticky") should block.
-	pb.incrementPoller("sticky")
+		// sticky has 1 poller, non-sticky has 0 — balance("sticky") should block.
+		pb.incrementPoller("sticky")
 
-	done := make(chan error, 1)
-	go func() {
-		done <- pb.balance(context.Background(), "sticky")
-	}()
+		done := make(chan error, 1)
+		go func() {
+			done <- pb.balance(context.Background(), "sticky")
+		}()
 
-	// Verify it's still blocked.
-	select {
-	case <-done:
-		t.Fatal("balance should be blocking")
-	case <-time.After(50 * time.Millisecond):
-	}
+		synctest.Wait()
+		select {
+		case <-done:
+			t.Fatal("balance should be blocking")
+		default:
+		}
 
-	// Start a non-sticky poller — this should unblock balance.
-	pb.incrementPoller("non-sticky")
-
-	select {
-	case err := <-done:
-		require.NoError(t, err)
-	case <-time.After(time.Second):
-		t.Fatal("balance should have returned after non-sticky poller started")
-	}
+		// Start a non-sticky poller — this should unblock balance.
+		pb.incrementPoller("non-sticky")
+		synctest.Wait()
+		require.NoError(t, <-done)
+	})
 }
 
 func (s *ScalableTaskPollerSuite) TestNewScalableTaskPollerAllTypes() {

--- a/internal/internal_worker_base_test.go
+++ b/internal/internal_worker_base_test.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -1017,96 +1018,83 @@ func (p *recordingTaskProcessor) ProcessTask(any) error {
 }
 
 func TestStopTimeoutBoundsPollerDrain(t *testing.T) {
-	pollStarted := make(chan struct{}, 1)
-	releasePoll := make(chan struct{})
-	var releasePollOnce sync.Once
-	releaseBlockedPoller := func() {
-		releasePollOnce.Do(func() {
-			close(releasePoll)
+	synctest.Test(t, func(t *testing.T) {
+		pollStarted := make(chan struct{}, 1)
+		releasePoll := make(chan struct{})
+		var releasePollOnce sync.Once
+		releaseBlockedPoller := func() {
+			releasePollOnce.Do(func() {
+				close(releasePoll)
+			})
+		}
+		defer releaseBlockedPoller()
+		tp := &blockingShutdownPoller{
+			pollStarted: pollStarted,
+			releasePoll: releasePoll,
+		}
+		workerPollCompleteOnShutdown := &atomic.Bool{}
+		workerPollCompleteOnShutdown.Store(true)
+
+		bw := newBaseWorker(baseWorkerOptions{
+			slotSupplier:     &testSlotSupplier{},
+			maxTaskPerSecond: 1000,
+			taskPollers: []scalableTaskPoller{
+				{taskPollerType: "test", pollerCount: 1, taskPoller: tp},
+			},
+			taskProcessor:                noopTaskProcessor{},
+			workerType:                   "StopTimeoutTest",
+			logger:                       ilog.NewNopLogger(),
+			stopTimeout:                  50 * time.Millisecond,
+			metricsHandler:               metrics.NopHandler,
+			workerPollCompleteOnShutdown: workerPollCompleteOnShutdown,
 		})
-	}
-	defer releaseBlockedPoller()
-	tp := &blockingShutdownPoller{
-		pollStarted: pollStarted,
-		releasePoll: releasePoll,
-	}
-	workerPollCompleteOnShutdown := &atomic.Bool{}
-	workerPollCompleteOnShutdown.Store(true)
 
-	bw := newBaseWorker(baseWorkerOptions{
-		slotSupplier:     &testSlotSupplier{},
-		maxTaskPerSecond: 1000,
-		taskPollers: []scalableTaskPoller{
-			{taskPollerType: "test", pollerCount: 1, taskPoller: tp},
-		},
-		taskProcessor:                noopTaskProcessor{},
-		workerType:                   "StopTimeoutTest",
-		logger:                       ilog.NewNopLogger(),
-		stopTimeout:                  50 * time.Millisecond,
-		metricsHandler:               metrics.NopHandler,
-		workerPollCompleteOnShutdown: workerPollCompleteOnShutdown,
-	})
+		bw.Start()
+		<-pollStarted
 
-	bw.Start()
-	<-pollStarted
-
-	stopDone := make(chan struct{})
-	start := time.Now()
-	go func() {
+		start := time.Now()
 		bw.Stop()
-		close(stopDone)
-	}()
-
-	// Stop() should return after stopTimeout (~50ms), not block for the
-	// full pollTaskServiceTimeOut (70s).
-	select {
-	case <-stopDone:
-		elapsed := time.Since(start)
-		require.Less(t, elapsed, time.Second,
+		require.Equal(t, 50*time.Millisecond, time.Since(start),
 			"Stop() should return after stopTimeout, not wait for pollTaskServiceTimeOut")
-	case <-time.After(time.Second):
+
 		releaseBlockedPoller()
 		require.True(t, awaitWaitGroup(&bw.stopWG, time.Second),
 			"worker goroutines should finish after blocked poll is released")
-		t.Fatal("Stop() should return after stopTimeout, not wait for pollTaskServiceTimeOut")
-	}
-
-	releaseBlockedPoller()
-	require.True(t, awaitWaitGroup(&bw.stopWG, time.Second),
-		"worker goroutines should finish after blocked poll is released")
+	})
 }
 
 func TestLegacyStopReturnsPromptlyWithBlockedPoller(t *testing.T) {
-	pollStarted := make(chan struct{}, 1)
-	tp := &stopAwareShutdownPoller{
-		pollStarted: pollStarted,
-	}
+	synctest.Test(t, func(t *testing.T) {
+		pollStarted := make(chan struct{}, 1)
+		tp := &stopAwareShutdownPoller{
+			pollStarted: pollStarted,
+		}
 
-	bw := newBaseWorker(baseWorkerOptions{
-		slotSupplier:     &testSlotSupplier{},
-		maxTaskPerSecond: 1000,
-		taskPollers: []scalableTaskPoller{
-			{taskPollerType: "test", pollerCount: 1, taskPoller: tp},
-		},
-		taskProcessor:                noopTaskProcessor{},
-		workerType:                   "LegacyStopTimeoutTest",
-		logger:                       ilog.NewNopLogger(),
-		stopTimeout:                  5 * time.Second,
-		metricsHandler:               metrics.NopHandler,
-		workerPollCompleteOnShutdown: &atomic.Bool{},
+		bw := newBaseWorker(baseWorkerOptions{
+			slotSupplier:     &testSlotSupplier{},
+			maxTaskPerSecond: 1000,
+			taskPollers: []scalableTaskPoller{
+				{taskPollerType: "test", pollerCount: 1, taskPoller: tp},
+			},
+			taskProcessor:                noopTaskProcessor{},
+			workerType:                   "LegacyStopTimeoutTest",
+			logger:                       ilog.NewNopLogger(),
+			stopTimeout:                  5 * time.Second,
+			metricsHandler:               metrics.NopHandler,
+			workerPollCompleteOnShutdown: &atomic.Bool{},
+		})
+		tp.stopC = bw.stopCh
+
+		bw.Start()
+		<-pollStarted
+
+		start := time.Now()
+		bw.Stop()
+
+		require.Zero(t, time.Since(start),
+			"legacy Stop() should return promptly when a blocked poll observes shutdown")
+		require.True(t, tp.stopped.Load(), "blocked poller should observe shutdown")
 	})
-	tp.stopC = bw.stopCh
-
-	bw.Start()
-	<-pollStarted
-
-	start := time.Now()
-	bw.Stop()
-	elapsed := time.Since(start)
-
-	require.Less(t, elapsed, time.Second,
-		"legacy Stop() should return promptly when a blocked poll observes shutdown")
-	require.True(t, tp.stopped.Load(), "blocked poller should observe shutdown")
 }
 
 type blockingShutdownPoller struct {

--- a/internal/internal_worker_heartbeat_test.go
+++ b/internal/internal_worker_heartbeat_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/golang/mock/gomock"
@@ -28,61 +29,49 @@ import (
 // (heartbeatCtx), stop() cancels the context first, unblocking the RPC.
 func TestStopCancelsInFlightHeartbeatRPC(t *testing.T) {
 	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockService := workflowservicemock.NewMockWorkflowServiceClient(ctrl)
 
-	ctrl := gomock.NewController(t)
-	mockService := workflowservicemock.NewMockWorkflowServiceClient(ctrl)
+		mockService.EXPECT().GetSystemInfo(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(&workflowservice.GetSystemInfoResponse{}, nil).AnyTimes()
 
-	mockService.EXPECT().GetSystemInfo(gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(&workflowservice.GetSystemInfoResponse{}, nil).AnyTimes()
+		// Simulate an RPC that blocks until its context is cancelled.
+		heartbeatStarted := false
+		mockService.EXPECT().RecordWorkerHeartbeat(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, _ *workflowservice.RecordWorkerHeartbeatRequest, _ ...grpc.CallOption) (*workflowservice.RecordWorkerHeartbeatResponse, error) {
+				heartbeatStarted = true
+				<-ctx.Done()
+				return nil, ctx.Err()
+			}).AnyTimes()
 
-	// Simulate an RPC that blocks until its context is cancelled.
-	heartbeatStarted := make(chan struct{})
-	mockService.EXPECT().RecordWorkerHeartbeat(gomock.Any(), gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, _ *workflowservice.RecordWorkerHeartbeatRequest, _ ...grpc.CallOption) (*workflowservice.RecordWorkerHeartbeatResponse, error) {
-			close(heartbeatStarted)
-			<-ctx.Done()
-			return nil, ctx.Err()
-		}).AnyTimes()
+		wfClient := NewServiceClient(mockService, nil, ClientOptions{})
 
-	wfClient := NewServiceClient(mockService, nil, ClientOptions{})
+		heartbeatCtx, heartbeatCancel := context.WithCancel(context.Background())
+		hw := &sharedNamespaceWorker{
+			client:          wfClient,
+			namespace:       "test-ns",
+			interval:        50 * time.Millisecond,
+			workerCtx:       heartbeatCtx,
+			heartbeatCancel: heartbeatCancel,
+			callbacks: map[string]func() *workerpb.WorkerHeartbeat{
+				"worker1": func() *workerpb.WorkerHeartbeat { return &workerpb.WorkerHeartbeat{} },
+			},
+			stopC:    make(chan struct{}),
+			stoppedC: make(chan struct{}),
+			logger:   ilog.NewDefaultLogger(),
+		}
+		hw.started.Store(true)
+		go hw.run()
 
-	heartbeatCtx, heartbeatCancel := context.WithCancel(context.Background())
-	hw := &sharedNamespaceWorker{
-		client:          wfClient,
-		namespace:       "test-ns",
-		interval:        50 * time.Millisecond,
-		workerCtx:       heartbeatCtx,
-		heartbeatCancel: heartbeatCancel,
-		callbacks: map[string]func() *workerpb.WorkerHeartbeat{
-			"worker1": func() *workerpb.WorkerHeartbeat { return &workerpb.WorkerHeartbeat{} },
-		},
-		stopC:    make(chan struct{}),
-		stoppedC: make(chan struct{}),
-		logger:   ilog.NewDefaultLogger(),
-	}
-	hw.started.Store(true)
-	go hw.run()
+		synctest.Wait()
+		if !heartbeatStarted {
+			t.Fatal("heartbeat RPC did not start")
+		}
 
-	// Wait for the heartbeat RPC to be in-flight.
-	select {
-	case <-heartbeatStarted:
-	case <-time.After(5 * time.Second):
-		t.Fatal("timed out waiting for heartbeat RPC to start")
-	}
-
-	// stop() should return promptly because heartbeatCancel() unblocks the
-	// in-flight RPC. Without the fix, this hangs forever.
-	done := make(chan struct{})
-	go func() {
+		// stop() should return because heartbeatCancel() unblocks the in-flight RPC.
 		hw.stop()
-		close(done)
-	}()
-
-	select {
-	case <-done:
-	case <-time.After(5 * time.Second):
-		t.Fatal("timed out waiting for stop() — in-flight heartbeat RPC was not cancelled")
-	}
+	})
 }
 
 func TestWorkerCommandPollUsesWorkerCommandsQueue(t *testing.T) {
@@ -214,75 +203,75 @@ func TestWorkerCommandCancelActivity(t *testing.T) {
 
 func TestWorkerCommandsDisabledDoesNotPoll(t *testing.T) {
 	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockService := workflowservicemock.NewMockWorkflowServiceClient(ctrl)
+		mockService.EXPECT().GetSystemInfo(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(&workflowservice.GetSystemInfoResponse{}, nil).AnyTimes()
+		mockService.EXPECT().RecordWorkerHeartbeat(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(&workflowservice.RecordWorkerHeartbeatResponse{}, nil).AnyTimes()
+		wfClient := NewServiceClient(mockService, nil, ClientOptions{
+			Namespace: "test-ns",
+			Identity:  "worker-identity",
+		})
 
-	ctrl := gomock.NewController(t)
-	mockService := workflowservicemock.NewMockWorkflowServiceClient(ctrl)
-	mockService.EXPECT().GetSystemInfo(gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(&workflowservice.GetSystemInfoResponse{}, nil).AnyTimes()
-	mockService.EXPECT().RecordWorkerHeartbeat(gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(&workflowservice.RecordWorkerHeartbeatResponse{}, nil).AnyTimes()
-	wfClient := NewServiceClient(mockService, nil, ClientOptions{
-		Namespace: "test-ns",
-		Identity:  "worker-identity",
+		heartbeatCtx, heartbeatCancel := context.WithCancel(context.Background())
+		hw := &sharedNamespaceWorker{
+			client:                  wfClient,
+			namespace:               "test-ns",
+			interval:                10 * time.Millisecond,
+			workerCtx:               heartbeatCtx,
+			heartbeatCancel:         heartbeatCancel,
+			callbacks:               map[string]func() *workerpb.WorkerHeartbeat{"worker1": func() *workerpb.WorkerHeartbeat { return &workerpb.WorkerHeartbeat{} }},
+			workerCommandsSupported: false,
+			workerControlTaskQueue:  "temporal-sys/worker-commands/test-ns/grouping-key",
+			workerInstanceKey:       "worker-command-worker",
+			metricsHandler:          metrics.NopHandler,
+			stopC:                   make(chan struct{}),
+			stoppedC:                make(chan struct{}),
+			logger:                  ilog.NewDefaultLogger(),
+		}
+		hw.started.Store(true)
+		go hw.run()
+		time.Sleep(25 * time.Millisecond)
+		hw.stop()
 	})
-
-	heartbeatCtx, heartbeatCancel := context.WithCancel(context.Background())
-	hw := &sharedNamespaceWorker{
-		client:                  wfClient,
-		namespace:               "test-ns",
-		interval:                10 * time.Millisecond,
-		workerCtx:               heartbeatCtx,
-		heartbeatCancel:         heartbeatCancel,
-		callbacks:               map[string]func() *workerpb.WorkerHeartbeat{"worker1": func() *workerpb.WorkerHeartbeat { return &workerpb.WorkerHeartbeat{} }},
-		workerCommandsSupported: false,
-		workerControlTaskQueue:  "temporal-sys/worker-commands/test-ns/grouping-key",
-		workerInstanceKey:       "worker-command-worker",
-		metricsHandler:          metrics.NopHandler,
-		stopC:                   make(chan struct{}),
-		stoppedC:                make(chan struct{}),
-		logger:                  ilog.NewDefaultLogger(),
-	}
-	hw.started.Store(true)
-	go hw.run()
-	time.Sleep(25 * time.Millisecond)
-	hw.stop()
 }
 
 func TestWorkerHeartbeatSendsImmediatelyWithIdentity(t *testing.T) {
 	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockService := workflowservicemock.NewMockWorkflowServiceClient(ctrl)
 
-	ctrl := gomock.NewController(t)
-	mockService := workflowservicemock.NewMockWorkflowServiceClient(ctrl)
+		mockService.EXPECT().GetSystemInfo(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(&workflowservice.GetSystemInfoResponse{}, nil).AnyTimes()
 
-	mockService.EXPECT().GetSystemInfo(gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(&workflowservice.GetSystemInfoResponse{}, nil).AnyTimes()
+		var request *workflowservice.RecordWorkerHeartbeatRequest
+		mockService.EXPECT().RecordWorkerHeartbeat(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, req *workflowservice.RecordWorkerHeartbeatRequest, _ ...grpc.CallOption) (*workflowservice.RecordWorkerHeartbeatResponse, error) {
+				request = req
+				return &workflowservice.RecordWorkerHeartbeatResponse{}, nil
+			}).AnyTimes()
 
-	requestCh := make(chan *workflowservice.RecordWorkerHeartbeatRequest, 1)
-	mockService.EXPECT().RecordWorkerHeartbeat(gomock.Any(), gomock.Any(), gomock.Any()).
-		DoAndReturn(func(_ context.Context, request *workflowservice.RecordWorkerHeartbeatRequest, _ ...grpc.CallOption) (*workflowservice.RecordWorkerHeartbeatResponse, error) {
-			select {
-			case requestCh <- request:
-			default:
-			}
-			return &workflowservice.RecordWorkerHeartbeatResponse{}, nil
-		}).AnyTimes()
+		wfClient := NewServiceClient(mockService, nil, ClientOptions{
+			Namespace:               "test-ns",
+			Identity:                "test-client-identity",
+			WorkerHeartbeatInterval: time.Minute,
+		})
+		wfClient.namespaceData = &namespaceData{
+			capabilities: &namespacepb.NamespaceInfo_Capabilities{WorkerHeartbeats: true},
+		}
+		worker := NewAggregatedWorker(wfClient, "test-task-queue", WorkerOptions{})
+		if err := worker.registerHeartbeatWorker(); err != nil {
+			t.Fatal(err)
+		}
+		defer worker.unregisterHeartbeatWorker()
 
-	wfClient := NewServiceClient(mockService, nil, ClientOptions{
-		Namespace:               "test-ns",
-		Identity:                "test-client-identity",
-		WorkerHeartbeatInterval: time.Minute,
-	})
-	wfClient.namespaceData = &namespaceData{
-		capabilities: &namespacepb.NamespaceInfo_Capabilities{WorkerHeartbeats: true},
-	}
-	worker := NewAggregatedWorker(wfClient, "test-task-queue", WorkerOptions{})
-	if err := worker.registerHeartbeatWorker(); err != nil {
-		t.Fatal(err)
-	}
-	defer worker.unregisterHeartbeatWorker()
-
-	select {
-	case request := <-requestCh:
+		synctest.Wait()
+		if request == nil {
+			t.Fatal("initial worker heartbeat was not sent")
+		}
 		if request.GetNamespace() != "test-ns" {
 			t.Fatalf("namespace = %q, want test-ns", request.GetNamespace())
 		}
@@ -292,9 +281,7 @@ func TestWorkerHeartbeatSendsImmediatelyWithIdentity(t *testing.T) {
 		if len(request.GetWorkerHeartbeat()) != 1 {
 			t.Fatalf("worker heartbeat count = %d, want 1", len(request.GetWorkerHeartbeat()))
 		}
-	case <-time.After(500 * time.Millisecond):
-		t.Fatal("timed out waiting for initial worker heartbeat")
-	}
+	})
 }
 
 func TestWorkerHeartbeatElapsedSinceLastHeartbeatUnsetOnInitialHeartbeat(t *testing.T) {

--- a/internal/internal_workflow_client_test.go
+++ b/internal/internal_workflow_client_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	activitypb "go.temporal.io/api/activity/v1"
@@ -1111,19 +1112,21 @@ func (s *workflowRunSuite) TestExecuteWorkflowWithUpdate_DefaultTimeout() {
 }
 
 func (s *workflowRunSuite) TestExecuteWorkflowWithUpdate_OperationNotExecuted() {
-	startOp := s.workflowClient.NewWithStartWorkflowOperation(
-		StartWorkflowOptions{
-			ID:                       workflowID,
-			WorkflowIDConflictPolicy: enumspb.WORKFLOW_ID_CONFLICT_POLICY_FAIL,
-			TaskQueue:                taskqueue,
-		}, workflowType,
-	)
+	synctest.Test(s.T(), func(t *testing.T) {
+		startOp := s.workflowClient.NewWithStartWorkflowOperation(
+			StartWorkflowOptions{
+				ID:                       workflowID,
+				WorkflowIDConflictPolicy: enumspb.WORKFLOW_ID_CONFLICT_POLICY_FAIL,
+				TaskQueue:                taskqueue,
+			}, workflowType,
+		)
 
-	ctxWithTimeout, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
-	defer cancel()
+		ctxWithTimeout, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+		defer cancel()
 
-	_, err := startOp.Get(ctxWithTimeout)
-	require.EqualError(s.T(), err, "context deadline exceeded: operation was not executed")
+		_, err := startOp.Get(ctxWithTimeout)
+		require.EqualError(t, err, "context deadline exceeded: operation was not executed")
+	})
 }
 
 func (s *workflowRunSuite) TestExecuteWorkflowWithUpdate_Abort() {
@@ -1158,35 +1161,37 @@ func (s *workflowRunSuite) TestExecuteWorkflowWithUpdate_Abort() {
 
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
-			s.workflowServiceClient.EXPECT().
-				ExecuteMultiOperation(gomock.Any(), gomock.Any(), gomock.Any()).
-				DoAndReturn(tt.respFunc)
+			synctest.Test(s.T(), func(t *testing.T) {
+				s.workflowServiceClient.EXPECT().
+					ExecuteMultiOperation(gomock.Any(), gomock.Any(), gomock.Any()).
+					DoAndReturn(tt.respFunc)
 
-			startOp := s.workflowClient.NewWithStartWorkflowOperation(
-				StartWorkflowOptions{
-					ID:                       workflowID,
-					WorkflowIDConflictPolicy: enumspb.WORKFLOW_ID_CONFLICT_POLICY_FAIL,
-					TaskQueue:                taskqueue,
-				}, workflowType,
-			)
+				startOp := s.workflowClient.NewWithStartWorkflowOperation(
+					StartWorkflowOptions{
+						ID:                       workflowID,
+						WorkflowIDConflictPolicy: enumspb.WORKFLOW_ID_CONFLICT_POLICY_FAIL,
+						TaskQueue:                taskqueue,
+					}, workflowType,
+				)
 
-			ctxWithTimeout, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
-			defer cancel()
+				ctxWithTimeout, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+				defer cancel()
 
-			_, err := s.workflowClient.UpdateWithStartWorkflow(
-				ctxWithTimeout,
-				UpdateWithStartWorkflowOptions{
-					UpdateOptions: UpdateWorkflowOptions{
-						UpdateName:   "update",
-						WaitForStage: WorkflowUpdateStageCompleted,
+				_, err := s.workflowClient.UpdateWithStartWorkflow(
+					ctxWithTimeout,
+					UpdateWithStartWorkflowOptions{
+						UpdateOptions: UpdateWorkflowOptions{
+							UpdateName:   "update",
+							WaitForStage: WorkflowUpdateStageCompleted,
+						},
+						StartWorkflowOperation: startOp,
 					},
-					StartWorkflowOperation: startOp,
-				},
-			)
+				)
 
-			var expectedErr *WorkflowUpdateServiceTimeoutOrCanceledError
-			require.ErrorAs(s.T(), err, &expectedErr)
-			require.ErrorContains(s.T(), err, tt.expectedErr)
+				var expectedErr *WorkflowUpdateServiceTimeoutOrCanceledError
+				require.ErrorAs(t, err, &expectedErr)
+				require.ErrorContains(t, err, tt.expectedErr)
+			})
 		})
 	}
 }
@@ -2672,57 +2677,56 @@ func TestUpdate(t *testing.T) {
 		require.Equal(t, want, got)
 	})
 	t.Run("default ctx timeout", func(t *testing.T) {
-		svc, client := init(t)
-		handle := client.GetWorkflowUpdateHandle(GetWorkflowUpdateHandleOptions{})
-		expectedDeadline := time.Now().Add(pollUpdateTimeout)
-		var actualDeadline time.Time // assigned below in mock
-		svc.EXPECT().PollWorkflowExecutionUpdate(gomock.Any(), gomock.Any()).
-			DoAndReturn(
-				func(
-					ctx context.Context,
-					_ *workflowservice.PollWorkflowExecutionUpdateRequest,
-					_ ...grpc.CallOption,
-				) (*workflowservice.PollWorkflowExecutionUpdateResponse, error) {
-					actualDeadline, _ = ctx.Deadline()
-					return nil, errors.New("intentional error")
-				},
-			)
-		_ = handle.Get(context.TODO(), nil)
+		synctest.Test(t, func(t *testing.T) {
+			svc, client := init(t)
+			handle := client.GetWorkflowUpdateHandle(GetWorkflowUpdateHandleOptions{})
+			expectedDeadline := time.Now().Add(pollUpdateTimeout)
+			var actualDeadline time.Time // assigned below in mock
+			svc.EXPECT().PollWorkflowExecutionUpdate(gomock.Any(), gomock.Any()).
+				DoAndReturn(
+					func(
+						ctx context.Context,
+						_ *workflowservice.PollWorkflowExecutionUpdateRequest,
+						_ ...grpc.CallOption,
+					) (*workflowservice.PollWorkflowExecutionUpdateResponse, error) {
+						actualDeadline, _ = ctx.Deadline()
+						return nil, errors.New("intentional error")
+					},
+				)
+			_ = handle.Get(context.TODO(), nil)
 
-		// can't tell what the exact deadline will be so assert that the
-		// observed deadline passed to server rpc is within 2 seconds of the
-		// default pollUpdateTimout that is used when no other deadline/timeout
-		// is supplied by the caller.
-		require.WithinDuration(t, expectedDeadline, actualDeadline, 2*time.Second)
+			require.Equal(t, expectedDeadline, actualDeadline)
+		})
 	})
 	t.Run("parent ctx timeout", func(t *testing.T) {
-		svc, client := init(t)
-		handle := client.GetWorkflowUpdateHandle(GetWorkflowUpdateHandleOptions{})
-		callerDeadline := time.Now().Add(50 * time.Millisecond)
-		svc.EXPECT().PollWorkflowExecutionUpdate(gomock.Any(), gomock.Any()).
-			DoAndReturn(
-				func(
-					ctx context.Context,
-					_ *workflowservice.PollWorkflowExecutionUpdateRequest,
-					_ ...grpc.CallOption,
-				) (*workflowservice.PollWorkflowExecutionUpdateResponse, error) {
-					thisDeadline, ok := ctx.Deadline()
-					require.True(t, ok)
-					require.LessOrEqual(t, thisDeadline, callerDeadline,
-						"caller timeout can be shortened but not extended")
-					ctxWillTimeoutIn := time.Until(thisDeadline)
-					sleepCtx(ctx, ctxWillTimeoutIn+3*time.Second)
-					require.ErrorIs(t, ctx.Err(), context.DeadlineExceeded)
-					return nil, status.Error(codes.DeadlineExceeded, context.DeadlineExceeded.Error())
-				},
-			)
-		callerCtx, cancel := context.WithDeadline(context.TODO(), callerDeadline)
-		defer cancel()
-		var got string
-		err := handle.Get(callerCtx, &got)
-		require.Error(t, err)
-		var rpcErr *WorkflowUpdateServiceTimeoutOrCanceledError
-		require.ErrorAs(t, err, &rpcErr)
+		synctest.Test(t, func(t *testing.T) {
+			svc, client := init(t)
+			handle := client.GetWorkflowUpdateHandle(GetWorkflowUpdateHandleOptions{})
+			callerDeadline := time.Now().Add(50 * time.Millisecond)
+			svc.EXPECT().PollWorkflowExecutionUpdate(gomock.Any(), gomock.Any()).
+				DoAndReturn(
+					func(
+						ctx context.Context,
+						_ *workflowservice.PollWorkflowExecutionUpdateRequest,
+						_ ...grpc.CallOption,
+					) (*workflowservice.PollWorkflowExecutionUpdateResponse, error) {
+						thisDeadline, ok := ctx.Deadline()
+						require.True(t, ok)
+						require.Equal(t, callerDeadline, thisDeadline)
+						ctxWillTimeoutIn := time.Until(thisDeadline)
+						sleepCtx(ctx, ctxWillTimeoutIn+3*time.Second)
+						require.ErrorIs(t, ctx.Err(), context.DeadlineExceeded)
+						return nil, status.Error(codes.DeadlineExceeded, context.DeadlineExceeded.Error())
+					},
+				)
+			callerCtx, cancel := context.WithDeadline(context.TODO(), callerDeadline)
+			defer cancel()
+			var got string
+			err := handle.Get(callerCtx, &got)
+			require.Error(t, err)
+			var rpcErr *WorkflowUpdateServiceTimeoutOrCanceledError
+			require.ErrorAs(t, err, &rpcErr)
+		})
 	})
 	t.Run("parent ctx cancelled", func(t *testing.T) {
 		svc, client := init(t)

--- a/internal/internal_workflow_test.go
+++ b/internal/internal_workflow_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/mock"
@@ -1402,44 +1403,37 @@ func (s *WorkflowUnitTest) Test_MutatingFunctionsInUpdateValidator() {
 }
 
 func (s *WorkflowUnitTest) Test_StaleGoroutinesAreShutDown() {
-	env := s.NewTestWorkflowEnvironment()
-	deferred := make(chan struct{})
-	after := make(chan struct{})
-	wf := func(ctx Context) error {
-		Go(ctx, func(ctx Context) {
-			defer func() { close(deferred) }()
-			_ = Sleep(ctx, time.Hour) // outlive the workflow
-			close(after)
-		})
-		_ = Sleep(ctx, time.Minute)
-		return nil
-	}
-	env.RegisterWorkflow(wf)
+	synctest.Test(s.T(), func(t *testing.T) {
+		env := s.NewTestWorkflowEnvironment()
+		deferred := make(chan struct{})
+		after := make(chan struct{})
+		wf := func(ctx Context) error {
+			Go(ctx, func(ctx Context) {
+				defer func() { close(deferred) }()
+				_ = Sleep(ctx, time.Hour) // outlive the workflow
+				close(after)
+			})
+			_ = Sleep(ctx, time.Minute)
+			return nil
+		}
+		env.RegisterWorkflow(wf)
 
-	env.ExecuteWorkflow(wf)
-	s.True(env.IsWorkflowCompleted())
-	s.NoError(env.GetWorkflowError())
+		env.ExecuteWorkflow(wf)
+		require.True(t, env.IsWorkflowCompleted())
+		require.NoError(t, env.GetWorkflowError())
 
-	// goroutines are shut down async at the moment, so wait with a timeout.
-	// give it up to 1s total.
-
-	started := time.Now()
-	maxWait := time.NewTimer(time.Second)
-	defer maxWait.Stop()
-	select {
-	case <-deferred:
-		s.T().Logf("deferred callback executed after %v", time.Since(started))
-	case <-maxWait.C:
-		s.Fail("deferred func should have been called within 1 second")
-	}
-	// if deferred code has run, this has already occurred-or-not.
-	// if it timed out waiting for the deferred code, it has waited long enough, and this is mostly a curiosity.
-	select {
-	case <-after:
-		s.Fail("code after sleep should not have run")
-	default:
-		s.T().Log("code after sleep correctly not executed")
-	}
+		synctest.Wait()
+		select {
+		case <-deferred:
+		default:
+			t.Fatal("stale workflow goroutine did not run its deferred callback")
+		}
+		select {
+		case <-after:
+			t.Fatal("stale workflow goroutine continued after its blocking sleep")
+		default:
+		}
+	})
 }
 
 func TestQueryFnValidation(t *testing.T) {

--- a/internal/resource_tuner_cancel_test.go
+++ b/internal/resource_tuner_cancel_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/require"
@@ -63,41 +64,37 @@ func TestReserveSlotHonorsContextCancellation(t *testing.T) {
 		{"ramp throttle already elapsed", 50 * time.Millisecond},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			rcOpts := DefaultResourceControllerOptions()
-			rcOpts.MemTargetPercent = 0.8
-			rcOpts.CpuTargetPercent = 0.9
-			// Over the memory target, so the controller always declines and TryReserveSlot always
-			// returns nil. This is the sustained-pressure case the tuner exists to handle.
-			rcOpts.InfoSupplier = &FakeSystemInfoSupplier{memUse: 0.95, cpuUse: 0.95}
+			synctest.Test(t, func(t *testing.T) {
+				rcOpts := DefaultResourceControllerOptions()
+				rcOpts.MemTargetPercent = 0.8
+				rcOpts.CpuTargetPercent = 0.9
+				// Over the memory target, so the controller always declines and TryReserveSlot always
+				// returns nil. This is the sustained-pressure case the tuner exists to handle.
+				rcOpts.InfoSupplier = &FakeSystemInfoSupplier{memUse: 0.95, cpuUse: 0.95}
 
-			supplier, err := NewResourceBasedSlotSupplier(NewResourceController(rcOpts),
-				ResourceBasedSlotSupplierOptions{MinSlots: 0, MaxSlots: 1000, RampThrottle: tc.ramp})
-			require.NoError(t, err)
+				supplier, err := NewResourceBasedSlotSupplier(NewResourceController(rcOpts),
+					ResourceBasedSlotSupplierOptions{MinSlots: 0, MaxSlots: 1000, RampThrottle: tc.ramp})
+				require.NoError(t, err)
 
-			info := &reserveCallCounter{} // NumIssuedSlots is 10, past MinSlots
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
+				info := &reserveCallCounter{} // NumIssuedSlots is 10, past MinSlots
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
 
-			reserveErr := make(chan error, 1)
-			go func() {
-				_, err := supplier.ReserveSlot(ctx, info)
-				reserveErr <- err
-			}()
+				reserveErr := make(chan error, 1)
+				go func() {
+					_, err := supplier.ReserveSlot(ctx, info)
+					reserveErr <- err
+				}()
 
-			// Each retry iteration calls NumIssuedSlots once. Waiting for a second call means the
-			// loop is spinning, so cancelling now exercises the retry path rather than entry.
-			require.Eventually(t, func() bool {
-				return info.calls.Load() > 1
-			}, 2*time.Second, time.Millisecond, "ReserveSlot did not enter its retry loop")
+				// Each retry iteration calls NumIssuedSlots once. Waiting until ReserveSlot blocks on
+				// its retry timer means cancelling now exercises the retry path rather than entry.
+				synctest.Wait()
+				require.Greater(t, info.calls.Load(), int64(1), "ReserveSlot did not enter its retry loop")
 
-			cancel()
-
-			select {
-			case err := <-reserveErr:
-				require.ErrorIs(t, err, context.Canceled)
-			case <-time.After(2 * time.Second):
-				t.Fatal("ReserveSlot did not return after its context was cancelled")
-			}
+				cancel()
+				synctest.Wait()
+				require.ErrorIs(t, <-reserveErr, context.Canceled)
+			})
 		})
 	}
 }

--- a/internal/resource_tuner_eager_test.go
+++ b/internal/resource_tuner_eager_test.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/require"
@@ -142,23 +143,24 @@ func TestRampThrottleBoundsIssuanceAcrossConcurrentReserveSlot(t *testing.T) {
 // lastIssuedMu before the ramp wait must not let issuance past MinSlots exceed one slot per
 // RampThrottle.
 func TestRampThrottleStillBoundsIssuance(t *testing.T) {
-	const ramp = 100 * time.Millisecond
+	synctest.Test(t, func(t *testing.T) {
+		const ramp = 100 * time.Millisecond
 
-	rcOpts := DefaultResourceControllerOptions()
-	rcOpts.MemTargetPercent = 0.8
-	rcOpts.CpuTargetPercent = 0.9
-	rcOpts.InfoSupplier = &FakeSystemInfoSupplier{memUse: 0.1, cpuUse: 0.1}
+		rcOpts := DefaultResourceControllerOptions()
+		rcOpts.MemTargetPercent = 0.8
+		rcOpts.CpuTargetPercent = 0.9
+		rcOpts.InfoSupplier = &FakeSystemInfoSupplier{memUse: 0.1, cpuUse: 0.1}
 
-	supplier, err := NewResourceBasedSlotSupplier(NewResourceController(rcOpts),
-		ResourceBasedSlotSupplierOptions{MinSlots: 0, MaxSlots: 1000, RampThrottle: ramp})
-	require.NoError(t, err)
+		supplier, err := NewResourceBasedSlotSupplier(NewResourceController(rcOpts),
+			ResourceBasedSlotSupplierOptions{MinSlots: 0, MaxSlots: 1000, RampThrottle: ramp})
+		require.NoError(t, err)
 
-	info := &countingReserveInfo{issued: 10} // past MinSlots, so the throttle applies
+		info := &countingReserveInfo{issued: 10} // past MinSlots, so the throttle applies
 
-	require.NotNil(t, supplier.TryReserveSlot(info), "first slot should issue")
-	require.Nil(t, supplier.TryReserveSlot(info), "second slot within RampThrottle must be throttled")
+		require.NotNil(t, supplier.TryReserveSlot(info), "first slot should issue")
+		require.Nil(t, supplier.TryReserveSlot(info), "second slot within RampThrottle must be throttled")
 
-	require.Eventually(t, func() bool {
-		return supplier.TryReserveSlot(info) != nil
-	}, ramp*5, ramp/10, "slot should issue again after RampThrottle elapses")
+		time.Sleep(ramp + time.Nanosecond)
+		require.NotNil(t, supplier.TryReserveSlot(info), "slot should issue again after RampThrottle elapses")
+	})
 }

--- a/internal/workflow_deadlock_test.go
+++ b/internal/workflow_deadlock_test.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"context"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/require"
@@ -11,61 +12,67 @@ import (
 )
 
 func TestDeadlockDetector(t *testing.T) {
-	// Create a 500ms ticker and confirm it pauses/resumes properly. We have
-	// chosen to use real time instead of an abstract clock here for simplicity.
-	d := newDeadlockDetector()
-	ticker := d.begin(500 * time.Millisecond)
-	defer ticker.end()
-	d.pause()
-	// Confirm never reached while paused
-	select {
-	case <-time.After(600 * time.Millisecond):
-	case <-ticker.reached():
-		t.Fatal("unexpectedly reached deadlock")
-	}
-	// Resume and confirm reached
-	d.resume()
-	select {
-	case <-time.After(600 * time.Millisecond):
-		t.Fatal("unexpectedly didn't deadlock")
-	case <-ticker.reached():
-	}
+	synctest.Test(t, func(t *testing.T) {
+		const timeout = 500 * time.Millisecond
+		d := newDeadlockDetector()
+		ticker := d.begin(timeout)
+		defer ticker.end()
+		d.pause()
+
+		time.Sleep(timeout + 100*time.Millisecond)
+		select {
+		case <-ticker.reached():
+			t.Fatal("unexpectedly reached deadlock while paused")
+		default:
+		}
+
+		d.resume()
+		time.Sleep(timeout)
+		synctest.Wait()
+		select {
+		case <-ticker.reached():
+		default:
+			t.Fatal("deadlock timeout was not reached after resume")
+		}
+	})
 }
 
 func TestDataConverterWithoutDeadlockDetection(t *testing.T) {
-	runWorkflow := func(conv converter.DataConverter) error {
-		var suite WorkflowTestSuite
-		activityFn := func(ctx context.Context, arg string) error {
-			return nil
+	synctest.Test(t, func(t *testing.T) {
+		runWorkflow := func(conv converter.DataConverter) error {
+			var suite WorkflowTestSuite
+			activityFn := func(ctx context.Context, arg string) error {
+				return nil
+			}
+			workflowFn := func(ctx Context) error {
+				ctx = WithDataConverter(ctx, conv)
+				ctx = WithActivityOptions(ctx, ActivityOptions{ScheduleToCloseTimeout: 10 * time.Second})
+				return ExecuteActivity(ctx, activityFn, "some arg").Get(ctx, nil)
+			}
+			env := suite.NewTestWorkflowEnvironment()
+			env.SetWorkerOptions(WorkerOptions{DeadlockDetectionTimeout: 400 * time.Millisecond})
+			env.RegisterWorkflow(workflowFn)
+			env.RegisterActivity(activityFn)
+			env.ExecuteWorkflow(workflowFn)
+			require.True(t, env.IsWorkflowCompleted())
+			return env.GetWorkflowError()
 		}
-		workflowFn := func(ctx Context) error {
-			ctx = WithDataConverter(ctx, conv)
-			ctx = WithActivityOptions(ctx, ActivityOptions{ScheduleToCloseTimeout: 10 * time.Second})
-			return ExecuteActivity(ctx, activityFn, "some arg").Get(ctx, nil)
-		}
-		env := suite.NewTestWorkflowEnvironment()
-		env.SetWorkerOptions(WorkerOptions{DeadlockDetectionTimeout: 400 * time.Millisecond})
-		env.RegisterWorkflow(workflowFn)
-		env.RegisterActivity(activityFn)
-		env.ExecuteWorkflow(workflowFn)
-		require.True(t, env.IsWorkflowCompleted())
-		return env.GetWorkflowError()
-	}
 
-	// Run with a slow converter and confirm a deadlock is detected
-	conv := converter.GetDefaultDataConverter()
-	conv = &slowToPayloadsConverter{conv}
-	require.ErrorContains(t, runWorkflow(conv), "Potential deadlock detected")
+		// Run with a slow converter and confirm a deadlock is detected
+		conv := converter.GetDefaultDataConverter()
+		conv = &slowToPayloadsConverter{conv}
+		require.ErrorContains(t, runWorkflow(conv), "Potential deadlock detected")
 
-	// Run with that same payload converter without deadlock detection
-	conv = DataConverterWithoutDeadlockDetection(conv)
-	require.NoError(t, runWorkflow(conv))
+		// Run with that same payload converter without deadlock detection
+		conv = DataConverterWithoutDeadlockDetection(conv)
+		require.NoError(t, runWorkflow(conv))
 
-	// Also confirm outside of workflow, pause/resume is noop
-	_, err := conv.ToPayload("foo")
-	require.NoError(t, err)
-	_, err = conv.(ContextAware).WithWorkflowContext(Background()).ToPayload("foo")
-	require.NoError(t, err)
+		// Also confirm outside of workflow, pause/resume is noop
+		_, err := conv.ToPayload("foo")
+		require.NoError(t, err)
+		_, err = conv.(ContextAware).WithWorkflowContext(Background()).ToPayload("foo")
+		require.NoError(t, err)
+	})
 }
 
 type slowToPayloadsConverter struct{ converter.DataConverter }

--- a/internal/workflow_deadlock_test.go
+++ b/internal/workflow_deadlock_test.go
@@ -11,6 +11,11 @@ import (
 	"go.temporal.io/sdk/converter"
 )
 
+const (
+	deadlockDetectionTime = 400 * time.Millisecond
+	payloadConverterTime  = 600 * time.Millisecond
+)
+
 func TestDeadlockDetector(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		const timeout = 500 * time.Millisecond
@@ -49,7 +54,7 @@ func TestDataConverterWithoutDeadlockDetection(t *testing.T) {
 			return ExecuteActivity(ctx, activityFn, "some arg").Get(ctx, nil)
 		}
 		env := suite.NewTestWorkflowEnvironment()
-		env.SetWorkerOptions(WorkerOptions{DeadlockDetectionTimeout: 400 * time.Millisecond})
+		env.SetWorkerOptions(WorkerOptions{DeadlockDetectionTimeout: deadlockDetectionTime})
 		env.RegisterWorkflow(workflowFn)
 		env.RegisterActivity(activityFn)
 		env.ExecuteWorkflow(workflowFn)
@@ -59,16 +64,12 @@ func TestDataConverterWithoutDeadlockDetection(t *testing.T) {
 
 	t.Run("detects deadlock", func(t *testing.T) {
 		synctest.Test(t, func(t *testing.T) {
-			converterReturned := make(chan struct{})
 			conv := &slowToPayloadsConverter{
 				DataConverter: converter.GetDefaultDataConverter(),
-				onReturn:      func() { close(converterReturned) },
 			}
 			require.ErrorContains(t, runWorkflow(t, conv), "Potential deadlock detected")
 
-			// Deadlock detection returns while the converter is still sleeping. Let
-			// that abandoned workflow coroutine finish before leaving this bubble.
-			<-converterReturned
+			time.Sleep(payloadConverterTime - deadlockDetectionTime)
 			synctest.Wait()
 		})
 	})
@@ -99,14 +100,10 @@ func TestDataConverterWithoutDeadlockDetection(t *testing.T) {
 
 type slowToPayloadsConverter struct {
 	converter.DataConverter
-	onReturn func()
 }
 
 func (s *slowToPayloadsConverter) ToPayloads(value ...interface{}) (*commonpb.Payloads, error) {
-	time.Sleep(600 * time.Millisecond)
-	if s.onReturn != nil {
-		defer s.onReturn()
-	}
+	time.Sleep(payloadConverterTime)
 	return s.DataConverter.ToPayloads(value...)
 }
 

--- a/internal/workflow_deadlock_test.go
+++ b/internal/workflow_deadlock_test.go
@@ -38,47 +38,75 @@ func TestDeadlockDetector(t *testing.T) {
 }
 
 func TestDataConverterWithoutDeadlockDetection(t *testing.T) {
-	synctest.Test(t, func(t *testing.T) {
-		runWorkflow := func(conv converter.DataConverter) error {
-			var suite WorkflowTestSuite
-			activityFn := func(ctx context.Context, arg string) error {
-				return nil
-			}
-			workflowFn := func(ctx Context) error {
-				ctx = WithDataConverter(ctx, conv)
-				ctx = WithActivityOptions(ctx, ActivityOptions{ScheduleToCloseTimeout: 10 * time.Second})
-				return ExecuteActivity(ctx, activityFn, "some arg").Get(ctx, nil)
-			}
-			env := suite.NewTestWorkflowEnvironment()
-			env.SetWorkerOptions(WorkerOptions{DeadlockDetectionTimeout: 400 * time.Millisecond})
-			env.RegisterWorkflow(workflowFn)
-			env.RegisterActivity(activityFn)
-			env.ExecuteWorkflow(workflowFn)
-			require.True(t, env.IsWorkflowCompleted())
-			return env.GetWorkflowError()
+	runWorkflow := func(t *testing.T, conv converter.DataConverter) error {
+		var suite WorkflowTestSuite
+		activityFn := func(ctx context.Context, arg string) error {
+			return nil
 		}
+		workflowFn := func(ctx Context) error {
+			ctx = WithDataConverter(ctx, conv)
+			ctx = WithActivityOptions(ctx, ActivityOptions{ScheduleToCloseTimeout: 10 * time.Second})
+			return ExecuteActivity(ctx, activityFn, "some arg").Get(ctx, nil)
+		}
+		env := suite.NewTestWorkflowEnvironment()
+		env.SetWorkerOptions(WorkerOptions{DeadlockDetectionTimeout: 400 * time.Millisecond})
+		env.RegisterWorkflow(workflowFn)
+		env.RegisterActivity(activityFn)
+		env.ExecuteWorkflow(workflowFn)
+		require.True(t, env.IsWorkflowCompleted())
+		return env.GetWorkflowError()
+	}
 
-		// Run with a slow converter and confirm a deadlock is detected
-		conv := converter.GetDefaultDataConverter()
-		conv = &slowToPayloadsConverter{conv}
-		require.ErrorContains(t, runWorkflow(conv), "Potential deadlock detected")
+	t.Run("detects deadlock", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			converterReturned := make(chan struct{})
+			conv := &slowToPayloadsConverter{
+				DataConverter: converter.GetDefaultDataConverter(),
+				onReturn:      func() { close(converterReturned) },
+			}
+			require.ErrorContains(t, runWorkflow(t, conv), "Potential deadlock detected")
 
-		// Run with that same payload converter without deadlock detection
-		conv = DataConverterWithoutDeadlockDetection(conv)
-		require.NoError(t, runWorkflow(conv))
+			// Deadlock detection returns while the converter is still sleeping. Let
+			// that abandoned workflow coroutine finish before leaving this bubble.
+			<-converterReturned
+			synctest.Wait()
+		})
+	})
 
-		// Also confirm outside of workflow, pause/resume is noop
-		_, err := conv.ToPayload("foo")
-		require.NoError(t, err)
-		_, err = conv.(ContextAware).WithWorkflowContext(Background()).ToPayload("foo")
-		require.NoError(t, err)
+	t.Run("disables deadlock detection", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			conv := converter.DataConverter(&slowToPayloadsConverter{
+				DataConverter: converter.GetDefaultDataConverter(),
+			})
+			conv = DataConverterWithoutDeadlockDetection(conv)
+			require.NoError(t, runWorkflow(t, conv))
+		})
+	})
+
+	t.Run("outside workflow", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			conv := converter.DataConverter(&slowToPayloadsConverter{
+				DataConverter: converter.GetDefaultDataConverter(),
+			})
+			conv = DataConverterWithoutDeadlockDetection(conv)
+			_, err := conv.ToPayload("foo")
+			require.NoError(t, err)
+			_, err = conv.(ContextAware).WithWorkflowContext(Background()).ToPayload("foo")
+			require.NoError(t, err)
+		})
 	})
 }
 
-type slowToPayloadsConverter struct{ converter.DataConverter }
+type slowToPayloadsConverter struct {
+	converter.DataConverter
+	onReturn func()
+}
 
 func (s *slowToPayloadsConverter) ToPayloads(value ...interface{}) (*commonpb.Payloads, error) {
 	time.Sleep(600 * time.Millisecond)
+	if s.onReturn != nil {
+		defer s.onReturn()
+	}
 	return s.DataConverter.ToPayloads(value...)
 }
 


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->
Switched over a bunch of tests to use[ synctest](https://pkg.go.dev/testing/synctest)

## Why?
<!-- Tell your future self why have you made these changes -->
synctest was introduced in Go 1.24, seems like a perfect tool for us to reduce nondeterministic test flakes

## Checklist
<!--- add/delete as needed --->

1. Closes #2559

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no runtime behavior modifications; risk is limited to CI signal if synctest assumptions differ from prior flaky timing tests.
> 
> **Overview**
> Migrates many timing- and concurrency-sensitive tests to **`testing/synctest`**, so goroutines and timers run in a deterministic bubble instead of relying on real wall-clock delays.
> 
> Tests that used **`require.Eventually`**, long **`time.Sleep`** values, or **`time.After`** timeouts now wrap bodies in **`synctest.Test`** and advance synchronization with **`synctest.Wait()`** (and shorter sleeps where virtual time still matters). Assertions are tightened in several places—for example exact elapsed times for poll cooldowns, context cancellation, LRU TTL expiry, and backoff retry counts.
> 
> Coverage spans **contrib** (lambda worker, workflowstreams), **internal** (backoff, LRU cache, extstore callbacks, coroutines/dispatcher defers, eager activities, task handlers, base worker shutdown/autoscaling, heartbeats, workflow client update polling, resource tuner ramp throttle), and related packages. **Production code is unchanged**; this is a test-harness and flake-reduction refactor only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f122e46fa530d1c3ef4f189a01ccf01c7661780. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->