### PR TITLE
Configure test-focused linters

### DIFF
--- a/converter/data_converter_test.go
+++ b/converter/data_converter_test.go
@@ -29,6 +29,11 @@ func testDataConverterFunction(t *testing.T, dc DataConverter, f interface{}, ar
 	return retValues[0].Interface().(string)
 }
 
+func serializableBackgroundContext() context.Context {
+	// This test serializes the concrete context value; testing.T's cancelable context cannot round-trip through JSON.
+	return context.Background()
+}
+
 func TestDefaultDataConverter(t *testing.T) {
 	t.Parallel()
 	t.Run("result", func(t *testing.T) {
@@ -36,7 +41,7 @@ func TestDefaultDataConverter(t *testing.T) {
 		f1 := func(ctx context.Context, r []byte) string {
 			return "result"
 		}
-		r1 := testDataConverterFunction(t, defaultDataConverter, f1, context.Background(), []byte("test"))
+		r1 := testDataConverterFunction(t, defaultDataConverter, f1, serializableBackgroundContext(), []byte("test"))
 		require.Equal(t, r1, "result")
 	})
 	t.Run("empty", func(t *testing.T) {

--- a/converter/grpc_interceptor_test.go
+++ b/converter/grpc_interceptor_test.go
@@ -60,7 +60,7 @@ func TestPayloadCodecGRPCClientInterceptor(t *testing.T) {
 	client := workflowservice.NewWorkflowServiceClient(c)
 
 	_, err = client.StartWorkflowExecution(
-		context.Background(),
+		t.Context(),
 		&workflowservice.StartWorkflowExecutionRequest{
 			Input: unencodedPayloads(),
 		},
@@ -70,7 +70,7 @@ func TestPayloadCodecGRPCClientInterceptor(t *testing.T) {
 	require.Equal("binary/zlib", payloadEncoding(server.startWorkflowExecutionRequest.Input))
 
 	response, err := client.PollActivityTaskQueue(
-		context.Background(),
+		t.Context(),
 		&workflowservice.PollActivityTaskQueueRequest{},
 	)
 	require.NoError(err)
@@ -101,7 +101,7 @@ func TestFailureGRPCClientInterceptor(t *testing.T) {
 	client := workflowservice.NewWorkflowServiceClient(c)
 
 	_, err = client.RespondWorkflowTaskFailed(
-		context.Background(),
+		t.Context(),
 		&workflowservice.RespondWorkflowTaskFailedRequest{
 			Failure: &failure.Failure{
 				Message:    "internal error: code 123",
@@ -115,7 +115,7 @@ func TestFailureGRPCClientInterceptor(t *testing.T) {
 	require.Equal("", server.respondWorkflowTaskFailedRequest.Failure.StackTrace)
 
 	res, err := client.PollWorkflowTaskQueue(
-		context.Background(),
+		t.Context(),
 		&workflowservice.PollWorkflowTaskQueueRequest{},
 	)
 	require.NoError(err)

--- a/internal/cmd/build/go.mod
+++ b/internal/cmd/build/go.mod
@@ -3,8 +3,10 @@ module go.temporal.io/sdk/internal/cmd/build
 go 1.25.4
 
 require (
+	github.com/Antonboom/testifylint v1.6.4
 	github.com/BurntSushi/toml v1.4.1-0.20240526193622-a339e1f7089c
 	github.com/kisielk/errcheck v1.8.0
+	github.com/ldez/usetesting v0.5.0
 	go.temporal.io/sdk v1.32.1
 	honnef.co/go/tools v0.6.0
 )

--- a/internal/cmd/build/go.sum
+++ b/internal/cmd/build/go.sum
@@ -1,3 +1,5 @@
+github.com/Antonboom/testifylint v1.6.4 h1:gs9fUEy+egzxkEbq9P4cpcMB6/G0DYdMeiFS87UiqmQ=
+github.com/Antonboom/testifylint v1.6.4/go.mod h1:YO33FROXX2OoUfwjz8g+gUxQXio5i9qpVy7nXGbxDD4=
 github.com/BurntSushi/toml v1.4.1-0.20240526193622-a339e1f7089c h1:pxW6RcqyfI9/kWtOwnv/G+AzdKuy2ZrqINhenH4HyNs=
 github.com/BurntSushi/toml v1.4.1-0.20240526193622-a339e1f7089c/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
@@ -32,6 +34,8 @@ github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/ldez/usetesting v0.5.0 h1:3/QtzZObBKLy1F4F8jLuKJiKBjjVFi1IavpoWbmqLwc=
+github.com/ldez/usetesting v0.5.0/go.mod h1:Spnb4Qppf8JTuRgblLrEWb7IE6rDmUpGvxY3iRrzvDQ=
 github.com/nexus-rpc/nexus-proto-annotations v0.1.0 h1:2fELd+9sqUtNu6Fg//pw8YFsxOvp8vZ8hfP0nHhNI80=
 github.com/nexus-rpc/nexus-proto-annotations v0.1.0/go.mod h1:n3UjF1bPCW8llR8tHvbxJ+27yPWrhpo8w/Yg1IOuY0Y=
 github.com/nexus-rpc/sdk-go v0.6.0 h1:QRgnP2zTbxEbiyWG/aXH8uSC5LV/Mg1fqb19jb4DBlo=

--- a/internal/cmd/build/main.go
+++ b/internal/cmd/build/main.go
@@ -17,8 +17,10 @@ import (
 	"sort"
 	"strings"
 
+	_ "github.com/Antonboom/testifylint/analyzer"
 	_ "github.com/BurntSushi/toml"
 	_ "github.com/kisielk/errcheck/errcheck"
+	_ "github.com/ldez/usetesting"
 	_ "honnef.co/go/tools/staticcheck"
 
 	"go.temporal.io/sdk/client"
@@ -89,6 +91,33 @@ func (b *builder) check() error {
 		return fmt.Errorf("failed getting staticcheck: %w", err)
 	} else if err := b.runCmd(b.cmdFromRoot(staticCheck, "./...")); err != nil {
 		return fmt.Errorf("staticcheck failed: %w", err)
+	}
+	// Run usetesting
+	if useTesting, err := b.getInstalledTool("github.com/ldez/usetesting/cmd/usetesting"); err != nil {
+		return fmt.Errorf("failed getting usetesting: %w", err)
+	} else if err := b.runCmd(b.cmdFromRoot(
+		useTesting,
+		"-contextbackground",
+		"-contexttodo",
+		"-oschdir=false",
+		"-oscreatetemp",
+		"-osmkdirtemp",
+		"-ossetenv",
+		"-ostempdir",
+		"./...",
+	)); err != nil {
+		return fmt.Errorf("usetesting failed: %w", err)
+	}
+	// Run correctness-oriented testifylint checks. Staticcheck remains the style baseline.
+	if testifyLint, err := b.getInstalledTool("github.com/Antonboom/testifylint"); err != nil {
+		return fmt.Errorf("failed getting testifylint: %w", err)
+	} else if err := b.runCmd(b.cmdFromRoot(
+		testifyLint,
+		"-disable-all",
+		"-enable=nil-compare,suite-broken-parallel,suite-method-signature,useless-assert",
+		"./...",
+	)); err != nil {
+		return fmt.Errorf("testifylint failed: %w", err)
 	}
 	// Run doclink check
 	if err := b.runCmd(b.cmdFromRoot("go", "run", "./internal/cmd/tools/doclink/doclink.go")); err != nil {

--- a/internal/common/backoff/retry_test.go
+++ b/internal/common/backoff/retry_test.go
@@ -33,7 +33,7 @@ func TestRetrySuccess(t *testing.T) {
 	policy.SetMaximumInterval(5 * time.Millisecond)
 	policy.SetMaximumAttempts(10)
 
-	err := Retry(context.Background(), op, policy, nil)
+	err := Retry(t.Context(), op, policy, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, 5, i)
 }
@@ -55,7 +55,7 @@ func TestNoRetryAfterContextDone(t *testing.T) {
 	policy.SetMaximumInterval(50 * time.Millisecond)
 	policy.SetMaximumAttempts(10)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
 	defer cancel()
 
 	err := Retry(ctx, op, policy, nil)
@@ -80,7 +80,7 @@ func TestRetryFailed(t *testing.T) {
 	policy.SetMaximumInterval(5 * time.Millisecond)
 	policy.SetMaximumAttempts(5)
 
-	err := Retry(context.Background(), op, policy, nil)
+	err := Retry(t.Context(), op, policy, nil)
 	assert.Error(t, err)
 	assert.Equal(t, 5, i)
 }
@@ -110,7 +110,7 @@ func TestIsRetryableSuccess(t *testing.T) {
 	policy.SetMaximumInterval(5 * time.Millisecond)
 	policy.SetMaximumAttempts(10)
 
-	err := Retry(context.Background(), op, policy, isRetryable)
+	err := Retry(t.Context(), op, policy, isRetryable)
 	assert.NoError(t, err, "Retry count: %v", i)
 	assert.Equal(t, 5, i)
 }
@@ -132,7 +132,7 @@ func TestIsRetryableFailure(t *testing.T) {
 	policy.SetMaximumInterval(5 * time.Millisecond)
 	policy.SetMaximumAttempts(10)
 
-	err := Retry(context.Background(), op, policy, IgnoreErrors([]error{&someError{}}))
+	err := Retry(t.Context(), op, policy, IgnoreErrors([]error{&someError{}}))
 	assert.Error(t, err)
 	assert.Equal(t, 1, i)
 }
@@ -210,7 +210,7 @@ func TestRetryDeadlineExceeded(t *testing.T) {
 	policy.SetBackoffCoefficient(1)
 	policy.SetMaximumAttempts(3)
 
-	err := Retry(context.Background(), op, policy, nil)
+	err := Retry(t.Context(), op, policy, nil)
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, actualError)
 
@@ -223,7 +223,7 @@ func TestRetryDeadlineExceeded(t *testing.T) {
 		}
 		return actualError
 	}
-	err = Retry(context.Background(), op, policy, nil)
+	err = Retry(t.Context(), op, policy, nil)
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, actualError)
 }

--- a/internal/common/metrics/grpc_test.go
+++ b/internal/common/metrics/grpc_test.go
@@ -36,7 +36,7 @@ func TestGRPCInterceptor(t *testing.T) {
 	client := grpc_health_v1.NewHealthClient(cc)
 
 	// Make successful call
-	_, err = client.Check(context.Background(), &grpc_health_v1.HealthCheckRequest{Service: "myservice"})
+	_, err = client.Check(t.Context(), &grpc_health_v1.HealthCheckRequest{Service: "myservice"})
 	require.NoError(t, err)
 
 	// Check counters and timers
@@ -53,7 +53,7 @@ func TestGRPCInterceptor(t *testing.T) {
 	// Now clear the metrics and set a handler with tags and long poll on the
 	// context and make a known failing call
 	handler.Clear()
-	ctx := context.WithValue(context.Background(), metrics.HandlerContextKey{},
+	ctx := context.WithValue(t.Context(), metrics.HandlerContextKey{},
 		handler.WithTags(map[string]string{"roottag": "roottagval"}))
 	ctx = context.WithValue(ctx, metrics.LongPollContextKey{}, true)
 	_, err = client.Check(ctx, &grpc_health_v1.HealthCheckRequest{Service: "unknown"})

--- a/internal/context_aware_data_converter_test.go
+++ b/internal/context_aware_data_converter_test.go
@@ -118,7 +118,7 @@ func TestContextAwareDataConverter(t *testing.T) {
 	})
 	t.Run("with activity context", func(t *testing.T) {
 		t.Parallel()
-		ctx := context.Background()
+		ctx := t.Context()
 		ctx = context.WithValue(ctx, ContextAwareDataConverterContextKey, "e")
 
 		dc := WithContext(ctx, contextAwareDataConverter)

--- a/internal/credentials_test.go
+++ b/internal/credentials_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"crypto/tls"
 	"testing"
 
@@ -64,7 +63,7 @@ func TestAPIKeyCredentials_ExplicitTLSConfigPreservedWithAPIKey(t *testing.T) {
 
 func TestConnectionOptions_TLSAndTLSDisabledMutuallyExclusive(t *testing.T) {
 	// Test that setting both TLS and TLSDisabled returns an error
-	_, err := NewClient(context.Background(), ClientOptions{
+	_, err := NewClient(t.Context(), ClientOptions{
 		HostPort: "localhost:7233",
 		ConnectionOptions: ConnectionOptions{
 			TLS:         &tls.Config{},

--- a/internal/extstore/extstore_test.go
+++ b/internal/extstore/extstore_test.go
@@ -201,7 +201,7 @@ func TestExternalStorageToParams_SingleDriverSynthesizesSelector(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NotNil(t, params.driverSelector)
-	selected, err := params.driverSelector.SelectDriver(StorageDriverStoreContext{Context: context.Background()}, nil)
+	selected, err := params.driverSelector.SelectDriver(StorageDriverStoreContext{Context: t.Context()}, nil)
 	require.NoError(t, err)
 	require.Equal(t, driver, selected)
 }
@@ -334,7 +334,7 @@ func TestStoreVisitor_NoDriverNoop(t *testing.T) {
 	visitor := NewExternalStorageVisitor(params)
 
 	p := makePayload(t, "hello")
-	result, err := visitPayloads(context.Background(), visitor, []*commonpb.Payload{p})
+	result, err := visitPayloads(t.Context(), visitor, []*commonpb.Payload{p})
 	require.NoError(t, err)
 	require.True(t, proto.Equal(p, result[0]))
 }
@@ -350,7 +350,7 @@ func TestStoreVisitor_BelowThreshold_NotStored(t *testing.T) {
 	visitor := NewExternalStorageVisitor(params)
 
 	p := makePayload(t, "small")
-	result, err := visitPayloads(context.Background(), visitor, []*commonpb.Payload{p})
+	result, err := visitPayloads(t.Context(), visitor, []*commonpb.Payload{p})
 	require.NoError(t, err)
 	require.True(t, proto.Equal(p, result[0]), "small payload should be unchanged")
 	require.Equal(t, 0, driver.storeCount)
@@ -369,7 +369,7 @@ func TestStoreVisitor_AtThreshold_Stored(t *testing.T) {
 	p := makeOversizedPayload(t, threshold)
 	require.GreaterOrEqual(t, proto.Size(p), threshold)
 
-	result, err := visitPayloads(context.Background(), visitor, []*commonpb.Payload{p})
+	result, err := visitPayloads(t.Context(), visitor, []*commonpb.Payload{p})
 	require.NoError(t, err)
 	require.Equal(t, metadataEncodingProtoJSON, string(result[0].Metadata[metadataEncoding]))
 	require.Equal(t, 1, driver.storeCount)
@@ -386,7 +386,7 @@ func TestStoreVisitor_AboveThreshold_Stored(t *testing.T) {
 	visitor := NewExternalStorageVisitor(params)
 
 	p := makeOversizedPayload(t, threshold+1)
-	result, err := visitPayloads(context.Background(), visitor, []*commonpb.Payload{p})
+	result, err := visitPayloads(t.Context(), visitor, []*commonpb.Payload{p})
 	require.NoError(t, err)
 	require.Equal(t, metadataEncodingProtoJSON, string(result[0].Metadata[metadataEncoding]))
 	require.Equal(t, 1, driver.storeCount)
@@ -406,7 +406,7 @@ func TestStoreVisitor_MultiplePayloads_Batched(t *testing.T) {
 	small := &commonpb.Payload{Data: []byte("x")} // proto.Size ≈ 3, well below threshold
 	big2 := makeOversizedPayload(t, threshold)
 
-	result, err := visitPayloads(context.Background(), visitor, []*commonpb.Payload{big1, small, big2})
+	result, err := visitPayloads(t.Context(), visitor, []*commonpb.Payload{big1, small, big2})
 	require.NoError(t, err)
 	require.Len(t, result, 3)
 	require.Equal(t, metadataEncodingProtoJSON, string(result[0].Metadata[metadataEncoding]))
@@ -430,7 +430,7 @@ func TestStoreVisitor_SelectorNil_PayloadInline(t *testing.T) {
 	visitor := NewExternalStorageVisitor(params)
 
 	p := makeOversizedPayload(t, defaultPayloadSizeThreshold+1)
-	result, err := visitPayloads(context.Background(), visitor, []*commonpb.Payload{p})
+	result, err := visitPayloads(t.Context(), visitor, []*commonpb.Payload{p})
 	require.NoError(t, err)
 	require.Empty(t, result[0].ExternalPayloads, "selector returned nil so payload should be inline")
 	require.Equal(t, 0, driver.storeCount)
@@ -452,7 +452,7 @@ func TestStoreVisitor_SelectorBelowThreshold_NotCalled(t *testing.T) {
 	visitor := NewExternalStorageVisitor(params)
 
 	p := makePayload(t, "small")
-	result, err := visitPayloads(context.Background(), visitor, []*commonpb.Payload{p})
+	result, err := visitPayloads(t.Context(), visitor, []*commonpb.Payload{p})
 	require.NoError(t, err)
 	require.False(t, selectorCalled, "selector must not be invoked for sub-threshold payloads")
 	require.Empty(t, result[0].ExternalPayloads)
@@ -480,7 +480,7 @@ func TestStoreVisitor_SelectorRoutes_TwoDrivers(t *testing.T) {
 
 	p1 := makePayload(t, "a")
 	p2 := makePayload(t, "b")
-	_, err = visitPayloads(context.Background(), visitor, []*commonpb.Payload{p1, p2})
+	_, err = visitPayloads(t.Context(), visitor, []*commonpb.Payload{p1, p2})
 	require.NoError(t, err)
 	require.Equal(t, 1, d1.storeCount)
 	require.Equal(t, 1, d2.storeCount)
@@ -499,7 +499,7 @@ func TestStoreVisitor_SelectorUnregisteredDriver(t *testing.T) {
 	require.NoError(t, err)
 	visitor := NewExternalStorageVisitor(params)
 
-	_, err = visitPayloads(context.Background(), visitor, []*commonpb.Payload{makePayload(t, "x")})
+	_, err = visitPayloads(t.Context(), visitor, []*commonpb.Payload{makePayload(t, "x")})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "my-unregistered-driver")
 }
@@ -516,7 +516,7 @@ func TestStoreVisitor_SelectorError(t *testing.T) {
 	require.NoError(t, err)
 	visitor := NewExternalStorageVisitor(params)
 
-	_, err = visitPayloads(context.Background(), visitor, []*commonpb.Payload{makePayload(t, "x")})
+	_, err = visitPayloads(t.Context(), visitor, []*commonpb.Payload{makePayload(t, "x")})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "selector error")
 }
@@ -530,7 +530,7 @@ func TestStoreVisitor_WrongClaimCount(t *testing.T) {
 	require.NoError(t, err)
 	visitor := NewExternalStorageVisitor(params)
 
-	_, err = visitPayloads(context.Background(), visitor, []*commonpb.Payload{makePayload(t, "x")})
+	_, err = visitPayloads(t.Context(), visitor, []*commonpb.Payload{makePayload(t, "x")})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "my-bad-count-driver")
 }
@@ -545,7 +545,7 @@ func TestStoreVisitor_StoreError(t *testing.T) {
 	require.NoError(t, err)
 	visitor := NewExternalStorageVisitor(params)
 
-	_, err = visitPayloads(context.Background(), visitor, []*commonpb.Payload{makePayload(t, "x")})
+	_, err = visitPayloads(t.Context(), visitor, []*commonpb.Payload{makePayload(t, "x")})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "my-bad-error-driver")
 	require.Contains(t, err.Error(), "store failed")
@@ -560,7 +560,7 @@ func TestStoreVisitor_StorePanic(t *testing.T) {
 	require.NoError(t, err)
 	visitor := NewExternalStorageVisitor(params)
 
-	_, err = visitPayloads(context.Background(), visitor, []*commonpb.Payload{makePayload(t, "x")})
+	_, err = visitPayloads(t.Context(), visitor, []*commonpb.Payload{makePayload(t, "x")})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "my-panic-store-driver")
 	require.Contains(t, err.Error(), "store panic")
@@ -589,7 +589,7 @@ func TestStoreVisitor_CancelOnError(t *testing.T) {
 	visitor := NewExternalStorageVisitor(params)
 
 	p1, p2 := makePayload(t, "a"), makePayload(t, "b")
-	_, err = visitPayloads(context.Background(), visitor, []*commonpb.Payload{p1, p2})
+	_, err = visitPayloads(t.Context(), visitor, []*commonpb.Payload{p1, p2})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "store error")
 
@@ -611,7 +611,7 @@ func TestStoreVisitor_Callback(t *testing.T) {
 	visitor := NewExternalStorageVisitor(params)
 
 	cb := &testCallback{}
-	ctx := WithStorageOperationCallback(context.Background(), cb)
+	ctx := WithStorageOperationCallback(t.Context(), cb)
 	_, err = visitPayloads(ctx, visitor, []*commonpb.Payload{makePayload(t, "x"), makePayload(t, "y")})
 	require.NoError(t, err)
 	require.Equal(t, 2, cb.count)
@@ -634,7 +634,7 @@ func TestStoreVisitor_Callback_ExternalCountOnly(t *testing.T) {
 	big2 := makeOversizedPayload(t, threshold)
 
 	cb := &testCallback{}
-	ctx := WithStorageOperationCallback(context.Background(), cb)
+	ctx := WithStorageOperationCallback(t.Context(), cb)
 	_, err = visitPayloads(ctx, visitor, []*commonpb.Payload{small, big1, big2})
 	require.NoError(t, err)
 	require.Equal(t, 2, cb.count)
@@ -653,7 +653,7 @@ func TestRetrievalVisitor_InlinePassthrough(t *testing.T) {
 	visitor := NewExternalRetrievalVisitor(params)
 
 	p := makePayload(t, "inline")
-	result, err := visitPayloads(context.Background(), visitor, []*commonpb.Payload{p})
+	result, err := visitPayloads(t.Context(), visitor, []*commonpb.Payload{p})
 	require.NoError(t, err)
 	require.True(t, proto.Equal(p, result[0]))
 	require.Equal(t, 0, driver.retrieveCount)
@@ -671,12 +671,12 @@ func TestRetrievalVisitor_Mixed(t *testing.T) {
 	inline := makePayload(t, "inline")
 	big := makeOversizedPayload(t, 100)
 
-	stored, err := visitPayloads(context.Background(), storeVisitor, []*commonpb.Payload{big})
+	stored, err := visitPayloads(t.Context(), storeVisitor, []*commonpb.Payload{big})
 	require.NoError(t, err)
 	ref := stored[0]
 
 	retrieveVisitor := NewExternalRetrievalVisitor(storeParams)
-	result, err := visitPayloads(context.Background(), retrieveVisitor, []*commonpb.Payload{inline, ref})
+	result, err := visitPayloads(t.Context(), retrieveVisitor, []*commonpb.Payload{inline, ref})
 	require.NoError(t, err)
 	require.True(t, proto.Equal(inline, result[0]))
 	require.True(t, proto.Equal(big, result[1]))
@@ -693,11 +693,11 @@ func TestRetrievalVisitor_BatchedByDriver(t *testing.T) {
 	retrieveVisitor := NewExternalRetrievalVisitor(params)
 
 	p1, p2 := makePayload(t, "first"), makePayload(t, "second")
-	refs, err := visitPayloads(context.Background(), storeVisitor, []*commonpb.Payload{p1, p2})
+	refs, err := visitPayloads(t.Context(), storeVisitor, []*commonpb.Payload{p1, p2})
 	require.NoError(t, err)
 
 	driver.retrieveCount = 0
-	result, err := visitPayloads(context.Background(), retrieveVisitor, refs)
+	result, err := visitPayloads(t.Context(), retrieveVisitor, refs)
 	require.NoError(t, err)
 	require.Equal(t, 1, driver.retrieveCount, "both claims should be batched into one Retrieve call")
 	require.True(t, proto.Equal(p1, result[0]))
@@ -725,10 +725,10 @@ func TestRetrievalVisitor_MultiDriver(t *testing.T) {
 	retrieveVisitor := NewExternalRetrievalVisitor(params)
 
 	p1, p2 := makePayload(t, "a"), makePayload(t, "b")
-	refs, err := visitPayloads(context.Background(), storeVisitor, []*commonpb.Payload{p1, p2})
+	refs, err := visitPayloads(t.Context(), storeVisitor, []*commonpb.Payload{p1, p2})
 	require.NoError(t, err)
 
-	result, err := visitPayloads(context.Background(), retrieveVisitor, refs)
+	result, err := visitPayloads(t.Context(), retrieveVisitor, refs)
 	require.NoError(t, err)
 	require.True(t, proto.Equal(p1, result[0]))
 	require.True(t, proto.Equal(p2, result[1]))
@@ -749,7 +749,7 @@ func TestRetrievalVisitor_UnknownDriver(t *testing.T) {
 	}, 10)
 	require.NoError(t, err)
 
-	_, err = visitPayloads(context.Background(), visitor, []*commonpb.Payload{ref})
+	_, err = visitPayloads(t.Context(), visitor, []*commonpb.Payload{ref})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "unregistered-driver")
 }
@@ -765,10 +765,10 @@ func TestRetrievalVisitor_RetrieveError(t *testing.T) {
 	storeVisitor := NewExternalStorageVisitor(params)
 	retrieveVisitor := NewExternalRetrievalVisitor(params)
 
-	refs, err := visitPayloads(context.Background(), storeVisitor, []*commonpb.Payload{makePayload(t, "x")})
+	refs, err := visitPayloads(t.Context(), storeVisitor, []*commonpb.Payload{makePayload(t, "x")})
 	require.NoError(t, err)
 
-	_, err = visitPayloads(context.Background(), retrieveVisitor, refs)
+	_, err = visitPayloads(t.Context(), retrieveVisitor, refs)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "my-bad-error-driver")
 	require.Contains(t, err.Error(), "retrieve error")
@@ -788,7 +788,7 @@ func TestRetrievalVisitor_RetrievePanic(t *testing.T) {
 	}, 10)
 	require.NoError(t, err)
 
-	_, err = visitPayloads(context.Background(), visitor, []*commonpb.Payload{ref})
+	_, err = visitPayloads(t.Context(), visitor, []*commonpb.Payload{ref})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "my-panic-retrieve-driver")
 	require.Contains(t, err.Error(), "retrieve panic")
@@ -808,7 +808,7 @@ func TestRetrievalVisitor_CancelOnError(t *testing.T) {
 	})
 	require.NoError(t, err)
 	storeVisitor := NewExternalStorageVisitor(storeParams)
-	refs, err := visitPayloads(context.Background(), storeVisitor, []*commonpb.Payload{makePayload(t, "x")})
+	refs, err := visitPayloads(t.Context(), storeVisitor, []*commonpb.Payload{makePayload(t, "x")})
 	require.NoError(t, err)
 	errRef := refs[0]
 
@@ -827,7 +827,7 @@ func TestRetrievalVisitor_CancelOnError(t *testing.T) {
 	require.NoError(t, err)
 	visitor := NewExternalRetrievalVisitor(retrieveParams)
 
-	_, err = visitPayloads(context.Background(), visitor, []*commonpb.Payload{errRef, blockRef})
+	_, err = visitPayloads(t.Context(), visitor, []*commonpb.Payload{errRef, blockRef})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "retrieve error")
 
@@ -852,7 +852,7 @@ func TestRetrievalVisitor_WrongPayloadCount(t *testing.T) {
 	}, 10)
 	require.NoError(t, err)
 
-	_, err = visitPayloads(context.Background(), visitor, []*commonpb.Payload{ref})
+	_, err = visitPayloads(t.Context(), visitor, []*commonpb.Payload{ref})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "my-bad-count-driver")
 }
@@ -868,11 +868,11 @@ func TestRetrievalVisitor_Callback(t *testing.T) {
 	storeVisitor := NewExternalStorageVisitor(params)
 	retrieveVisitor := NewExternalRetrievalVisitor(params)
 
-	refs, err := visitPayloads(context.Background(), storeVisitor, []*commonpb.Payload{makePayload(t, "x")})
+	refs, err := visitPayloads(t.Context(), storeVisitor, []*commonpb.Payload{makePayload(t, "x")})
 	require.NoError(t, err)
 
 	cb := &testCallback{}
-	ctx := WithStorageOperationCallback(context.Background(), cb)
+	ctx := WithStorageOperationCallback(t.Context(), cb)
 	_, err = visitPayloads(ctx, retrieveVisitor, refs)
 	require.NoError(t, err)
 	require.Greater(t, cb.duration, time.Duration(0))
@@ -891,14 +891,14 @@ func TestRetrievalVisitor_Callback_ExternalCountOnly(t *testing.T) {
 
 	big1 := makeOversizedPayload(t, threshold)
 	big2 := makeOversizedPayload(t, threshold)
-	refs, err := visitPayloads(context.Background(), storeVisitor, []*commonpb.Payload{big1, big2})
+	refs, err := visitPayloads(t.Context(), storeVisitor, []*commonpb.Payload{big1, big2})
 	require.NoError(t, err)
 
 	inline := makePayload(t, "inline")
 	batch := []*commonpb.Payload{inline, refs[0], refs[1]}
 
 	cb := &testCallback{}
-	ctx := WithStorageOperationCallback(context.Background(), cb)
+	ctx := WithStorageOperationCallback(t.Context(), cb)
 	_, err = visitPayloads(ctx, retrieveVisitor, batch)
 	require.NoError(t, err)
 	require.Equal(t, 2, cb.count)
@@ -921,7 +921,7 @@ func TestRetrievalVisitor_LegacyFormat(t *testing.T) {
 
 	// Store a payload to get a real claim key in the driver.
 	original := makePayload(t, "legacy-compat-value")
-	refs, err := visitPayloads(context.Background(), NewExternalStorageVisitor(params), []*commonpb.Payload{original})
+	refs, err := visitPayloads(t.Context(), NewExternalStorageVisitor(params), []*commonpb.Payload{original})
 	require.NoError(t, err)
 
 	// Extract the claim data from the new-format reference and rebuild it as a
@@ -938,7 +938,7 @@ func TestRetrievalVisitor_LegacyFormat(t *testing.T) {
 		Data:     legacyData,
 	}
 
-	result, err := visitPayloads(context.Background(), NewExternalRetrievalVisitor(params), []*commonpb.Payload{legacyPayload})
+	result, err := visitPayloads(t.Context(), NewExternalRetrievalVisitor(params), []*commonpb.Payload{legacyPayload})
 	require.NoError(t, err)
 	require.True(t, proto.Equal(original, result[0]))
 }
@@ -1029,11 +1029,11 @@ func TestStoreRetrieveRoundTrip_Single(t *testing.T) {
 	retrieveVisitor := NewExternalRetrievalVisitor(params)
 
 	original := makePayload(t, "round-trip value")
-	refs, err := visitPayloads(context.Background(), storeVisitor, []*commonpb.Payload{original})
+	refs, err := visitPayloads(t.Context(), storeVisitor, []*commonpb.Payload{original})
 	require.NoError(t, err)
 	require.Equal(t, metadataEncodingProtoJSON, string(refs[0].Metadata[metadataEncoding]))
 
-	restored, err := visitPayloads(context.Background(), retrieveVisitor, refs)
+	restored, err := visitPayloads(t.Context(), retrieveVisitor, refs)
 	require.NoError(t, err)
 	require.True(t, proto.Equal(original, restored[0]))
 }
@@ -1052,10 +1052,10 @@ func TestStoreRetrieveRoundTrip_MixedInline(t *testing.T) {
 	small := makePayload(t, "s")
 	big := makeOversizedPayload(t, threshold+1)
 
-	refs, err := visitPayloads(context.Background(), storeVisitor, []*commonpb.Payload{small, big})
+	refs, err := visitPayloads(t.Context(), storeVisitor, []*commonpb.Payload{small, big})
 	require.NoError(t, err)
 
-	restored, err := visitPayloads(context.Background(), retrieveVisitor, refs)
+	restored, err := visitPayloads(t.Context(), retrieveVisitor, refs)
 	require.NoError(t, err)
 	require.True(t, proto.Equal(small, restored[0]), "inline payload unchanged")
 	require.True(t, proto.Equal(big, restored[1]), "stored payload restored")
@@ -1087,7 +1087,7 @@ func TestStoreRetrieveRoundTrip_PointerAndValueReceiverDrivers(t *testing.T) {
 	p1 := makePayload(t, "via-ptr-driver")
 	p2 := makePayload(t, "via-val-driver")
 
-	refs, err := visitPayloads(context.Background(), storeVisitor, []*commonpb.Payload{p1, p2})
+	refs, err := visitPayloads(t.Context(), storeVisitor, []*commonpb.Payload{p1, p2})
 	require.NoError(t, err)
 
 	// Confirm each payload was routed to the expected driver.
@@ -1100,7 +1100,7 @@ func TestStoreRetrieveRoundTrip_PointerAndValueReceiverDrivers(t *testing.T) {
 	require.Equal(t, "val-driver", ref1.DriverName)
 
 	// Both payloads should round-trip back to their original values.
-	result, err := visitPayloads(context.Background(), retrieveVisitor, refs)
+	result, err := visitPayloads(t.Context(), retrieveVisitor, refs)
 	require.NoError(t, err)
 	require.True(t, proto.Equal(p1, result[0]))
 	require.True(t, proto.Equal(p2, result[1]))

--- a/internal/grpc_dialer_test.go
+++ b/internal/grpc_dialer_test.go
@@ -41,7 +41,7 @@ import (
 func TestErrorWrapper_SimpleError(t *testing.T) {
 	require := require.New(t)
 
-	svcerr := errorInterceptor(context.Background(), "method", "request", "reply", nil,
+	svcerr := errorInterceptor(t.Context(), "method", "request", "reply", nil,
 		func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
 			return status.Error(codes.NotFound, "Something not found")
 		})
@@ -53,7 +53,7 @@ func TestErrorWrapper_SimpleError(t *testing.T) {
 func TestErrorWrapper_ErrorWithFailure(t *testing.T) {
 	require := require.New(t)
 
-	svcerr := errorInterceptor(context.Background(), "method", "request", "reply", nil,
+	svcerr := errorInterceptor(t.Context(), "method", "request", "reply", nil,
 		func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
 			st, _ := status.New(codes.AlreadyExists, "Something started").WithDetails(&errordetails.WorkflowExecutionAlreadyStartedFailure{
 				StartRequestId: "srId",
@@ -85,7 +85,7 @@ func (a authHeadersProvider) GetHeaders(context.Context) (map[string]string, err
 }
 
 func TestHeadersProvider_PopulateAuthToken(t *testing.T) {
-	require.NoError(t, headersProviderInterceptor(authHeadersProvider{token: "test-auth-token"})(context.Background(), "method", "request", "reply", nil,
+	require.NoError(t, headersProviderInterceptor(authHeadersProvider{token: "test-auth-token"})(t.Context(), "method", "request", "reply", nil,
 		func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
 			md, ok := metadata.FromOutgoingContext(ctx)
 			if !ok {
@@ -100,7 +100,7 @@ func TestHeadersProvider_PopulateAuthToken(t *testing.T) {
 }
 
 func TestHeadersProvider_Error(t *testing.T) {
-	require.Error(t, headersProviderInterceptor(authHeadersProvider{err: errors.New("failed to populate headers")})(context.Background(), "method", "request", "reply", nil,
+	require.Error(t, headersProviderInterceptor(authHeadersProvider{err: errors.New("failed to populate headers")})(t.Context(), "method", "request", "reply", nil,
 		func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
 			return nil
 		}))
@@ -140,7 +140,7 @@ func TestMissingGetServerInfo(t *testing.T) {
 			lastErr = err
 		} else {
 			_, err := workflowservice.NewWorkflowServiceClient(conn).GetSystemInfo(
-				context.Background(),
+				t.Context(),
 				&workflowservice.GetSystemInfoRequest{},
 			)
 			_ = conn.Close()
@@ -153,7 +153,7 @@ func TestMissingGetServerInfo(t *testing.T) {
 	require.NoError(t, lastErr)
 
 	// Create a new client and confirm client has empty capabilities set
-	client, err := DialClient(context.Background(), ClientOptions{HostPort: l.Addr().String()})
+	client, err := DialClient(t.Context(), ClientOptions{HostPort: l.Addr().String()})
 	require.NoError(t, err)
 	workflowClient := client.(*WorkflowClient)
 	require.True(t, proto.Equal(&workflowservice.GetSystemInfoResponse_Capabilities{}, workflowClient.capabilities))
@@ -163,7 +163,7 @@ func TestInternalErrorRetry(t *testing.T) {
 	// Build a common retry policy that will retry 2 times (so 3 attempts total)
 	retryConfig := retry.NewGrpcRetryConfig(10 * time.Nanosecond)
 	retryConfig.SetMaximumAttempts(3)
-	ctx := context.WithValue(context.Background(), retry.ConfigKey, retryConfig)
+	ctx := context.WithValue(t.Context(), retry.ConfigKey, retryConfig)
 
 	// Start a server that wants you to retry internal errors (the default)
 	srv, err := startTestGRPCServer()
@@ -174,7 +174,7 @@ func TestInternalErrorRetry(t *testing.T) {
 	srv.signalWorkflowExecutionResponseError = status.Error(codes.Internal, "oh no, an internal error")
 
 	// Create client and make call
-	client, err := DialClient(context.Background(), ClientOptions{HostPort: srv.addr})
+	client, err := DialClient(t.Context(), ClientOptions{HostPort: srv.addr})
 	require.NoError(t, err)
 	defer client.Close()
 	_, err = client.WorkflowService().SignalWorkflowExecution(ctx, &workflowservice.SignalWorkflowExecutionRequest{})
@@ -195,7 +195,7 @@ func TestInternalErrorRetry(t *testing.T) {
 	srv.signalWorkflowExecutionResponseError = status.Error(codes.Internal, "oh no, an internal error")
 
 	// Create client and make call
-	client, err = DialClient(context.Background(), ClientOptions{HostPort: srv.addr})
+	client, err = DialClient(t.Context(), ClientOptions{HostPort: srv.addr})
 	require.NoError(t, err)
 	defer client.Close()
 	_, err = client.WorkflowService().SignalWorkflowExecution(ctx, &workflowservice.SignalWorkflowExecutionRequest{})
@@ -213,19 +213,19 @@ func TestEagerAndLazyClient(t *testing.T) {
 	srv.getSystemInfoResponseError = fmt.Errorf("some server failure")
 
 	// Confirm eager dial fails
-	_, err = DialClient(context.Background(), ClientOptions{HostPort: srv.addr})
+	_, err = DialClient(t.Context(), ClientOptions{HostPort: srv.addr})
 	require.EqualError(t, err, "failed reaching server: some server failure")
 
 	// Confirm lazy dial succeeds but fails signal workflow
 	c, err := NewLazyClient(ClientOptions{HostPort: srv.addr})
 	require.NoError(t, err)
 	defer c.Close()
-	err = c.SignalWorkflow(context.Background(), "workflow1", "", "my-signal", nil)
+	err = c.SignalWorkflow(t.Context(), "workflow1", "", "my-signal", nil)
 	require.EqualError(t, err, "failed reaching server: some server failure")
 
 	// But if we call again without a sys info response error, it will succeed
 	srv.getSystemInfoResponseError = nil
-	err = c.SignalWorkflow(context.Background(), "workflow1", "", "my-signal", nil)
+	err = c.SignalWorkflow(t.Context(), "workflow1", "", "my-signal", nil)
 	require.NoError(t, err)
 	// Verify version headers are set
 	require.Equal(
@@ -240,7 +240,7 @@ func TestEagerAndLazyClient(t *testing.T) {
 	)
 
 	// Now that there's no sys info response error, eager should succeed
-	c, err = DialClient(context.Background(), ClientOptions{HostPort: srv.addr})
+	c, err = DialClient(t.Context(), ClientOptions{HostPort: srv.addr})
 	require.NoError(t, err)
 	defer c.Close()
 	// Verify version headers are set
@@ -257,7 +257,7 @@ func TestEagerAndLazyClient(t *testing.T) {
 
 	// And even if it starts erroring, the success was memoized so calls succeed
 	srv.getSystemInfoResponseError = fmt.Errorf("some server failure")
-	err = c.SignalWorkflow(context.Background(), "workflow1", "", "my-signal", nil)
+	err = c.SignalWorkflow(t.Context(), "workflow1", "", "my-signal", nil)
 	require.NoError(t, err)
 }
 
@@ -272,26 +272,26 @@ func TestCheckHealth(t *testing.T) {
 
 	// Confirm fail if can't init
 	srv.getSystemInfoResponseError = fmt.Errorf("some server failure")
-	_, err = c.CheckHealth(context.Background(), nil)
+	_, err = c.CheckHealth(t.Context(), nil)
 	require.EqualError(t, err, "failed reaching server: some server failure")
 
 	// Now if it can init, but health not registered
 	srv.getSystemInfoResponseError = nil
-	_, err = c.CheckHealth(context.Background(), nil)
+	_, err = c.CheckHealth(t.Context(), nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "health check error")
 
 	// Now register the service but set it as bad
 	srv.healthServer.SetServingStatus("temporal.api.workflowservice.v1.WorkflowService",
 		grpc_health_v1.HealthCheckResponse_NOT_SERVING)
-	_, err = c.CheckHealth(context.Background(), nil)
+	_, err = c.CheckHealth(t.Context(), nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "NOT_SERVING")
 
 	// Now set as serving and succeed
 	srv.healthServer.SetServingStatus("temporal.api.workflowservice.v1.WorkflowService",
 		grpc_health_v1.HealthCheckResponse_SERVING)
-	_, err = c.CheckHealth(context.Background(), nil)
+	_, err = c.CheckHealth(t.Context(), nil)
 	require.NoError(t, err)
 }
 
@@ -320,7 +320,7 @@ func TestDialOptions(t *testing.T) {
 			return invoker(ctx, method, req, reply, cc, opts...)
 		}
 	}
-	client, err := DialClient(context.Background(), ClientOptions{
+	client, err := DialClient(t.Context(), ClientOptions{
 		HostPort: srv.addr,
 		ConnectionOptions: ConnectionOptions{
 			DialOptions: []grpc.DialOption{
@@ -333,7 +333,7 @@ func TestDialOptions(t *testing.T) {
 	defer client.Close()
 
 	// Make call we know will error (ignore error)
-	_, _ = client.WorkflowService().SignalWorkflowExecution(context.TODO(),
+	_, _ = client.WorkflowService().SignalWorkflowExecution(t.Context(),
 		&workflowservice.SignalWorkflowExecutionRequest{})
 
 	// Confirm trace
@@ -370,14 +370,14 @@ func TestGrpcCompression(t *testing.T) {
 			require.NoError(t, err)
 			defer srv.Stop()
 
-			client, err := DialClient(context.Background(), ClientOptions{
+			client, err := DialClient(t.Context(), ClientOptions{
 				HostPort:          srv.addr,
 				ConnectionOptions: tc.connectionOptions,
 			})
 			require.NoError(t, err)
 			defer client.Close()
 
-			_, err = client.WorkflowService().SignalWorkflowExecution(context.Background(),
+			_, err = client.WorkflowService().SignalWorkflowExecution(t.Context(),
 				&workflowservice.SignalWorkflowExecutionRequest{
 					Namespace:  "test-namespace",
 					SignalName: strings.Repeat("test-signal", 100),
@@ -402,7 +402,7 @@ func TestGrpcCompressionDowngradesUnsupportedMethod(t *testing.T) {
 	srv.rejectGzipGetSystemInfo = true
 	srv.statsHandler.reset()
 
-	client, err := DialClient(context.Background(), ClientOptions{HostPort: srv.addr})
+	client, err := DialClient(t.Context(), ClientOptions{HostPort: srv.addr})
 	require.NoError(t, err)
 	defer client.Close()
 
@@ -412,14 +412,14 @@ func TestGrpcCompressionDowngradesUnsupportedMethod(t *testing.T) {
 	require.Equal(t, grpcgzip.Name, getSystemInfoHistory[0])
 	require.NotEqual(t, grpcgzip.Name, getSystemInfoHistory[1])
 
-	_, err = client.WorkflowService().GetSystemInfo(context.Background(), &workflowservice.GetSystemInfoRequest{})
+	_, err = client.WorkflowService().GetSystemInfo(t.Context(), &workflowservice.GetSystemInfoRequest{})
 	require.NoError(t, err)
 	getSystemInfoHistory = srv.statsHandler.compressionHistoryForMethod(getSystemInfoMethod)
 	require.Len(t, getSystemInfoHistory, 3)
 	require.Equal(t, 1, countCompression(getSystemInfoHistory, grpcgzip.Name))
 	require.NotEqual(t, grpcgzip.Name, getSystemInfoHistory[2])
 
-	_, err = client.WorkflowService().SignalWorkflowExecution(context.Background(),
+	_, err = client.WorkflowService().SignalWorkflowExecution(t.Context(),
 		&workflowservice.SignalWorkflowExecutionRequest{
 			Namespace:  "test-namespace",
 			SignalName: strings.Repeat("test-signal", 100),
@@ -439,7 +439,7 @@ func TestGrpcCompressionNoneDoesNotInstallDowngrade(t *testing.T) {
 	srv.rejectGzipGetSystemInfo = true
 	srv.statsHandler.reset()
 
-	client, err := DialClient(context.Background(), ClientOptions{
+	client, err := DialClient(t.Context(), ClientOptions{
 		HostPort: srv.addr,
 		ConnectionOptions: ConnectionOptions{
 			GrpcCompression: &GrpcCompressionNone{},
@@ -464,7 +464,7 @@ func TestGrpcCompressionDoesNotDowngradeGenericUnimplemented(t *testing.T) {
 	require.NoError(t, err)
 	defer client.Close()
 
-	_, err = client.WorkflowService().GetSystemInfo(context.Background(), &workflowservice.GetSystemInfoRequest{})
+	_, err = client.WorkflowService().GetSystemInfo(t.Context(), &workflowservice.GetSystemInfoRequest{})
 	require.Error(t, err)
 
 	getSystemInfoHistory := srv.statsHandler.compressionHistoryForMethod(workflowServiceMethod("GetSystemInfo"))
@@ -473,7 +473,7 @@ func TestGrpcCompressionDoesNotDowngradeGenericUnimplemented(t *testing.T) {
 }
 
 func TestCustomResolver(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
 	// Create two gRPC servers
 	s1, err := startTestGRPCServer()
@@ -488,7 +488,7 @@ func TestCustomResolver(t *testing.T) {
 	builder := manual.NewBuilderWithScheme(scheme)
 	builder.InitialState(resolver.State{Addresses: []resolver.Address{{Addr: s1.addr}, {Addr: s2.addr}}})
 	resolver.Register(builder)
-	client, err := DialClient(context.Background(), ClientOptions{HostPort: scheme + ":///whatever"})
+	client, err := DialClient(t.Context(), ClientOptions{HostPort: scheme + ":///whatever"})
 	require.NoError(t, err)
 	defer client.Close()
 
@@ -510,7 +510,7 @@ func TestCustomResolver(t *testing.T) {
 	var peerOut peer.Peer
 	for len(connected) < 2 {
 		req.RequestId = uuid.NewString()
-		_, err := client.WorkflowService().SignalWorkflowExecution(context.Background(), &req, grpc.Peer(&peerOut))
+		_, err := client.WorkflowService().SignalWorkflowExecution(t.Context(), &req, grpc.Peer(&peerOut))
 		if err == nil {
 			connected[peerOut.Addr] = struct{}{}
 		}
@@ -552,12 +552,12 @@ func TestResourceExhaustedCause(t *testing.T) {
 		Cause: enums.RESOURCE_EXHAUSTED_CAUSE_CONCURRENT_LIMIT,
 	})
 	srv.getSystemInfoResponseError = s.Err()
-	_, err = DialClient(context.Background(), ClientOptions{HostPort: srv.addr, MetricsHandler: handler})
+	_, err = DialClient(t.Context(), ClientOptions{HostPort: srv.addr, MetricsHandler: handler})
 	require.Error(t, err)
 
 	// Attempt dial with a cause-less resource exhausted
 	srv.getSystemInfoResponseError = status.New(codes.ResourceExhausted, "some resource exhausted").Err()
-	_, err = DialClient(context.Background(), ClientOptions{HostPort: srv.addr, MetricsHandler: handler})
+	_, err = DialClient(t.Context(), ClientOptions{HostPort: srv.addr, MetricsHandler: handler})
 	require.Error(t, err)
 
 	// Make sure we have 1 metric with cause and 1 without
@@ -580,7 +580,7 @@ func TestCredentialsAPIKey(t *testing.T) {
 	defer srv.Stop()
 
 	// Fixed string
-	client, err := DialClient(context.Background(), ClientOptions{
+	client, err := DialClient(t.Context(), ClientOptions{
 		HostPort:    srv.addr,
 		Credentials: NewAPIKeyStaticCredentials("my-api-key"),
 		ConnectionOptions: ConnectionOptions{
@@ -608,7 +608,7 @@ func TestCredentialsAPIKey(t *testing.T) {
 
 	// Overwrite via context
 	_, err = client.WorkflowService().GetSystemInfo(
-		metadata.AppendToOutgoingContext(context.Background(), "authorization", "overridden value"),
+		metadata.AppendToOutgoingContext(t.Context(), "authorization", "overridden value"),
 		&workflowservice.GetSystemInfoRequest{},
 	)
 	require.NoError(t, err)
@@ -619,7 +619,7 @@ func TestCredentialsAPIKey(t *testing.T) {
 	)
 
 	// Callback
-	client, err = DialClient(context.Background(), ClientOptions{
+	client, err = DialClient(t.Context(), ClientOptions{
 		HostPort: srv.addr,
 		Credentials: NewAPIKeyDynamicCredentials(func(ctx context.Context) (string, error) {
 			return "my-callback-api-key", nil
@@ -654,13 +654,13 @@ func TestExistingContextMetadataJoinedWithSDKHeaders(t *testing.T) {
 	require.NoError(t, err)
 	defer srv.Stop()
 
-	client, err := DialClient(context.Background(), ClientOptions{HostPort: srv.addr})
+	client, err := DialClient(t.Context(), ClientOptions{HostPort: srv.addr})
 	require.NoError(t, err)
 	defer client.Close()
 
 	// Create a context with existing metadata
 	ctxWithMD := metadata.NewOutgoingContext(
-		context.Background(),
+		t.Context(),
 		metadata.New(map[string]string{"custom-header": "custom-value"}),
 	)
 
@@ -690,7 +690,7 @@ func TestNamespaceInterceptor(t *testing.T) {
 	defer srv.Stop()
 
 	// Fixed string
-	client, err := DialClient(context.Background(), ClientOptions{
+	client, err := DialClient(t.Context(), ClientOptions{
 		Namespace: "test-namespace",
 		HostPort:  srv.addr,
 	})
@@ -703,7 +703,7 @@ func TestNamespaceInterceptor(t *testing.T) {
 		metadata.ValueFromIncomingContext(srv.getSystemInfoRequestContext, temporalNamespaceHeaderKey),
 	)
 	// Verify namespace header is set on a request that does have namespace on the request
-	require.NoError(t, client.SignalWorkflow(context.Background(), "workflowid", "runid", "signalname", nil))
+	require.NoError(t, client.SignalWorkflow(t.Context(), "workflowid", "runid", "signalname", nil))
 	require.Equal(
 		t,
 		[]string{"test-namespace"},

--- a/internal/internal_activity_client_test.go
+++ b/internal/internal_activity_client_test.go
@@ -53,7 +53,7 @@ func TestExecuteActivityHeaderAvailableToInterceptors(t *testing.T) {
 	dummyActivity := func(ctx context.Context) error { return nil }
 	client.registry.RegisterActivityWithOptions(dummyActivity, RegisterActivityOptions{})
 
-	_, err := client.ExecuteActivity(context.Background(), ClientStartActivityOptions{
+	_, err := client.ExecuteActivity(t.Context(), ClientStartActivityOptions{
 		TaskQueue:           "test-tq",
 		ID:                  "test-activity-id",
 		StartToCloseTimeout: 1,

--- a/internal/internal_nexus_client_test.go
+++ b/internal/internal_nexus_client_test.go
@@ -56,7 +56,7 @@ func TestExecuteNexusOperationHeaderAvailableToInterceptors(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	_, err = nexusClient.ExecuteOperation(context.Background(), "test-op", "test-input", ClientStartNexusOperationOptions{
+	_, err = nexusClient.ExecuteOperation(t.Context(), "test-op", "test-input", ClientStartNexusOperationOptions{
 		ID: "test-op-id",
 	})
 	// We expect the short-circuit error from our interceptor.
@@ -111,7 +111,7 @@ func TestExecuteNexusOperationNexusHeaderAvailableToInterceptors(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	_, err = nexusClient.ExecuteOperation(context.Background(), "test-op", "test-input", ClientStartNexusOperationOptions{
+	_, err = nexusClient.ExecuteOperation(t.Context(), "test-op", "test-input", ClientStartNexusOperationOptions{
 		ID: "test-op-id",
 	})
 	require.ErrorContains(t, err, "short-circuit")
@@ -139,7 +139,7 @@ type mockOperationReference struct {
 	inputType reflect.Type
 }
 
-func (m mockOperationReference) Name() string         { return m.name }
+func (m mockOperationReference) Name() string            { return m.name }
 func (m mockOperationReference) InputType() reflect.Type { return m.inputType }
 
 func TestResolveNexusOperationName(t *testing.T) {

--- a/internal/internal_nexus_signal_link_test.go
+++ b/internal/internal_nexus_signal_link_test.go
@@ -48,7 +48,7 @@ func newSignalLinkTestClient(t *testing.T) (*workflowservicemock.MockWorkflowSer
 		Return(&workflowservice.GetSystemInfoResponse{}, nil)
 	client := NewServiceClient(svc, nil, ClientOptions{Namespace: signalLinkTestNamespace})
 	nctx := &NexusOperationContext{Namespace: signalLinkTestNamespace, TaskQueue: "tq"}
-	ctx := context.WithValue(context.Background(), nexusOperationContextKey, nctx)
+	ctx := context.WithValue(t.Context(), nexusOperationContextKey, nctx)
 	return svc, client, ctx, nctx
 }
 
@@ -214,5 +214,5 @@ func TestSignalOutsideNexusContextCapturesNoResponseLink(t *testing.T) {
 		Return(&workflowservice.SignalWorkflowExecutionResponse{Link: responseLink}, nil)
 
 	// No NexusOperationContext on the context, so this must not panic.
-	require.NoError(t, client.SignalWorkflow(context.Background(), signalLinkTestWorkflowID, "target-run", "test-signal", "payload"))
+	require.NoError(t, client.SignalWorkflow(t.Context(), signalLinkTestWorkflowID, "target-run", "test-signal", "payload"))
 }

--- a/internal/internal_task_handlers_test.go
+++ b/internal/internal_task_handlers_test.go
@@ -138,7 +138,7 @@ func TestTaskHandlersTestSuite(t *testing.T) {
 func TestActivityCancellationCallbacksCancel(t *testing.T) {
 	registry := newActivityCancellationCallbacks()
 	taskToken := []byte{1, 2, 3}
-	ctx, cancel := context.WithCancelCause(context.Background())
+	ctx, cancel := context.WithCancelCause(t.Context())
 
 	unregister := registry.register(taskToken, cancel)
 	require.True(t, registry.cancel([]byte{1, 2, 3}))
@@ -2750,7 +2750,7 @@ func TestHistoryIteratorMaxEventID(t *testing.T) {
 		createTestEventWorkflowTaskCompleted(4, &historypb.WorkflowTaskCompletedEventAttributes{}),
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	mockCtrl := gomock.NewController(t)
 	mockService := workflowservicemock.NewMockWorkflowServiceClient(mockCtrl)
 	mockService.EXPECT().GetWorkflowExecutionHistory(gomock.Any(), gomock.Any(), gomock.Any()).Return(&workflowservice.GetWorkflowExecutionHistoryResponse{

--- a/internal/internal_task_pollers_test.go
+++ b/internal/internal_task_pollers_test.go
@@ -88,7 +88,7 @@ func TestPollRequestsIncludeWorkerControlTaskQueue(t *testing.T) {
 		logger:                ilog.NewDefaultLogger(),
 		numNormalPollerMetric: newNumPollerMetric(metrics.NopHandler, metrics.PollerTypeWorkflowTask),
 	}
-	_, err := wtp.poll(context.Background())
+	_, err := wtp.poll(t.Context())
 	require.NoError(t, err)
 
 	service.EXPECT().PollActivityTaskQueue(gomock.Any(), gomock.Any(), gomock.Any()).
@@ -107,7 +107,7 @@ func TestPollRequestsIncludeWorkerControlTaskQueue(t *testing.T) {
 		logger:          ilog.NewDefaultLogger(),
 		numPollerMetric: newNumPollerMetric(metrics.NopHandler, metrics.PollerTypeActivityTask),
 	}
-	_, err = atp.poll(context.Background())
+	_, err = atp.poll(t.Context())
 	require.NoError(t, err)
 }
 

--- a/internal/internal_worker_base_test.go
+++ b/internal/internal_worker_base_test.go
@@ -1217,7 +1217,7 @@ func TestPollerBalancerReturnsNilWhenOwnCountZero(t *testing.T) {
 	pb.registerPollerType("sticky")
 	pb.registerPollerType("non-sticky")
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Both types have count 0 — balance should return nil immediately for either type.
 	err := pb.balance(ctx, "sticky")
@@ -1234,7 +1234,7 @@ func TestPollerBalancerReturnsNilWhenOwnCountZero(t *testing.T) {
 
 	// Even though non-sticky count is 0, we should NOT block because our own count is 0.
 	// Run with a timeout to catch the bug where it would block indefinitely.
-	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
 	defer cancel()
 	err = pb.balance(ctx, "sticky")
 	require.NoError(t, err, "balance should return nil when own count is 0, not block on other type's barrier")
@@ -1256,7 +1256,7 @@ func TestPollerBalancerBlocksWhenOtherTypeHasNoPollers(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		done <- pb.balance(context.Background(), "sticky")
+		done <- pb.balance(t.Context(), "sticky")
 	}()
 
 	// Verify it's still blocked.

--- a/internal/internal_worker_heartbeat_test.go
+++ b/internal/internal_worker_heartbeat_test.go
@@ -46,7 +46,7 @@ func TestStopCancelsInFlightHeartbeatRPC(t *testing.T) {
 
 	wfClient := NewServiceClient(mockService, nil, ClientOptions{})
 
-	heartbeatCtx, heartbeatCancel := context.WithCancel(context.Background())
+	heartbeatCtx, heartbeatCancel := context.WithCancel(t.Context())
 	hw := &sharedNamespaceWorker{
 		client:          wfClient,
 		namespace:       "test-ns",
@@ -118,7 +118,7 @@ func TestWorkerCommandPollUsesWorkerCommandsQueue(t *testing.T) {
 			return &workflowservice.PollNexusTaskQueueResponse{}, nil
 		})
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	hw := &sharedNamespaceWorker{
 		client: &WorkflowClient{
@@ -179,7 +179,7 @@ func TestWorkerCommandCancelActivity(t *testing.T) {
 		})
 
 	activityCancellationCallbacks := newActivityCancellationCallbacks()
-	activityCtx, activityCancel := context.WithCancelCause(context.Background())
+	activityCtx, activityCancel := context.WithCancelCause(t.Context())
 	defer activityCancel(nil)
 	unregisterActivity := activityCancellationCallbacks.register(activityTaskToken, activityCancel)
 	defer unregisterActivity()
@@ -226,7 +226,7 @@ func TestWorkerCommandsDisabledDoesNotPoll(t *testing.T) {
 		Identity:  "worker-identity",
 	})
 
-	heartbeatCtx, heartbeatCancel := context.WithCancel(context.Background())
+	heartbeatCtx, heartbeatCancel := context.WithCancel(t.Context())
 	hw := &sharedNamespaceWorker{
 		client:                  wfClient,
 		namespace:               "test-ns",

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -3008,7 +3008,7 @@ func testActivityErrorWithDetailsHelper(ctx context.Context, t *testing.T, dataC
 
 func TestActivityErrorWithDetailsWithDataConverter(t *testing.T) {
 	dc := iconverter.NewTestDataConverter()
-	ctx, _ := newActivityContext(context.Background(), nil, &activityEnvironment{dataConverter: dc})
+	ctx, _ := newActivityContext(t.Context(), nil, &activityEnvironment{dataConverter: dc})
 	testActivityErrorWithDetailsHelper(ctx, t, dc)
 }
 
@@ -3075,7 +3075,7 @@ func testActivityCanceledErrorHelper(ctx context.Context, t *testing.T, dataConv
 
 func TestActivityCanceledErrorWithDataConverter(t *testing.T) {
 	dc := iconverter.NewTestDataConverter()
-	ctx, _ := newActivityContext(context.Background(), nil, &activityEnvironment{dataConverter: dc})
+	ctx, _ := newActivityContext(t.Context(), nil, &activityEnvironment{dataConverter: dc})
 	testActivityCanceledErrorHelper(ctx, t, dc)
 }
 
@@ -3106,7 +3106,7 @@ func testActivityExecutionVariousTypesHelper(ctx context.Context, t *testing.T, 
 
 func TestActivityExecutionVariousTypesWithDataConverter(t *testing.T) {
 	dc := iconverter.NewTestDataConverter()
-	ctx, _ := newActivityContext(context.Background(), nil, &activityEnvironment{
+	ctx, _ := newActivityContext(t.Context(), nil, &activityEnvironment{
 		dataConverter: dc,
 	})
 	testActivityExecutionVariousTypesHelper(ctx, t, dc)
@@ -3243,7 +3243,7 @@ func TestWorkerOptionNonDefaults(t *testing.T) {
 		WorkerLocalActivitiesPerSecond:                 222,
 		WorkerActivitiesPerSecond:                      99,
 		StickyScheduleToStartTimeout:                   555 * time.Minute,
-		BackgroundActivityContext:                      context.Background(),
+		BackgroundActivityContext:                      t.Context(),
 		MaxConcurrentWorkflowTaskExternalStorageVisits: 7,
 		MaxEagerActivityReservationsPerWorkflowTask:    &maxEagerActivityReservationsPerWorkflowTask,
 	}
@@ -3343,7 +3343,7 @@ func TestLocalActivityWorkerOnly(t *testing.T) {
 }
 
 func assertWorkerExecutionParamsEqual(t *testing.T, paramsA workerExecutionParameters, paramsB workerExecutionParameters) {
-	require.Equal(t, paramsA.TaskQueue, paramsA.TaskQueue)
+	require.Equal(t, paramsA.TaskQueue, paramsB.TaskQueue)
 	require.Equal(t, paramsA.Identity, paramsB.Identity)
 	require.Equal(t, paramsA.DataConverter, paramsB.DataConverter)
 	require.Equal(t, paramsA.Tuner, paramsB.Tuner)

--- a/internal/internal_workflow_client_test.go
+++ b/internal/internal_workflow_client_test.go
@@ -1527,7 +1527,7 @@ func TestLoadCapabilitiesUnknownMethodUnimplementedUsesEmptyCapabilities(t *test
 		getSystemInfoTimeout:     defaultGetSystemInfoTimeout,
 	}
 
-	capabilities, err := client.loadCapabilities(context.Background())
+	capabilities, err := client.loadCapabilities(t.Context())
 	require.NoError(t, err)
 	require.True(t, proto.Equal(&workflowservice.GetSystemInfoResponse_Capabilities{}, capabilities))
 }
@@ -1548,7 +1548,7 @@ func TestLoadCapabilitiesNonUnknownMethodUnimplementedFails(t *testing.T) {
 		getSystemInfoTimeout:     defaultGetSystemInfoTimeout,
 	}
 
-	_, err := client.loadCapabilities(context.Background())
+	_, err := client.loadCapabilities(t.Context())
 	require.Error(t, err)
 	require.ErrorContains(t, err, "failed reaching server")
 	require.ErrorContains(t, err, "frontend has not loaded GetSystemInfo")
@@ -2470,7 +2470,7 @@ func TestClientCloseCount(t *testing.T) {
 	server, err := startTestGRPCServer()
 	require.NoError(t, err)
 	defer server.Stop()
-	client, err := DialClient(context.Background(), ClientOptions{HostPort: server.addr})
+	client, err := DialClient(t.Context(), ClientOptions{HostPort: server.addr})
 	require.NoError(t, err)
 	workflowClient := client.(*WorkflowClient)
 
@@ -2478,11 +2478,11 @@ func TestClientCloseCount(t *testing.T) {
 	require.EqualValues(t, 1, atomic.LoadInt32(workflowClient.unclosedClients))
 
 	// Create two more and confirm counts
-	client2, err := NewClientFromExisting(context.Background(), client, ClientOptions{})
+	client2, err := NewClientFromExisting(t.Context(), client, ClientOptions{})
 	require.NoError(t, err)
 	require.EqualValues(t, 2, atomic.LoadInt32(workflowClient.unclosedClients))
 	require.Same(t, workflowClient.unclosedClients, client2.(*WorkflowClient).unclosedClients)
-	client3, err := NewClientFromExisting(context.Background(), client, ClientOptions{})
+	client3, err := NewClientFromExisting(t.Context(), client, ClientOptions{})
 	require.NoError(t, err)
 	require.EqualValues(t, 3, atomic.LoadInt32(workflowClient.unclosedClients))
 	require.Same(t, workflowClient.unclosedClients, client3.(*WorkflowClient).unclosedClients)
@@ -2511,7 +2511,7 @@ func TestCompletedUpdateHandle(t *testing.T) {
 	t.Run("error case", func(t *testing.T) {
 		err := errors.New(t.Name())
 		uh := completedUpdateHandle{err: err}
-		require.Error(t, uh.Get(context.TODO(), nil))
+		require.Error(t, uh.Get(t.Context(), nil))
 	})
 
 	t.Run("value case", func(t *testing.T) {
@@ -2520,13 +2520,13 @@ func TestCompletedUpdateHandle(t *testing.T) {
 		require.NoError(t, err)
 		uh := completedUpdateHandle{value: newEncodedValue(payloads, dc)}
 		var out string
-		require.NoError(t, uh.Get(context.TODO(), &out))
+		require.NoError(t, uh.Get(t.Context(), &out))
 		require.Equal(t, t.Name(), out)
 	})
 
 	t.Run("nil does not panic", func(t *testing.T) {
 		uh := completedUpdateHandle{}
-		require.NotPanics(t, func() { _ = uh.Get(context.TODO(), nil) })
+		require.NotPanics(t, func() { _ = uh.Get(t.Context(), nil) })
 	})
 }
 
@@ -2613,14 +2613,14 @@ func TestUpdate(t *testing.T) {
 			},
 			nil,
 		)
-		handle, err := client.UpdateWorkflow(context.TODO(), req)
+		handle, err := client.UpdateWorkflow(t.Context(), req)
 		require.NoError(t, err)
 		var got string
-		err = handle.Get(context.TODO(), &got)
+		err = handle.Get(t.Context(), &got)
 		require.NoError(t, err)
 		require.Equal(t, want, got)
 		// Verify that calling Get with nil does not panic
-		err = handle.Get(context.TODO(), nil)
+		err = handle.Get(t.Context(), nil)
 		require.NoError(t, err)
 	})
 	t.Run("sync error", func(t *testing.T) {
@@ -2636,10 +2636,10 @@ func TestUpdate(t *testing.T) {
 			},
 			nil,
 		)
-		handle, err := client.UpdateWorkflow(context.TODO(), req)
+		handle, err := client.UpdateWorkflow(t.Context(), req)
 		require.NoError(t, err)
 		var got string
-		err = handle.Get(context.TODO(), &got)
+		err = handle.Get(t.Context(), &got)
 		require.Error(t, err)
 		require.ErrorContains(t, err, want.Error())
 	})
@@ -2663,14 +2663,14 @@ func TestUpdate(t *testing.T) {
 				},
 				nil,
 			).Times(2)
-		handle, err := client.UpdateWorkflow(context.TODO(), req)
+		handle, err := client.UpdateWorkflow(t.Context(), req)
 		require.NoError(t, err)
 		var got string
-		err = handle.Get(context.TODO(), &got)
+		err = handle.Get(t.Context(), &got)
 		require.NoError(t, err)
 		require.Equal(t, want, got)
 		// Verify that calling Get with nil does not panic
-		err = handle.Get(context.TODO(), nil)
+		err = handle.Get(t.Context(), nil)
 		require.NoError(t, err)
 	})
 	t.Run("async delayed accepted", func(t *testing.T) {
@@ -2693,10 +2693,10 @@ func TestUpdate(t *testing.T) {
 				},
 				nil,
 			)
-		handle, err := client.UpdateWorkflow(context.TODO(), req)
+		handle, err := client.UpdateWorkflow(t.Context(), req)
 		require.NoError(t, err)
 		var got string
-		err = handle.Get(context.TODO(), &got)
+		err = handle.Get(t.Context(), &got)
 		require.Error(t, err)
 		require.ErrorContains(t, err, want.Error())
 	})
@@ -2728,14 +2728,14 @@ func TestUpdate(t *testing.T) {
 				},
 				nil,
 			).Times(2)
-		handle, err := client.UpdateWorkflow(context.TODO(), req)
+		handle, err := client.UpdateWorkflow(t.Context(), req)
 		require.NoError(t, err)
 		var got string
-		err = handle.Get(context.TODO(), &got)
+		err = handle.Get(t.Context(), &got)
 		require.NoError(t, err)
 		require.Equal(t, want, got)
 		// Verify that calling Get with nil does not panic
-		err = handle.Get(context.TODO(), nil)
+		err = handle.Get(t.Context(), nil)
 		require.NoError(t, err)
 	})
 	t.Run("internal retry on nil outcome", func(t *testing.T) {
@@ -2766,10 +2766,10 @@ func TestUpdate(t *testing.T) {
 				nil,
 			)
 
-		handle, err := client.UpdateWorkflow(context.TODO(), req)
+		handle, err := client.UpdateWorkflow(t.Context(), req)
 		require.NoError(t, err)
 		var got string
-		err = handle.Get(context.TODO(), &got)
+		err = handle.Get(t.Context(), &got)
 		require.NoError(t, err)
 		require.Equal(t, want, got)
 	})
@@ -2789,7 +2789,7 @@ func TestUpdate(t *testing.T) {
 					return nil, errors.New("intentional error")
 				},
 			)
-		_ = handle.Get(context.TODO(), nil)
+		_ = handle.Get(t.Context(), nil)
 
 		// can't tell what the exact deadline will be so assert that the
 		// observed deadline passed to server rpc is within 2 seconds of the
@@ -2818,7 +2818,7 @@ func TestUpdate(t *testing.T) {
 					return nil, status.Error(codes.DeadlineExceeded, context.DeadlineExceeded.Error())
 				},
 			)
-		callerCtx, cancel := context.WithDeadline(context.TODO(), callerDeadline)
+		callerCtx, cancel := context.WithDeadline(t.Context(), callerDeadline)
 		defer cancel()
 		var got string
 		err := handle.Get(callerCtx, &got)
@@ -2839,7 +2839,7 @@ func TestUpdate(t *testing.T) {
 					return nil, status.Error(codes.Canceled, context.Canceled.Error())
 				},
 			)
-		callerCtx, cancel := context.WithCancel(context.TODO())
+		callerCtx, cancel := context.WithCancel(t.Context())
 		cancel()
 		var got string
 		err := handle.Get(callerCtx, &got)
@@ -2870,14 +2870,14 @@ func TestUpdate(t *testing.T) {
 				},
 				nil,
 			)
-		handle, err := client.UpdateWorkflow(context.TODO(), req)
+		handle, err := client.UpdateWorkflow(t.Context(), req)
 		require.NoError(t, err)
 		var got string
-		err = handle.Get(context.TODO(), &got)
+		err = handle.Get(t.Context(), &got)
 		require.NoError(t, err)
 		require.Equal(t, want, got)
 		// Verify that calling Get with nil does not panic
-		err = handle.Get(context.TODO(), nil)
+		err = handle.Get(t.Context(), nil)
 		require.NoError(t, err)
 	})
 	t.Run("sync multiple step success", func(t *testing.T) {
@@ -2910,14 +2910,14 @@ func TestUpdate(t *testing.T) {
 				},
 				nil,
 			).Times(1)
-		handle, err := client.UpdateWorkflow(context.TODO(), req)
+		handle, err := client.UpdateWorkflow(t.Context(), req)
 		require.NoError(t, err)
 		var got string
-		err = handle.Get(context.TODO(), &got)
+		err = handle.Get(t.Context(), &got)
 		require.NoError(t, err)
 		require.Equal(t, want, got)
 		// Verify that calling Get with nil does not panic
-		err = handle.Get(context.TODO(), nil)
+		err = handle.Get(t.Context(), nil)
 		require.NoError(t, err)
 	})
 	t.Run("sync success exposes payloads", func(t *testing.T) {
@@ -2939,7 +2939,7 @@ func TestUpdate(t *testing.T) {
 		)
 		// Use PollWorkflowUpdate directly to access the raw output.
 		output, err := client.PollWorkflowUpdate(
-			context.TODO(),
+			t.Context(),
 			refFromRequest(req),
 		)
 		require.NoError(t, err)
@@ -2966,7 +2966,7 @@ func TestUpdate(t *testing.T) {
 		)
 		// Use PollWorkflowUpdate directly to access the raw output.
 		output, err := client.PollWorkflowUpdate(
-			context.TODO(),
+			t.Context(),
 			refFromRequest(req),
 		)
 		require.NoError(t, err)
@@ -3016,7 +3016,7 @@ func TestPollActivityResult(t *testing.T) {
 				nil,
 			)
 		out, err := client.interceptor.PollActivityResult(
-			context.Background(),
+			t.Context(),
 			&ClientPollActivityResultInput{ActivityID: "test-id", RunID: "run-id"},
 		)
 		require.NoError(t, err)
@@ -3044,7 +3044,7 @@ func TestPollActivityResult(t *testing.T) {
 				nil,
 			)
 		out, err := client.interceptor.PollActivityResult(
-			context.Background(),
+			t.Context(),
 			&ClientPollActivityResultInput{ActivityID: "test-id", RunID: "run-id"},
 		)
 		require.NoError(t, err)

--- a/internal/payload_limits_test.go
+++ b/internal/payload_limits_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"slices"
 	"strings"
 	"testing"
@@ -233,7 +232,7 @@ func TestPayloadLimitsVisitorSpecializations(t *testing.T) {
 				"k": {Payloads: []*commonpb.Payload{makeTestPayload(200)}},
 			},
 		}
-		err := visitProtoPayloads(context.Background(), visitor, msg, 0)
+		err := visitProtoPayloads(t.Context(), visitor, msg, 0)
 		require.Error(t, err)
 		var pse payloadSizeError
 		require.ErrorAs(t, err, &pse)
@@ -247,7 +246,7 @@ func TestPayloadLimitsVisitorSpecializations(t *testing.T) {
 				"k": {Payloads: []*commonpb.Payload{makeTestPayload(200)}},
 			},
 		}
-		err := visitProtoPayloads(context.Background(), visitor, msg, 0)
+		err := visitProtoPayloads(t.Context(), visitor, msg, 0)
 		require.NoError(t, err)
 		require.True(t, hasWarningLine(logger))
 	})
@@ -259,7 +258,7 @@ func TestPayloadLimitsVisitorSpecializations(t *testing.T) {
 		msg := &commandpb.RecordMarkerCommandAttributes{
 			Details: map[string]*commonpb.Payloads{"k": {Payloads: []*commonpb.Payload{makeTestPayload(1)}}},
 		}
-		err := visitProtoPayloads(context.Background(), visitor, msg, 0)
+		err := visitProtoPayloads(t.Context(), visitor, msg, 0)
 		require.NoError(t, err)
 		require.Empty(t, logger.Lines())
 	})
@@ -273,7 +272,7 @@ func TestPayloadLimitsVisitorSpecializations(t *testing.T) {
 				IndexedFields: map[string]*commonpb.Payload{"k": makeTestPayload(200)},
 			},
 		}
-		err := visitProtoPayloads(context.Background(), visitor, msg, 0)
+		err := visitProtoPayloads(t.Context(), visitor, msg, 0)
 		require.Error(t, err)
 		var pse payloadSizeError
 		require.ErrorAs(t, err, &pse)
@@ -287,7 +286,7 @@ func TestPayloadLimitsVisitorSpecializations(t *testing.T) {
 				IndexedFields: map[string]*commonpb.Payload{"k": makeTestPayload(200)},
 			},
 		}
-		err := visitProtoPayloads(context.Background(), visitor, msg, 0)
+		err := visitProtoPayloads(t.Context(), visitor, msg, 0)
 		require.NoError(t, err)
 		require.True(t, hasWarningLine(logger))
 	})
@@ -301,7 +300,7 @@ func TestPayloadLimitsVisitorSpecializations(t *testing.T) {
 				IndexedFields: map[string]*commonpb.Payload{"k": makeTestPayload(1)},
 			},
 		}
-		err := visitProtoPayloads(context.Background(), visitor, msg, 0)
+		err := visitProtoPayloads(t.Context(), visitor, msg, 0)
 		require.NoError(t, err)
 		require.Empty(t, logger.Lines())
 	})
@@ -314,7 +313,7 @@ func TestPayloadLimitsVisitorSpecializations(t *testing.T) {
 				Fields: map[string]*commonpb.Payload{"k": makeTestPayload(200)},
 			},
 		}
-		err := visitProtoPayloads(context.Background(), visitor, msg, 0)
+		err := visitProtoPayloads(t.Context(), visitor, msg, 0)
 		require.Error(t, err)
 		var pse payloadSizeError
 		require.ErrorAs(t, err, &pse)
@@ -328,7 +327,7 @@ func TestPayloadLimitsVisitorSpecializations(t *testing.T) {
 				Fields: map[string]*commonpb.Payload{"k": makeTestPayload(200)},
 			},
 		}
-		err := visitProtoPayloads(context.Background(), visitor, msg, 0)
+		err := visitProtoPayloads(t.Context(), visitor, msg, 0)
 		require.NoError(t, err)
 		require.True(t, hasWarningLine(logger))
 	})
@@ -342,7 +341,7 @@ func TestPayloadLimitsVisitorSpecializations(t *testing.T) {
 				Fields: map[string]*commonpb.Payload{"k": makeTestPayload(1)},
 			},
 		}
-		err := visitProtoPayloads(context.Background(), visitor, msg, 0)
+		err := visitProtoPayloads(t.Context(), visitor, msg, 0)
 		require.NoError(t, err)
 		require.Empty(t, logger.Lines())
 	})
@@ -386,7 +385,7 @@ func TestPayloadLimitsVisitorSpecializations(t *testing.T) {
 			visitor, setErrorLimits := newPayloadLimitsVisitor(payloadLimits{payloadSize: 10000}, nil)
 			setErrorLimits(&payloadLimits{payloadSize: 10})
 			msg := tc.makeMsg()
-			err := visitProtoPayloads(context.Background(), visitor, msg, 0)
+			err := visitProtoPayloads(t.Context(), visitor, msg, 0)
 			require.NoError(t, err)
 			tc.assertField(t, msg)
 		})
@@ -394,7 +393,7 @@ func TestPayloadLimitsVisitorSpecializations(t *testing.T) {
 			logger := ilog.NewMemoryLogger()
 			visitor, _ := newPayloadLimitsVisitor(payloadLimits{payloadSize: 10}, logger)
 			msg := tc.makeMsg()
-			err := visitProtoPayloads(context.Background(), visitor, msg, 0)
+			err := visitProtoPayloads(t.Context(), visitor, msg, 0)
 			require.NoError(t, err)
 			require.True(t, hasWarningLine(logger))
 		})
@@ -403,7 +402,7 @@ func TestPayloadLimitsVisitorSpecializations(t *testing.T) {
 			visitor, setErrorLimits := newPayloadLimitsVisitor(payloadLimits{payloadSize: 10}, logger)
 			setErrorLimits(&payloadLimits{payloadSize: 10})
 			msg := tc.makeMsg()
-			err := visitProtoPayloads(context.Background(), visitor, msg, 0)
+			err := visitProtoPayloads(t.Context(), visitor, msg, 0)
 			require.NoError(t, err)
 			require.Empty(t, logger.Lines())
 		})
@@ -445,7 +444,7 @@ func TestPayloadLimitsVisitorSpecializations(t *testing.T) {
 			logger := ilog.NewMemoryLogger()
 			visitor, setErrorLimits := newPayloadLimitsVisitor(payloadLimits{payloadSize: 10}, logger)
 			setErrorLimits(&payloadLimits{payloadSize: 10, memoSize: 10})
-			err := visitProtoPayloads(context.Background(), visitor, tc.msg, 0)
+			err := visitProtoPayloads(t.Context(), visitor, tc.msg, 0)
 			require.NoError(t, err)
 			require.True(t, hasWarningLine(logger))
 		})
@@ -475,7 +474,7 @@ func TestPayloadLimitsVisitorSpecializations(t *testing.T) {
 				},
 			},
 		}
-		err := visitProtoPayloads(context.Background(), visitor, msg, 0)
+		err := visitProtoPayloads(t.Context(), visitor, msg, 0)
 		require.NoError(t, err)
 		require.Empty(t, logger.Lines())
 	})
@@ -501,7 +500,7 @@ func TestCreateScheduleRequestSpecialization(t *testing.T) {
 		visitor, setErrorLimits := newPayloadLimitsVisitor(payloadLimits{payloadSize: 10000, memoSize: 10000}, nil)
 		setErrorLimits(&payloadLimits{payloadSize: 100})
 		msg := makeScheduleRequest(60, 60)
-		err := visitProtoPayloads(context.Background(), visitor, msg, 0)
+		err := visitProtoPayloads(t.Context(), visitor, msg, 0)
 		require.Error(t, err)
 		var pse payloadSizeError
 		require.ErrorAs(t, err, &pse)
@@ -511,7 +510,7 @@ func TestCreateScheduleRequestSpecialization(t *testing.T) {
 		logger := ilog.NewMemoryLogger()
 		visitor, _ := newPayloadLimitsVisitor(payloadLimits{payloadSize: 10, memoSize: 10000}, logger)
 		msg := makeScheduleRequest(60, 60)
-		err := visitProtoPayloads(context.Background(), visitor, msg, 0)
+		err := visitProtoPayloads(t.Context(), visitor, msg, 0)
 		require.NoError(t, err)
 		require.True(t, hasWarningLine(logger))
 	})
@@ -521,7 +520,7 @@ func TestCreateScheduleRequestSpecialization(t *testing.T) {
 		visitor, setErrorLimits := newPayloadLimitsVisitor(payloadLimits{payloadSize: 10000, memoSize: 10}, logger)
 		setErrorLimits(&payloadLimits{payloadSize: 10000, memoSize: 10})
 		msg := makeScheduleRequest(200, 1)
-		err := visitProtoPayloads(context.Background(), visitor, msg, 0)
+		err := visitProtoPayloads(t.Context(), visitor, msg, 0)
 		require.NoError(t, err)
 		require.False(t, hasMemoWarningLine(logger))
 	})
@@ -535,7 +534,7 @@ func TestCreateScheduleRequestSpecialization(t *testing.T) {
 				Action: &schedulepb.ScheduleAction{},
 			},
 		}
-		err := visitProtoPayloads(context.Background(), visitor, msg, 0)
+		err := visitProtoPayloads(t.Context(), visitor, msg, 0)
 		require.NoError(t, err)
 	})
 }
@@ -554,7 +553,7 @@ func TestMemoLimitsVisitorWarning(t *testing.T) {
 	t.Run("warning when aggregate memo size exceeds limit", func(t *testing.T) {
 		logger := ilog.NewMemoryLogger()
 		visitor, _ := newPayloadLimitsVisitor(payloadLimits{payloadSize: 10000, memoSize: 10}, logger)
-		err := visitProtoPayloads(context.Background(), visitor, makeMemo(200), 0)
+		err := visitProtoPayloads(t.Context(), visitor, makeMemo(200), 0)
 		require.NoError(t, err)
 		require.True(t, hasMemoWarningLine(logger))
 	})
@@ -562,7 +561,7 @@ func TestMemoLimitsVisitorWarning(t *testing.T) {
 	t.Run("no warning when aggregate memo size is under limit", func(t *testing.T) {
 		logger := ilog.NewMemoryLogger()
 		visitor, _ := newPayloadLimitsVisitor(payloadLimits{payloadSize: 10000, memoSize: 10000}, logger)
-		err := visitProtoPayloads(context.Background(), visitor, makeMemo(10), 0)
+		err := visitProtoPayloads(t.Context(), visitor, makeMemo(10), 0)
 		require.NoError(t, err)
 		require.Empty(t, logger.Lines())
 	})
@@ -570,7 +569,7 @@ func TestMemoLimitsVisitorWarning(t *testing.T) {
 	t.Run("zero memo warning limit disables memo warning", func(t *testing.T) {
 		logger := ilog.NewMemoryLogger()
 		visitor, _ := newPayloadLimitsVisitor(payloadLimits{payloadSize: 10000, memoSize: 0}, logger)
-		err := visitProtoPayloads(context.Background(), visitor, makeMemo(10000), 0)
+		err := visitProtoPayloads(t.Context(), visitor, makeMemo(10000), 0)
 		require.NoError(t, err)
 		require.Empty(t, logger.Lines())
 	})
@@ -579,7 +578,7 @@ func TestMemoLimitsVisitorWarning(t *testing.T) {
 		logger := ilog.NewMemoryLogger()
 		// memo limit low, payload limit high — only memo warning should fire
 		visitor, _ := newPayloadLimitsVisitor(payloadLimits{payloadSize: 10000, memoSize: 10}, logger)
-		err := visitProtoPayloads(context.Background(), visitor, makeMemo(200), 0)
+		err := visitProtoPayloads(t.Context(), visitor, makeMemo(200), 0)
 		require.NoError(t, err)
 		require.True(t, hasMemoWarningLine(logger))
 		require.False(t, hasWarningLine(logger))
@@ -591,7 +590,7 @@ func TestMemoLimitsVisitorWarning(t *testing.T) {
 		msg := &workflowservice.StartWorkflowExecutionRequest{
 			Memo: &commonpb.Memo{Fields: map[string]*commonpb.Payload{"k": makeTestPayload(200)}},
 		}
-		err := visitProtoPayloads(context.Background(), visitor, msg, 0)
+		err := visitProtoPayloads(t.Context(), visitor, msg, 0)
 		require.NoError(t, err)
 		require.True(t, hasMemoWarningLine(logger))
 	})
@@ -603,7 +602,7 @@ func TestMemoLimitsVisitorWarning(t *testing.T) {
 		msg := &workflowservice.UpdateScheduleRequest{
 			Memo: &commonpb.Memo{Fields: map[string]*commonpb.Payload{"k": makeTestPayload(200)}},
 		}
-		err := visitProtoPayloads(context.Background(), visitor, msg, 0)
+		err := visitProtoPayloads(t.Context(), visitor, msg, 0)
 		require.NoError(t, err)
 		require.True(t, hasMemoWarningLine(logger))
 	})
@@ -617,7 +616,7 @@ func TestMemoLimitsVisitorError(t *testing.T) {
 	t.Run("error when aggregate memo size exceeds error limit", func(t *testing.T) {
 		visitor, setErrorLimits := newPayloadLimitsVisitor(payloadLimits{payloadSize: 10000, memoSize: 10000}, nil)
 		setErrorLimits(&payloadLimits{memoSize: 10})
-		err := visitProtoPayloads(context.Background(), visitor, makeMemo(200), 0)
+		err := visitProtoPayloads(t.Context(), visitor, makeMemo(200), 0)
 		require.Error(t, err)
 		var pse payloadSizeError
 		require.ErrorAs(t, err, &pse)
@@ -628,14 +627,14 @@ func TestMemoLimitsVisitorError(t *testing.T) {
 	t.Run("no error when memo size is under error limit", func(t *testing.T) {
 		visitor, setErrorLimits := newPayloadLimitsVisitor(payloadLimits{payloadSize: 10000, memoSize: 10000}, nil)
 		setErrorLimits(&payloadLimits{memoSize: 10000})
-		err := visitProtoPayloads(context.Background(), visitor, makeMemo(10), 0)
+		err := visitProtoPayloads(t.Context(), visitor, makeMemo(10), 0)
 		require.NoError(t, err)
 	})
 
 	t.Run("zero memo error limit means no error check", func(t *testing.T) {
 		visitor, setErrorLimits := newPayloadLimitsVisitor(payloadLimits{payloadSize: 10000, memoSize: 10000}, nil)
 		setErrorLimits(&payloadLimits{memoSize: 0})
-		err := visitProtoPayloads(context.Background(), visitor, makeMemo(100000), 0)
+		err := visitProtoPayloads(t.Context(), visitor, makeMemo(100000), 0)
 		require.NoError(t, err)
 	})
 
@@ -643,7 +642,7 @@ func TestMemoLimitsVisitorError(t *testing.T) {
 		visitor, setErrorLimits := newPayloadLimitsVisitor(payloadLimits{payloadSize: 10000, memoSize: 10000}, nil)
 		// memo error limit low, payload error limit high
 		setErrorLimits(&payloadLimits{payloadSize: 100000, memoSize: 10})
-		err := visitProtoPayloads(context.Background(), visitor, makeMemo(200), 0)
+		err := visitProtoPayloads(t.Context(), visitor, makeMemo(200), 0)
 		require.Error(t, err)
 		var pse payloadSizeError
 		require.ErrorAs(t, err, &pse)

--- a/internal/payload_visitor_test.go
+++ b/internal/payload_visitor_test.go
@@ -64,7 +64,7 @@ func scheduleActivitiesRequest(n int) *workflowservice.RespondWorkflowTaskComple
 func TestVisitProtoPayloads_ConcurrentVisitors(t *testing.T) {
 	const n = 4
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 
 	arrived := make(chan struct{}, n)
@@ -116,7 +116,7 @@ func TestVisitProtoPayloads_SequentialVisitors(t *testing.T) {
 		return p, nil
 	})
 
-	require.NoError(t, visitProtoPayloads(context.Background(), visitor, scheduleActivitiesRequest(n), 1))
+	require.NoError(t, visitProtoPayloads(t.Context(), visitor, scheduleActivitiesRequest(n), 1))
 	require.EqualValues(t, 1, peak,
 		"expected at most 1 concurrent visitor call with concurrencyLimit=1")
 }
@@ -210,7 +210,7 @@ func TestCompositePayloadVisitor(t *testing.T) {
 			},
 		}
 		composite := newCompositePayloadVisitor(v).(PayloadVisitorWithContextHook)
-		_, err := composite.ContextHook(context.Background(), &commandpb.RecordMarkerCommandAttributes{})
+		_, err := composite.ContextHook(t.Context(), &commandpb.RecordMarkerCommandAttributes{})
 		require.NoError(t, err)
 		require.True(t, hookCalled)
 	})
@@ -237,7 +237,7 @@ func TestCompositePayloadVisitor(t *testing.T) {
 			},
 		}
 		composite := newCompositePayloadVisitor(v1, v2).(PayloadVisitorWithContextHook)
-		returnedCtx, err := composite.ContextHook(context.Background(), &commandpb.RecordMarkerCommandAttributes{})
+		returnedCtx, err := composite.ContextHook(t.Context(), &commandpb.RecordMarkerCommandAttributes{})
 		require.NoError(t, err)
 		require.True(t, v2SawKey1)
 		require.Equal(t, true, returnedCtx.Value(key2{}))
@@ -264,7 +264,7 @@ func TestCompositePayloadVisitor(t *testing.T) {
 			},
 		}
 		composite := newCompositePayloadVisitor(v1, v2).(PayloadVisitorWithContextHook)
-		_, err := composite.ContextHook(context.Background(), &commandpb.RecordMarkerCommandAttributes{})
+		_, err := composite.ContextHook(t.Context(), &commandpb.RecordMarkerCommandAttributes{})
 		require.ErrorIs(t, err, expectedErr)
 		require.False(t, v2Called)
 	})

--- a/internal/resource_tuner_cancel_test.go
+++ b/internal/resource_tuner_cancel_test.go
@@ -41,7 +41,7 @@ func TestReserveSlotRejectsAlreadyCancelledContext(t *testing.T) {
 		ResourceBasedSlotSupplierOptions{MinSlots: 100, MaxSlots: 1000, RampThrottle: 0})
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 
 	permit, err := supplier.ReserveSlot(ctx, &reserveCallCounter{}) // NumIssuedSlots is 10, under MinSlots
@@ -75,7 +75,7 @@ func TestReserveSlotHonorsContextCancellation(t *testing.T) {
 			require.NoError(t, err)
 
 			info := &reserveCallCounter{} // NumIssuedSlots is 10, past MinSlots
-			ctx, cancel := context.WithCancel(context.Background())
+			ctx, cancel := context.WithCancel(t.Context())
 			defer cancel()
 
 			reserveErr := make(chan error, 1)

--- a/internal/resource_tuner_eager_test.go
+++ b/internal/resource_tuner_eager_test.go
@@ -54,7 +54,7 @@ func TestTryReserveSlotDoesNotBlockDuringRampWait(t *testing.T) {
 	require.NotNil(t, supplier.TryReserveSlot(info), "first eager reserve should succeed")
 	callsBeforeReserve := info.numIssuedCalls.Load()
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	reserveReturned := make(chan struct{})
 	go func() {
@@ -109,7 +109,7 @@ func TestRampThrottleBoundsIssuanceAcrossConcurrentReserveSlot(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			<-start
-			permit, err := supplier.ReserveSlot(context.Background(), info)
+			permit, err := supplier.ReserveSlot(t.Context(), info)
 			at := time.Now()
 
 			mu.Lock()

--- a/internal/serialization_context_client_test.go
+++ b/internal/serialization_context_client_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"context"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -40,7 +39,7 @@ func TestClientStartWorkflow_SerializationContext(t *testing.T) {
 	service.EXPECT().StartWorkflowExecution(gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(&workflowservice.StartWorkflowExecutionResponse{RunId: "run-1"}, nil)
 
-	_, err := client.ExecuteWorkflow(context.Background(), StartWorkflowOptions{
+	_, err := client.ExecuteWorkflow(t.Context(), StartWorkflowOptions{
 		ID:        "wf-start-test",
 		TaskQueue: "test-tq",
 	}, "myWorkflow", "arg1")
@@ -69,7 +68,7 @@ func TestClientSignalWorkflow_SerializationContext(t *testing.T) {
 	service.EXPECT().SignalWorkflowExecution(gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(&workflowservice.SignalWorkflowExecutionResponse{}, nil)
 
-	err := client.SignalWorkflow(context.Background(), "target-wf-signal", "", "my-signal", "data")
+	err := client.SignalWorkflow(t.Context(), "target-wf-signal", "", "my-signal", "data")
 	require.NoError(err)
 
 	captured := dc.getCapturedContexts()
@@ -96,7 +95,7 @@ func TestClientQueryWorkflow_SerializationContext(t *testing.T) {
 	service.EXPECT().QueryWorkflow(gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(&workflowservice.QueryWorkflowResponse{QueryResult: queryResult}, nil)
 
-	result, err := client.QueryWorkflow(context.Background(), "target-wf-query", "", "my-query")
+	result, err := client.QueryWorkflow(t.Context(), "target-wf-query", "", "my-query")
 	require.NoError(err)
 
 	var str string
@@ -124,7 +123,7 @@ func TestClientTerminateWorkflow_SerializationContext(t *testing.T) {
 	service.EXPECT().TerminateWorkflowExecution(gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(&workflowservice.TerminateWorkflowExecutionResponse{}, nil)
 
-	err := client.TerminateWorkflow(context.Background(), "target-wf-terminate", "", "reason", "detail")
+	err := client.TerminateWorkflow(t.Context(), "target-wf-terminate", "", "reason", "detail")
 	require.NoError(err)
 
 	captured := dc.getCapturedContexts()
@@ -156,7 +155,7 @@ func TestClientDescribeWorkflow_SerializationContext(t *testing.T) {
 			},
 		}, nil)
 
-	desc, err := client.DescribeWorkflow(context.Background(), "wf-describe-test", "run-1")
+	desc, err := client.DescribeWorkflow(t.Context(), "wf-describe-test", "run-1")
 	require.NoError(err)
 	require.NotNil(desc)
 
@@ -197,7 +196,7 @@ func TestClientPollWorkflowUpdate_SerializationContext(t *testing.T) {
 		},
 		UpdateId: "update-1",
 	}
-	output, err := client.PollWorkflowUpdate(context.Background(), ref)
+	output, err := client.PollWorkflowUpdate(t.Context(), ref)
 	require.NoError(err)
 	require.NotNil(output)
 
@@ -249,7 +248,7 @@ func TestClientUpdateWithStartWorkflow_SerializationContext(t *testing.T) {
 	)
 
 	_, err := client.UpdateWithStartWorkflow(
-		context.Background(),
+		t.Context(),
 		UpdateWithStartWorkflowOptions{
 			UpdateOptions: UpdateWorkflowOptions{
 				UpdateName:   "my-update",

--- a/internal/workflow_deadlock_test.go
+++ b/internal/workflow_deadlock_test.go
@@ -94,7 +94,7 @@ func TestDataConverterWithoutDeadlockDetectionContext(t *testing.T) {
 	})
 	t.Run("with activity context", func(t *testing.T) {
 		t.Parallel()
-		ctx := context.Background()
+		ctx := t.Context()
 		ctx = context.WithValue(ctx, ContextAwareDataConverterContextKey, "e")
 
 		dc := WithContext(ctx, conv)

--- a/internal/workflow_random_test.go
+++ b/internal/workflow_random_test.go
@@ -23,8 +23,6 @@ func TestWorkflowRandomTestSuite(t *testing.T) {
 }
 
 func (s *workflowRandomTestSuite) TestDeriveSeed() {
-	s.Require().Equal(deriveSeed(workflowRandomTestRunID, workflowRandomTestName), deriveSeed(workflowRandomTestRunID, workflowRandomTestName))
-
 	cases := []struct {
 		runID string
 		name  string

--- a/mocks/mock_test.go
+++ b/mocks/mock_test.go
@@ -1,7 +1,6 @@
 package mocks
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/mock"
@@ -27,39 +26,39 @@ func Test_MockClient(t *testing.T) {
 	mockWorkflowRun.On("Get", mock.Anything, mock.Anything).Return(nil).Times(2)
 
 	mockClient.On("ExecuteWorkflow", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(mockWorkflowRun, nil).Once()
-	wr, err := mockClient.ExecuteWorkflow(context.Background(), client.StartWorkflowOptions{}, testWorkflowName, testWorkflowInput)
+	wr, err := mockClient.ExecuteWorkflow(t.Context(), client.StartWorkflowOptions{}, testWorkflowName, testWorkflowInput)
 	mockClient.AssertExpectations(t)
 	require.NoError(t, err)
 	require.Equal(t, testWorkflowID, wr.GetID())
 	require.Equal(t, testRunID, wr.GetRunID())
-	require.NoError(t, mockWorkflowRun.Get(context.Background(), &testWorkflowID))
+	require.NoError(t, mockWorkflowRun.Get(t.Context(), &testWorkflowID))
 
 	mockClient.On("SignalWithStartWorkflow", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(mockWorkflowRun, nil).Once()
-	wr, err = mockClient.SignalWithStartWorkflow(context.Background(), "wid", "signal", "val", client.StartWorkflowOptions{}, testWorkflowName, testWorkflowInput)
+	wr, err = mockClient.SignalWithStartWorkflow(t.Context(), "wid", "signal", "val", client.StartWorkflowOptions{}, testWorkflowName, testWorkflowInput)
 	mockClient.AssertExpectations(t)
 	require.NoError(t, err)
 	require.Equal(t, testWorkflowID, wr.GetID())
 	require.Equal(t, testRunID, wr.GetRunID())
 
 	mockClient.On("CancelWorkflow", mock.Anything, testWorkflowID, testRunID).Return(nil).Once()
-	err = mockClient.CancelWorkflow(context.Background(), testWorkflowID, testRunID)
+	err = mockClient.CancelWorkflow(t.Context(), testWorkflowID, testRunID)
 	mockClient.AssertExpectations(t)
 	require.NoError(t, err)
 	require.Equal(t, testWorkflowID, wr.GetID())
 	require.Equal(t, testRunID, wr.GetRunID())
 
 	mockClient.On("GetWorkflow", mock.Anything, testWorkflowID, testRunID).Return(mockWorkflowRun).Once()
-	wr = mockClient.GetWorkflow(context.Background(), testWorkflowID, testRunID)
+	wr = mockClient.GetWorkflow(t.Context(), testWorkflowID, testRunID)
 	mockClient.AssertExpectations(t)
 	require.Equal(t, testWorkflowID, wr.GetID())
 	require.Equal(t, testRunID, wr.GetRunID())
-	require.NoError(t, wr.Get(context.Background(), &testWorkflowID))
+	require.NoError(t, wr.Get(t.Context(), &testWorkflowID))
 
 	mockHistoryIter := &HistoryEventIterator{}
 	mockHistoryIter.On("HasNext").Return(true).Once()
 	mockHistoryIter.On("Next").Return(&historypb.HistoryEvent{}, nil).Once()
 	mockClient.On("GetWorkflowHistory", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(mockHistoryIter).Once()
-	historyIter := mockClient.GetWorkflowHistory(context.Background(), testWorkflowID, testRunID, true, enumspb.HISTORY_EVENT_FILTER_TYPE_CLOSE_EVENT)
+	historyIter := mockClient.GetWorkflowHistory(t.Context(), testWorkflowID, testRunID, true, enumspb.HISTORY_EVENT_FILTER_TYPE_CLOSE_EVENT)
 	mockClient.AssertExpectations(t)
 	mockWorkflowRun.AssertExpectations(t)
 
@@ -88,7 +87,7 @@ func Test_MockResetWorkflowExecution(t *testing.T) {
 	}
 
 	mockClient.On("ResetWorkflowExecution", mock.Anything, mock.Anything).Return(resp, nil).Once()
-	actualResp, err := mockClient.ResetWorkflowExecution(context.Background(), req)
+	actualResp, err := mockClient.ResetWorkflowExecution(t.Context(), req)
 	mockClient.AssertExpectations(t)
 	require.NoError(t, err)
 	require.Equal(t, "new-run-id", actualResp.GetRunId())
@@ -102,7 +101,7 @@ func Test_MockScheduleClient(t *testing.T) {
 	mockScheduleHandle.On("GetID").Return(testScheduleID).Times(1)
 
 	mockClient.On("Create", mock.Anything, mock.Anything).Return(mockScheduleHandle, nil).Once()
-	wr, err := mockClient.Create(context.Background(), client.ScheduleOptions{})
+	wr, err := mockClient.Create(t.Context(), client.ScheduleOptions{})
 	mockClient.AssertExpectations(t)
 	require.NoError(t, err)
 	require.Equal(t, testScheduleID, wr.GetID())

--- a/temporalnexus/temporal_operation_test.go
+++ b/temporalnexus/temporal_operation_test.go
@@ -162,13 +162,13 @@ func TestDoubleStartGuard(t *testing.T) {
 	started.Store(true)
 	nc := NexusClient{asyncStarted: &started}
 
-	_, err := StartUntypedWorkflow[string](context.Background(), nc, client.StartWorkflowOptions{}, "ignored")
+	_, err := StartUntypedWorkflow[string](t.Context(), nc, client.StartWorkflowOptions{}, "ignored")
 	var handlerErr *nexus.HandlerError
 	require.ErrorAs(t, err, &handlerErr)
 	require.Equal(t, nexus.HandlerErrorTypeBadRequest, handlerErr.Type)
 	require.Contains(t, handlerErr.Message, "only one async operation")
 
-	_, err = StartWorkflow(context.Background(), nc, client.StartWorkflowOptions{}, func(_ workflow.Context, _ string) (string, error) { return "", nil }, "ignored")
+	_, err = StartWorkflow(t.Context(), nc, client.StartWorkflowOptions{}, func(_ workflow.Context, _ string) (string, error) { return "", nil }, "ignored")
 	require.ErrorAs(t, err, &handlerErr)
 	require.Equal(t, nexus.HandlerErrorTypeBadRequest, handlerErr.Type)
 }
@@ -180,7 +180,7 @@ func TestStartUpdateWorkflowGuards(t *testing.T) {
 	}
 	// attempt running async with an exhuasted nexusClient handler
 	nc.asyncStarted.Store(true)
-	ctx := internal.ContextWithNexusOperationContext(context.Background(), &internal.NexusOperationContext{})
+	ctx := internal.ContextWithNexusOperationContext(t.Context(), &internal.NexusOperationContext{})
 	_, err := StartUpdateWorkflow[string](ctx, nc, client.UpdateWorkflowOptions{
 		WorkflowID:   "emptyWorkflowID!",
 		UpdateName:   "upd",

--- a/testsuite/devserver_internal_test.go
+++ b/testsuite/devserver_internal_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestWaitServerReady_respectsTimeout(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	ctx, cancel := context.WithTimeout(t.Context(), time.Millisecond)
 	defer cancel()
 
 	hostPort, err := getFreeHostPort()

--- a/testsuite/devserver_test.go
+++ b/testsuite/devserver_test.go
@@ -1,7 +1,6 @@
 package testsuite_test
 
 import (
-	"context"
 	"github.com/stretchr/testify/require"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/sdk/client"
@@ -13,40 +12,40 @@ import (
 )
 
 func TestStartDevServer_Defaults(t *testing.T) {
-	server, err := testsuite.StartDevServer(context.Background(), testsuite.DevServerOptions{})
+	server, err := testsuite.StartDevServer(t.Context(), testsuite.DevServerOptions{})
 	require.NoError(t, err)
 	defer func() { _ = server.Stop() }()
-	info, err := server.Client().WorkflowService().GetSystemInfo(context.Background(), &workflowservice.GetSystemInfoRequest{})
+	info, err := server.Client().WorkflowService().GetSystemInfo(t.Context(), &workflowservice.GetSystemInfoRequest{})
 	require.NoError(t, err)
 	require.NotNil(t, info.Capabilities)
 }
 
 func TestStartDevServer_SpecificVersion(t *testing.T) {
-	server, err := testsuite.StartDevServer(context.Background(), testsuite.DevServerOptions{CachedDownload: testsuite.CachedDownload{Version: "v1.6.1"}})
+	server, err := testsuite.StartDevServer(t.Context(), testsuite.DevServerOptions{CachedDownload: testsuite.CachedDownload{Version: "v1.6.1"}})
 	require.NoError(t, err)
 	defer func() { _ = server.Stop() }()
-	info, err := server.Client().WorkflowService().GetSystemInfo(context.Background(), &workflowservice.GetSystemInfoRequest{})
+	info, err := server.Client().WorkflowService().GetSystemInfo(t.Context(), &workflowservice.GetSystemInfoRequest{})
 	require.NoError(t, err)
 	require.NotNil(t, info.Capabilities)
 }
 
 func TestStartDevServer_CustomNamespace(t *testing.T) {
-	server, err := testsuite.StartDevServer(context.Background(), testsuite.DevServerOptions{ClientOptions: &client.Options{Namespace: "testing"}})
+	server, err := testsuite.StartDevServer(t.Context(), testsuite.DevServerOptions{ClientOptions: &client.Options{Namespace: "testing"}})
 	require.NoError(t, err)
 	defer func() { _ = server.Stop() }()
-	info, err := server.Client().WorkflowService().DescribeNamespace(context.Background(), &workflowservice.DescribeNamespaceRequest{Namespace: "testing"})
+	info, err := server.Client().WorkflowService().DescribeNamespace(t.Context(), &workflowservice.DescribeNamespaceRequest{Namespace: "testing"})
 	require.NoError(t, err)
 	require.Equal(t, "testing", info.NamespaceInfo.Name)
 }
 
 func TestStartDevServer_FrontendHostPort(t *testing.T) {
-	server, err := testsuite.StartDevServer(context.Background(), testsuite.DevServerOptions{})
+	server, err := testsuite.StartDevServer(t.Context(), testsuite.DevServerOptions{})
 	require.NoError(t, err)
 	defer func() { _ = server.Stop() }()
 	hostPort := server.FrontendHostPort()
 	client, err := client.Dial(client.Options{HostPort: hostPort})
 	require.NoError(t, err)
-	info, err := client.WorkflowService().GetSystemInfo(context.Background(), &workflowservice.GetSystemInfoRequest{})
+	info, err := client.WorkflowService().GetSystemInfo(t.Context(), &workflowservice.GetSystemInfoRequest{})
 	require.NoError(t, err)
 	require.NotNil(t, info.Capabilities)
 }
@@ -75,29 +74,29 @@ func TestStartDevServer_SearchAttributes(t *testing.T) {
 	}
 
 	// Confirm that when used in env without SAs it fails
-	server, err := testsuite.StartDevServer(context.Background(), testsuite.DevServerOptions{})
+	server, err := testsuite.StartDevServer(t.Context(), testsuite.DevServerOptions{})
 	require.NoError(t, err)
 	defer func() { _ = server.Stop() }()
 
-	_, err = server.Client().ExecuteWorkflow(context.Background(), client.StartWorkflowOptions{
+	_, err = server.Client().ExecuteWorkflow(t.Context(), client.StartWorkflowOptions{
 		TypedSearchAttributes: sa,
 	}, func(ctx workflow.Context) error { return nil })
 	require.Error(t, err)
 
 	// Confirm that when used in env with SAs it succeeds
-	server1, err := testsuite.StartDevServer(context.Background(), opts)
+	server1, err := testsuite.StartDevServer(t.Context(), opts)
 	require.NoError(t, err)
 	defer func() { _ = server1.Stop() }()
 
 	c := server1.Client()
 
-	run, err := c.ExecuteWorkflow(context.Background(), client.StartWorkflowOptions{
+	run, err := c.ExecuteWorkflow(t.Context(), client.StartWorkflowOptions{
 		TypedSearchAttributes: sa,
 		TaskQueue:             "dev-server-search-attributes-test",
 	}, func(ctx workflow.Context) error { return nil })
 	require.NoError(t, err)
 
-	describe, err := c.DescribeWorkflow(context.Background(), run.GetID(), run.GetRunID())
+	describe, err := c.DescribeWorkflow(t.Context(), run.GetID(), run.GetRunID())
 	require.NoError(t, err)
 	saTime, found := sa.GetTime(attrTime)
 	require.True(t, found)


### PR DESCRIPTION
## What changed

- Add pinned `usetesting` and `testifylint` tools to the canonical build check.
- Enable testing-aware replacements for contexts, temporary directories, and environment variables.
- Adopt a narrow set of correctness-oriented testifylint checks while keeping Staticcheck as the style baseline.
- Update existing tests to use `t.Context()` instead of `context.Background()` or `context.TODO()`, so the test lifecycle can control cancellation.
- Fix two no-op assertions found during the testifylint evaluation.

## Why

The SDK already runs several automated code checks through go run . check. This PR adds two test-specific checks to the same command. They catch unsafe test resource handling and clear assertion mistakes before review. Only a small, correctness-focused subset of testifylint is enabled, so this PR does not introduce a large set of new formatting or style rules already covered by Staticcheck.

One serialization test intentionally retains `context.Background()` behind a helper because the concrete cancelable context returned by `t.Context()` cannot round-trip through that test's JSON conversion.

## Impact

This changes contributor checks and test code only. It does not change the public SDK API or runtime behavior.

## Closes #2564

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to contributor checks and test code; no public API or production runtime behavior is modified.
> 
> **Overview**
> Extends the canonical `go run . check` pipeline with **usetesting** (context, temp dirs, env) and a narrow **testifylint** correctness subset (`nil-compare`, `suite-broken-parallel`, `suite-method-signature`, `useless-assert`), with new pinned tool dependencies in `internal/cmd/build`.
> 
> Tests are updated to use **`t.Context()`** instead of `context.Background()` / `context.TODO()` so cancellation follows the test lifecycle. The data-converter round-trip test keeps **`context.Background()`** via `serializableBackgroundContext()` because `t.Context()` cannot JSON-serialize.
> 
> **testifylint** also drove two real fixes: `assertWorkerExecutionParamsEqual` now compares both parameter structs (it previously compared `TaskQueue` to itself), and a no-op self-comparison was removed from `TestDeriveSeed`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd886d42823b435338a0917ab999911cd0604088. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->