### PR TITLE
Clarify Standalone activity option documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ to docs, or any other relevant information.
 
 ### Fixed
 
+- Corrected stand-alone activity API documentation to use activity terminology, document that
+  `GetActivityHandleOptions.RunID` may be empty to target the latest run, and describe
+  `TerminateActivityOptions.Reason` as a termination reason.
+
 ### Security
 
 ## [1.48.0] - 2026-08-18

--- a/client/client.go
+++ b/client/client.go
@@ -970,7 +970,8 @@ type (
 	StartActivityOptions = internal.ClientStartActivityOptions
 
 	// GetActivityHandleOptions contains input for GetActivityHandle call.
-	// ActivityID and RunID are required.
+	// ActivityID is required. RunID is optional; if empty, the handle targets the latest Activity Execution with the given ID.
+	// To target a specific run when ActivityIDReusePolicy allows reuse of an activity ID, set RunID.
 	//
 	// NOTE: Experimental
 	GetActivityHandleOptions = internal.ClientGetActivityHandleOptions

--- a/internal/internal_activity_client.go
+++ b/internal/internal_activity_client.go
@@ -37,9 +37,10 @@ type (
 		//
 		// Required
 		TaskQueue string
-		// ScheduleToCloseTimeout - Total time the caller is willing to wait for the Activity Execution to complete.
-		// ScheduleToCloseTimeout limits the total time of an Activity's execution including retries
-		// 		(use StartToCloseTimeout to limit the time of a single attempt).
+		// ScheduleToCloseTimeout - Maximum duration the Temporal Server allows for an Activity Execution
+		// from scheduling through closure, including retries. This does not control how long a client waits
+		// for the result: ExecuteActivity returns after the start RPC, and the context passed to
+		// ActivityHandle.Get controls the client-side wait. Use StartToCloseTimeout to limit a single attempt.
 		// The zero value of this uses default value.
 		// Either this option or StartToCloseTimeout is required: Defaults to unlimited.
 		ScheduleToCloseTimeout time.Duration

--- a/internal/internal_activity_client.go
+++ b/internal/internal_activity_client.go
@@ -37,7 +37,7 @@ type (
 		//
 		// Required
 		TaskQueue string
-		// ScheduleToCloseTimeout - Total time that a workflow is willing to wait for an Activity to complete.
+		// ScheduleToCloseTimeout - Total time the caller is willing to wait for the Activity Execution to complete.
 		// ScheduleToCloseTimeout limits the total time of an Activity's execution including retries
 		// 		(use StartToCloseTimeout to limit the time of a single attempt).
 		// The zero value of this uses default value.
@@ -81,10 +81,10 @@ type (
 		// To disable retries, set MaximumAttempts to 1.
 		// The default RetryPolicy provided by the server can be overridden by the dynamic config.
 		RetryPolicy *RetryPolicy
-		// TypedSearchAttributes - Specifies Search Attributes that will be attached to the Workflow. Search Attributes are
-		// additional indexed information attributed to workflow and used for search and visibility. The search attributes
-		// can be used in query of List/Scan/Count workflow APIs. The key and its value type must be registered on Temporal
-		// server side. For supported operations on different server versions see [Visibility].
+		// TypedSearchAttributes - Specifies Search Attributes that will be attached to the Activity Execution. Search Attributes
+		// are additional indexed information attributed to the Activity Execution and used for search and visibility. The Search
+		// Attributes can be used in queries to ListActivities and CountActivities. The key and its value type must be registered on
+		// the Temporal Server. For supported operations on different server versions see [Visibility].
 		//
 		// Optional: default to none.
 		//
@@ -97,9 +97,8 @@ type (
 		//
 		// NOTE: Experimental
 		Summary string
-		// Details - General fixed details for this workflow execution that will appear in UI/CLI. This can be in
-		// Temporal markdown format and can span multiple lines. This is a fixed value on the workflow that cannot be
-		// updated. For details that can be updated, use SetCurrentDetails within the workflow.
+		// Details - General fixed details for this Activity Execution that will appear in UI/CLI. This can be in
+		// Temporal Markdown format and can span multiple lines. This value cannot be updated after the Activity Execution starts.
 		//
 		// Optional: defaults to none/empty.
 		//
@@ -122,7 +121,8 @@ type (
 	}
 
 	// ClientGetActivityHandleOptions contains input for GetActivityHandle call.
-	// ActivityID and RunID are required.
+	// ActivityID is required. RunID is optional; if empty, the handle targets the latest Activity Execution with the given ID.
+	// To target a specific run when ActivityIDReusePolicy allows reuse of an activity ID, set RunID.
 	//
 	// NOTE: Experimental
 	//
@@ -236,7 +236,7 @@ type (
 	//
 	// Exposed as: [go.temporal.io/sdk/client.TerminateActivityOptions]
 	ClientTerminateActivityOptions struct {
-		// Reason is optional description of the reason for cancellation.
+		// Reason is optional description of the reason for termination.
 		Reason string
 	}
 


### PR DESCRIPTION
## What was changed

- Corrected stand-alone activity option comments that described workflow behavior.
- Documented that an empty activity `RunID` targets the latest run and explained how ID reuse affects that choice.
- Corrected `TerminateActivityOptions.Reason` to describe termination rather than cancellation.
- Added an entry under the root `CHANGELOG.md` Unreleased `Fixed` section.

## Why?

The public documentation contradicted the supported stand-alone activity behavior and could lead callers toward workflow-only APIs or unnecessary `RunID` requirements.

## Checklist

1. Closes: N/A — documentation corrections

2. How was this tested:

- `go run . check`
- `go run . unit-test`
- Existing integration coverage exercises empty-`RunID`, cancellation, and termination behavior.

3. Any docs updates needed?

The affected public Go API comments and the root changelog are updated in this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and changelog-only changes; no runtime or API behavior is modified.
> 
> **Overview**
> Corrects public comments on the experimental standalone activity client APIs so they describe activity behavior instead of leftover workflow wording.
> 
> `GetActivityHandleOptions.RunID` is now documented as optional (empty means latest run; set it when ID reuse is allowed). `ScheduleToCloseTimeout` is distinguished from client-side wait via `ActivityHandle.Get`. Search attributes, details, and `TerminateActivityOptions.Reason` now refer to activity executions and termination rather than workflows/cancellation. Changelog notes the doc fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 344f9c9fb7f4ce895fbc32fc9f609f4edf11ec30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->