### PR TITLE
fix(extstore): update GCS driver metadata to be consistent with GCS docs.

### DIFF
--- a/contrib/gcp/gcsdriver/CHANGELOG.md
+++ b/contrib/gcp/gcsdriver/CHANGELOG.md
@@ -14,6 +14,13 @@ or Security.
 ### Breaking Changes
 
 - Raised the minimum supported Go version from 1.25.4 to 1.26.0.
+### Changed
+
+- Claim metadata now identifies the stored object with `object_name` instead of
+  `key`. Previous claims using `key` are still readable, so payloads already in 
+  history continue to resolve. Support for the legacy field will be removed when 
+  the driver reaches GA.
+- Store and retrieve error messages now report `object_name=` instead of `key=`.
 
 ## [0.1.0] - 2026-08-13
 

--- a/contrib/gcp/gcsdriver/CHANGELOG.md
+++ b/contrib/gcp/gcsdriver/CHANGELOG.md
@@ -14,12 +14,13 @@ or Security.
 ### Breaking Changes
 
 - Raised the minimum supported Go version from 1.25.4 to 1.26.0.
+
 ### Changed
 
-- Claim metadata now identifies the stored object with `object_name` instead of
-  `key`. Previous claims using `key` are still readable, so payloads already in 
-  history continue to resolve. Support for the legacy field will be removed when 
-  the driver reaches GA.
+- Claim metadata now identifies the stored object with `object_name`. The legacy
+  `key` field is still written and still read, so claims resolve in both
+  directions while a deployment runs mixed driver versions. Support for `key`
+  will be removed when the driver reaches GA.
 - Store and retrieve error messages now report `object_name=` instead of `key=`.
 
 ## [0.1.0] - 2026-08-13

