### PR TITLE
Fix query payload limits with external storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ to docs, or any other relevant information.
 
 ### Fixed
 
+- Fixed worker payload-limit validation running before external storage for query results.
 - Prevent workflow task failures when an activity with a custom ID completes while its cancellation
   command is pending.
 - `TestWorkflowEnvironment.MutableSideEffect` now honors the provided equals function and only

--- a/internal/payload_limits.go
+++ b/internal/payload_limits.go
@@ -127,11 +127,33 @@ func (v *payloadLimitsVisitorImpl) Visit(ctx *proxy.VisitPayloadsContext, payloa
 		size = int64((&commonpb.Payloads{Payloads: payloads}).Size())
 	}
 
-	err := v.checkPayloadSize(size, getPayloadLimitChecks(ctx.Context))
-	if err != nil {
+	checks := getPayloadLimitChecks(ctx.Context)
+	switch ctx.Parent.(type) {
+	case *querypb.WorkflowQueryResult, *workflowservice.RespondQueryTaskCompletedRequest:
+		checks = limitCheckAll
+	}
+	err := v.checkPayloadSize(size, checks)
+	if err == nil {
+		return payloads, nil
+	}
+
+	// Query payloads must be checked here, after earlier visitors have had a
+	// chance to offload them to external storage. Match the server behavior by
+	// translating oversized results into failed query responses.
+	switch parent := ctx.Parent.(type) {
+	case *querypb.WorkflowQueryResult:
+		parent.Answer = nil
+		parent.ErrorMessage = err.Error()
+		parent.ResultType = enumspb.QUERY_RESULT_TYPE_FAILED
+		return payloads, nil
+	case *workflowservice.RespondQueryTaskCompletedRequest:
+		parent.ErrorMessage = err.Error()
+		parent.QueryResult = nil
+		parent.CompletedType = enumspb.QUERY_RESULT_TYPE_FAILED
+		return payloads, nil
+	default:
 		return nil, err
 	}
-	return payloads, nil
 }
 
 // ContextHook is used here to specialize the limit check logic based on how server has one-off decisions
@@ -168,23 +190,9 @@ func (v *payloadLimitsVisitorImpl) ContextHook(ctx context.Context, msg proto.Me
 			return nil, err
 		}
 		ctx = withPayloadLimitChecks(ctx, limitCheckNone)
-	case *querypb.WorkflowQueryResult:
-		err := v.checkPayloadSize(int64(msg.GetAnswer().Size()), limitCheckAll)
-		// Server translates too large results into failed query results
-		if err != nil {
-			msg.Answer = nil
-			msg.ErrorMessage = err.Error()
-			msg.ResultType = enumspb.QUERY_RESULT_TYPE_FAILED
-		}
-		ctx = withPayloadLimitChecks(ctx, limitCheckNone)
-	case *workflowservice.RespondQueryTaskCompletedRequest:
-		err := v.checkPayloadSize(int64(msg.GetQueryResult().Size()), limitCheckAll)
-		// Server translates too large results into failed query results
-		if err != nil {
-			msg.ErrorMessage = err.Error()
-			msg.QueryResult = nil
-			msg.CompletedType = enumspb.QUERY_RESULT_TYPE_FAILED
-		}
+	// Query answer payloads are checked in Visit after earlier visitors transform them.
+	// Disable inherited checks for other query response payloads, including failure details.
+	case *querypb.WorkflowQueryResult, *workflowservice.RespondQueryTaskCompletedRequest:
 		ctx = withPayloadLimitChecks(ctx, limitCheckNone)
 	// CreateScheduleRequest has a custom size checking algorithm checked against the payload size limit.
 	case *workflowservice.CreateScheduleRequest:

