### PR TITLE
Fix sticky workflow cache retention after worker shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ to docs, or any other relevant information.
 
 ### Fixed
 
+- Stopped workers now release sticky workflow cache ownership immediately. When the final worker
+  stops, cached workflow state is cleared without waiting for garbage collection.
+
 ### Security
 
 ## [1.48.0] - 2026-08-18

--- a/internal/internal_task_handlers_interfaces_test.go
+++ b/internal/internal_task_handlers_interfaces_test.go
@@ -26,7 +26,9 @@ type (
 )
 
 // Sample Workflow task handler
-type sampleWorkflowTaskHandler struct{}
+type sampleWorkflowTaskHandler struct {
+	cache *WorkerCache
+}
 
 func (wth sampleWorkflowTaskHandler) ProcessWorkflowTask(
 	workflowTask *workflowTask,
@@ -46,7 +48,7 @@ func (wth sampleWorkflowTaskHandler) GetOrCreateWorkflowContext(
 	retme := &workflowExecutionContextImpl{
 		mutex: sync.Mutex{},
 		wth: &workflowTaskHandlerImpl{
-			cache: NewWorkerCache(),
+			cache: wth.cache,
 		},
 	}
 	// The mutex is expected to already be locked in situations where unlock on the execution
@@ -55,8 +57,8 @@ func (wth sampleWorkflowTaskHandler) GetOrCreateWorkflowContext(
 	return retme, nil
 }
 
-func newSampleWorkflowTaskHandler() *sampleWorkflowTaskHandler {
-	return &sampleWorkflowTaskHandler{}
+func newSampleWorkflowTaskHandler(t testing.TB) *sampleWorkflowTaskHandler {
+	return &sampleWorkflowTaskHandler{cache: newTestWorkerCache(t)}
 }
 
 // Sample ActivityTaskHandler
@@ -109,7 +111,7 @@ func (s *PollLayerInterfacesTestSuite) TestProcessWorkflowTaskInterface() {
 	s.NoError(err)
 
 	// Process task and respond to the service.
-	taskHandler := newSampleWorkflowTaskHandler()
+	taskHandler := newSampleWorkflowTaskHandler(s.T())
 	request, err := taskHandler.ProcessWorkflowTask(&workflowTask{task: response}, nil, nil)
 	completionRequest := request.rawRequest.(*workflowservice.RespondWorkflowTaskCompletedRequest)
 	s.NoError(err)

--- a/internal/internal_task_handlers_test.go
+++ b/internal/internal_task_handlers_test.go
@@ -125,9 +125,7 @@ func (t *TaskHandlersTestSuite) SetupSuite() {
 }
 
 func (t *TaskHandlersTestSuite) TearDownTest() {
-	if cache := *sharedWorkerCachePtr.workflowCache; cache != nil {
-		cache.Clear()
-	}
+	PurgeStickyWorkflowCache()
 }
 
 func TestTaskHandlersTestSuite(t *testing.T) {
@@ -517,7 +515,7 @@ func createTestEventTimerCanceled(eventID int64, id int) *historypb.HistoryEvent
 var testWorkflowTaskTaskqueue = "tq1"
 
 func (t *TaskHandlersTestSuite) getTestWorkerExecutionParams() workerExecutionParameters {
-	cache := NewWorkerCache()
+	cache := newTestWorkerCache(t.T())
 	return workerExecutionParameters{
 		TaskQueue:        testWorkflowTaskTaskqueue,
 		Namespace:        testNamespace,
@@ -1017,7 +1015,9 @@ func (t *TaskHandlersTestSuite) testSideEffectDeferHelper(cacheSize int) {
 	}
 
 	params := t.getTestWorkerExecutionParams()
-	params.cache = newWorkerCache(myWorkerCachePtr, &myWorkerCacheLock, cacheSize)
+	var cacheLease *workerCacheLease
+	params.cache, cacheLease = newWorkerCache(myWorkerCachePtr, &myWorkerCacheLock, cacheSize)
+	defer cacheLease.release()
 
 	taskHandler := newWorkflowTaskHandler(params, nil, t.registry)
 	task := createWorkflowTask(testEvents, 0, workflowName)
@@ -2690,7 +2690,8 @@ func TestResetIfDestroyedTaskPrep(t *testing.T) {
 			metricsHandler: metrics.NopHandler,
 			logger:         ilog.NewNopLogger(),
 			cache: &WorkerCache{
-				sharedCache: &sharedWorkerCache{workflowCache: &cache},
+				workflowCache:        cache,
+				maxWorkflowCacheSize: 1,
 			},
 		},
 	}

--- a/internal/internal_task_pollers_test.go
+++ b/internal/internal_task_pollers_test.go
@@ -112,7 +112,7 @@ func TestPollRequestsIncludeWorkerControlTaskQueue(t *testing.T) {
 }
 
 func TestWFTRacePrevention(t *testing.T) {
-	params := workerExecutionParameters{cache: NewWorkerCache()}
+	params := workerExecutionParameters{cache: newTestWorkerCache(t)}
 	ensureRequiredParams(&params)
 	var (
 		taskQueue    = taskqueuepb.TaskQueue{Name: t.Name() + "task-queue"}
@@ -205,7 +205,7 @@ func TestWFTRacePrevention(t *testing.T) {
 }
 
 func TestWFTCorruption(t *testing.T) {
-	cache := NewWorkerCache()
+	cache := newTestWorkerCache(t)
 	params := workerExecutionParameters{cache: cache}
 	ensureRequiredParams(&params)
 	wfType := commonpb.WorkflowType{Name: t.Name() + "-workflow-type"}
@@ -272,7 +272,7 @@ func TestWFTCorruption(t *testing.T) {
 	}()
 	completionChans[0] <- struct{}{}
 	// Until RespondWorkflowTaskCompleted returns an error the workflow should be in cache
-	require.True(t, (*cache.sharedCache.workflowCache).Exist(runID))
+	require.True(t, cache.getWorkflowCache().Exist(runID))
 	close(completionChans[0])
 	<-processTaskDone
 	// Workflow should not be in cache
@@ -280,7 +280,7 @@ func TestWFTCorruption(t *testing.T) {
 }
 
 func TestWFTReset(t *testing.T) {
-	cache := NewWorkerCache()
+	cache := newTestWorkerCache(t)
 	params := workerExecutionParameters{
 		cache: cache,
 	}
@@ -443,7 +443,7 @@ func (wth *panickingTaskHandler) ProcessWorkflowTask(
 }
 
 func TestWFTPanicInTaskHandler(t *testing.T) {
-	cache := NewWorkerCache()
+	cache := newTestWorkerCache(t)
 	params := workerExecutionParameters{cache: cache}
 	ensureRequiredParams(&params)
 	wfType := commonpb.WorkflowType{Name: t.Name() + "-workflow-type"}
@@ -486,7 +486,7 @@ func TestWFTPanicInTaskHandler(t *testing.T) {
 }
 
 func TestErrorToFailWorkflowTaskCause(t *testing.T) {
-	params := workerExecutionParameters{cache: NewWorkerCache()}
+	params := workerExecutionParameters{cache: newTestWorkerCache(t)}
 	ensureRequiredParams(&params)
 
 	taskHandler := newWorkflowTaskHandler(params, nil, newRegistry())

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -2402,6 +2402,12 @@ func NewAggregatedWorker(client *WorkflowClient, taskQueue string, options Worke
 	payloadLimitVisitor, setErrorLimits := newPayloadLimitsVisitor(client.payloadWarningLimits, logger)
 
 	cache, cacheLease := NewWorkerCache()
+	constructionComplete := false
+	defer func() {
+		if !constructionComplete {
+			cacheLease.release()
+		}
+	}()
 	workerPollCompleteOnShutdown := &atomic.Bool{}
 	workerParams := workerExecutionParameters{
 		Namespace:                        client.namespace,
@@ -2686,6 +2692,7 @@ func NewAggregatedWorker(client *WorkflowClient, taskQueue string, options Worke
 		}
 		return err
 	})
+	constructionComplete = true
 	return aw
 }
 

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -2683,14 +2683,10 @@ func NewAggregatedWorker(client *WorkflowClient, taskQueue string, options Worke
 				return plugin.StartWorker(ctx, options, next)
 			}
 		}
-		err := start(context.Background(), WorkerPluginStartWorkerOptions{
+		return start(context.Background(), WorkerPluginStartWorkerOptions{
 			WorkerInstanceKey: workerInstanceKey,
 			WorkerRegistry:    aw,
 		})
-		if err != nil {
-			aw.Stop()
-		}
-		return err
 	})
 	constructionComplete = true
 	return aw

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -1291,6 +1291,7 @@ type AggregatedWorker struct {
 	heartbeatMetrics             *heartbeatMetricsHandler
 	heartbeatCallback            func() *workerpb.WorkerHeartbeat
 	workerPollCompleteOnShutdown *atomic.Bool
+	cacheLease                   *workerCacheLease
 }
 
 // RegisterWorkflow registers workflow implementation with the AggregatedWorker
@@ -1671,6 +1672,9 @@ func (aw *AggregatedWorker) Stop() {
 	})
 
 	aw.unregisterHeartbeatWorker()
+	if aw.cacheLease != nil {
+		aw.cacheLease.release()
+	}
 
 	aw.logger.Info("Stopped Worker")
 }
@@ -2111,7 +2115,8 @@ func (aw *WorkflowReplayer) replayWorkflowHistoryRoot(
 		},
 		inboundVisitor: aw.inboundPayloadVisitor,
 	}
-	cache := NewWorkerCache()
+	cache, cacheLease := NewWorkerCache()
+	defer cacheLease.release()
 	params := workerExecutionParameters{
 		Namespace:             namespace,
 		TaskQueue:             taskQueue,
@@ -2396,7 +2401,7 @@ func NewAggregatedWorker(client *WorkflowClient, taskQueue string, options Worke
 
 	payloadLimitVisitor, setErrorLimits := newPayloadLimitsVisitor(client.payloadWarningLimits, logger)
 
-	cache := NewWorkerCache()
+	cache, cacheLease := NewWorkerCache()
 	workerPollCompleteOnShutdown := &atomic.Bool{}
 	workerParams := workerExecutionParameters{
 		Namespace:                        client.namespace,
@@ -2659,6 +2664,7 @@ func NewAggregatedWorker(client *WorkflowClient, taskQueue string, options Worke
 		heartbeatMetrics:             heartbeatMetrics,
 		heartbeatCallback:            heartbeatCallback,
 		workerPollCompleteOnShutdown: workerPollCompleteOnShutdown,
+		cacheLease:                   cacheLease,
 	}
 
 	// Set memoized start as a once-value that invokes plugins first
@@ -2671,10 +2677,14 @@ func NewAggregatedWorker(client *WorkflowClient, taskQueue string, options Worke
 				return plugin.StartWorker(ctx, options, next)
 			}
 		}
-		return start(context.Background(), WorkerPluginStartWorkerOptions{
+		err := start(context.Background(), WorkerPluginStartWorkerOptions{
 			WorkerInstanceKey: workerInstanceKey,
 			WorkerRegistry:    aw,
 		})
+		if err != nil {
+			aw.Stop()
+		}
+		return err
 	})
 	return aw
 }

--- a/internal/internal_worker_cache.go
+++ b/internal/internal_worker_cache.go
@@ -10,7 +10,16 @@ import (
 // A WorkerCache instance is held by each worker to hold cached data. The contents of this struct should always be
 // pointers for any data shared with other workers, and owned values for any instance-specific caches.
 type WorkerCache struct {
+	workflowCache        cache.Cache
+	maxWorkflowCacheSize int
+}
+
+// workerCacheLease owns one reference to a shared cache generation. Workflow
+// cache entries must not retain this lease, or they can prevent final release.
+type workerCacheLease struct {
 	sharedCache *sharedWorkerCache
+	lock        *sync.Mutex
+	releaseOnce sync.Once
 }
 
 // A container for data workers in this process may want to share with eachother
@@ -19,15 +28,14 @@ type sharedWorkerCache struct {
 	workerRefcount int
 
 	// A cache workers can use to store workflow state.
-	workflowCache *cache.Cache
+	workflowCache cache.Cache
 	// Max size for the cache
 	maxWorkflowCacheSize int
 }
 
-// A shared cache workers can use to store state. The cache is expected to be initialized with the first worker to be
-// instantiated. IE: All workers have a pointer to it. The pointer itself is never made nil, but when the refcount
-// reaches zero, the shared caches inside of it will be nilled out. Do not manipulate without holding
-// sharedWorkerCacheLock
+// The current cache generation shared by live workers. When its owner count
+// reaches zero, it is detached before being cleared. Do not manipulate without
+// holding sharedWorkerCacheLock.
 var sharedWorkerCachePtr = &sharedWorkerCache{}
 var sharedWorkerCacheLock sync.Mutex
 
@@ -51,14 +59,14 @@ func PurgeStickyWorkflowCache() {
 	defer sharedWorkerCacheLock.Unlock()
 
 	if sharedWorkerCachePtr.workflowCache != nil {
-		(*sharedWorkerCachePtr.workflowCache).Clear()
+		sharedWorkerCachePtr.workflowCache.Clear()
 	}
 }
 
-// NewWorkerCache Creates a new WorkerCache, and increases workerRefcount by one. Instances of WorkerCache decrement the refcounter as
-// a hook to runtime.SetFinalizer (ie: When they are freed by the GC). When there are no reachable instances of
-// WorkerCache, shared caches will be cleared
-func NewWorkerCache() *WorkerCache {
+// NewWorkerCache creates a cache handle and a lease for its shared generation.
+// The owner must release the lease when its lifecycle ends. A finalizer is kept
+// only as a fallback for owners that are abandoned without deterministic cleanup.
+func NewWorkerCache() (*WorkerCache, *workerCacheLease) {
 	sharedWorkerCacheLock.Lock()
 	desiredWorkflowCacheSize := desiredWorkflowCacheSize
 	sharedWorkerCacheLock.Unlock()
@@ -66,8 +74,8 @@ func NewWorkerCache() *WorkerCache {
 	return newWorkerCache(sharedWorkerCachePtr, &sharedWorkerCacheLock, desiredWorkflowCacheSize)
 }
 
-// This private version allows us to test functionality without affecting the global shared cache
-func newWorkerCache(storeIn *sharedWorkerCache, lock *sync.Mutex, cacheSize int) *WorkerCache {
+// This private version allows us to test functionality without affecting the global shared cache.
+func newWorkerCache(storeIn *sharedWorkerCache, lock *sync.Mutex, cacheSize int) (*WorkerCache, *workerCacheLease) {
 	lock.Lock()
 	defer lock.Unlock()
 
@@ -76,41 +84,52 @@ func newWorkerCache(storeIn *sharedWorkerCache, lock *sync.Mutex, cacheSize int)
 	}
 
 	if storeIn.workerRefcount == 0 {
-		newcache := cache.New(cacheSize-1, &cache.Options{
+		workflowCache := cache.New(cacheSize-1, &cache.Options{
 			RemovedFunc: func(cachedEntity interface{}) {
 				wc := cachedEntity.(*workflowExecutionContextImpl)
 				wc.onEviction()
 			},
 		})
-		*storeIn = sharedWorkerCache{workflowCache: &newcache, workerRefcount: 0, maxWorkflowCacheSize: cacheSize}
+		*storeIn = sharedWorkerCache{workflowCache: workflowCache, maxWorkflowCacheSize: cacheSize}
 	}
 	storeIn.workerRefcount++
-	newWorkerCache := WorkerCache{
-		sharedCache: storeIn,
+	workerCache := &WorkerCache{
+		workflowCache:        storeIn.workflowCache,
+		maxWorkflowCacheSize: storeIn.maxWorkflowCacheSize,
 	}
-	runtime.SetFinalizer(&newWorkerCache, func(wc *WorkerCache) {
-		wc.close(lock)
+	lease := &workerCacheLease{
+		sharedCache: storeIn,
+		lock:        lock,
+	}
+	runtime.SetFinalizer(lease, func(lease *workerCacheLease) {
+		lease.release()
 	})
-	return &newWorkerCache
+	return workerCache, lease
 }
 
 func (wc *WorkerCache) getWorkflowCache() cache.Cache {
-	return *wc.sharedCache.workflowCache
+	return wc.workflowCache
 }
 
-func (wc *WorkerCache) close(lock *sync.Mutex) {
-	lock.Lock()
-	defer lock.Unlock()
+func (lease *workerCacheLease) release() {
+	lease.releaseOnce.Do(func() {
+		lease.lock.Lock()
+		lease.sharedCache.workerRefcount--
+		var releasedCache cache.Cache
+		if lease.sharedCache.workerRefcount == 0 {
+			releasedCache = lease.sharedCache.workflowCache
+			lease.sharedCache.workflowCache = nil
+		}
+		lease.lock.Unlock()
 
-	wc.sharedCache.workerRefcount--
-	if wc.sharedCache.workerRefcount == 0 {
-		// Delete cache if no more outstanding references
-		wc.sharedCache.workflowCache = nil
-	}
+		if releasedCache != nil {
+			releasedCache.Clear()
+		}
+	})
 }
 
 func (wc *WorkerCache) getWorkflowContext(runID string) *workflowExecutionContextImpl {
-	o := (*wc.sharedCache.workflowCache).Get(runID)
+	o := wc.workflowCache.Get(runID)
 	if o == nil {
 		return nil
 	}
@@ -119,7 +138,7 @@ func (wc *WorkerCache) getWorkflowContext(runID string) *workflowExecutionContex
 }
 
 func (wc *WorkerCache) putWorkflowContext(runID string, wec *workflowExecutionContextImpl) (*workflowExecutionContextImpl, error) {
-	existing, err := (*wc.sharedCache.workflowCache).PutIfNotExist(runID, wec)
+	existing, err := wc.workflowCache.PutIfNotExist(runID, wec)
 	if err != nil {
 		return nil, err
 	}
@@ -127,7 +146,7 @@ func (wc *WorkerCache) putWorkflowContext(runID string, wec *workflowExecutionCo
 }
 
 func (wc *WorkerCache) removeWorkflowContext(runID string) {
-	(*wc.sharedCache.workflowCache).Delete(runID)
+	wc.workflowCache.Delete(runID)
 }
 
 // MaxWorkflowCacheSize returns the maximum allowed size of the sticky cache
@@ -135,5 +154,5 @@ func (wc *WorkerCache) MaxWorkflowCacheSize() int {
 	if wc == nil {
 		return desiredWorkflowCacheSize
 	}
-	return wc.sharedCache.maxWorkflowCacheSize
+	return wc.maxWorkflowCacheSize
 }

--- a/internal/internal_worker_cache_test.go
+++ b/internal/internal_worker_cache_test.go
@@ -3,8 +3,11 @@ package internal
 import (
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/suite"
+	commoncache "go.temporal.io/sdk/internal/common/cache"
+	"go.temporal.io/sdk/internal/common/metrics"
 )
 
 type (
@@ -17,23 +20,108 @@ func TestWorkerCacheTestSuite(t *testing.T) {
 	suite.Run(t, new(WorkerCacheSuite))
 }
 
+func newTestWorkerCache(t testing.TB) *WorkerCache {
+	t.Helper()
+	workerCache, lease := NewWorkerCache()
+	t.Cleanup(lease.release)
+	return workerCache
+}
+
 func (s *WorkerCacheSuite) TestCreateAndFree() {
 	cachePtr := &sharedWorkerCache{}
 	var lock sync.Mutex
 
-	cache := newWorkerCache(cachePtr, &lock, 10)
+	cache, lease := newWorkerCache(cachePtr, &lock, 10)
 	s.NotNil(cache)
 	s.NotNil(cachePtr)
 	s.NotNil(cachePtr.workflowCache)
 	s.Equal(cachePtr.workerRefcount, 1)
-	cache2 := newWorkerCache(cachePtr, &lock, 10)
+	cache2, lease2 := newWorkerCache(cachePtr, &lock, 10)
 	s.NotNil(cache2)
 	s.NotNil(cachePtr.workflowCache)
 	s.Equal(cachePtr.workerRefcount, 2)
-	cache.close(&lock)
+	workflowContext := &workflowExecutionContextImpl{
+		wth: &workflowTaskHandlerImpl{metricsHandler: metrics.NopHandler},
+	}
+	_, err := cache.putWorkflowContext("run-id", workflowContext)
+	s.NoError(err)
+	lease.release()
 	s.Equal(cachePtr.workerRefcount, 1)
 	s.NotNil(cachePtr.workflowCache)
-	cache2.close(&lock)
+	s.Equal(1, cache.getWorkflowCache().Size())
+	lease2.release()
 	s.Equal(cachePtr.workerRefcount, 0)
+	s.Nil(cachePtr.workflowCache)
+	s.Zero(cache.getWorkflowCache().Size())
+
+	lease2.release()
+	s.Equal(0, cachePtr.workerRefcount)
+
+	cache3, lease3 := newWorkerCache(cachePtr, &lock, 10)
+	s.NotSame(cache.getWorkflowCache(), cache3.getWorkflowCache())
+	lease3.release()
+}
+
+func (s *WorkerCacheSuite) TestFinalReleaseClearsCacheAndRunsRemovalCallback() {
+	removed := make(chan interface{}, 1)
+	workflowCache := commoncache.New(10, &commoncache.Options{
+		RemovedFunc: func(value interface{}) {
+			removed <- value
+		},
+	})
+	value := &struct{}{}
+	workflowCache.Put("run-id", value)
+
+	cachePtr := &sharedWorkerCache{workerRefcount: 1, workflowCache: workflowCache}
+	var lock sync.Mutex
+	lease := &workerCacheLease{sharedCache: cachePtr, lock: &lock}
+	lease.release()
+
+	s.Zero(workflowCache.Size())
+	s.Nil(cachePtr.workflowCache)
+	select {
+	case removedValue := <-removed:
+		s.Same(value, removedValue)
+	case <-time.After(time.Second):
+		s.Fail("removal callback did not run")
+	}
+}
+
+func (s *WorkerCacheSuite) TestOldHandleCannotAffectLaterGeneration() {
+	cachePtr := &sharedWorkerCache{}
+	var lock sync.Mutex
+
+	oldCache, oldLease := newWorkerCache(cachePtr, &lock, 10)
+	oldLease.release()
+	newCache, newLease := newWorkerCache(cachePtr, &lock, 10)
+	defer newLease.release()
+
+	workflowContext := &workflowExecutionContextImpl{
+		wth: &workflowTaskHandlerImpl{metricsHandler: metrics.NopHandler},
+	}
+	_, err := newCache.putWorkflowContext("run-id", workflowContext)
+	s.NoError(err)
+
+	oldCache.removeWorkflowContext("run-id")
+	s.Same(workflowContext, newCache.getWorkflowContext("run-id"))
+	s.NotSame(oldCache.getWorkflowCache(), newCache.getWorkflowCache())
+}
+
+func (s *WorkerCacheSuite) TestConcurrentReleaseIsIdempotent() {
+	cachePtr := &sharedWorkerCache{}
+	var lock sync.Mutex
+	_, lease := newWorkerCache(cachePtr, &lock, 10)
+
+	var released sync.WaitGroup
+	for range 100 {
+		released.Add(1)
+		go func() {
+			defer released.Done()
+			lease.release()
+		}()
+	}
+	released.Wait()
+
+	s.Zero(cachePtr.workerRefcount)
 	s.Nil(cachePtr.workflowCache)
 }

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -42,6 +42,15 @@ type contextCapturingDC struct {
 	contexts *[]converter.SerializationContext
 }
 
+type slotSupplierWithSysInfo struct {
+	SlotSupplier
+	provider SysInfoProvider
+}
+
+func (s *slotSupplierWithSysInfo) SysInfoProvider() SysInfoProvider {
+	return s.provider
+}
+
 func (dc *contextCapturingDC) WithSerializationContext(ctx converter.SerializationContext) converter.DataConverter {
 	*dc.contexts = append(*dc.contexts, ctx)
 	return &contextCapturingDC{
@@ -2113,6 +2122,39 @@ func (s *internalWorkerTestSuite) TestWorkerStartFailureReleasesCacheOwnership()
 	client := NewServiceClient(service, nil, ClientOptions{Namespace: "testNamespace"})
 	worker := NewAggregatedWorker(client, "testTaskQueue", WorkerOptions{})
 	s.ErrorIs(worker.Start(), startErr)
+
+	sharedWorkerCacheLock.Lock()
+	s.Equal(refcountBefore, sharedWorkerCachePtr.workerRefcount)
+	sharedWorkerCacheLock.Unlock()
+}
+
+func (s *internalWorkerTestSuite) TestWorkerConstructionFailureReleasesCacheOwnership() {
+	fixedTuner, err := NewFixedSizeTuner(FixedSizeTunerOptions{})
+	s.NoError(err)
+	workflowSupplier := &slotSupplierWithSysInfo{
+		SlotSupplier: fixedTuner.GetWorkflowTaskSlotSupplier(),
+		provider:     &FakeSystemInfoSupplier{},
+	}
+	tuner, err := NewCompositeTuner(CompositeTunerOptions{
+		WorkflowSlotSupplier:        workflowSupplier,
+		ActivitySlotSupplier:        fixedTuner.GetActivityTaskSlotSupplier(),
+		LocalActivitySlotSupplier:   fixedTuner.GetLocalActivitySlotSupplier(),
+		NexusSlotSupplier:           fixedTuner.GetNexusSlotSupplier(),
+		SessionActivitySlotSupplier: fixedTuner.GetSessionActivitySlotSupplier(),
+	})
+	s.NoError(err)
+
+	sharedWorkerCacheLock.Lock()
+	refcountBefore := sharedWorkerCachePtr.workerRefcount
+	sharedWorkerCacheLock.Unlock()
+
+	client := NewServiceClient(s.service, nil, ClientOptions{Namespace: "testNamespace"})
+	s.Panics(func() {
+		NewAggregatedWorker(client, "testTaskQueue", WorkerOptions{
+			Tuner:           tuner,
+			SysInfoProvider: &FakeSystemInfoSupplier{},
+		})
+	})
 
 	sharedWorkerCacheLock.Lock()
 	s.Equal(refcountBefore, sharedWorkerCachePtr.workerRefcount)

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -47,6 +47,33 @@ type slotSupplierWithSysInfo struct {
 	provider SysInfoProvider
 }
 
+type startFailWorkerPlugin struct {
+	WorkerPluginBase
+	startErr  error
+	stopCalls atomic.Int32
+}
+
+func (p *startFailWorkerPlugin) Name() string {
+	return "start-fail-worker-plugin"
+}
+
+func (p *startFailWorkerPlugin) StartWorker(
+	context.Context,
+	WorkerPluginStartWorkerOptions,
+	func(context.Context, WorkerPluginStartWorkerOptions) error,
+) error {
+	return p.startErr
+}
+
+func (p *startFailWorkerPlugin) StopWorker(
+	ctx context.Context,
+	options WorkerPluginStopWorkerOptions,
+	next func(context.Context, WorkerPluginStopWorkerOptions),
+) {
+	p.stopCalls.Add(1)
+	next(ctx, options)
+}
+
 func (s *slotSupplierWithSysInfo) SysInfoProvider() SysInfoProvider {
 	return s.provider
 }
@@ -2102,13 +2129,56 @@ func (s *internalWorkerTestSuite) TestWorkerStopReleasesCacheOwnership() {
 
 	worker.Stop()
 	s.Zero(workerCache.getWorkflowCache().Size())
+	s.NotPanics(worker.Stop)
 
 	sharedWorkerCacheLock.Lock()
 	s.Equal(refcountBefore, sharedWorkerCachePtr.workerRefcount)
 	sharedWorkerCacheLock.Unlock()
 }
 
-func (s *internalWorkerTestSuite) TestWorkerStartFailureReleasesCacheOwnership() {
+func (s *internalWorkerTestSuite) TestWorkersShareCacheUntilFinalStop() {
+	sharedWorkerCacheLock.Lock()
+	refcountBefore := sharedWorkerCachePtr.workerRefcount
+	sharedWorkerCacheLock.Unlock()
+	s.Zero(refcountBefore)
+
+	firstWorker := createWorker(s.service)
+	secondWorker := createWorker(s.service)
+	firstCache := firstWorker.executionParams.cache
+	secondCache := secondWorker.executionParams.cache
+	s.Same(firstCache.getWorkflowCache(), secondCache.getWorkflowCache())
+
+	workflowContext := &workflowExecutionContextImpl{
+		wth: &workflowTaskHandlerImpl{
+			cache:          firstCache,
+			metricsHandler: metrics.NopHandler,
+		},
+	}
+	_, err := firstCache.putWorkflowContext("shared-run", workflowContext)
+	s.NoError(err)
+	s.Same(workflowContext, secondCache.getWorkflowContext("shared-run"))
+
+	firstWorker.Stop()
+	s.Same(workflowContext, secondCache.getWorkflowContext("shared-run"))
+
+	secondWorker.Stop()
+	s.Zero(firstCache.getWorkflowCache().Size())
+
+	thirdWorker := createWorker(s.service)
+	thirdCache := thirdWorker.executionParams.cache
+	s.NotSame(firstCache.getWorkflowCache(), thirdCache.getWorkflowCache())
+	_, err = thirdCache.putWorkflowContext("new-run", &workflowExecutionContextImpl{
+		wth: &workflowTaskHandlerImpl{
+			cache:          thirdCache,
+			metricsHandler: metrics.NopHandler,
+		},
+	})
+	s.NoError(err)
+	s.NotNil(thirdCache.getWorkflowContext("new-run"))
+	thirdWorker.Stop()
+}
+
+func (s *internalWorkerTestSuite) TestWorkerStartFailureReleasesCacheOwnershipOnStop() {
 	service := workflowservicemock.NewMockWorkflowServiceClient(s.mockCtrl)
 	startErr := errors.New("start failed")
 	service.EXPECT().GetSystemInfo(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, startErr).Times(1)
@@ -2123,6 +2193,61 @@ func (s *internalWorkerTestSuite) TestWorkerStartFailureReleasesCacheOwnership()
 	worker := NewAggregatedWorker(client, "testTaskQueue", WorkerOptions{})
 	s.ErrorIs(worker.Start(), startErr)
 
+	sharedWorkerCacheLock.Lock()
+	s.Equal(refcountBefore+1, sharedWorkerCachePtr.workerRefcount)
+	sharedWorkerCacheLock.Unlock()
+
+	worker.Stop()
+
+	sharedWorkerCacheLock.Lock()
+	s.Equal(refcountBefore, sharedWorkerCachePtr.workerRefcount)
+	sharedWorkerCacheLock.Unlock()
+}
+
+func (s *internalWorkerTestSuite) TestWorkerPluginStartFailureDoesNotImplicitlyStop() {
+	service := workflowservicemock.NewMockWorkflowServiceClient(s.mockCtrl)
+	service.EXPECT().ShutdownWorker(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(&workflowservice.ShutdownWorkerResponse{}, nil).Times(1)
+	startErr := errors.New("plugin start failed")
+	plugin := &startFailWorkerPlugin{startErr: startErr}
+
+	sharedWorkerCacheLock.Lock()
+	refcountBefore := sharedWorkerCachePtr.workerRefcount
+	sharedWorkerCacheLock.Unlock()
+
+	client := NewServiceClient(service, nil, ClientOptions{Namespace: "testNamespace"})
+	worker := NewAggregatedWorker(client, "testTaskQueue", WorkerOptions{
+		Plugins: []WorkerPlugin{plugin},
+	})
+	s.ErrorIs(worker.Start(), startErr)
+	s.Zero(plugin.stopCalls.Load())
+
+	sharedWorkerCacheLock.Lock()
+	s.Equal(refcountBefore+1, sharedWorkerCachePtr.workerRefcount)
+	sharedWorkerCacheLock.Unlock()
+
+	worker.Stop()
+	s.Equal(int32(1), plugin.stopCalls.Load())
+
+	sharedWorkerCacheLock.Lock()
+	s.Equal(refcountBefore, sharedWorkerCachePtr.workerRefcount)
+	sharedWorkerCacheLock.Unlock()
+}
+
+func (s *internalWorkerTestSuite) TestWorkerFatalErrorReleasesCacheOwnership() {
+	sharedWorkerCacheLock.Lock()
+	refcountBefore := sharedWorkerCachePtr.workerRefcount
+	sharedWorkerCacheLock.Unlock()
+
+	worker := createWorker(s.service)
+	s.NoError(worker.Start())
+	worker.executionParams.WorkerFatalErrorCallback(errors.New("fatal worker error"))
+
+	select {
+	case <-worker.stopC:
+	default:
+		s.Fail("fatal error did not stop worker")
+	}
 	sharedWorkerCacheLock.Lock()
 	s.Equal(refcountBefore, sharedWorkerCachePtr.workerRefcount)
 	sharedWorkerCacheLock.Unlock()

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -302,8 +302,14 @@ func (s *internalWorkerTestSuite) TestReplayWorkflowHistory() {
 	replayer, err := NewWorkflowReplayer(WorkflowReplayerOptions{})
 	require.NoError(s.T(), err)
 	replayer.RegisterWorkflow(testReplayWorkflow)
+	sharedWorkerCacheLock.Lock()
+	refcountBeforeReplay := sharedWorkerCachePtr.workerRefcount
+	sharedWorkerCacheLock.Unlock()
 	err = replayer.ReplayWorkflowHistory(logger, history)
 	require.NoError(s.T(), err)
+	sharedWorkerCacheLock.Lock()
+	s.Equal(refcountBeforeReplay, sharedWorkerCachePtr.workerRefcount)
+	sharedWorkerCacheLock.Unlock()
 }
 
 func (s *internalWorkerTestSuite) TestReplayWorkflowHistory_IncompleteWorkflowExecution() {
@@ -1730,7 +1736,7 @@ func (s *internalWorkerTestSuite) testWorkflowTaskHandlerHelper(params workerExe
 }
 
 func (s *internalWorkerTestSuite) TestWorkflowTaskHandlerWithDataConverter() {
-	cache := NewWorkerCache()
+	cache := newTestWorkerCache(s.T())
 	params := workerExecutionParameters{
 		Namespace:     testNamespace,
 		Identity:      "identity",
@@ -2061,6 +2067,56 @@ func (s *internalWorkerTestSuite) TestNoActivitiesOrWorkflows() {
 	assert.True(t, w.activityWorker.worker.isWorkerStarted)
 	assert.True(t, w.workflowWorker.worker.isWorkerStarted)
 	w.Stop()
+}
+
+func (s *internalWorkerTestSuite) TestWorkerStopReleasesCacheOwnership() {
+	sharedWorkerCacheLock.Lock()
+	refcountBefore := sharedWorkerCachePtr.workerRefcount
+	sharedWorkerCacheLock.Unlock()
+	s.Zero(refcountBefore)
+
+	worker := createWorker(s.service)
+	workerCache := worker.executionParams.cache
+	workflowContext := &workflowExecutionContextImpl{
+		wth: &workflowTaskHandlerImpl{
+			cache:          workerCache,
+			metricsHandler: metrics.NopHandler,
+		},
+	}
+	_, err := workerCache.putWorkflowContext("retained-run", workflowContext)
+	s.NoError(err)
+	s.Equal(1, workerCache.getWorkflowCache().Size())
+
+	sharedWorkerCacheLock.Lock()
+	s.Equal(refcountBefore+1, sharedWorkerCachePtr.workerRefcount)
+	sharedWorkerCacheLock.Unlock()
+
+	worker.Stop()
+	s.Zero(workerCache.getWorkflowCache().Size())
+
+	sharedWorkerCacheLock.Lock()
+	s.Equal(refcountBefore, sharedWorkerCachePtr.workerRefcount)
+	sharedWorkerCacheLock.Unlock()
+}
+
+func (s *internalWorkerTestSuite) TestWorkerStartFailureReleasesCacheOwnership() {
+	service := workflowservicemock.NewMockWorkflowServiceClient(s.mockCtrl)
+	startErr := errors.New("start failed")
+	service.EXPECT().GetSystemInfo(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, startErr).Times(1)
+	service.EXPECT().ShutdownWorker(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(&workflowservice.ShutdownWorkerResponse{}, nil).Times(1)
+
+	sharedWorkerCacheLock.Lock()
+	refcountBefore := sharedWorkerCachePtr.workerRefcount
+	sharedWorkerCacheLock.Unlock()
+
+	client := NewServiceClient(service, nil, ClientOptions{Namespace: "testNamespace"})
+	worker := NewAggregatedWorker(client, "testTaskQueue", WorkerOptions{})
+	s.ErrorIs(worker.Start(), startErr)
+
+	sharedWorkerCacheLock.Lock()
+	s.Equal(refcountBefore, sharedWorkerCachePtr.workerRefcount)
+	sharedWorkerCacheLock.Unlock()
 }
 
 func (s *internalWorkerTestSuite) TestCleanupIsBestEffort() {

--- a/internal/internal_workers_test.go
+++ b/internal/internal_workers_test.go
@@ -89,7 +89,7 @@ func (s *WorkersTestSuite) TestWorkflowWorker() {
 		BackgroundContext:       ctx,
 		BackgroundContextCancel: cancel,
 	}
-	overrides := &workerOverrides{workflowTaskHandler: newSampleWorkflowTaskHandler()}
+	overrides := &workerOverrides{workflowTaskHandler: newSampleWorkflowTaskHandler(s.T())}
 	client := &WorkflowClient{workflowService: s.service}
 	workflowWorker := newWorkflowWorkerInternal(client, executionParameters, nil, overrides, newRegistry())
 	s.Nil(workflowWorker.worker.options.taskPollers)
@@ -190,7 +190,7 @@ func (s *WorkersTestSuite) TestWorkflowWorkerSlotSupplier() {
 			Tuner:                   tuner,
 			WorkerStopTimeout:       time.Second,
 		}
-		overrides := &workerOverrides{workflowTaskHandler: newSampleWorkflowTaskHandler()}
+		overrides := &workerOverrides{workflowTaskHandler: newSampleWorkflowTaskHandler(s.T())}
 		client := &WorkflowClient{workflowService: s.service}
 		workflowWorker := newWorkflowWorkerInternal(client, executionParameters, nil, overrides, newRegistry())
 		_ = workflowWorker.Start()
@@ -450,7 +450,7 @@ func (s *WorkersTestSuite) TestPollWorkflowTaskQueue_InternalServiceError() {
 		),
 		Logger: ilog.NewNopLogger(),
 	}
-	overrides := &workerOverrides{workflowTaskHandler: newSampleWorkflowTaskHandler()}
+	overrides := &workerOverrides{workflowTaskHandler: newSampleWorkflowTaskHandler(s.T())}
 	client := &WorkflowClient{workflowService: s.service}
 	workflowWorker := newWorkflowWorkerInternal(client, executionParameters, nil, overrides, newRegistry())
 	_ = workflowWorker.Start()

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -8587,6 +8587,86 @@ func (ts *IntegrationTestSuite) TestShutdownDuringActiveTimerActivityWorkflows()
 	}
 }
 
+func (ts *IntegrationTestSuite) TestStickyCacheSharedWorkerLifecycle() {
+	if os.Getenv("WORKFLOW_CACHE_SIZE") == "0" {
+		ts.T().Skip("sticky cache is disabled")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
+	defer cancel()
+
+	run, err := ts.client.ExecuteWorkflow(ctx, client.StartWorkflowOptions{
+		ID:        "sticky-cache-shared-workers-" + uuid.NewString(),
+		TaskQueue: ts.taskQueueName,
+	}, "StickyCacheSharedWorkerLifecycle")
+	ts.NoError(err)
+	defer func() {
+		_ = ts.client.TerminateWorkflow(ctx, run.GetID(), run.GetRunID(), "test complete")
+	}()
+	ts.waitForHistoryEvent(
+		run.GetID(),
+		run.GetRunID(),
+		enumspb.EVENT_TYPE_WORKFLOW_TASK_COMPLETED,
+		10*time.Second,
+	)
+
+	queryCount := func(expected int) {
+		var lastErr error
+		var lastCount int
+		matched := assert.Eventually(ts.T(), func() bool {
+			value, queryErr := ts.client.QueryWorkflow(ctx, run.GetID(), run.GetRunID(), "sticky-cache-count")
+			if queryErr != nil {
+				lastErr = queryErr
+				return false
+			}
+			lastErr = value.Get(&lastCount)
+			return lastErr == nil && lastCount == expected
+		}, 10*time.Second, 20*time.Millisecond)
+		if !matched {
+			ts.FailNowf("workflow query did not reach expected value", "expected=%d actual=%d lastErr=%v", expected, lastCount, lastErr)
+		}
+	}
+	queryCount(0)
+
+	secondWorker := worker.New(ts.client, ts.taskQueueName, worker.Options{})
+	ts.registerWorkflowsAndActivities(secondWorker)
+	ts.NoError(secondWorker.Start())
+	secondWorkerStopped := false
+	defer func() {
+		if !secondWorkerStopped {
+			secondWorker.Stop()
+		}
+	}()
+
+	ts.worker.Stop()
+	ts.workerStopped = true
+	ts.NoError(ts.client.SignalWorkflow(
+		ctx,
+		run.GetID(),
+		run.GetRunID(),
+		"sticky-cache-increment",
+		1,
+	))
+	queryCount(1)
+
+	secondWorker.Stop()
+	secondWorkerStopped = true
+
+	thirdWorker := worker.New(ts.client, ts.taskQueueName, worker.Options{})
+	ts.registerWorkflowsAndActivities(thirdWorker)
+	ts.NoError(thirdWorker.Start())
+	defer thirdWorker.Stop()
+
+	ts.NoError(ts.client.SignalWorkflow(
+		ctx,
+		run.GetID(),
+		run.GetRunID(),
+		"sticky-cache-increment",
+		1,
+	))
+	queryCount(2)
+}
+
 func (ts *IntegrationTestSuite) TestLocalActivitySummary() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/test/workflow_test.go
+++ b/test/workflow_test.go
@@ -1494,6 +1494,19 @@ func (w *Workflows) ShutdownDuringActiveTimerActivityWorkflow(ctx workflow.Conte
 	}
 }
 
+func (w *Workflows) StickyCacheSharedWorkerLifecycle(ctx workflow.Context) error {
+	count := 0
+	if err := workflow.SetQueryHandler(ctx, "sticky-cache-count", func() (int, error) { return count, nil }); err != nil {
+		return err
+	}
+	signals := workflow.GetSignalChannel(ctx, "sticky-cache-increment")
+	for {
+		var increment int
+		signals.Receive(ctx, &increment)
+		count += increment
+	}
+}
+
 func (w *Workflows) SignalWorkflow(ctx workflow.Context) (*commonpb.WorkflowType, error) {
 	s := workflow.NewSelector(ctx)
 
@@ -4346,6 +4359,10 @@ func (w *Workflows) register(worker worker.Worker) {
 	worker.RegisterWorkflow(w.ActivityWaitForWorkerStop)
 	worker.RegisterWorkflow(w.ActivityHeartbeatUntilSignal)
 	worker.RegisterWorkflow(w.ShutdownDuringActiveTimerActivityWorkflow)
+	worker.RegisterWorkflowWithOptions(
+		w.StickyCacheSharedWorkerLifecycle,
+		workflow.RegisterOptions{Name: "StickyCacheSharedWorkerLifecycle"},
+	)
 	worker.RegisterWorkflow(w.Basic)
 	worker.RegisterWorkflow(w.Deadlocked)
 	worker.RegisterWorkflow(w.DeadlockedWithLocalActivity)


### PR DESCRIPTION
## What was changed

Fix sticky workflow-cache retention after workers stop.

Workers now hold an explicit cache lease and release it during `Stop()`, with the finalizer retained as a fallback. Live workers share one cache generation; the final owner clears it.

NOTE: The previous cache-retention behavior masked an integration-test isolation bug. Once deterministic cache cleanup was added, tests that disabled caching left the process-global setting at zero for later tests. Test setup now restores the configured cache size before each test.

## Why

Final cache release previously depended on GC finalization. Cached workflow state could keep the ownership graph reachable, retaining workflow state and coroutines after all workers stopped.

With 32 incomplete workflows holding 1 MiB each, local profiling reduced retained heap from approximately 34.6 MB to 20 KB and retained workflow coroutines from 32 to zero.

This primarily benefits long-lived processes that repeatedly create and stop workers. Processes that exit immediately after stopping workers will see little benefit.

Full investigation: [e0d367e6](https://github.com/temporalio/sdk-go/commit/e0d367e6)

## Impact and risk

The final worker now clears cached workflows during `Stop()`. Cache traversal and callback scheduling are synchronous; workflow cleanup remains asynchronous. Clearing 10,000 entries took approximately 3–4 ms locally, though large caches may cause a short-lived CPU and goroutine spike.

The next worker starts with a cold cache and replays workflow histories as tasks arrive. Shutdown may also produce a `sticky_cache_total_forced_eviction` spike under the existing metric semantics.

Tests cover shared ownership, final release, failure paths, concurrent release, fresh cache generations, and processing after worker recreation.

  ## Checklist

  1. Closes #2582