--- a/contrib/gcp/gcsdriver/README.md
+++ b/contrib/gcp/gcsdriver/README.md
@@ -42,9 +42,9 @@ c, err := client.Dial(client.Options{
 
 Credentials are resolved automatically from Application Default Credentials (ADC) — environment variables, `gcloud auth application-default login`, workload identity, and so on.
 
-## Key Structure
+## Object Name Structure
 
-Payloads are stored under content-addressable keys derived from a SHA-256 hash of the serialized payload bytes, segmented by Namespace and Workflow/Standalone Activity identifiers when the target is available:
+Payloads are stored under content-addressable object names derived from a SHA-256 hash of the serialized payload bytes, segmented by Namespace and Workflow/Standalone Activity identifiers when the target is available:
 
 ```
 # Workflow payload
@@ -62,8 +62,8 @@ Characters outside GCS's safe set are percent-encoded per byte of their UTF-8 re
 ## Notes
 
 - Any driver used to store payloads must also be configured on the component that retrieves them. If the client stores Workflow inputs using this driver, the worker must include it in its `ExternalStorage.Drivers` list to retrieve them.
-- The target GCS bucket must already exist; the driver will not create it.
-- Identical serialized bytes within the same Namespace and Workflow (or Standalone Activity) share the same GCS object — the key is content-addressable within that scope. The same bytes used across different Workflows or Namespaces produce distinct GCS objects because the key includes the Namespace and Workflow/Standalone Activity identifiers.
+- The target GCS bucket must already exist.
+- Identical serialized bytes within the same Namespace and Workflow (or Standalone Activity) share the same GCS object and the object name is content-addressable within that scope. The same bytes used across different Workflows or Namespaces produce distinct GCS objects because the object name includes the Namespace and Workflow/Standalone Activity identifiers.
 - Only payloads at or above `ExternalStorage.PayloadSizeThreshold` (default: 256 KiB) are offloaded; smaller payloads are stored inline. Set `ExternalStorage.PayloadSizeThreshold` to `0` or leave unset to use the default threshold. To store all payloads in external storage, set `ExternalStorage.PayloadSizeThreshold` to `1`.
 - `Options.MaxPayloadSize` (default: 50 MiB) sets a hard upper limit on the serialized size of any single payload. An error is returned at store time if a payload exceeds this limit.
 - Override `Options.DriverName` only when registering multiple `gcsdriver` instances with distinct configurations under the same `ExternalStorage.Drivers` list.

--- a/contrib/gcp/gcsdriver/doc.go
+++ b/contrib/gcp/gcsdriver/doc.go
@@ -1,7 +1,7 @@
 // Package gcsdriver provides a GCS-backed [go.temporal.io/sdk/converter.StorageDriver]
 // for the Temporal Go SDK's external payload storage system. Large payloads are
-// offloaded to Google Cloud Storage using content-addressable keys derived from their
-// SHA-256 hash.
+// offloaded to Google Cloud Storage using content-addressable object names derived
+// from their SHA-256 hash.
 //
 // # Usage
 //

--- a/contrib/gcp/gcsdriver/driver.go
+++ b/contrib/gcp/gcsdriver/driver.go
@@ -20,14 +20,19 @@ const (
 	driverType            = "gcp.gcsdriver"
 	defaultDriverName     = "gcp.gcsdriver"
 	hashAlgorithm         = "sha256"
-	keyVersion            = "v0"
+	objectNameVersion     = "v0"
 	nullSegment           = "null"
 	maxGCSObjectNameBytes = 1024
 
 	claimKeyBucket        = "bucket"
-	claimKeyKey           = "key"
+	claimKeyObjectName    = "object_name"
 	claimKeyHashAlgorithm = "hash_algorithm"
 	claimKeyHashValue     = "hash_value"
+
+	// TODO: v0.1.0 stored the object name under "key". Retrieve still accepts it so
+	// claims already written to history remain readable. Remove once the driver
+	// reaches GA.
+	claimKeyObjectNameLegacy = "key"
 )
 
 // BucketFunc resolves the target GCS bucket for a given payload. Use
@@ -64,7 +69,8 @@ type Options struct {
 }
 
 // gcsStorageDriver implements converter.StorageDriver by storing payloads in
-// Google Cloud Storage using content-addressable keys based on SHA-256 hashes.
+// Google Cloud Storage using content-addressable object names based on SHA-256
+// hashes.
 type gcsStorageDriver struct {
 	client         Client
 	bucketFunc     BucketFunc
@@ -150,20 +156,20 @@ func (d *gcsStorageDriver) Store(
 	g.SetLimit(10)
 	for i, pp := range prepared {
 		g.Go(func() error {
-			key := objectKey(ctx.Target, pp.hexDigest)
-			exists, err := d.client.ObjectExists(gctx, pp.bucket, key)
+			name := objectName(ctx.Target, pp.hexDigest)
+			exists, err := d.client.ObjectExists(gctx, pp.bucket, name)
 			if err != nil {
-				return fmt.Errorf("existence check failed [bucket=%s, key=%s%s]: %w", pp.bucket, key, describeClient(d.client), err)
+				return fmt.Errorf("existence check failed [bucket=%s, object_name=%s%s]: %w", pp.bucket, name, describeClient(d.client), err)
 			}
 			if !exists {
-				if err := d.client.PutObject(gctx, pp.bucket, key, pp.data); err != nil {
-					return fmt.Errorf("upload failed [bucket=%s, key=%s%s]: %w", pp.bucket, key, describeClient(d.client), err)
+				if err := d.client.PutObject(gctx, pp.bucket, name, pp.data); err != nil {
+					return fmt.Errorf("upload failed [bucket=%s, object_name=%s%s]: %w", pp.bucket, name, describeClient(d.client), err)
 				}
 			}
 			claims[i] = converter.StorageDriverClaim{
 				ClaimData: map[string]string{
 					claimKeyBucket:        pp.bucket,
-					claimKeyKey:           key,
+					claimKeyObjectName:    name,
 					claimKeyHashAlgorithm: hashAlgorithm,
 					claimKeyHashValue:     pp.hexDigest,
 				},
@@ -194,14 +200,16 @@ func (d *gcsStorageDriver) Retrieve(
 			if !ok {
 				return fmt.Errorf("claim missing field %q", claimKeyBucket)
 			}
-			key, ok := c.ClaimData[claimKeyKey]
+			name, ok := c.ClaimData[claimKeyObjectName]
 			if !ok {
-				return fmt.Errorf("claim missing field %q", claimKeyKey)
+				if name, ok = c.ClaimData[claimKeyObjectNameLegacy]; !ok {
+					return fmt.Errorf("claim missing field %q", claimKeyObjectName)
+				}
 			}
 
-			data, err := d.client.GetObject(gctx, bucket, key)
+			data, err := d.client.GetObject(gctx, bucket, name)
 			if err != nil {
-				return fmt.Errorf("download failed [bucket=%s, key=%s%s]: %w", bucket, key, describeClient(d.client), err)
+				return fmt.Errorf("download failed [bucket=%s, object_name=%s%s]: %w", bucket, name, describeClient(d.client), err)
 			}
 
 			algo, ok := c.ClaimData[claimKeyHashAlgorithm]
@@ -218,14 +226,14 @@ func (d *gcsStorageDriver) Retrieve(
 			}
 			if actualHash := sha256Hex(data); actualHash != expectedHash {
 				return fmt.Errorf(
-					"integrity check failed [bucket=%s, key=%s]: expected hash %s, got %s",
-					bucket, key, expectedHash, actualHash,
+					"integrity check failed [bucket=%s, object_name=%s]: expected hash %s, got %s",
+					bucket, name, expectedHash, actualHash,
 				)
 			}
 
 			var payload commonpb.Payload
 			if err := proto.Unmarshal(data, &payload); err != nil {
-				return fmt.Errorf("failed to unmarshal payload [bucket=%s, key=%s]: %w", bucket, key, err)
+				return fmt.Errorf("failed to unmarshal payload [bucket=%s, object_name=%s]: %w", bucket, name, err)
 			}
 			payloads[i] = &payload
 			return nil
@@ -238,28 +246,28 @@ func (d *gcsStorageDriver) Retrieve(
 	return payloads, nil
 }
 
-func objectKey(target converter.StorageDriverTargetInfo, hexDigest string) string {
+func objectName(target converter.StorageDriverTargetInfo, hexDigest string) string {
 	digestSegment := "/d/" + hashAlgorithm + "/" + hexDigest
-	var key string
+	var name string
 	switch t := target.(type) {
 	case converter.StorageDriverWorkflowInfo:
-		key = keyVersion +
+		name = objectNameVersion +
 			"/ns/" + encodeObjectNameSegment(t.Namespace) +
 			"/wt/" + encodeObjectNameSegment(t.WorkflowType) +
 			"/wi/" + encodeObjectNameSegment(t.WorkflowID) +
 			"/ri/" + encodeObjectNameSegment(t.RunID) +
 			digestSegment
 	case converter.StorageDriverActivityInfo:
-		key = keyVersion +
+		name = objectNameVersion +
 			"/ns/" + encodeObjectNameSegment(t.Namespace) +
 			"/at/" + encodeObjectNameSegment(t.ActivityType) +
 			"/ai/" + encodeObjectNameSegment(t.ActivityID) +
 			"/ri/" + encodeObjectNameSegment(t.RunID) +
 			digestSegment
 	default:
-		return keyVersion + digestSegment
+		return objectNameVersion + digestSegment
 	}
-	if len(key) > maxGCSObjectNameBytes {
+	if len(name) > maxGCSObjectNameBytes {
 		// Preserve namespace scope for authorization policies.
 		var ns string
 		switch t := target.(type) {
@@ -268,9 +276,9 @@ func objectKey(target converter.StorageDriverTargetInfo, hexDigest string) strin
 		case converter.StorageDriverActivityInfo:
 			ns = t.Namespace
 		}
-		return keyVersion + "/ns/" + encodeObjectNameSegment(ns) + digestSegment
+		return objectNameVersion + "/ns/" + encodeObjectNameSegment(ns) + digestSegment
 	}
-	return key
+	return name
 }
 
 // describeClient returns ", k=v, k=v" diagnostic info from the client's

--- a/contrib/gcp/gcsdriver/driver.go
+++ b/contrib/gcp/gcsdriver/driver.go
@@ -29,9 +29,9 @@ const (
 	claimKeyHashAlgorithm = "hash_algorithm"
 	claimKeyHashValue     = "hash_value"
 
-	// TODO: v0.1.0 stored the object name under "key". Retrieve still accepts it so
-	// claims already written to history remain readable. Remove once the driver
-	// reaches GA.
+	// TODO: v0.1.0 stored the object name under "key". Store still writes it and
+	// Retrieve still accepts it, so claims stay readable in both directions while
+	// a deployment runs mixed driver versions. Remove once the driver reaches GA.
 	claimKeyObjectNameLegacy = "key"
 )
 
@@ -168,10 +168,11 @@ func (d *gcsStorageDriver) Store(
 			}
 			claims[i] = converter.StorageDriverClaim{
 				ClaimData: map[string]string{
-					claimKeyBucket:        pp.bucket,
-					claimKeyObjectName:    name,
-					claimKeyHashAlgorithm: hashAlgorithm,
-					claimKeyHashValue:     pp.hexDigest,
+					claimKeyBucket:           pp.bucket,
+					claimKeyObjectName:       name,
+					claimKeyObjectNameLegacy: name,
+					claimKeyHashAlgorithm:    hashAlgorithm,
+					claimKeyHashValue:        pp.hexDigest,
 				},
 			}
 			return nil

--- a/contrib/gcp/gcsdriver/driver_test.go
+++ b/contrib/gcp/gcsdriver/driver_test.go
@@ -179,6 +179,18 @@ func TestStore_SinglePayload(t *testing.T) {
 	assert.Equal(t, expectedDigest, claims[0].ClaimData["hash_value"])
 }
 
+// Claims must stay readable by v0.1.0, which looks for the object name under
+// "key".
+func TestStore_WritesLegacyObjectNameClaim(t *testing.T) {
+	d := newDriver(t, newMemClient())
+
+	claims, err := d.Store(storeCtx(), []*commonpb.Payload{testPayload("hello")})
+	require.NoError(t, err)
+	require.Len(t, claims, 1)
+
+	assert.Equal(t, claims[0].ClaimData[claimKeyObjectName], claims[0].ClaimData[claimKeyObjectNameLegacy])
+}
+
 func TestStore_EmptyPayloads(t *testing.T) {
 	mc := newMemClient()
 	d := newDriver(t, mc)
@@ -442,21 +454,6 @@ func TestRetrieve_LegacyObjectNameClaim(t *testing.T) {
 	}}
 
 	restored, err := d.Retrieve(retrieveCtx(), []converter.StorageDriverClaim{legacy})
-	require.NoError(t, err)
-	require.Len(t, restored, 1)
-	assert.True(t, proto.Equal(original, restored[0]))
-}
-
-func TestRetrieve_ObjectNameTakesPrecedenceOverLegacy(t *testing.T) {
-	mc := newMemClient()
-	d := newDriver(t, mc)
-	original := testPayload("addressed by object_name")
-
-	claims, err := d.Store(storeCtx(), []*commonpb.Payload{original})
-	require.NoError(t, err)
-	claims[0].ClaimData[claimKeyObjectNameLegacy] = "v0/d/sha256/nonexistent"
-
-	restored, err := d.Retrieve(retrieveCtx(), claims)
 	require.NoError(t, err)
 	require.Len(t, restored, 1)
 	assert.True(t, proto.Equal(original, restored[0]))

--- a/contrib/gcp/gcsdriver/driver_test.go
+++ b/contrib/gcp/gcsdriver/driver_test.go
@@ -168,14 +168,14 @@ func TestStore_SinglePayload(t *testing.T) {
 
 	assert.Equal(t, "test-bucket", claims[0].ClaimData["bucket"])
 	assert.Equal(t, "sha256", claims[0].ClaimData["hash_algorithm"])
-	assert.NotEmpty(t, claims[0].ClaimData["key"])
+	assert.NotEmpty(t, claims[0].ClaimData["object_name"])
 	assert.NotEmpty(t, claims[0].ClaimData["hash_value"])
 
-	// Verify key format.
+	// Verify object name format.
 	data, _ := proto.Marshal(p)
 	h := sha256.Sum256(data)
 	expectedDigest := hex.EncodeToString(h[:])
-	assert.Equal(t, "v0/d/sha256/"+expectedDigest, claims[0].ClaimData["key"])
+	assert.Equal(t, "v0/d/sha256/"+expectedDigest, claims[0].ClaimData["object_name"])
 	assert.Equal(t, expectedDigest, claims[0].ClaimData["hash_value"])
 }
 
@@ -217,12 +217,12 @@ func TestStore_MultiplePayloads(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, claims, 3)
 
-	// Each should have unique keys.
-	keys := map[string]bool{}
+	// Each should have unique object names.
+	names := map[string]bool{}
 	for _, c := range claims {
-		keys[c.ClaimData["key"]] = true
+		names[c.ClaimData[claimKeyObjectName]] = true
 	}
-	assert.Len(t, keys, 3)
+	assert.Len(t, names, 3)
 }
 
 func TestStore_MaxPayloadSizeExceeded(t *testing.T) {
@@ -305,7 +305,7 @@ func TestStore_PutObjectError(t *testing.T) {
 	d := newDriver(t, ec)
 
 	_, err := d.Store(storeCtx(), []*commonpb.Payload{testPayload("x")})
-	assert.ErrorContains(t, err, "upload failed [bucket=test-bucket, key=")
+	assert.ErrorContains(t, err, "upload failed [bucket=test-bucket, object_name=")
 	assert.ErrorContains(t, err, ", client_project_id=my-project]: access denied")
 }
 
@@ -317,7 +317,7 @@ func TestStore_ObjectExistsError(t *testing.T) {
 	d := newDriver(t, ec)
 
 	_, err := d.Store(storeCtx(), []*commonpb.Payload{testPayload("x")})
-	assert.ErrorContains(t, err, "existence check failed [bucket=test-bucket, key=")
+	assert.ErrorContains(t, err, "existence check failed [bucket=test-bucket, object_name=")
 	assert.ErrorContains(t, err, ", client_project_id=my-project]: network timeout")
 }
 
@@ -372,7 +372,7 @@ func TestRetrieve_HashVerificationFailure(t *testing.T) {
 	}
 
 	_, err = d.Retrieve(retrieveCtx(), claims)
-	assert.ErrorContains(t, err, "integrity check failed [bucket=test-bucket, key=")
+	assert.ErrorContains(t, err, "integrity check failed [bucket=test-bucket, object_name=")
 }
 
 func TestRetrieve_UnsupportedHashAlgorithm(t *testing.T) {
@@ -389,39 +389,77 @@ func TestRetrieve_UnsupportedHashAlgorithm(t *testing.T) {
 	assert.EqualError(t, err, `unsupported hash algorithm "md5"`)
 }
 
-func TestRetrieve_MissingKey(t *testing.T) {
+func TestRetrieve_ObjectNotFound(t *testing.T) {
 	mc := newMemClient()
 	d := newDriver(t, mc)
 
 	claims := []converter.StorageDriverClaim{{
 		ClaimData: map[string]string{
 			"bucket":         "test-bucket",
-			"key":            "v0/d/sha256/nonexistent",
+			"object_name":    "v0/d/sha256/nonexistent",
 			"hash_algorithm": "sha256",
 			"hash_value":     "abc",
 		},
 	}}
 
 	_, err := d.Retrieve(retrieveCtx(), claims)
-	assert.EqualError(t, err, "download failed [bucket=test-bucket, key=v0/d/sha256/nonexistent, client_project_id=my-project]: not found: test-bucket/v0/d/sha256/nonexistent")
+	assert.EqualError(t, err, "download failed [bucket=test-bucket, object_name=v0/d/sha256/nonexistent, client_project_id=my-project]: not found: test-bucket/v0/d/sha256/nonexistent")
 }
 
 func TestRetrieve_ClaimMissingBucket(t *testing.T) {
 	d := newDriver(t, newMemClient())
 	claims := []converter.StorageDriverClaim{{
-		ClaimData: map[string]string{claimKeyKey: "v0/d/sha256/abc"},
+		ClaimData: map[string]string{claimKeyObjectName: "v0/d/sha256/abc"},
 	}}
 	_, err := d.Retrieve(retrieveCtx(), claims)
 	assert.EqualError(t, err, `claim missing field "bucket"`)
 }
 
-func TestRetrieve_ClaimMissingKey(t *testing.T) {
+func TestRetrieve_ClaimMissingObjectName(t *testing.T) {
 	d := newDriver(t, newMemClient())
 	claims := []converter.StorageDriverClaim{{
 		ClaimData: map[string]string{claimKeyBucket: "test-bucket"},
 	}}
 	_, err := d.Retrieve(retrieveCtx(), claims)
-	assert.EqualError(t, err, `claim missing field "key"`)
+	assert.EqualError(t, err, `claim missing field "object_name"`)
+}
+
+// Claims written by v0.1.0 carry the object name under "key".
+func TestRetrieve_LegacyObjectNameClaim(t *testing.T) {
+	mc := newMemClient()
+	d := newDriver(t, mc)
+	original := testPayload("stored by v0.1.0")
+
+	claims, err := d.Store(storeCtx(), []*commonpb.Payload{original})
+	require.NoError(t, err)
+	require.Len(t, claims, 1)
+
+	legacy := converter.StorageDriverClaim{ClaimData: map[string]string{
+		claimKeyBucket:           claims[0].ClaimData[claimKeyBucket],
+		claimKeyObjectNameLegacy: claims[0].ClaimData[claimKeyObjectName],
+		claimKeyHashAlgorithm:    claims[0].ClaimData[claimKeyHashAlgorithm],
+		claimKeyHashValue:        claims[0].ClaimData[claimKeyHashValue],
+	}}
+
+	restored, err := d.Retrieve(retrieveCtx(), []converter.StorageDriverClaim{legacy})
+	require.NoError(t, err)
+	require.Len(t, restored, 1)
+	assert.True(t, proto.Equal(original, restored[0]))
+}
+
+func TestRetrieve_ObjectNameTakesPrecedenceOverLegacy(t *testing.T) {
+	mc := newMemClient()
+	d := newDriver(t, mc)
+	original := testPayload("addressed by object_name")
+
+	claims, err := d.Store(storeCtx(), []*commonpb.Payload{original})
+	require.NoError(t, err)
+	claims[0].ClaimData[claimKeyObjectNameLegacy] = "v0/d/sha256/nonexistent"
+
+	restored, err := d.Retrieve(retrieveCtx(), claims)
+	require.NoError(t, err)
+	require.Len(t, restored, 1)
+	assert.True(t, proto.Equal(original, restored[0]))
 }
 
 func TestRetrieve_NilClaimData(t *testing.T) {
@@ -441,7 +479,7 @@ func TestRetrieve_GetObjectError(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = d.Retrieve(retrieveCtx(), claims)
-	assert.ErrorContains(t, err, "download failed [bucket=test-bucket, key=")
+	assert.ErrorContains(t, err, "download failed [bucket=test-bucket, object_name=")
 	assert.ErrorContains(t, err, ", client_project_id=my-project]: throttled")
 }
 
@@ -469,13 +507,13 @@ func TestRetrieve_ClaimMissingHashValue(t *testing.T) {
 	assert.EqualError(t, err, `claim missing field "hash_value"`)
 }
 
-// --- Key generation tests ---
+// --- Object name generation tests ---
 
-func TestObjectKey_NoTarget(t *testing.T) {
-	assert.Equal(t, "v0/d/sha256/abc123", objectKey(nil, "abc123"))
+func TestObjectName_NoTarget(t *testing.T) {
+	assert.Equal(t, "v0/d/sha256/abc123", objectName(nil, "abc123"))
 }
 
-func TestObjectKey_WorkflowInfo(t *testing.T) {
+func TestObjectName_WorkflowInfo(t *testing.T) {
 	target := converter.StorageDriverWorkflowInfo{
 		Namespace:    "default",
 		WorkflowType: "MyWorkflow",
@@ -484,11 +522,11 @@ func TestObjectKey_WorkflowInfo(t *testing.T) {
 	}
 	assert.Equal(t,
 		"v0/ns/default/wt/MyWorkflow/wi/wf-123/ri/run-456/d/sha256/abc123",
-		objectKey(target, "abc123"),
+		objectName(target, "abc123"),
 	)
 }
 
-func TestObjectKey_ActivityInfo(t *testing.T) {
+func TestObjectName_ActivityInfo(t *testing.T) {
 	target := converter.StorageDriverActivityInfo{
 		Namespace:    "default",
 		ActivityType: "MyActivity",
@@ -497,11 +535,11 @@ func TestObjectKey_ActivityInfo(t *testing.T) {
 	}
 	assert.Equal(t,
 		"v0/ns/default/at/MyActivity/ai/act-789/ri/run-abc/d/sha256/abc123",
-		objectKey(target, "abc123"),
+		objectName(target, "abc123"),
 	)
 }
 
-func TestObjectKey_WorkflowInfo_EmptyFields(t *testing.T) {
+func TestObjectName_WorkflowInfo_EmptyFields(t *testing.T) {
 	// Empty strings should fall back to "null" in each segment.
 	target := converter.StorageDriverWorkflowInfo{
 		Namespace: "my-ns",
@@ -509,22 +547,22 @@ func TestObjectKey_WorkflowInfo_EmptyFields(t *testing.T) {
 	}
 	assert.Equal(t,
 		"v0/ns/my-ns/wt/null/wi/null/ri/null/d/sha256/abc123",
-		objectKey(target, "abc123"),
+		objectName(target, "abc123"),
 	)
 }
 
-func TestObjectKey_ActivityInfo_EmptyFields(t *testing.T) {
+func TestObjectName_ActivityInfo_EmptyFields(t *testing.T) {
 	target := converter.StorageDriverActivityInfo{
 		Namespace: "my-ns",
 		// ActivityType, ActivityID, RunID intentionally empty
 	}
 	assert.Equal(t,
 		"v0/ns/my-ns/at/null/ai/null/ri/null/d/sha256/abc123",
-		objectKey(target, "abc123"),
+		objectName(target, "abc123"),
 	)
 }
 
-func TestObjectKey_WorkflowInfo_SpecialChars(t *testing.T) {
+func TestObjectName_WorkflowInfo_SpecialChars(t *testing.T) {
 	// GCS encoding: / and % are encoded, but spaces, +, = are left intact.
 	target := converter.StorageDriverWorkflowInfo{
 		Namespace:    "my namespace",
@@ -532,16 +570,16 @@ func TestObjectKey_WorkflowInfo_SpecialChars(t *testing.T) {
 		WorkflowID:   "wf id+1",
 		RunID:        "run=abc",
 	}
-	key := objectKey(target, "abc123")
+	name := objectName(target, "abc123")
 	assert.Equal(t,
 		"v0/ns/my namespace/wt/my%2Fworkflow/wi/wf id+1/ri/run=abc/d/sha256/abc123",
-		key,
+		name,
 	)
 }
 
-func TestObjectKey_LongKeyFallback(t *testing.T) {
-	// When the generated key exceeds 1024 bytes, objectKey falls back to the
-	// generic digest-only path.
+func TestObjectName_LongNameFallback(t *testing.T) {
+	// When the generated object name exceeds 1024 bytes, objectName falls back
+	// to the generic digest-only path.
 	longID := strings.Repeat("x", 300)
 	target := converter.StorageDriverWorkflowInfo{
 		Namespace:    longID,
@@ -549,8 +587,8 @@ func TestObjectKey_LongKeyFallback(t *testing.T) {
 		WorkflowID:   longID,
 		RunID:        longID,
 	}
-	key := objectKey(target, "abc123")
-	assert.Equal(t, "v0/ns/"+longID+"/d/sha256/abc123", key)
+	name := objectName(target, "abc123")
+	assert.Equal(t, "v0/ns/"+longID+"/d/sha256/abc123", name)
 }
 
 func TestEncodeObjectNameSegment_Empty(t *testing.T) {
@@ -631,8 +669,8 @@ func TestStore_WithWorkflowTarget(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, claims, 1)
 
-	key := claims[0].ClaimData["key"]
-	assert.Contains(t, key, "v0/ns/default/wt/MyWorkflow/wi/wf-123/ri/run-456/d/sha256/")
+	name := claims[0].ClaimData[claimKeyObjectName]
+	assert.Contains(t, name, "v0/ns/default/wt/MyWorkflow/wi/wf-123/ri/run-456/d/sha256/")
 }
 
 func TestStore_WithActivityTarget(t *testing.T) {
@@ -650,8 +688,8 @@ func TestStore_WithActivityTarget(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, claims, 1)
 
-	key := claims[0].ClaimData["key"]
-	assert.Contains(t, key, "v0/ns/default/at/MyActivity/ai/act-789/ri/run-abc/d/sha256/")
+	name := claims[0].ClaimData[claimKeyObjectName]
+	assert.Contains(t, name, "v0/ns/default/at/MyActivity/ai/act-789/ri/run-abc/d/sha256/")
 }
 
 func TestStore_RoundTrip_WithWorkflowTarget(t *testing.T) {
@@ -674,8 +712,9 @@ func TestStore_RoundTrip_WithWorkflowTarget(t *testing.T) {
 	assert.True(t, proto.Equal(original, restored[0]))
 }
 
-func TestStore_DifferentTargets_SamePayload_DifferentKeys(t *testing.T) {
-	// The same payload stored under different targets produces different keys.
+func TestStore_DifferentTargets_SamePayload_DifferentObjectNames(t *testing.T) {
+	// The same payload stored under different targets produces different object
+	// names.
 	mc := newMemClient()
 	d := newDriver(t, mc)
 	p := testPayload("shared payload")
@@ -689,7 +728,7 @@ func TestStore_DifferentTargets_SamePayload_DifferentKeys(t *testing.T) {
 	actClaims, err := d.Store(storeCtxWithTarget(actTarget), []*commonpb.Payload{p})
 	require.NoError(t, err)
 
-	assert.NotEqual(t, wfClaims[0].ClaimData["key"], actClaims[0].ClaimData["key"])
+	assert.NotEqual(t, wfClaims[0].ClaimData[claimKeyObjectName], actClaims[0].ClaimData[claimKeyObjectName])
 }
 
 func TestDescribeClient_EmptyDescribe(t *testing.T) {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
- claim metadata field `key` changed to `object_name`

## Why?
- consistency with gcs language and other temporal sdks
- Fixes https://github.com/temporalio/sdk-go/issues/2572

## Checklist
- updated tests
- updated readme
- updated changelog