### PR TITLE
Fix activity/workflow alias collision for anonymous functions (#2141)

### DIFF
--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -10,6 +10,7 @@ import (
 	"math"
 	"os"
 	"reflect"
+	"regexp"
 	"runtime"
 	"sort"
 	"strconv"
@@ -2724,6 +2725,10 @@ func isError(inType reflect.Type) bool {
 	return inType != nil && inType.Implements(errorElem)
 }
 
+// closureNamePattern matches the compiler-generated name of a Go closure, e.g.
+// "pkg.Outer.func1" or a nested "pkg.Outer.func1.2".
+var closureNamePattern = regexp.MustCompile(`\.func\d`)
+
 func getFunctionName(i interface{}) (name string, isMethod bool) {
 	if fullName, ok := i.(string); ok {
 		return fullName, false
@@ -2732,6 +2737,14 @@ func getFunctionName(i interface{}) (name string, isMethod bool) {
 	// Full function name that has a struct pointer receiver has the following format
 	// <prefix>.(*<type>).<function>
 	isMethod = strings.ContainsAny(fullName, "*")
+	// Closures are named "<enclosing>.funcN" by the Go runtime, so their short
+	// name collapses every closure in a scope to "func1", "func2", ... These
+	// collide in the registry's alias maps and can misroute one activity to
+	// another's registration (see temporalio/sdk-go#2141). Keep the
+	// fully-qualified name so each closure has a stable, unique identity.
+	if closureNamePattern.MatchString(fullName) {
+		return fullName, isMethod
+	}
 	elements := strings.Split(fullName, ".")
 	shortName := elements[len(elements)-1]
 	// This allows to call activities by method pointer

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -3665,3 +3665,44 @@ func (s *internalWorkerTestSuite) TestRegisterMultipleDynamicWorkflow() {
 	require.Error(s.T(), err)
 	require.Contains(s.T(), err.Error(), "dynamic activity already registered")
 }
+
+// firstClosureA and firstClosureB each return their enclosing function's first
+// closure. The Go runtime names both "<pkg>.firstClosureX.func1", so their short
+// names collide as "func1" — the collision behind temporalio/sdk-go#2141.
+func firstClosureA() func(context.Context) error {
+	return func(context.Context) error { return nil }
+}
+
+func firstClosureB() func(context.Context) error {
+	return func(context.Context) error { return nil }
+}
+
+type getFunctionNameActivities struct{}
+
+func (*getFunctionNameActivities) NamedActivity(context.Context) error { return nil }
+
+func TestGetFunctionName_ClosuresKeepQualifiedName(t *testing.T) {
+	// The Go compiler numbers closures per package ("func1", "func2", ...), so
+	// each package restarts at "func1" and the bare short name collides across
+	// packages. That misroutes activities in the registry's alias maps
+	// (temporalio/sdk-go#2141). A closure must therefore keep its fully-qualified
+	// name, which retains the enclosing identity and is unique across packages.
+	nameA, isMethod := getFunctionName(firstClosureA())
+	require.False(t, isMethod)
+	require.Contains(t, nameA, "firstClosureA",
+		"closure name must retain its enclosing identity, got %q", nameA)
+
+	nameB, _ := getFunctionName(firstClosureB())
+	require.Contains(t, nameB, "firstClosureB", "got %q", nameB)
+	require.NotEqual(t, nameA, nameB)
+
+	// Named functions keep their short name.
+	namedFn, _ := getFunctionName(testWorkflowHello)
+	require.Equal(t, "testWorkflowHello", namedFn)
+
+	// Methods keep their short name and are reported as methods.
+	a := &getFunctionNameActivities{}
+	method, isMethod := getFunctionName(a.NamedActivity)
+	require.True(t, isMethod)
+	require.Equal(t, "NamedActivity", method)
+}


### PR DESCRIPTION
## What was changed

`getFunctionName` collapses a function's runtime name to its last dot-separated element. For a closure the Go compiler emits `<enclosing>.funcN`, and that numbering restarts per package, so **every package's first closure is `func1`**. The bare `func1` is then used as the key in the test environment's activity and workflow **alias maps**.

The result: an activity registered in one package with an anonymous function and an explicit `Name` stores `aliasMap["func1"] = "SomeActivity"`. A *different* closure in another package (e.g. an inline local activity) also resolves to `func1`, matches that alias, and gets routed to the wrong registration — panicking on the signature mismatch. This is the collision reported in #2141.

The fix keeps the fully-qualified name for closures (detected via the compiler's `.funcN` marker), giving each closure a stable, unique identity across packages. Named functions and methods are unaffected — they still resolve to their short names (`Foo`, `RunActivity`, etc.).

## Why

Closes #2141. The alias maps need a key that uniquely identifies a function; the short name does not for closures.

## Checklist

1. Added `TestGetFunctionName_ClosuresKeepQualifiedName` in `internal/internal_worker_test.go`. It fails before the change (both closures resolve to `func1`) and passes after (each retains its enclosing identity), and asserts named functions/methods are unchanged.
2. `go test ./internal/` passes (full package, no regressions); `gofmt` and `go vet ./internal/` are clean.
