### PR TITLE
Fix WorkflowReplayer for method-expression local activities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,15 @@ to docs, or any other relevant information.
 
 ### Fixed
 
+- Fixed `WorkflowReplayer` failing to replay workflows that execute local
+  activities referenced by method expression (e.g.
+  `ExecuteLocalActivity(ctx, (*Activities).Foo)`). The replayer only exposes
+  `RegisterWorkflow`, so such method-expression local activities can never be
+  registered and previously failed validation with
+  `expected N args for function: Foo but found M`. The replay fallback that
+  already existed for string-named local activities now also applies to
+  method-expression local activities.
+
 ### Security
 
 ## [1.48.0] - 2026-08-18

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -221,6 +221,25 @@ func testReplayWorkflowLocalActivity(ctx Context) error {
 	return err
 }
 
+type replayLocalActivities struct{}
+
+func (a *replayLocalActivities) ReplayLocalActivity(context.Context) error {
+	return nil
+}
+
+func testReplayWorkflowMethodLocalActivity(ctx Context) error {
+	ao := LocalActivityOptions{
+		ScheduleToCloseTimeout: time.Second,
+	}
+	ctx = WithLocalActivityOptions(ctx, ao)
+	err := ExecuteLocalActivity(ctx, (*replayLocalActivities).ReplayLocalActivity).Get(ctx, nil)
+	if err != nil {
+		getLogger().Error("activity failed with error.", tagError, err)
+		panic("Failed workflow")
+	}
+	return err
+}
+
 func testReplayWorkflowFromFile(ctx Context) error {
 	ao := ActivityOptions{
 		ScheduleToStartTimeout: time.Minute,
@@ -360,6 +379,38 @@ func (s *internalWorkerTestSuite) TestReplayWorkflowHistory_LocalActivity() {
 	replayer, err := NewWorkflowReplayer(WorkflowReplayerOptions{})
 	require.NoError(s.T(), err)
 	replayer.RegisterWorkflow(testReplayWorkflowLocalActivity)
+	err = replayer.ReplayWorkflowHistory(logger, history)
+	require.NoError(s.T(), err)
+}
+
+func (s *internalWorkerTestSuite) TestReplayWorkflowHistory_MethodLocalActivity() {
+	taskQueue := "taskQueue1"
+	testEvents := []*historypb.HistoryEvent{
+		createTestEventWorkflowExecutionStarted(1, &historypb.WorkflowExecutionStartedEventAttributes{
+			WorkflowType: &commonpb.WorkflowType{Name: "testReplayWorkflowMethodLocalActivity"},
+			TaskQueue:    &taskqueuepb.TaskQueue{Name: taskQueue},
+			Input:        testEncodeFunctionArgs(converter.GetDefaultDataConverter()),
+		}),
+		createTestEventWorkflowTaskScheduled(2, &historypb.WorkflowTaskScheduledEventAttributes{}),
+		createTestEventWorkflowTaskStarted(3),
+		createTestEventWorkflowTaskCompleted(4, &historypb.WorkflowTaskCompletedEventAttributes{}),
+
+		createTestEventMarkerRecorded(5, &historypb.MarkerRecordedEventAttributes{
+			MarkerName:                   localActivityMarkerName,
+			Details:                      s.createLocalActivityMarkerDataForTest("1"),
+			WorkflowTaskCompletedEventId: 4,
+		}),
+
+		createTestEventWorkflowExecutionCompleted(6, &historypb.WorkflowExecutionCompletedEventAttributes{
+			WorkflowTaskCompletedEventId: 4,
+		}),
+	}
+
+	history := &historypb.History{Events: testEvents}
+	logger := getLogger()
+	replayer, err := NewWorkflowReplayer(WorkflowReplayerOptions{})
+	require.NoError(s.T(), err)
+	replayer.RegisterWorkflow(testReplayWorkflowMethodLocalActivity)
 	err = replayer.ReplayWorkflowHistory(logger, history)
 	require.NoError(s.T(), err)
 }

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -1224,6 +1224,14 @@ func (wc *workflowEnvironmentInterceptor) ExecuteLocalActivity(ctx Context, type
 		// that called local activities using non nil receiver.
 		if ok {
 			activityFn = activity.GetFunction()
+		} else if IsReplayNamespace(GetWorkflowInfo(ctx).Namespace) {
+			// When running the replayer (but not necessarily during all replays),
+			// we don't require the activities to be registered, so use a dummy
+			// function. Method-expression local activities are never registered
+			// on the WorkflowReplayer (it only exposes RegisterWorkflow), and
+			// validating localCtx.fn would fail because the unbound method
+			// expression carries an extra receiver argument.
+			activityFn = func(context.Context) error { panic("dummy replayer function") }
 		} else {
 			if err := validateFunctionArgs(localCtx.fn, args, false); err != nil {
 				settable.Set(nil, err)


### PR DESCRIPTION
## What

Closes #2589.

`WorkflowReplayer` could not replay workflows that execute a **local activity referenced by a method expression**, e.g.

```go
ExecuteLocalActivity(ctx, (*Activities).Foo)
```

Replaying such a workflow failed with:

```
expected 2 args for function: Foo but found 0
```

## Root cause

In `internal/workflow.go`, `ExecuteLocalActivity` looks the activity up in the registry on replay. The string-name branch (`localCtx.fn == nil`) already has an `IsReplayNamespace(...)` fallback that substitutes a dummy function when the activity is unregistered, so replay works. The `isMethod` branch had **no such fallback**: on a registry miss it called `validateFunctionArgs(localCtx.fn, args, ...)` against the *unbound method expression*, which carries an extra receiver argument, and failed.

`WorkflowReplayer` only exposes `RegisterWorkflow`/`RegisterDynamicWorkflow` (activities can't be registered on it), so a method-expression local activity can never be made to hit the registry — the replay always failed.

## Fix

Extend the existing `IsReplayNamespace` dummy-function fallback to the `isMethod` branch, mirroring the string-name branch exactly. One branch added in `internal/workflow.go` (+8 lines).

## Tests

Added `TestReplayWorkflowHistory_MethodLocalActivity` in `internal/internal_worker_test.go` — a workflow that calls `ExecuteLocalActivity(ctx, (*replayLocalActivities).ReplayLocalActivity)` replayed through `NewWorkflowReplayer`, following the existing `TestReplayWorkflowHistory_LocalActivity` pattern.

## Validation (real results, Go 1.25.4)

```
$ go test ./internal/ -run 'TestInternalWorkerTestSuite/TestReplayWorkflowHistory_MethodLocalActivity' -count=1
ok  	go.temporal.io/sdk/internal	0.059s
```

Verified genuine RED→GREEN — reverting only the `internal/workflow.go` fix (keeping the test) reproduces the exact reported error:

```
$ git stash push internal/workflow.go   # keep the test, drop the fix
$ go test ./internal/ -run '.../TestReplayWorkflowHistory_MethodLocalActivity' -count=1
ERROR activity failed with error. Error expected 2 args for function: ReplayLocalActivity but found 0
--- FAIL: TestInternalWorkerTestSuite/TestReplayWorkflowHistory_MethodLocalActivity
FAIL
```

Restoring the fix → green again. Full worker suite passes with no regressions:

```
$ go test ./internal/ -run 'TestInternalWorkerTestSuite' -count=1
ok  	go.temporal.io/sdk/internal	1.104s
```

`go vet ./internal/` clean; both changed `.go` files are `gofmt`-clean (I intentionally did not reformat unrelated lines). Added a `### Fixed` CHANGELOG.md entry to satisfy the changelog check.

First-time contributor here — happy to adjust the approach (the alternative discussed in the issue, adding `RegisterActivity` to `WorkflowReplayer`, is more involved and API-surface-changing; this mirrors the existing string-name fallback with minimal risk).
