### PR TITLE
Document pull request template

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,8 @@ externally.
 
 ## Pull request expectations
 
+- Use the organization-wide [pull request template](https://github.com/temporalio/.github/blob/main/.github/pull_request_template.md)
+  when creating or updating a pull request description.
 - Keep changes focused and include tests for behavior changes.
 - Run `go run . check` from `internal/cmd/build`.
 - Run relevant unit tests, and integration tests with `-dev-server` when the


### PR DESCRIPTION
## What was changed

- Added guidance to `AGENTS.md` requiring the organization-wide pull request template when creating or updating PR descriptions.
- The guidance is also available through the existing `CLAUDE.md` symlink.

## Why?

Keep agent-created pull request descriptions consistent with Temporal's organization-wide format.

## Checklist

1. Closes: N/A
2. How was this tested: `git diff --check`
3. Any docs updates needed? No; this is the documentation update.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to agent/contributor guidance with no impact on SDK behavior or production code.
> 
> **Overview**
> Adds a bullet under **Pull request expectations** in `AGENTS.md` (also visible via the `CLAUDE.md` symlink) telling contributors and agents to use Temporal’s organization-wide [pull request template](https://github.com/temporalio/.github/blob/main/.github/pull_request_template.md) when writing or updating PR descriptions.
> 
> No runtime, API, or test behavior changes—only contributor guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 292a342b5f4460f3fe46efcd1e653160eae5f90e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->