### PR TITLE
fix(extstore): correct minimum Go SDK requirement to v1.43.1

### DIFF
--- a/contrib/aws/s3driver/CHANGELOG.md
+++ b/contrib/aws/s3driver/CHANGELOG.md
@@ -11,6 +11,11 @@ or Security.
 
 ## [Unreleased]
 
+### Fixed
+
+- Corrected the module's minimum Temporal Go SDK requirement from v1.25.1 to
+  v1.43.1.
+
 ### Changed
 
 - S3 object key path segments are now percent-encoded against S3's safe

--- a/contrib/aws/s3driver/awssdkv2/CHANGELOG.md
+++ b/contrib/aws/s3driver/awssdkv2/CHANGELOG.md
@@ -10,3 +10,8 @@ or Security.
 # Changelog
 
 ## [Unreleased]
+
+### Fixed
+
+- Corrected the module's minimum Temporal Go SDK requirement from v1.25.1 to
+  v1.43.1.

--- a/contrib/aws/s3driver/awssdkv2/go.mod
+++ b/contrib/aws/s3driver/awssdkv2/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/johannesboyne/gofakes3 v0.0.0-20260208201424-4c385a1f6a73
 	github.com/stretchr/testify v1.10.0
 	go.temporal.io/api v1.63.4
-	go.temporal.io/sdk v1.25.1
+	go.temporal.io/sdk v1.43.1
 	go.temporal.io/sdk/contrib/aws/s3driver v0.0.0
 )
 

--- a/contrib/aws/s3driver/go.mod
+++ b/contrib/aws/s3driver/go.mod
@@ -5,7 +5,7 @@ go 1.25.4
 require (
 	github.com/stretchr/testify v1.10.0
 	go.temporal.io/api v1.63.4
-	go.temporal.io/sdk v1.25.1
+	go.temporal.io/sdk v1.43.1
 	golang.org/x/sync v0.20.0
 	google.golang.org/protobuf v1.36.11
 )

--- a/contrib/gcp/gcsdriver/gcssdk/go.mod
+++ b/contrib/gcp/gcsdriver/gcssdk/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/fsouza/fake-gcs-server v1.50.2
 	github.com/stretchr/testify v1.11.1
 	go.temporal.io/api v1.63.4
-	go.temporal.io/sdk v1.25.1
+	go.temporal.io/sdk v1.43.1
 	go.temporal.io/sdk/contrib/gcp/gcsdriver v0.0.0-00010101000000-000000000000
 )
 

--- a/contrib/gcp/gcsdriver/go.mod
+++ b/contrib/gcp/gcsdriver/go.mod
@@ -5,7 +5,7 @@ go 1.25.4
 require (
 	github.com/stretchr/testify v1.10.0
 	go.temporal.io/api v1.63.4
-	go.temporal.io/sdk v1.25.1
+	go.temporal.io/sdk v1.43.1
 	golang.org/x/sync v0.20.0
 	google.golang.org/protobuf v1.36.11
 )


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Update the minimum Go SDK requirement for the external storage drivers.

## Why?

Accurately reflect that the drivers require the Go SDK version that shipped the public preview of external storage.

## Checklist
<!--- add/delete as needed --->

1. How was this tested: Remove `replace` directive for SDK, build, test, and vet.

1. Any docs updates needed? No
