### PR TITLE
Run checks for contrib modules

### DIFF
--- a/contrib/aws/lambdaworker/runworker.go
+++ b/contrib/aws/lambdaworker/runworker.go
@@ -128,7 +128,7 @@ func runWorkerInternal(
 			workTime := time.Until(deadline) - configCtx.ShutdownDeadlineBuffer
 			if workTime <= time.Second {
 				return fmt.Errorf(
-					"Lambda timeout leaves almost no time for work "+
+					"lambda timeout leaves almost no time for work "+
 						"(workTime %v, shutdownBuffer %v); increase the "+
 						"function timeout or decrease the shutdown deadline "+
 						"buffer",

--- a/contrib/aws/s3driver/awssdkv2/client.go
+++ b/contrib/aws/s3driver/awssdkv2/client.go
@@ -75,6 +75,6 @@ func (c *s3Client) GetObject(ctx context.Context, bucket, key string) ([]byte, e
 	if err != nil {
 		return nil, err
 	}
-	defer output.Body.Close()
+	defer func() { _ = output.Body.Close() }()
 	return io.ReadAll(output.Body)
 }

--- a/contrib/aws/s3driver/driver.go
+++ b/contrib/aws/s3driver/driver.go
@@ -77,10 +77,10 @@ var _ converter.StorageDriver = (*s3StorageDriver)(nil)
 // NOTE: Experimental
 func NewDriver(opts Options) (converter.StorageDriver, error) {
 	if opts.Client == nil {
-		return nil, errors.New("Client is required")
+		return nil, errors.New("client is required")
 	}
 	if opts.Bucket == nil {
-		return nil, errors.New("Bucket is required")
+		return nil, errors.New("bucket is required")
 	}
 	name := opts.DriverName
 	if name == "" {
@@ -91,7 +91,7 @@ func NewDriver(opts Options) (converter.StorageDriver, error) {
 		maxSize = defaultMaxPayloadSize
 	}
 	if maxSize < 0 {
-		return nil, fmt.Errorf("MaxPayloadSize must be positive, got %d", maxSize)
+		return nil, fmt.Errorf("max payload size must be positive, got %d", maxSize)
 	}
 	return &s3StorageDriver{
 		client:         opts.Client,

--- a/contrib/aws/s3driver/driver.go
+++ b/contrib/aws/s3driver/driver.go
@@ -91,7 +91,7 @@ func NewDriver(opts Options) (converter.StorageDriver, error) {
 		maxSize = defaultMaxPayloadSize
 	}
 	if maxSize < 0 {
-		return nil, fmt.Errorf("max payload size must be positive, got %d", maxSize)
+		return nil, fmt.Errorf("MaxPayloadSize must be positive, got %d", maxSize)
 	}
 	return &s3StorageDriver{
 		client:         opts.Client,

--- a/contrib/aws/s3driver/driver_test.go
+++ b/contrib/aws/s3driver/driver_test.go
@@ -126,14 +126,14 @@ func TestNewS3StorageDriver_NilClient(t *testing.T) {
 	_, err := NewDriver(Options{
 		Bucket: StaticBucket("b"),
 	})
-	assert.EqualError(t, err, "Client is required")
+	assert.EqualError(t, err, "client is required")
 }
 
 func TestNewS3StorageDriver_NilBucketFunc(t *testing.T) {
 	_, err := NewDriver(Options{
 		Client: newMemClient(),
 	})
-	assert.EqualError(t, err, "Bucket is required")
+	assert.EqualError(t, err, "bucket is required")
 }
 
 func TestNewS3StorageDriver_NegativeMaxPayloadSize(t *testing.T) {
@@ -142,7 +142,7 @@ func TestNewS3StorageDriver_NegativeMaxPayloadSize(t *testing.T) {
 		Bucket:         StaticBucket("b"),
 		MaxPayloadSize: -1,
 	})
-	assert.EqualError(t, err, "MaxPayloadSize must be positive, got -1")
+	assert.EqualError(t, err, "max payload size must be positive, got -1")
 }
 
 // --- StaticBucket tests ---

--- a/contrib/aws/s3driver/driver_test.go
+++ b/contrib/aws/s3driver/driver_test.go
@@ -142,7 +142,7 @@ func TestNewS3StorageDriver_NegativeMaxPayloadSize(t *testing.T) {
 		Bucket:         StaticBucket("b"),
 		MaxPayloadSize: -1,
 	})
-	assert.EqualError(t, err, "max payload size must be positive, got -1")
+	assert.EqualError(t, err, "MaxPayloadSize must be positive, got -1")
 }
 
 // --- StaticBucket tests ---

--- a/contrib/datadog/tracing/interceptor.go
+++ b/contrib/datadog/tracing/interceptor.go
@@ -137,14 +137,14 @@ func (t *tracerImpl) ContextWithSpan(ctx context.Context, span interceptor.Trace
 func SpanFromWorkflowContext(ctx workflow.Context) (*tracer.Span, bool) {
 	val := ctx.Value(activeSpanContextKey)
 	if val == nil {
-		return tracer.SpanFromContext(nil)
+		return nil, false
 	}
 
 	if span, ok := val.(*tracerSpan); ok {
 		return span.Span, true
 	}
 
-	return tracer.SpanFromContext(nil)
+	return nil, false
 }
 
 func genSpanID(idempotencyKey string) uint64 {

--- a/contrib/envconfig/client_config_load_test.go
+++ b/contrib/envconfig/client_config_load_test.go
@@ -11,15 +11,14 @@ import (
 
 func TestLoadClientOptionsFile(t *testing.T) {
 	// Put some data in temp file and set the env var to use that file
-	f, err := os.CreateTemp("", "")
+	f, err := os.CreateTemp(t.TempDir(), "")
 	require.NoError(t, err)
-	defer os.Remove(f.Name())
 	_, err = f.Write([]byte(`
 [profile.default]
 address = "my-address"
 namespace = "my-namespace"`))
-	f.Close()
 	require.NoError(t, err)
+	require.NoError(t, f.Close())
 
 	// Explicitly set
 	opts, err := envconfig.LoadClientOptions(envconfig.LoadClientOptionsRequest{

--- a/contrib/gcp/gcsdriver/driver.go
+++ b/contrib/gcp/gcsdriver/driver.go
@@ -80,10 +80,10 @@ var _ converter.StorageDriver = (*gcsStorageDriver)(nil)
 // NOTE: Experimental
 func NewDriver(opts Options) (converter.StorageDriver, error) {
 	if opts.Client == nil {
-		return nil, errors.New("Client is required")
+		return nil, errors.New("client is required")
 	}
 	if opts.Bucket == nil {
-		return nil, errors.New("Bucket is required")
+		return nil, errors.New("bucket is required")
 	}
 	name := opts.DriverName
 	if name == "" {
@@ -94,7 +94,7 @@ func NewDriver(opts Options) (converter.StorageDriver, error) {
 		maxSize = defaultMaxPayloadSize
 	}
 	if maxSize < 0 {
-		return nil, fmt.Errorf("MaxPayloadSize must be positive, got %d", maxSize)
+		return nil, fmt.Errorf("max payload size must be positive, got %d", maxSize)
 	}
 	return &gcsStorageDriver{
 		client:         opts.Client,

--- a/contrib/gcp/gcsdriver/driver.go
+++ b/contrib/gcp/gcsdriver/driver.go
@@ -94,7 +94,7 @@ func NewDriver(opts Options) (converter.StorageDriver, error) {
 		maxSize = defaultMaxPayloadSize
 	}
 	if maxSize < 0 {
-		return nil, fmt.Errorf("max payload size must be positive, got %d", maxSize)
+		return nil, fmt.Errorf("MaxPayloadSize must be positive, got %d", maxSize)
 	}
 	return &gcsStorageDriver{
 		client:         opts.Client,

--- a/contrib/gcp/gcsdriver/driver_test.go
+++ b/contrib/gcp/gcsdriver/driver_test.go
@@ -144,7 +144,7 @@ func TestNewGCSStorageDriver_NegativeMaxPayloadSize(t *testing.T) {
 		Bucket:         StaticBucket("b"),
 		MaxPayloadSize: -1,
 	})
-	assert.EqualError(t, err, "max payload size must be positive, got -1")
+	assert.EqualError(t, err, "MaxPayloadSize must be positive, got -1")
 }
 
 // --- StaticBucket tests ---

--- a/contrib/gcp/gcsdriver/driver_test.go
+++ b/contrib/gcp/gcsdriver/driver_test.go
@@ -128,14 +128,14 @@ func TestNewGCSStorageDriver_NilClient(t *testing.T) {
 	_, err := NewDriver(Options{
 		Bucket: StaticBucket("b"),
 	})
-	assert.EqualError(t, err, "Client is required")
+	assert.EqualError(t, err, "client is required")
 }
 
 func TestNewGCSStorageDriver_NilBucketFunc(t *testing.T) {
 	_, err := NewDriver(Options{
 		Client: newMemClient(),
 	})
-	assert.EqualError(t, err, "Bucket is required")
+	assert.EqualError(t, err, "bucket is required")
 }
 
 func TestNewGCSStorageDriver_NegativeMaxPayloadSize(t *testing.T) {
@@ -144,7 +144,7 @@ func TestNewGCSStorageDriver_NegativeMaxPayloadSize(t *testing.T) {
 		Bucket:         StaticBucket("b"),
 		MaxPayloadSize: -1,
 	})
-	assert.EqualError(t, err, "MaxPayloadSize must be positive, got -1")
+	assert.EqualError(t, err, "max payload size must be positive, got -1")
 }
 
 // --- StaticBucket tests ---

--- a/contrib/gcp/gcsdriver/gcssdk/client.go
+++ b/contrib/gcp/gcsdriver/gcssdk/client.go
@@ -50,7 +50,7 @@ func (c *gcsClient) GetObject(ctx context.Context, bucket, key string) ([]byte, 
 	if err != nil {
 		return nil, err
 	}
-	defer r.Close()
+	defer func() { _ = r.Close() }()
 	return io.ReadAll(r)
 }
 

--- a/contrib/opentelemetry/handler_test.go
+++ b/contrib/opentelemetry/handler_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
@@ -29,7 +30,7 @@ func TestTags(t *testing.T) {
 	handlerWithTag.Counter("testCounter").Inc(1)
 	// Assert result
 	var rm metricdata.ResourceMetrics
-	metricReader.Collect(ctx, &rm)
+	require.NoError(t, metricReader.Collect(ctx, &rm))
 	assert.Len(t, rm.ScopeMetrics, 1)
 	metrics := rm.ScopeMetrics[0].Metrics
 	assert.Len(t, metrics, 1)
@@ -70,7 +71,7 @@ func TestCounterHandler(t *testing.T) {
 	testCounter2.Inc(5)
 	// Assert result
 	var rm metricdata.ResourceMetrics
-	metricReader.Collect(ctx, &rm)
+	require.NoError(t, metricReader.Collect(ctx, &rm))
 	assert.Len(t, rm.ScopeMetrics, 1)
 	metrics := rm.ScopeMetrics[0].Metrics
 	assert.Len(t, metrics, 1)
@@ -107,7 +108,7 @@ func TestCounterHandlerWithMonotonicCounters(t *testing.T) {
 	taggedHandler.Counter("testCounter").Inc(3)
 
 	var rm metricdata.ResourceMetrics
-	metricReader.Collect(ctx, &rm)
+	require.NoError(t, metricReader.Collect(ctx, &rm))
 	assert.Len(t, rm.ScopeMetrics, 1)
 	metrics := rm.ScopeMetrics[0].Metrics
 	assert.Len(t, metrics, 1)
@@ -150,7 +151,7 @@ func TestGaugeHandler(t *testing.T) {
 
 	// Assert result
 	var rm metricdata.ResourceMetrics
-	metricReader.Collect(ctx, &rm)
+	require.NoError(t, metricReader.Collect(ctx, &rm))
 	assert.Len(t, rm.ScopeMetrics, 1)
 	metrics := rm.ScopeMetrics[0].Metrics
 	assert.Len(t, metrics, 1)
@@ -190,7 +191,7 @@ func TestTimerHandler(t *testing.T) {
 	testTimer2.Record(time.Millisecond)
 
 	var rm metricdata.ResourceMetrics
-	metricReader.Collect(ctx, &rm)
+	require.NoError(t, metricReader.Collect(ctx, &rm))
 	assert.Len(t, rm.ScopeMetrics, 1)
 	metrics := rm.ScopeMetrics[0].Metrics
 	assert.Len(t, metrics, 1)

--- a/contrib/opentelemetry/tracing_interceptor.go
+++ b/contrib/opentelemetry/tracing_interceptor.go
@@ -187,7 +187,7 @@ func SpanFromWorkflowContext(ctx workflow.Context) (trace.Span, bool) {
 	}
 
 	// Fallback to OpenTelemetry span extraction behavior
-	return trace.SpanFromContext(nil), false
+	return trace.SpanFromContext(context.Background()), false
 }
 
 func (t *tracer) StartSpan(opts *interceptor.TracerStartSpanOptions) (interceptor.TracerSpan, error) {

--- a/internal/cmd/build/main.go
+++ b/internal/cmd/build/main.go
@@ -74,25 +74,64 @@ func (b *builder) run() error {
 }
 
 func (b *builder) check() error {
+	moduleDirs, err := b.checkModuleDirs()
+	if err != nil {
+		return fmt.Errorf("failed finding modules to check: %w", err)
+	}
+
 	// Run go vet
-	if err := b.runCmd(b.cmdFromRoot("go", "vet", "./...")); err != nil {
+	if err := b.runCmdInDirs(moduleDirs, "go", "vet", "./..."); err != nil {
 		return fmt.Errorf("go vet failed: %w", err)
 	}
 	// Run errcheck
 	if errCheck, err := b.getInstalledTool("github.com/kisielk/errcheck"); err != nil {
 		return fmt.Errorf("failed getting errcheck: %w", err)
-	} else if err := b.runCmd(b.cmdFromRoot(errCheck, "./...")); err != nil {
+	} else if err := b.runCmdInDirs(moduleDirs, errCheck, "./..."); err != nil {
 		return fmt.Errorf("errcheck failed: %w", err)
 	}
 	// Run staticcheck
 	if staticCheck, err := b.getInstalledTool("honnef.co/go/tools/cmd/staticcheck"); err != nil {
 		return fmt.Errorf("failed getting staticcheck: %w", err)
-	} else if err := b.runCmd(b.cmdFromRoot(staticCheck, "./...")); err != nil {
+	} else if err := b.runCmdInDirs(moduleDirs, staticCheck, "./..."); err != nil {
 		return fmt.Errorf("staticcheck failed: %w", err)
 	}
 	// Run doclink check
 	if err := b.runCmd(b.cmdFromRoot("go", "run", "./internal/cmd/tools/doclink/doclink.go")); err != nil {
 		return fmt.Errorf("doclink check failed: %w", err)
+	}
+	return nil
+}
+
+func (b *builder) checkModuleDirs() ([]string, error) {
+	moduleDirs := []string{b.rootDir}
+	contribDir := filepath.Join(b.rootDir, "contrib")
+	err := filepath.WalkDir(contribDir, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.Name() == "go.mod" {
+			moduleDirs = append(moduleDirs, filepath.Dir(p))
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(moduleDirs[1:])
+	return moduleDirs, nil
+}
+
+func (b *builder) runCmdInDirs(dirs []string, args ...string) error {
+	for _, dir := range dirs {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		if err := b.runCmd(cmd); err != nil {
+			moduleDir, relErr := filepath.Rel(b.rootDir, dir)
+			if relErr != nil {
+				moduleDir = dir
+			}
+			return fmt.Errorf("failed in module %q: %w", moduleDir, err)
+		}
 	}
 	return nil
 }

--- a/internal/cmd/build/main_test.go
+++ b/internal/cmd/build/main_test.go
@@ -9,10 +9,42 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
 )
+
+func TestCheckModuleDirs(t *testing.T) {
+	rootDir := t.TempDir()
+	for _, moduleDir := range []string{
+		"contrib/alpha",
+		"contrib/nested/bravo",
+		"internal/ignored",
+	} {
+		dir := filepath.Join(rootDir, filepath.FromSlash(moduleDir))
+		if err := os.MkdirAll(dir, 0777); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "go.mod"), nil, 0666); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	b := &builder{rootDir: rootDir}
+	moduleDirs, err := b.checkModuleDirs()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{
+		rootDir,
+		filepath.Join(rootDir, "contrib", "alpha"),
+		filepath.Join(rootDir, "contrib", "nested", "bravo"),
+	}
+	if !slices.Equal(moduleDirs, want) {
+		t.Fatalf("expected module dirs %q, got %q", want, moduleDirs)
+	}
+}
 
 func TestTestOutputFlagsDefaultToFailures(t *testing.T) {
 	flags := addTestOutputFlags(flag.NewFlagSet("test", flag.ContinueOnError))


### PR DESCRIPTION
## What was changed
  - Run `go vet`, `errcheck`, and `staticcheck` for the root SDK module and every Go module under `contrib/`.
  - Discover contrib modules automatically from their `go.mod` files, including nested modules.
  - Add test coverage for module discovery.
  - Fix the existing analyzer findings surfaced in contrib packages.

## Why?
This stopped working when #1293 replaced the Makefile with the Go build tool. 

The previous Makefile discovered every `go.mod` in the repository and ran `vet`, `errcheck`, and `staticcheck` from each module directory. The replacement build command ran each tool only once from the repository root. Because `./...` does not traverse nested Go modules, contrib modules were unintentionally excluded.

This change restores that per-module behavior for the root SDK and all modules under `contrib/`.

## Checklist
<!--- add/delete as needed --->

1. Closes #2557

2. How was this tested:
`go run . check` goes from 
<details>
```
➜  build git:(main) ✗ go run . check
2026/08/13 17:35:36 Running /Users/andrewyuan/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.4.darwin-arm64/bin/go in /Users/andrewyuan/all/sdk-go with args [vet ./...]
2026/08/13 17:35:37 Installing github.com/kisielk/errcheck
2026/08/13 17:35:37 Running /Users/andrewyuan/go/bin/errcheck in /Users/andrewyuan/all/sdk-go with args [./...]
2026/08/13 17:35:38 Installing honnef.co/go/tools/cmd/staticcheck
2026/08/13 17:35:38 Running /Users/andrewyuan/go/bin/staticcheck in /Users/andrewyuan/all/sdk-go with args [./...]
2026/08/13 17:35:38 Running /Users/andrewyuan/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.4.darwin-arm64/bin/go in /Users/andrewyuan/all/sdk-go with args [run ./internal/cmd/tools/doclink/doclink.go]
```
</details>

to

<details>
```
➜  build git:(contrib-check) go run . check
2026/08/13 17:34:45 Running /Users/andrewyuan/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.4.darwin-arm64/bin/go in /Users/andrewyuan/all/sdk-go-contrib-check with args [vet ./...]
2026/08/13 17:34:45 Running /Users/andrewyuan/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.4.darwin-arm64/bin/go in /Users/andrewyuan/all/sdk-go-contrib-check/contrib/aws/lambdaworker with args [vet ./...]
2026/08/13 17:34:46 Running /Users/andrewyuan/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.4.darwin-arm64/bin/go in /Users/andrewyuan/all/sdk-go-contrib-check/contrib/aws/lambdaworker/otel with args [vet ./...]
2026/08/13 17:34:46 Running /Users/andrewyuan/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.4.darwin-arm64/bin/go in /Users/andrewyuan/all/sdk-go-contrib-check/contrib/aws/s3driver with args [vet ./...]
2026/08/13 17:34:46 Running /Users/andrewyuan/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.4.darwin-arm64/bin/go in /Users/andrewyuan/all/sdk-go-contrib-check/contrib/aws/s3driver/awssdkv2 with args [vet ./...]
2026/08/13 17:34:47 Running /Users/andrewyuan/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.4.darwin-arm64/bin/go in /Users/andrewyuan/all/sdk-go-contrib-check/contrib/datadog with args [vet ./...]
2026/08/13 17:34:47 Running /Users/andrewyuan/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.4.darwin-arm64/bin/go in /Users/andrewyuan/all/sdk-go-contrib-check/contrib/envconfig with args [vet ./...]
2026/08/13 17:34:47 Running /Users/andrewyuan/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.4.darwin-arm64/bin/go in /Users/andrewyuan/all/sdk-go-contrib-check/contrib/gcp/gcsdriver with args [vet ./...]
2026/08/13 17:34:48 Running /Users/andrewyuan/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.4.darwin-arm64/bin/go in /Users/andrewyuan/all/sdk-go-contrib-check/contrib/gcp/gcsdriver/gcssdk with args [vet ./...]
2026/08/13 17:34:48 Running /Users/andrewyuan/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.4.darwin-arm64/bin/go in /Users/andrewyuan/all/sdk-go-contrib-check/contrib/googleadk with args [vet ./...]
2026/08/13 17:34:49 Running /Users/andrewyuan/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.4.darwin-arm64/bin/go in /Users/andrewyuan/all/sdk-go-contrib-check/contrib/opentelemetry with args [vet ./...]
2026/08/13 17:34:49 Running /Users/andrewyuan/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.4.darwin-arm64/bin/go in /Users/andrewyuan/all/sdk-go-contrib-check/contrib/opentracing with args [vet ./...]
2026/08/13 17:34:49 Running /Users/andrewyuan/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.4.darwin-arm64/bin/go in /Users/andrewyuan/all/sdk-go-contrib-check/contrib/sysinfo with args [vet ./...]
2026/08/13 17:34:50 Running /Users/andrewyuan/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.4.darwin-arm64/bin/go in /Users/andrewyuan/all/sdk-go-contrib-check/contrib/tally with args [vet ./...]
2026/08/13 17:34:50 Running /Users/andrewyuan/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.4.darwin-arm64/bin/go in /Users/andrewyuan/all/sdk-go-contrib-check/contrib/tools/workflowcheck with args [vet ./...]
2026/08/13 17:34:50 Running /Users/andrewyuan/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.4.darwin-arm64/bin/go in /Users/andrewyuan/all/sdk-go-contrib-check/contrib/workflowstreams with args [vet ./...]
2026/08/13 17:34:51 Installing github.com/kisielk/errcheck
2026/08/13 17:34:51 Running /Users/andrewyuan/go/bin/errcheck in /Users/andrewyuan/all/sdk-go-contrib-check with args [./...]
2026/08/13 17:34:51 Running /Users/andrewyuan/go/bin/errcheck in /Users/andrewyuan/all/sdk-go-contrib-check/contrib/aws/lambdaworker with args [./...]
2026/08/13 17:34:52 Running /Users/andrewyuan/go/bin/errcheck in /Users/andrewyuan/all/sdk-go-contrib-check/contrib/aws/lambdaworker/otel with args [./...]
2026/08/13 17:34:52 Running /Users/andrewyuan/go/bin/errcheck in /Users/andrewyuan/all/sdk-go-contrib-check/contrib/aws/s3driver with args [./...]
2026/08/13 17:34:52 Running /Users/andrewyuan/go/bin/errcheck in /Users/andrewyuan/all/sdk-go-contrib-check/contrib/aws/s3driver/awssdkv2 with args [./...]
2026/08/13 17:34:53 Running /Users/andrewyuan/go/bin/errcheck in /Users/andrewyuan/all/sdk-go-contrib-check/contrib/datadog with args [./...]
2026/08/13 17:34:53 Running /Users/andrewyuan/go/bin/errcheck in /Users/andrewyuan/all/sdk-go-contrib-check/contrib/envconfig with args [./...]
2026/08/13 17:34:53 Running /Users/andrewyuan/go/bin/errcheck in /Users/andrewyuan/all/sdk-go-contrib-check/contrib/gcp/gcsdriver with args [./...]
2026/08/13 17:34:53 Running /Users/andrewyuan/go/bin/errcheck in /Users/andrewyuan/all/sdk-go-contrib-check/contrib/gcp/gcsdriver/gcssdk with args [./...]
2026/08/13 17:34:54 Running /Users/andrewyuan/go/bin/errcheck in /Users/andrewyuan/all/sdk-go-contrib-check/contrib/googleadk with args [./...]
2026/08/13 17:34:54 Running /Users/andrewyuan/go/bin/errcheck in /Users/andrewyuan/all/sdk-go-contrib-check/contrib/opentelemetry with args [./...]
2026/08/13 17:34:54 Running /Users/andrewyuan/go/bin/errcheck in /Users/andrewyuan/all/sdk-go-contrib-check/contrib/opentracing with args [./...]
2026/08/13 17:34:55 Running /Users/andrewyuan/go/bin/errcheck in /Users/andrewyuan/all/sdk-go-contrib-check/contrib/sysinfo with args [./...]
2026/08/13 17:34:55 Running /Users/andrewyuan/go/bin/errcheck in /Users/andrewyuan/all/sdk-go-contrib-check/contrib/tally with args [./...]
2026/08/13 17:34:55 Running /Users/andrewyuan/go/bin/errcheck in /Users/andrewyuan/all/sdk-go-contrib-check/contrib/tools/workflowcheck with args [./...]
2026/08/13 17:34:55 Running /Users/andrewyuan/go/bin/errcheck in /Users/andrewyuan/all/sdk-go-contrib-check/contrib/workflowstreams with args [./...]
2026/08/13 17:34:56 Installing honnef.co/go/tools/cmd/staticcheck
2026/08/13 17:34:56 Running /Users/andrewyuan/go/bin/staticcheck in /Users/andrewyuan/all/sdk-go-contrib-check with args [./...]
2026/08/13 17:34:57 Running /Users/andrewyuan/go/bin/staticcheck in /Users/andrewyuan/all/sdk-go-contrib-check/contrib/aws/lambdaworker with args [./...]
2026/08/13 17:34:57 Running /Users/andrewyuan/go/bin/staticcheck in /Users/andrewyuan/all/sdk-go-contrib-check/contrib/aws/lambdaworker/otel with args [./...]
2026/08/13 17:34:57 Running /Users/andrewyuan/go/bin/staticcheck in /Users/andrewyuan/all/sdk-go-contrib-check/contrib/aws/s3driver with args [./...]
2026/08/13 17:34:58 Running /Users/andrewyuan/go/bin/staticcheck in /Users/andrewyuan/all/sdk-go-contrib-check/contrib/aws/s3driver/awssdkv2 with args [./...]
2026/08/13 17:34:58 Running /Users/andrewyuan/go/bin/staticcheck in /Users/andrewyuan/all/sdk-go-contrib-check/contrib/datadog with args [./...]
2026/08/13 17:34:59 Running /Users/andrewyuan/go/bin/staticcheck in /Users/andrewyuan/all/sdk-go-contrib-check/contrib/envconfig with args [./...]
2026/08/13 17:34:59 Running /Users/andrewyuan/go/bin/staticcheck in /Users/andrewyuan/all/sdk-go-contrib-check/contrib/gcp/gcsdriver with args [./...]
2026/08/13 17:34:59 Running /Users/andrewyuan/go/bin/staticcheck in /Users/andrewyuan/all/sdk-go-contrib-check/contrib/gcp/gcsdriver/gcssdk with args [./...]
2026/08/13 17:35:00 Running /Users/andrewyuan/go/bin/staticcheck in /Users/andrewyuan/all/sdk-go-contrib-check/contrib/googleadk with args [./...]
2026/08/13 17:35:00 Running /Users/andrewyuan/go/bin/staticcheck in /Users/andrewyuan/all/sdk-go-contrib-check/contrib/opentelemetry with args [./...]
2026/08/13 17:35:01 Running /Users/andrewyuan/go/bin/staticcheck in /Users/andrewyuan/all/sdk-go-contrib-check/contrib/opentracing with args [./...]
2026/08/13 17:35:01 Running /Users/andrewyuan/go/bin/staticcheck in /Users/andrewyuan/all/sdk-go-contrib-check/contrib/sysinfo with args [./...]
2026/08/13 17:35:01 Running /Users/andrewyuan/go/bin/staticcheck in /Users/andrewyuan/all/sdk-go-contrib-check/contrib/tally with args [./...]
2026/08/13 17:35:02 Running /Users/andrewyuan/go/bin/staticcheck in /Users/andrewyuan/all/sdk-go-contrib-check/contrib/tools/workflowcheck with args [./...]
2026/08/13 17:35:02 Running /Users/andrewyuan/go/bin/staticcheck in /Users/andrewyuan/all/sdk-go-contrib-check/contrib/workflowstreams with args [./...]
2026/08/13 17:35:02 Running /Users/andrewyuan/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.4.darwin-arm64/bin/go in /Users/andrewyuan/all/sdk-go-contrib-check with args [run ./internal/cmd/tools/doclink/doclink.go]
```
</details>

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are mostly CI scope and linter-driven hygiene; workflow span fallbacks are minor and align with safer nil/context handling rather than altering core SDK behavior.
> 
> **Overview**
> Restores **per-module static analysis** for the root SDK and every `contrib/` Go module (including nested `go.mod` files). The build `check` command now discovers those modules via `checkModuleDirs` and runs `go vet`, `errcheck`, and `staticcheck` from each directory through `runCmdInDirs`, with a unit test for discovery.
> 
> **Contrib fixes** address findings from the newly enforced checks: lowercase static error strings in S3/GCS drivers and lambdaworker; `defer` closes that ignore `Close` errors in S3/GCS SDK clients; Datadog `SpanFromWorkflowContext` returns `nil, false` when no span is stored instead of calling `SpanFromContext(nil)`; OpenTelemetry’s workflow span helper uses `context.Background()` for the no-span fallback; envconfig and OpenTelemetry metric tests use `t.TempDir` / assert `Collect` errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3e55b2ebfa7cf0bee9fe01a6cd4c6d8f37f0144. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->