### PR TITLE
Add initial release notes for GCS storage driver 0.1.0

### DIFF
--- a/contrib/gcp/gcsdriver/CHANGELOG.md
+++ b/contrib/gcp/gcsdriver/CHANGELOG.md
@@ -11,6 +11,8 @@ or Security.
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-08-13
+
 ### Added
 
 - Initial release of the GCS storage driver for external payload storage,


### PR DESCRIPTION
## What was changed
Update changelog for 0.1.0 release

## Why?
yes

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog update with no runtime or API changes.
> 
> **Overview**
> Adds a **0.1.0** release section to `contrib/gcp/gcsdriver/CHANGELOG.md` dated **2026-08-13**, sitting between `[Unreleased]` and the existing **Added** notes for the initial GCS external payload storage driver release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4cecc765847f3423f49c708e0e8d3c8697557c8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->