### PR TITLE
Add testify suite assertion lifecycle check

### DIFF
--- a/internal/cmd/build/cmd/testsuiteassertions/main.go
+++ b/internal/cmd/build/cmd/testsuiteassertions/main.go
@@ -1,0 +1,10 @@
+package main
+
+import (
+	"go.temporal.io/sdk/internal/cmd/build/testsuiteassertions"
+	"golang.org/x/tools/go/analysis/singlechecker"
+)
+
+func main() {
+	singlechecker.Main(testsuiteassertions.Analyzer)
+}

--- a/internal/cmd/build/go.mod
+++ b/internal/cmd/build/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/BurntSushi/toml v1.4.1-0.20240526193622-a339e1f7089c
 	github.com/kisielk/errcheck v1.8.0
 	go.temporal.io/sdk v1.32.1
+	golang.org/x/tools v0.44.0
 	honnef.co/go/tools v0.6.0
 )
 
@@ -31,7 +32,6 @@ require (
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 	golang.org/x/time v0.10.0 // indirect
-	golang.org/x/tools v0.44.0 // indirect
 	golang.org/x/tools/go/expect v0.1.1-deprecated // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260414002931-afd174a4e478 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478 // indirect

--- a/internal/cmd/build/main.go
+++ b/internal/cmd/build/main.go
@@ -94,6 +94,18 @@ func (b *builder) check() error {
 	if err := b.runCmd(b.cmdFromRoot("go", "run", "./internal/cmd/tools/doclink/doclink.go")); err != nil {
 		return fmt.Errorf("doclink check failed: %w", err)
 	}
+	// Check embedded require assertions in testify suites.
+	testSuiteAssertions, err := b.getInstalledTool("go.temporal.io/sdk/internal/cmd/build/cmd/testsuiteassertions")
+	if err != nil {
+		return fmt.Errorf("failed getting testsuiteassertions: %w", err)
+	}
+	for _, moduleDir := range []string{".", "test"} {
+		cmd := b.cmdFromRoot(testSuiteAssertions, "./...")
+		cmd.Dir = filepath.Join(b.rootDir, moduleDir)
+		if err := b.runCmd(cmd); err != nil {
+			return fmt.Errorf("testsuiteassertions check failed in %s: %w", moduleDir, err)
+		}
+	}
 	return nil
 }
 

--- a/internal/cmd/build/main.go
+++ b/internal/cmd/build/main.go
@@ -121,7 +121,7 @@ func findModuleDirs(root fs.FS) ([]string, error) {
 		}
 		if entry.IsDir() {
 			switch entry.Name() {
-			case ".build", ".git", "node_modules", "vendor":
+			case ".build", ".git", "node_modules", "testdata", "vendor":
 				return fs.SkipDir
 			}
 			return nil

--- a/internal/cmd/build/main.go
+++ b/internal/cmd/build/main.go
@@ -94,12 +94,16 @@ func (b *builder) check() error {
 	if err := b.runCmd(b.cmdFromRoot("go", "run", "./internal/cmd/tools/doclink/doclink.go")); err != nil {
 		return fmt.Errorf("doclink check failed: %w", err)
 	}
-	// Check embedded require assertions in testify suites.
+	// Check SetupTest bindings for embedded require assertions in testify suites.
 	testSuiteAssertions, err := b.getInstalledTool("go.temporal.io/sdk/internal/cmd/build/cmd/testsuiteassertions")
 	if err != nil {
 		return fmt.Errorf("failed getting testsuiteassertions: %w", err)
 	}
-	for _, moduleDir := range []string{".", "test"} {
+	moduleDirs, err := findModuleDirs(os.DirFS(b.rootDir))
+	if err != nil {
+		return fmt.Errorf("failed finding Go modules: %w", err)
+	}
+	for _, moduleDir := range moduleDirs {
 		cmd := b.cmdFromRoot(testSuiteAssertions, "./...")
 		cmd.Dir = filepath.Join(b.rootDir, moduleDir)
 		if err := b.runCmd(cmd); err != nil {
@@ -107,6 +111,31 @@ func (b *builder) check() error {
 		}
 	}
 	return nil
+}
+
+func findModuleDirs(root fs.FS) ([]string, error) {
+	var moduleDirs []string
+	err := fs.WalkDir(root, ".", func(p string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			switch entry.Name() {
+			case ".build", ".git", "node_modules", "vendor":
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if entry.Name() == "go.mod" {
+			moduleDirs = append(moduleDirs, path.Dir(p))
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(moduleDirs)
+	return moduleDirs, nil
 }
 
 func (b *builder) integrationTest() error {

--- a/internal/cmd/build/main_test.go
+++ b/internal/cmd/build/main_test.go
@@ -22,6 +22,7 @@ func TestFindModuleDirs(t *testing.T) {
 		"test/go.mod":                    {},
 		"contrib/example/go.mod":         {},
 		"contrib/example/nested/file.go": {},
+		"testdata/fixture/go.mod":        {},
 		"vendor/dependency/go.mod":       {},
 		".build/scratch/go.mod":          {},
 	})

--- a/internal/cmd/build/main_test.go
+++ b/internal/cmd/build/main_test.go
@@ -9,10 +9,30 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
+	"testing/fstest"
 	"time"
 )
+
+func TestFindModuleDirs(t *testing.T) {
+	moduleDirs, err := findModuleDirs(fstest.MapFS{
+		"go.mod":                         {},
+		"test/go.mod":                    {},
+		"contrib/example/go.mod":         {},
+		"contrib/example/nested/file.go": {},
+		"vendor/dependency/go.mod":       {},
+		".build/scratch/go.mod":          {},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{".", "contrib/example", "test"}
+	if !slices.Equal(want, moduleDirs) {
+		t.Fatalf("expected module directories %v, got %v", want, moduleDirs)
+	}
+}
 
 func TestTestOutputFlagsDefaultToFailures(t *testing.T) {
 	flags := addTestOutputFlags(flag.NewFlagSet("test", flag.ContinueOnError))

--- a/internal/cmd/build/testsuiteassertions/analyzer.go
+++ b/internal/cmd/build/testsuiteassertions/analyzer.go
@@ -37,6 +37,8 @@ type suiteType struct {
 // run reports testify suites that do not refresh embedded require assertions in SetupTest.
 func run(pass *analysis.Pass) (any, error) {
 	suites := make(map[*types.TypeName]*suiteType)
+	// Pass 1: collect affected suite declarations across the package. SetupTest
+	// may be declared in another file, so discovery must finish before validation.
 	for _, file := range pass.Files {
 		for _, decl := range file.Decls {
 			genDecl, ok := decl.(*ast.GenDecl)
@@ -88,6 +90,8 @@ func run(pass *analysis.Pass) (any, error) {
 		}
 	}
 
+	// Pass 2: match SetupTest methods to the collected suite types, then validate
+	// each hook's signature and first-statement assertion rebinding.
 	for _, file := range pass.Files {
 		for _, decl := range file.Decls {
 			fn, ok := decl.(*ast.FuncDecl)
@@ -112,6 +116,8 @@ func run(pass *analysis.Pass) (any, error) {
 		}
 	}
 
+	// Pass 3: after every method has been seen, report affected suites that did
+	// not declare SetupTest anywhere in the package.
 	for typeName, suite := range suites {
 		if !suite.ignored && suite.setupTest == nil {
 			pass.Reportf(suite.spec.Name.Pos(), "%s embeds require.Assertions and suite.Suite; add SetupTest to rebind assertions with require.New(receiver.T())", typeName.Name())

--- a/internal/cmd/build/testsuiteassertions/analyzer.go
+++ b/internal/cmd/build/testsuiteassertions/analyzer.go
@@ -15,9 +15,9 @@ import (
 )
 
 const (
-	requirePackage = "github.com/stretchr/testify/require"
-	suitePackage   = "github.com/stretchr/testify/suite"
-	ignorePrefix   = "//testsuiteassertions:ignore "
+	requirePackage  = "github.com/stretchr/testify/require"
+	suitePackage    = "github.com/stretchr/testify/suite"
+	ignoreDirective = "//testsuiteassertions:ignore"
 )
 
 // Analyzer checks that suites embedding require.Assertions refresh it in SetupTest.
@@ -70,14 +70,18 @@ func run(pass *analysis.Pass) (any, error) {
 					}
 				}
 				if assertionsField != nil && hasSuite {
-					ignored := hasIgnoreDirective(spec.Doc) || hasIgnoreDirective(spec.Comment)
+					commentGroups := []*ast.CommentGroup{spec.Doc, spec.Comment}
 					if len(genDecl.Specs) == 1 {
-						ignored = ignored || hasIgnoreDirective(genDecl.Doc)
+						commentGroups = append(commentGroups, genDecl.Doc)
 					}
+					ignored, invalidIgnore := findIgnoreDirective(commentGroups...)
 					suites[named.Obj()] = &suiteType{
 						spec:            spec,
 						assertionsField: assertionsField,
-						ignored:         ignored,
+						ignored:         ignored || invalidIgnore.IsValid(),
+					}
+					if invalidIgnore.IsValid() {
+						pass.Reportf(spec.Name.Pos(), "%s requires a reason", ignoreDirective)
 					}
 				}
 			}
@@ -173,7 +177,7 @@ func rebindsAssertions(pass *analysis.Pass, fn *ast.FuncDecl, receiver, assertio
 }
 
 func isAssertionsSelector(pass *analysis.Pass, expr ast.Expr, receiver, assertionsField *types.Var) bool {
-	selector, ok := expr.(*ast.SelectorExpr)
+	selector, ok := ast.Unparen(expr).(*ast.SelectorExpr)
 	if !ok || pass.TypesInfo.Selections[selector] == nil || pass.TypesInfo.Selections[selector].Obj() != assertionsField {
 		return false
 	}
@@ -182,6 +186,10 @@ func isAssertionsSelector(pass *analysis.Pass, expr ast.Expr, receiver, assertio
 }
 
 func isRequireNewForCurrentTest(pass *analysis.Pass, expr ast.Expr, receiver *types.Var) bool {
+	expr = ast.Unparen(expr)
+	if star, ok := expr.(*ast.StarExpr); ok {
+		expr = ast.Unparen(star.X)
+	}
 	call, ok := expr.(*ast.CallExpr)
 	if !ok || len(call.Args) != 1 {
 		return false
@@ -214,14 +222,28 @@ func isRequireNewForCurrentTest(pass *analysis.Pass, expr ast.Expr, receiver *ty
 	return ok && pass.TypesInfo.ObjectOf(ident) == receiver
 }
 
-func hasIgnoreDirective(group *ast.CommentGroup) bool {
-	if group == nil {
-		return false
-	}
-	for _, comment := range group.List {
-		if strings.HasPrefix(comment.Text, ignorePrefix) && strings.TrimSpace(strings.TrimPrefix(comment.Text, ignorePrefix)) != "" {
-			return true
+func findIgnoreDirective(groups ...*ast.CommentGroup) (valid bool, invalid token.Pos) {
+	for _, group := range groups {
+		if group == nil {
+			continue
+		}
+		for _, comment := range group.List {
+			if !strings.HasPrefix(comment.Text, ignoreDirective) {
+				continue
+			}
+			reason := strings.TrimPrefix(comment.Text, ignoreDirective)
+			if reason != "" && !strings.HasPrefix(reason, " ") && !strings.HasPrefix(reason, "\t") {
+				continue
+			}
+			if strings.TrimSpace(reason) != "" {
+				valid = true
+			} else if !invalid.IsValid() {
+				invalid = comment.Pos()
+			}
 		}
 	}
-	return false
+	if valid {
+		invalid = token.NoPos
+	}
+	return valid, invalid
 }

--- a/internal/cmd/build/testsuiteassertions/analyzer.go
+++ b/internal/cmd/build/testsuiteassertions/analyzer.go
@@ -1,0 +1,214 @@
+// Package testsuiteassertions checks testify suites for stale embedded require assertions.
+// Place //testsuiteassertions:ignore followed by a reason on a suite type declaration
+// when its assertions are intentionally suite-scoped.
+package testsuiteassertions
+
+import (
+	"go/ast"
+	"go/token"
+	"go/types"
+	"strings"
+
+	"golang.org/x/tools/go/analysis"
+)
+
+const (
+	requirePackage = "github.com/stretchr/testify/require"
+	suitePackage   = "github.com/stretchr/testify/suite"
+	ignorePrefix   = "//testsuiteassertions:ignore "
+)
+
+// Analyzer checks that suites embedding require.Assertions refresh it in SetupTest.
+var Analyzer = &analysis.Analyzer{
+	Name: "testsuiteassertions",
+	Doc:  "check that testify suites refresh embedded require assertions for each test",
+	Run:  run,
+}
+
+type suiteType struct {
+	spec            *ast.TypeSpec
+	assertionsField *types.Var
+	ignored         bool
+	setupTest       *ast.FuncDecl
+}
+
+// run reports testify suites that do not refresh embedded require assertions for each test.
+func run(pass *analysis.Pass) (any, error) {
+	suites := make(map[*types.TypeName]*suiteType)
+	for _, file := range pass.Files {
+		for _, decl := range file.Decls {
+			genDecl, ok := decl.(*ast.GenDecl)
+			if !ok || genDecl.Tok != token.TYPE {
+				continue
+			}
+			for _, rawSpec := range genDecl.Specs {
+				spec, ok := rawSpec.(*ast.TypeSpec)
+				if !ok {
+					continue
+				}
+				named, _ := types.Unalias(pass.TypesInfo.TypeOf(spec.Name)).(*types.Named)
+				if named == nil {
+					continue
+				}
+				structType, _ := named.Underlying().(*types.Struct)
+				if structType == nil {
+					continue
+				}
+				var assertionsField *types.Var
+				hasSuite := false
+				for field := range structType.Fields() {
+					if !field.Embedded() {
+						continue
+					}
+					switch {
+					case isNamed(field.Type(), requirePackage, "Assertions"):
+						assertionsField = field
+					case isNamed(field.Type(), suitePackage, "Suite"):
+						hasSuite = true
+					}
+				}
+				if assertionsField != nil && hasSuite {
+					ignored := hasIgnoreDirective(spec.Doc) || hasIgnoreDirective(spec.Comment)
+					if len(genDecl.Specs) == 1 {
+						ignored = ignored || hasIgnoreDirective(genDecl.Doc)
+					}
+					suites[named.Obj()] = &suiteType{
+						spec:            spec,
+						assertionsField: assertionsField,
+						ignored:         ignored,
+					}
+				}
+			}
+		}
+	}
+
+	for _, file := range pass.Files {
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Recv == nil || fn.Name.Name != "SetupTest" {
+				continue
+			}
+			typeName, receiver := receiverType(pass, fn)
+			if suite := suites[typeName]; suite != nil {
+				suite.setupTest = fn
+				if !suite.ignored && !rebindsAssertions(pass, fn, receiver, suite.assertionsField) {
+					receiverName := "receiver"
+					if receiver != nil {
+						receiverName = receiver.Name()
+					}
+					pass.Reportf(fn.Name.Pos(), "%s.SetupTest must rebind embedded require.Assertions with require.New(%s.T())", typeName.Name(), receiverName)
+				}
+			}
+		}
+	}
+
+	for typeName, suite := range suites {
+		if !suite.ignored && suite.setupTest == nil {
+			pass.Reportf(suite.spec.Name.Pos(), "%s embeds require.Assertions and suite.Suite; add SetupTest to rebind assertions with require.New(receiver.T())", typeName.Name())
+		}
+	}
+	return nil, nil
+}
+
+func isNamed(typ types.Type, packagePath, name string) bool {
+	if pointer, ok := types.Unalias(typ).(*types.Pointer); ok {
+		typ = pointer.Elem()
+	}
+	named, _ := types.Unalias(typ).(*types.Named)
+	return named != nil && named.Obj().Pkg() != nil && named.Obj().Pkg().Path() == packagePath && named.Obj().Name() == name
+}
+
+func receiverType(pass *analysis.Pass, fn *ast.FuncDecl) (*types.TypeName, *types.Var) {
+	field := fn.Recv.List[0]
+	var receiver *types.Var
+	if len(field.Names) != 0 {
+		receiver, _ = pass.TypesInfo.ObjectOf(field.Names[0]).(*types.Var)
+	}
+	typ := types.Unalias(pass.TypesInfo.TypeOf(field.Type))
+	if pointer, ok := typ.(*types.Pointer); ok {
+		typ = types.Unalias(pointer.Elem())
+	}
+	named, _ := typ.(*types.Named)
+	if named == nil {
+		return nil, receiver
+	}
+	return named.Obj(), receiver
+}
+
+func rebindsAssertions(pass *analysis.Pass, fn *ast.FuncDecl, receiver, assertionsField *types.Var) bool {
+	found := false
+	ast.Inspect(fn.Body, func(node ast.Node) bool {
+		if _, ok := node.(*ast.FuncLit); ok {
+			return false
+		}
+		assign, ok := node.(*ast.AssignStmt)
+		if !ok {
+			return true
+		}
+		for i, lhs := range assign.Lhs {
+			if i >= len(assign.Rhs) || !isAssertionsSelector(pass, lhs, receiver, assertionsField) {
+				continue
+			}
+			if isRequireNewForCurrentTest(pass, assign.Rhs[i], receiver) {
+				found = true
+				return false
+			}
+		}
+		return !found
+	})
+	return found
+}
+
+func isAssertionsSelector(pass *analysis.Pass, expr ast.Expr, receiver, assertionsField *types.Var) bool {
+	selector, ok := expr.(*ast.SelectorExpr)
+	if !ok || pass.TypesInfo.Selections[selector] == nil || pass.TypesInfo.Selections[selector].Obj() != assertionsField {
+		return false
+	}
+	ident, ok := selector.X.(*ast.Ident)
+	return ok && pass.TypesInfo.ObjectOf(ident) == receiver
+}
+
+func isRequireNewForCurrentTest(pass *analysis.Pass, expr ast.Expr, receiver *types.Var) bool {
+	call, ok := expr.(*ast.CallExpr)
+	if !ok || len(call.Args) != 1 {
+		return false
+	}
+	newSelector, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	newFunc, _ := pass.TypesInfo.ObjectOf(newSelector.Sel).(*types.Func)
+	if newFunc == nil || newFunc.Pkg() == nil || newFunc.Pkg().Path() != requirePackage || newFunc.Name() != "New" {
+		return false
+	}
+	tCall, ok := call.Args[0].(*ast.CallExpr)
+	if !ok || len(tCall.Args) != 0 {
+		return false
+	}
+	tSelector, ok := tCall.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	selection := pass.TypesInfo.Selections[tSelector]
+	if selection == nil {
+		return false
+	}
+	tMethod, _ := selection.Obj().(*types.Func)
+	if tMethod == nil || tMethod.Pkg() == nil || tMethod.Pkg().Path() != suitePackage || tMethod.Name() != "T" {
+		return false
+	}
+	ident, ok := tSelector.X.(*ast.Ident)
+	return ok && pass.TypesInfo.ObjectOf(ident) == receiver
+}
+
+func hasIgnoreDirective(group *ast.CommentGroup) bool {
+	if group == nil {
+		return false
+	}
+	for _, comment := range group.List {
+		if strings.HasPrefix(comment.Text, ignorePrefix) && strings.TrimSpace(strings.TrimPrefix(comment.Text, ignorePrefix)) != "" {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cmd/build/testsuiteassertions/analyzer.go
+++ b/internal/cmd/build/testsuiteassertions/analyzer.go
@@ -50,7 +50,11 @@ func run(pass *analysis.Pass) (any, error) {
 				if !ok {
 					continue
 				}
-				named, _ := types.Unalias(pass.TypesInfo.TypeOf(spec.Name)).(*types.Named)
+				typeName, _ := pass.TypesInfo.ObjectOf(spec.Name).(*types.TypeName)
+				if typeName == nil || typeName.IsAlias() {
+					continue
+				}
+				named, _ := typeName.Type().(*types.Named)
 				if named == nil {
 					continue
 				}
@@ -77,7 +81,7 @@ func run(pass *analysis.Pass) (any, error) {
 						commentGroups = append(commentGroups, genDecl.Doc)
 					}
 					ignored, invalidIgnore := findIgnoreDirective(commentGroups...)
-					suites[named.Obj()] = &suiteType{
+					suites[typeName] = &suiteType{
 						spec:            spec,
 						assertionsField: assertionsField,
 						ignored:         ignored || invalidIgnore.IsValid(),

--- a/internal/cmd/build/testsuiteassertions/analyzer.go
+++ b/internal/cmd/build/testsuiteassertions/analyzer.go
@@ -1,4 +1,6 @@
-// Package testsuiteassertions checks testify suites for stale embedded require assertions.
+// Package testsuiteassertions checks that testify suites refresh embedded require
+// assertions when SetupTest begins. Nested Suite.Run transitions are outside the
+// scope of this analyzer.
 // Place //testsuiteassertions:ignore followed by a reason on a suite type declaration
 // when its assertions are intentionally suite-scoped.
 package testsuiteassertions
@@ -21,7 +23,7 @@ const (
 // Analyzer checks that suites embedding require.Assertions refresh it in SetupTest.
 var Analyzer = &analysis.Analyzer{
 	Name: "testsuiteassertions",
-	Doc:  "check that testify suites refresh embedded require assertions for each test",
+	Doc:  "check that testify suites refresh embedded require assertions in SetupTest",
 	Run:  run,
 }
 
@@ -32,7 +34,7 @@ type suiteType struct {
 	setupTest       *ast.FuncDecl
 }
 
-// run reports testify suites that do not refresh embedded require assertions for each test.
+// run reports testify suites that do not refresh embedded require assertions in SetupTest.
 func run(pass *analysis.Pass) (any, error) {
 	suites := make(map[*types.TypeName]*suiteType)
 	for _, file := range pass.Files {
@@ -91,12 +93,16 @@ func run(pass *analysis.Pass) (any, error) {
 			typeName, receiver := receiverType(pass, fn)
 			if suite := suites[typeName]; suite != nil {
 				suite.setupTest = fn
+				if !suite.ignored && !isSetupTestHook(pass, fn) {
+					pass.Reportf(fn.Name.Pos(), "%s.SetupTest must have signature func (*%s) SetupTest()", typeName.Name(), typeName.Name())
+					continue
+				}
 				if !suite.ignored && !rebindsAssertions(pass, fn, receiver, suite.assertionsField) {
 					receiverName := "receiver"
 					if receiver != nil {
 						receiverName = receiver.Name()
 					}
-					pass.Reportf(fn.Name.Pos(), "%s.SetupTest must rebind embedded require.Assertions with require.New(%s.T())", typeName.Name(), receiverName)
+					pass.Reportf(fn.Name.Pos(), "%s.SetupTest must rebind embedded require.Assertions with require.New(%s.T()) as its first statement", typeName.Name(), receiverName)
 				}
 			}
 		}
@@ -135,28 +141,35 @@ func receiverType(pass *analysis.Pass, fn *ast.FuncDecl) (*types.TypeName, *type
 	return named.Obj(), receiver
 }
 
+func isSetupTestHook(pass *analysis.Pass, fn *ast.FuncDecl) bool {
+	method, _ := pass.TypesInfo.ObjectOf(fn.Name).(*types.Func)
+	if method == nil {
+		return false
+	}
+	signature, _ := method.Type().(*types.Signature)
+	if signature == nil || signature.Recv() == nil || signature.Params().Len() != 0 || signature.Results().Len() != 0 {
+		return false
+	}
+	_, ok := types.Unalias(signature.Recv().Type()).(*types.Pointer)
+	return ok
+}
+
 func rebindsAssertions(pass *analysis.Pass, fn *ast.FuncDecl, receiver, assertionsField *types.Var) bool {
-	found := false
-	ast.Inspect(fn.Body, func(node ast.Node) bool {
-		if _, ok := node.(*ast.FuncLit); ok {
-			return false
-		}
-		assign, ok := node.(*ast.AssignStmt)
-		if !ok {
+	if fn.Body == nil || len(fn.Body.List) == 0 {
+		return false
+	}
+	assign, ok := fn.Body.List[0].(*ast.AssignStmt)
+	if !ok {
+		return false
+	}
+	for i, lhs := range assign.Lhs {
+		if i < len(assign.Rhs) &&
+			isAssertionsSelector(pass, lhs, receiver, assertionsField) &&
+			isRequireNewForCurrentTest(pass, assign.Rhs[i], receiver) {
 			return true
 		}
-		for i, lhs := range assign.Lhs {
-			if i >= len(assign.Rhs) || !isAssertionsSelector(pass, lhs, receiver, assertionsField) {
-				continue
-			}
-			if isRequireNewForCurrentTest(pass, assign.Rhs[i], receiver) {
-				found = true
-				return false
-			}
-		}
-		return !found
-	})
-	return found
+	}
+	return false
 }
 
 func isAssertionsSelector(pass *analysis.Pass, expr ast.Expr, receiver, assertionsField *types.Var) bool {

--- a/internal/cmd/build/testsuiteassertions/analyzer_test.go
+++ b/internal/cmd/build/testsuiteassertions/analyzer_test.go
@@ -1,0 +1,12 @@
+package testsuiteassertions_test
+
+import (
+	"testing"
+
+	"go.temporal.io/sdk/internal/cmd/build/testsuiteassertions"
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+func TestAnalyzer(t *testing.T) {
+	analysistest.Run(t, analysistest.TestData(), testsuiteassertions.Analyzer, "a")
+}

--- a/internal/cmd/build/testsuiteassertions/testdata/src/a/a.go
+++ b/internal/cmd/build/testsuiteassertions/testdata/src/a/a.go
@@ -14,6 +14,24 @@ func (s *validSuite) SetupTest() {
 	s.Assertions = req.New(s.T())
 }
 
+type parenthesizedSuite struct {
+	*req.Assertions
+	testifysuite.Suite
+}
+
+func (s *parenthesizedSuite) SetupTest() {
+	(s.Assertions) = (req.New(s.T()))
+}
+
+type valueEmbeddedAssertionsSuite struct {
+	req.Assertions
+	testifysuite.Suite
+}
+
+func (s *valueEmbeddedAssertionsSuite) SetupTest() {
+	s.Assertions = *req.New(s.T())
+}
+
 type missingSetupTestSuite struct { // want "missingSetupTestSuite embeds require.Assertions and suite.Suite; add SetupTest"
 	*req.Assertions
 	testifysuite.Suite
@@ -119,7 +137,7 @@ type ignoredSuite struct {
 }
 
 //testsuiteassertions:ignore
-type ignoreWithoutReasonSuite struct { // want "ignoreWithoutReasonSuite embeds require.Assertions and suite.Suite; add SetupTest"
+type ignoreWithoutReasonSuite struct { // want "//testsuiteassertions:ignore requires a reason"
 	*req.Assertions
 	testifysuite.Suite
 }

--- a/internal/cmd/build/testsuiteassertions/testdata/src/a/a.go
+++ b/internal/cmd/build/testsuiteassertions/testdata/src/a/a.go
@@ -1,0 +1,83 @@
+package a
+
+import (
+	req "github.com/stretchr/testify/require"
+	testifysuite "github.com/stretchr/testify/suite"
+)
+
+type validSuite struct {
+	*req.Assertions
+	testifysuite.Suite
+}
+
+func (s *validSuite) SetupTest() {
+	s.Assertions = req.New(s.T())
+}
+
+type missingSetupTestSuite struct { // want "missingSetupTestSuite embeds require.Assertions and suite.Suite; add SetupTest"
+	*req.Assertions
+	testifysuite.Suite
+}
+
+// PayloadLimitsTestSuite models the stale assertion lifecycle fixed by sdk-go PR #2333.
+type PayloadLimitsTestSuite struct {
+	*req.Assertions
+	testifysuite.Suite
+}
+
+func (ts *PayloadLimitsTestSuite) SetupSuite() {
+	ts.Assertions = req.New(ts.T())
+}
+
+func (ts *PayloadLimitsTestSuite) SetupTest() { // want "PayloadLimitsTestSuite.SetupTest must rebind embedded require.Assertions"
+	_ = ts.T()
+}
+
+type wrongTestSuite struct {
+	*req.Assertions
+	testifysuite.Suite
+}
+
+func (s *wrongTestSuite) SetupTest() { // want "wrongTestSuite.SetupTest must rebind embedded require.Assertions"
+	var other testifysuite.Suite
+	s.Assertions = req.New(other.T())
+}
+
+type unnamedReceiverSuite struct {
+	*req.Assertions
+	testifysuite.Suite
+}
+
+func (*unnamedReceiverSuite) SetupTest() { // want "unnamedReceiverSuite.SetupTest must rebind embedded require.Assertions"
+}
+
+type AssertionsAlias = req.Assertions
+type SuiteAlias = testifysuite.Suite
+
+type aliasSuite struct {
+	*AssertionsAlias
+	SuiteAlias
+}
+
+func (s *aliasSuite) SetupTest() {
+	s.AssertionsAlias = req.New(s.T())
+}
+
+//testsuiteassertions:ignore assertions are deliberately suite-scoped
+type ignoredSuite struct {
+	*req.Assertions
+	testifysuite.Suite
+}
+
+//testsuiteassertions:ignore
+type ignoreWithoutReasonSuite struct { // want "ignoreWithoutReasonSuite embeds require.Assertions and suite.Suite; add SetupTest"
+	*req.Assertions
+	testifysuite.Suite
+}
+
+type unrelatedAssertions struct{}
+
+type unrelatedSuite struct {
+	*unrelatedAssertions
+	testifysuite.Suite
+}

--- a/internal/cmd/build/testsuiteassertions/testdata/src/a/a.go
+++ b/internal/cmd/build/testsuiteassertions/testdata/src/a/a.go
@@ -51,6 +51,55 @@ type unnamedReceiverSuite struct {
 func (*unnamedReceiverSuite) SetupTest() { // want "unnamedReceiverSuite.SetupTest must rebind embedded require.Assertions"
 }
 
+type valueReceiverSuite struct {
+	*req.Assertions
+	testifysuite.Suite
+}
+
+func (s valueReceiverSuite) SetupTest() { // want "valueReceiverSuite.SetupTest must have signature func \\(\\*valueReceiverSuite\\) SetupTest\\(\\)"
+	s.Assertions = req.New(s.T())
+}
+
+type invalidSignatureSuite struct {
+	*req.Assertions
+	testifysuite.Suite
+}
+
+func (s *invalidSignatureSuite) SetupTest(_ int) { // want "invalidSignatureSuite.SetupTest must have signature func \\(\\*invalidSignatureSuite\\) SetupTest\\(\\)"
+	s.Assertions = req.New(s.T())
+}
+
+type conditionalRebindSuite struct {
+	*req.Assertions
+	testifysuite.Suite
+}
+
+func (s *conditionalRebindSuite) SetupTest() { // want "conditionalRebindSuite.SetupTest must rebind embedded require.Assertions"
+	if true {
+		s.Assertions = req.New(s.T())
+	}
+}
+
+type delayedRebindSuite struct {
+	*req.Assertions
+	testifysuite.Suite
+}
+
+func (s *delayedRebindSuite) SetupTest() { // want "delayedRebindSuite.SetupTest must rebind embedded require.Assertions"
+	_ = s.T()
+	s.Assertions = req.New(s.T())
+}
+
+type unreachableRebindSuite struct {
+	*req.Assertions
+	testifysuite.Suite
+}
+
+func (s *unreachableRebindSuite) SetupTest() { // want "unreachableRebindSuite.SetupTest must rebind embedded require.Assertions"
+	return
+	s.Assertions = req.New(s.T())
+}
+
 type AssertionsAlias = req.Assertions
 type SuiteAlias = testifysuite.Suite
 

--- a/internal/cmd/build/testsuiteassertions/testdata/src/a/a.go
+++ b/internal/cmd/build/testsuiteassertions/testdata/src/a/a.go
@@ -3,6 +3,7 @@ package a
 import (
 	req "github.com/stretchr/testify/require"
 	testifysuite "github.com/stretchr/testify/suite"
+	"importedsuite"
 )
 
 type validSuite struct {
@@ -129,6 +130,16 @@ type aliasSuite struct {
 func (s *aliasSuite) SetupTest() {
 	s.AssertionsAlias = req.New(s.T())
 }
+
+type aliasCannotSuppressSuite struct { // want "aliasCannotSuppressSuite embeds require.Assertions and suite.Suite; add SetupTest"
+	*req.Assertions
+	testifysuite.Suite
+}
+
+//testsuiteassertions:ignore aliases cannot define SetupTest
+type ignoredSuiteAlias = aliasCannotSuppressSuite
+
+type importedSuiteAlias = importedsuite.Suite
 
 //testsuiteassertions:ignore assertions are deliberately suite-scoped
 type ignoredSuite struct {

--- a/internal/cmd/build/testsuiteassertions/testdata/src/github.com/stretchr/testify/require/require.go
+++ b/internal/cmd/build/testsuiteassertions/testdata/src/github.com/stretchr/testify/require/require.go
@@ -1,0 +1,7 @@
+package require
+
+import "testing"
+
+type Assertions struct{}
+
+func New(*testing.T) *Assertions { return nil }

--- a/internal/cmd/build/testsuiteassertions/testdata/src/github.com/stretchr/testify/suite/suite.go
+++ b/internal/cmd/build/testsuiteassertions/testdata/src/github.com/stretchr/testify/suite/suite.go
@@ -1,0 +1,7 @@
+package suite
+
+import "testing"
+
+type Suite struct{}
+
+func (*Suite) T() *testing.T { return nil }

--- a/internal/cmd/build/testsuiteassertions/testdata/src/importedsuite/importedsuite.go
+++ b/internal/cmd/build/testsuiteassertions/testdata/src/importedsuite/importedsuite.go
@@ -1,0 +1,11 @@
+package importedsuite
+
+import (
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type Suite struct {
+	*require.Assertions
+	suite.Suite
+}

--- a/test/bindings_test.go
+++ b/test/bindings_test.go
@@ -35,6 +35,7 @@ func (ts *AsyncBindingsTestSuite) TearDownSuite() {
 }
 
 func (ts *AsyncBindingsTestSuite) SetupTest() {
+	ts.Assertions = require.New(ts.T())
 	ts.taskQueueName = taskQueuePrefix + "-" + ts.T().Name()
 	ts.worker = worker.New(ts.client, ts.taskQueueName, worker.Options{})
 	ts.worker.RegisterWorkflow(SimplestWorkflow)

--- a/test/dynamic_workflows_test.go
+++ b/test/dynamic_workflows_test.go
@@ -44,6 +44,7 @@ func (ts *DynamicWorkflowTestSuite) TearDownSuite() {
 }
 
 func (ts *DynamicWorkflowTestSuite) SetupTest() {
+	ts.Assertions = require.New(ts.T())
 	ts.taskQueueName = taskQueuePrefix + "-" + ts.T().Name()
 }
 

--- a/test/external_storage_test.go
+++ b/test/external_storage_test.go
@@ -162,6 +162,7 @@ func (s *ExternalStorageTestSuite) SetupSuite() {
 }
 
 func (s *ExternalStorageTestSuite) SetupTest() {
+	s.Assertions = require.New(s.T())
 	s.taskQueueName = taskQueuePrefix + "-ext-" + s.T().Name()
 	s.driver = newMemDriver("test")
 	var err error

--- a/test/worker_heartbeat_test.go
+++ b/test/worker_heartbeat_test.go
@@ -63,6 +63,7 @@ func (ts *WorkerHeartbeatTestSuite) TearDownSuite() {
 }
 
 func (ts *WorkerHeartbeatTestSuite) SetupTest() {
+	ts.Assertions = require.New(ts.T())
 	ts.taskQueueName = taskQueuePrefix + "-" + ts.T().Name()
 }
 

--- a/test/worker_tuner_test.go
+++ b/test/worker_tuner_test.go
@@ -37,6 +37,7 @@ func (ts *WorkerTunerTestSuite) TearDownSuite() {
 }
 
 func (ts *WorkerTunerTestSuite) SetupTest() {
+	ts.Assertions = require.New(ts.T())
 	ts.taskQueueName = taskQueuePrefix + "-" + ts.T().Name()
 }
 

--- a/test/worker_versioning_test.go
+++ b/test/worker_versioning_test.go
@@ -46,6 +46,7 @@ func (ts *WorkerVersioningTestSuite) TearDownSuite() {
 }
 
 func (ts *WorkerVersioningTestSuite) SetupTest() {
+	ts.Assertions = require.New(ts.T())
 	ts.taskQueueName = taskQueuePrefix + "-" + ts.T().Name()
 }
 

--- a/test/workflow_random_test.go
+++ b/test/workflow_random_test.go
@@ -44,6 +44,7 @@ func (ts *WorkflowRandomTestSuite) TearDownSuite() {
 }
 
 func (ts *WorkflowRandomTestSuite) SetupTest() {
+	ts.Assertions = require.New(ts.T())
 	ts.taskQueueName = taskQueuePrefix + "-" + ts.T().Name()
 
 	ts.worker = worker.New(ts.client, ts.taskQueueName, worker.Options{})

--- a/test/workflow_readonly_test.go
+++ b/test/workflow_readonly_test.go
@@ -129,6 +129,7 @@ func (ts *WorkflowReadOnlyTestSuite) TearDownSuite() {
 }
 
 func (ts *WorkflowReadOnlyTestSuite) SetupTest() {
+	ts.Assertions = require.New(ts.T())
 	ts.taskQueueName = taskQueuePrefix + "-" + ts.T().Name()
 
 	isReadOnlyRec = &isReadOnlyRecorder{calls: map[string]bool{}}


### PR DESCRIPTION
## What was changed
- Added a `go/analysis` checker for testify suites that embed both `*require.Assertions` and `suite.Suite`
- Require those suites to refresh the embedded assertions in `SetupTest` with `require.New(s.T())`
- Added to `go run . check`
- Fix existing stale assertion bindings
- support `//testsuiteassertions:ignore <reason>` for intentional exceptions

## Why?
Testify updates `suite.Suite` to reference the active test before each suite test, but a separately embedded `*require.Assertions` remains bound to the earlier `*testing.T` unless it is explicitly refreshed. Fatal assertions may therefore be attributed to the wrong test phase or operate on a stale test handle.

This has caused a few repeated fixes:
- #2333 rebound assertions in both `PayloadLimitsTestSuite.SetupTest` and `WorkerDeploymentTestSuite.SetupTest`
- #2510 rebound assertions in `IntegrationTestSuite.SetupTest` for better test separation
- d513a066 (cadence PR) rebound assertions in `IntegrationTestSuite.TearDownSuite` to use the correct teardown test handle.

Running this analyzer also identified eight existing suites with the same issue.

## Checklist
<!--- add/delete as needed --->

1. Closes #2560

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to build tooling and test suite setup; no production runtime or security-sensitive paths.
> 
> **Overview**
> Adds a **`testsuiteassertions`** `go/analysis` checker and runs it from **`go run . check`** across each discovered `go.mod` (via new **`findModuleDirs`**, skipping `vendor`, `testdata`, etc.).
> 
> The analyzer flags testify suite types that embed both **`require.Assertions`** and **`suite.Suite`** unless **`SetupTest`**’s first statement rebinds assertions with **`require.New(receiver.T())`**. **`//testsuiteassertions:ignore <reason>`** on the suite type opts out; ignore without a reason is reported.
> 
> Several integration test suites are updated to add that rebinding in **`SetupTest`**, matching the stale-assertion pattern addressed in prior PRs (#2333, #2510).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8841bcfd6cb2640ce97f743d18ee09f2214b73a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->