### PR TITLE
Document PayloadCodec failure behavior

### DIFF
--- a/converter/codec.go
+++ b/converter/codec.go
@@ -19,6 +19,18 @@ import (
 // For example, NewZlibCodec returns a PayloadCodec that can be used for
 // compression.
 // These can be used (and even chained) in NewCodecDataConverter.
+//
+// PayloadCodec methods may run while processing a Workflow Task or in a Client
+// or Activity context. When called during Workflow Task processing, returning
+// an error may fail the Workflow Execution, depending on the operation. A panic
+// is handled according to the Worker's WorkflowPanicPolicy. With the default
+// BlockWorkflow policy, a panic fails the current Workflow Task so that the
+// Temporal Service can retry it. With the FailWorkflow policy, a panic instead
+// fails the Workflow Execution.
+//
+// Codec implementations should handle transient failures locally when
+// possible. Panicking outside Workflow Task processing does not request a
+// Workflow Task retry.
 type PayloadCodec interface {
 	// Encode optionally encodes the given payloads which are guaranteed to never
 	// be nil. The parameters must not be mutated.


### PR DESCRIPTION
## What changed

Clarify the `PayloadCodec` API documentation:

- Codec methods can run during Workflow Task processing or in Client and Activity contexts.
- Returning an error during Workflow Task processing may fail the Workflow Execution, depending on the operation.
- A panic follows the configured `WorkflowPanicPolicy`.
- With the default `BlockWorkflow` policy, a panic fails the current Workflow Task so it can be retried.
- With `FailWorkflow`, a panic instead fails the Workflow Execution.
- Codec implementations should handle transient failures locally when possible.

## Why

This documents the existing mechanism for causing Workflow Task failure without introducing a new public error-marker API. It also makes the context and panic-policy limitations explicit.

Closes #2506.

## Validation

- `go run . check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only comment on PayloadCodec; no runtime or API behavior changes.
> 
> **Overview**
> Documents how `PayloadCodec` errors and panics behave depending on call context.
> 
> The `PayloadCodec` interface comment now states that methods can run during Workflow Task processing or in Client/Activity contexts, that returning an error during a Workflow Task may fail the Workflow Execution, and that panics follow `WorkflowPanicPolicy` (`BlockWorkflow` retries the task; `FailWorkflow` fails the execution). It also notes that codecs should handle transient failures locally and that panicking outside Workflow Task processing does not request a retry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f3ed31eaf727c8b975db6617da67be30755932e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->