### PR TITLE
Add payload validation error factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ to docs, or any other relevant information.
 
 ### Added
 
+- Added `temporal.NewPayloadValidationError` to create non-retryable application errors with
+  structured details for payload validation failures.
+
 ### Changed
 
 ### Deprecated

--- a/internal/error.go
+++ b/internal/error.go
@@ -406,6 +406,8 @@ var (
 // Exposed as: [go.temporal.io/sdk/temporal.ApplicationErrorCategory]
 type ApplicationErrorCategory int
 
+const payloadValidationErrorType = "PayloadValidationError"
+
 const (
 	// ApplicationErrorCategoryUnspecified represents an error with an unspecified category.
 	//
@@ -424,6 +426,13 @@ func NewApplicationError(msg string, errType string, nonRetryable bool, cause er
 		errType,
 		ApplicationErrorOptions{NonRetryable: nonRetryable, Cause: cause, Details: details},
 	)
+}
+
+// NewPayloadValidationError creates an ApplicationError for payloads that fail validation.
+//
+// Exposed as: [go.temporal.io/sdk/temporal.NewPayloadValidationError]
+func NewPayloadValidationError(details any) error {
+	return NewApplicationError("Payload validation failed", payloadValidationErrorType, true, nil, details)
 }
 
 // Exposed as: [go.temporal.io/sdk/temporal.NewApplicationError], [go.temporal.io/sdk/temporal.NewApplicationErrorWithOptions], [go.temporal.io/sdk/temporal.NewApplicationErrorWithCause], [go.temporal.io/sdk/temporal.NewNonRetryableApplicationError]

--- a/internal/internal_nexus_task_handler.go
+++ b/internal/internal_nexus_task_handler.go
@@ -602,11 +602,6 @@ func (h *nexusTaskHandler) nexusHandlerErrorToProto(handlerErr *nexus.HandlerErr
 	}, nil
 }
 
-// payloadValidationErrorType is the ApplicationError type reserved for payload validation failures raised by a data
-// converter. A non-retryable error of this type reports invalid input and is translated into a BAD_REQUEST handler
-// error.
-const payloadValidationErrorType = "PayloadValidationError"
-
 // payloadSerializer is a fake nexus Serializer that uses a data converter to read from an embedded payload instead of
 // using the given nexus.Context. Supports only Deserialize.
 type payloadSerializer struct {

--- a/internal/internal_nexus_task_handler_payload_serializer_test.go
+++ b/internal/internal_nexus_task_handler_payload_serializer_test.go
@@ -26,11 +26,8 @@ func TestPayloadSerializerDeserializeErrors(t *testing.T) {
 	payload, err := converter.GetDefaultDataConverter().ToPayload("input")
 	require.NoError(t, err)
 
-	nonRetryableValidationErr := NewApplicationErrorWithOptions(
-		"invalid payload",
-		payloadValidationErrorType,
-		ApplicationErrorOptions{NonRetryable: true},
-	)
+	violations := []map[string]string{{"path": "field", "reason": "must be an integer"}}
+	nonRetryableValidationErr := NewPayloadValidationError(violations)
 	retryableValidationErr := NewApplicationErrorWithOptions(
 		"transient validation failure",
 		payloadValidationErrorType,
@@ -66,7 +63,10 @@ func TestPayloadSerializerDeserializeErrors(t *testing.T) {
 				require.ErrorAs(t, handlerErr.Cause, &appErr)
 				require.Equal(t, payloadValidationErrorType, appErr.Type())
 				require.True(t, appErr.NonRetryable())
-				require.ErrorContains(t, appErr, "invalid payload")
+				require.Equal(t, "Payload validation failed", appErr.Message())
+				var gotViolations []map[string]string
+				require.NoError(t, appErr.Details(&gotViolations))
+				require.Equal(t, violations, gotViolations)
 			},
 		},
 		{

--- a/temporal/error.go
+++ b/temporal/error.go
@@ -188,6 +188,12 @@ func NewNonRetryableApplicationError(message, errType string, cause error, detai
 	)
 }
 
+// NewPayloadValidationError creates a non-retryable ApplicationError for payloads that fail validation.
+// The error has type PayloadValidationError and carries details as its single detail.
+func NewPayloadValidationError(details any) error {
+	return internal.NewPayloadValidationError(details)
+}
+
 // CanceledErrorOptions should be used to set all the desired attributes of a new CanceledError
 // To get a new instance use CanceledErrorAttributes function.
 type CanceledErrorOptions = internal.CanceledErrorOptions

--- a/temporal/error_test.go
+++ b/temporal/error_test.go
@@ -1,0 +1,25 @@
+package temporal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewPayloadValidationError(t *testing.T) {
+	violations := []map[string]string{
+		{"path": "user.age", "reason": "must be an integer"},
+		{"path": "user.name", "reason": "is required"},
+	}
+
+	err := NewPayloadValidationError(violations)
+	var applicationErr *ApplicationError
+	require.ErrorAs(t, err, &applicationErr)
+	require.Equal(t, "Payload validation failed", applicationErr.Message())
+	require.Equal(t, "PayloadValidationError", applicationErr.Type())
+	require.True(t, applicationErr.NonRetryable())
+
+	var gotViolations []map[string]string
+	require.NoError(t, applicationErr.Details(&gotViolations))
+	require.Equal(t, violations, gotViolations)
+}

--- a/test/nexus_test.go
+++ b/test/nexus_test.go
@@ -1190,11 +1190,9 @@ func (dc inputDeserializationErrorDataConverter) FromPayload(payload *common.Pay
 				temporal.ApplicationErrorOptions{NonRetryable: true},
 			)
 		case "payload-validation-error":
-			return temporal.NewApplicationErrorWithOptions(
-				"deserialization payload validation error",
-				"PayloadValidationError",
-				temporal.ApplicationErrorOptions{NonRetryable: true},
-			)
+			return temporal.NewPayloadValidationError([]map[string]string{
+				{"path": "operationInput", "reason": "must be valid"},
+			})
 		case "retryable-payload-validation-error":
 			return temporal.NewApplicationErrorWithOptions(
 				"deserialization retryable payload validation error",
@@ -1295,7 +1293,10 @@ func TestNexusOperationInputDeserializationError(t *testing.T) {
 		require.ErrorAs(t, handlerErr.Cause, &appErr)
 		require.Equal(t, "PayloadValidationError", appErr.Type())
 		require.True(t, appErr.NonRetryable())
-		require.ErrorContains(t, appErr, "deserialization payload validation error")
+		require.Equal(t, "Payload validation failed", appErr.Message())
+		var violations []map[string]string
+		require.NoError(t, appErr.Details(&violations))
+		require.Equal(t, []map[string]string{{"path": "operationInput", "reason": "must be valid"}}, violations)
 	})
 
 	t.Run("retryable-payload-validation-error", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- add `temporal.NewPayloadValidationError(details any)`
- construct the existing non-retryable `*temporal.ApplicationError` with type `PayloadValidationError`
- preserve `details` as the single application error detail
- replace positive manual payload-validation error construction in Nexus tests while retaining the retryable compatibility case

## Testing

- `go run . unit-test -run 'TestNewPayloadValidationError|TestPayloadSerializerDeserializeErrors'`
- `go test -race ./temporal ./internal -run 'TestNewPayloadValidationError|TestPayloadSerializerDeserializeErrors' -count=1`
- `go run . integration-test -dev-server -run '^TestNexusOperationInputDeserializationError$'`
- `go run . check`
- `gofmt` and `git diff --check`