--- a/internal/payload_limits_test.go
+++ b/internal/payload_limits_test.go
@@ -350,6 +350,7 @@ func TestPayloadLimitsVisitorSpecializations(t *testing.T) {
 	for _, tc := range []struct {
 		name        string
 		makeMsg     func() proto.Message
+		getPayloads func(proto.Message) *commonpb.Payloads
 		assertField func(t *testing.T, msg proto.Message)
 	}{
 		{
@@ -358,6 +359,9 @@ func TestPayloadLimitsVisitorSpecializations(t *testing.T) {
 				return &querypb.WorkflowQueryResult{
 					Answer: &commonpb.Payloads{Payloads: []*commonpb.Payload{makeTestPayload(200)}},
 				}
+			},
+			getPayloads: func(msg proto.Message) *commonpb.Payloads {
+				return msg.(*querypb.WorkflowQueryResult).Answer
 			},
 			assertField: func(t *testing.T, msg proto.Message) {
 				m := msg.(*querypb.WorkflowQueryResult)
@@ -372,6 +376,9 @@ func TestPayloadLimitsVisitorSpecializations(t *testing.T) {
 				return &workflowservice.RespondQueryTaskCompletedRequest{
 					QueryResult: &commonpb.Payloads{Payloads: []*commonpb.Payload{makeTestPayload(200)}},
 				}
+			},
+			getPayloads: func(msg proto.Message) *commonpb.Payloads {
+				return msg.(*workflowservice.RespondQueryTaskCompletedRequest).QueryResult
 			},
 			assertField: func(t *testing.T, msg proto.Message) {
 				m := msg.(*workflowservice.RespondQueryTaskCompletedRequest)
@@ -407,7 +414,49 @@ func TestPayloadLimitsVisitorSpecializations(t *testing.T) {
 			require.NoError(t, err)
 			require.Empty(t, logger.Lines())
 		})
+		t.Run(tc.name+" checks payload size after preceding visitor transforms it", func(t *testing.T) {
+			visitor, setErrorLimits := newPayloadLimitsVisitor(payloadLimits{payloadSize: 10000}, nil)
+			setErrorLimits(&payloadLimits{payloadSize: 10})
+			transformingVisitor := visitorFunc(func(
+				_ *proxy.VisitPayloadsContext,
+				_ []*commonpb.Payload,
+			) ([]*commonpb.Payload, error) {
+				return []*commonpb.Payload{makeTestPayload(1)}, nil
+			})
+			msg := tc.makeMsg()
+			err := visitProtoPayloads(
+				context.Background(),
+				newCompositePayloadVisitor(transformingVisitor, visitor),
+				msg,
+				0,
+			)
+			require.NoError(t, err)
+			payloads := tc.getPayloads(msg)
+			require.NotNil(t, payloads)
+			require.Len(t, payloads.Payloads, 1)
+			require.Len(t, payloads.Payloads[0].Data, 1)
+		})
 	}
+
+	t.Run("RespondQueryTaskCompletedRequest failure skips payload error and warning limits", func(t *testing.T) {
+		logger := ilog.NewMemoryLogger()
+		visitor, setErrorLimits := newPayloadLimitsVisitor(payloadLimits{payloadSize: 10}, logger)
+		setErrorLimits(&payloadLimits{payloadSize: 10})
+		msg := &workflowservice.RespondQueryTaskCompletedRequest{
+			CompletedType: enumspb.QUERY_RESULT_TYPE_FAILED,
+			Failure: &failurepb.Failure{
+				FailureInfo: &failurepb.Failure_ApplicationFailureInfo{
+					ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{
+						Details: &commonpb.Payloads{Payloads: []*commonpb.Payload{makeTestPayload(200)}},
+					},
+				},
+			},
+		}
+		err := visitProtoPayloads(context.Background(), visitor, msg, 0)
+		require.NoError(t, err)
+		require.Empty(t, logger.Lines())
+		require.NotNil(t, msg.Failure.GetApplicationFailureInfo().Details)
+	})
 
 	skipErrorOnlyTypes := []struct {
 		name string

--- a/test/external_storage_test.go
+++ b/test/external_storage_test.go
@@ -310,9 +310,9 @@ func (s *ExternalStorageTestSuite) TestSignal() {
 var extStoreQueryType = "ext-query"
 var extStoreQueryDone = "ext-query-done"
 
-func extStoreQueryWorkflow(ctx workflow.Context, queryResult string) error {
+func extStoreQueryWorkflow(ctx workflow.Context, queryResultSize int) error {
 	_ = workflow.SetQueryHandler(ctx, extStoreQueryType, func() (string, error) {
-		return queryResult, nil
+		return strings.Repeat("a", queryResultSize), nil
 	})
 	workflow.GetSignalChannel(ctx, extStoreQueryDone).Receive(ctx, nil)
 	return nil
@@ -322,12 +322,13 @@ func (s *ExternalStorageTestSuite) TestQuery() {
 	s.worker.RegisterWorkflow(extStoreQueryWorkflow)
 	s.NoError(s.worker.Start())
 
-	large := strings.Repeat("a", 2_000_000+1024)
+	const largeSize = 2_000_000 + 1024
+	large := strings.Repeat("a", largeSize)
 	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
 	defer cancel()
 
 	wfID := "ext-query-" + uuid.NewString()
-	run, err := s.client.ExecuteWorkflow(ctx, s.startOpts(wfID), extStoreQueryWorkflow, large)
+	run, err := s.client.ExecuteWorkflow(ctx, s.startOpts(wfID), extStoreQueryWorkflow, largeSize)
 	s.NoError(err)
 
 	// Poll until the workflow has registered its query handler.
@@ -341,12 +342,13 @@ func (s *ExternalStorageTestSuite) TestQuery() {
 	s.NoError(queryResp.Get(&result))
 	s.Equal(large, result)
 
+	storeCount, retrieveCount := s.driver.getStoreCounts()
+	s.Greater(storeCount, 0, "worker should have stored the large query result")
+	s.Greater(retrieveCount, 0, "client should have retrieved the large query result")
+
 	// Unblock the workflow.
 	s.NoError(s.client.SignalWorkflow(ctx, wfID, run.GetRunID(), extStoreQueryDone, nil))
 	s.NoError(run.Get(ctx, nil))
-
-	_, retrieveCount := s.driver.getStoreCounts()
-	s.Greater(retrieveCount, 0, "client should have retrieved the large query result")
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What was changed

- Move query answer payload-limit validation from the `ContextHook` to the payload `Visit` path, after earlier visitors can externalize the payload.
- Preserve the existing behavior that translates oversized inline answers into failed query responses.
- Keep query failure details exempt from payload-limit enforcement.
- Strengthen the external-storage query integration test so its store and retrieval assertions can only be satisfied by the query result.

## Why?

#2459 removed the early 2 MB check in `ProcessQuery` so external storage could run before payload-size enforcement. The worker payload-limit visitor still performs an equivalent query-result check from its `ContextHook`, which `proxy.VisitPayloads` invokes before traversing the result payload.

When the namespace advertises `BlobSizeLimitError`, that hook emits `TMPRL1103`, clears the query result, and marks it failed before the preceding external-storage visitor can replace the payload with a reference. Applications using read-write external storage must therefore disable the worker-wide payload error limit to return oversized queries.

This change performs the specialized query check on the payloads produced by earlier visitors, while retaining the server-compatible failure translation when the post-visit payload is still too large.

Follow-up to #2456 and #2459.

## How was this tested?

From `internal/cmd/build`:

- `go run . check`
- `go run . unit-test`
- `go run . integration-test -dev-server -run "TestExternalStorageSuite/TestQuery"`

The unit and integration test commands run with the race detector through the repository build tool.

## Docs

No API documentation changes are needed. The user-facing fix is included in `CHANGELOG.md`.