### PR TITLE
Bump Staticcheck for Go 1.27 and flag intentional findings

### DIFF
--- a/contrib/googleadk/tool_schema_test.go
+++ b/contrib/googleadk/tool_schema_test.go
@@ -26,7 +26,7 @@ type schemaArgs struct {
 	Query    string `json:"query"`
 	Untagged string
 	Secret   string      `json:"-"`
-	Dash     string      `json:"-,"`
+	Dash     string      `json:"-,"` //lint:ignore SA5008 Go 1.26 encoding/json uses json:"-," for a literal "-" field name; this compatibility case is intentional.
 	Inner    schemaInner `json:"inner"`
 }
 

--- a/converter/codec_test.go
+++ b/converter/codec_test.go
@@ -31,8 +31,8 @@ func ExampleCodecDataConverter_compression() {
 	// The zlib payload is smaller
 	fmt.Printf("Uncompressed payload size: %v (encoding: %s)\n",
 		len(uncompPayload.Data), uncompPayload.Metadata[MetadataEncoding])
-	fmt.Printf("Compressed payload size: %v (encoding: %s)\n",
-		len(compPayload.Data), compPayload.Metadata[MetadataEncoding])
+	fmt.Printf("Compressed payload is smaller? %v (encoding: %s)\n",
+		len(compPayload.Data) < len(uncompPayload.Data), compPayload.Metadata[MetadataEncoding])
 
 	// Convert from payload and confirm the same string. This uses the same
 	// compression converter because the converter does not do anything to
@@ -45,7 +45,7 @@ func ExampleCodecDataConverter_compression() {
 
 	// Output:
 	// Uncompressed payload size: 1202 (encoding: json/plain)
-	// Compressed payload size: 57 (encoding: binary/zlib)
+	// Compressed payload is smaller? true (encoding: binary/zlib)
 	// Uncompressed payload back to original? true
 	// Compressed payload back to original? true
 }

--- a/internal/cmd/build/go.mod
+++ b/internal/cmd/build/go.mod
@@ -8,8 +8,8 @@ require (
 	github.com/kisielk/errcheck v1.8.0
 	github.com/ldez/usetesting v0.5.0
 	go.temporal.io/sdk v1.32.1
-	golang.org/x/tools v0.44.0
-	honnef.co/go/tools v0.6.0
+	golang.org/x/tools v0.44.1-0.20260420230617-19499e7caabc
+	honnef.co/go/tools v0.8.0
 )
 
 require (
@@ -34,7 +34,6 @@ require (
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 	golang.org/x/time v0.10.0 // indirect
-	golang.org/x/tools/go/expect v0.1.1-deprecated // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260414002931-afd174a4e478 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478 // indirect
 	google.golang.org/grpc v1.82.1 // indirect

--- a/internal/cmd/build/go.sum
+++ b/internal/cmd/build/go.sum
@@ -110,8 +110,8 @@ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
-golang.org/x/tools v0.44.0 h1:UP4ajHPIcuMjT1GqzDWRlalUEoY+uzoZKnhOjbIPD2c=
-golang.org/x/tools v0.44.0/go.mod h1:KA0AfVErSdxRZIsOVipbv3rQhVXTnlU6UhKxHd1seDI=
+golang.org/x/tools v0.44.1-0.20260420230617-19499e7caabc h1:vSv/HN1q9eoPD7lMyJYVJ/GPYnqtqu6adMxUmrxOB78=
+golang.org/x/tools v0.44.1-0.20260420230617-19499e7caabc/go.mod h1:KA0AfVErSdxRZIsOVipbv3rQhVXTnlU6UhKxHd1seDI=
 golang.org/x/tools/go/expect v0.1.1-deprecated h1:jpBZDwmgPhXsKZC6WhL20P4b/wmnpsEAGHaNy0n/rJM=
 golang.org/x/tools/go/expect v0.1.1-deprecated/go.mod h1:eihoPOH+FgIqa3FpoTwguz/bVUSGBlGQU67vpBeOrBY=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -133,5 +133,5 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntN
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-honnef.co/go/tools v0.6.0 h1:TAODvD3knlq75WCp2nyGJtT4LeRV/o7NN9nYPeVJXf8=
-honnef.co/go/tools v0.6.0/go.mod h1:3puzxxljPCe8RGJX7BIy1plGbxEOZni5mR2aXe3/uk4=
+honnef.co/go/tools v0.8.0 h1:UacpzPr7D6i5BAjTkA7sNVcx4kIbhAZcQ4zYtKiXx68=
+honnef.co/go/tools v0.8.0/go.mod h1:XA+OnlRA9EDh/ukGvXMNSZNKGwFQJ+5dER0ioUkOxks=

--- a/internal/error_test.go
+++ b/internal/error_test.go
@@ -1402,8 +1402,9 @@ func TestFailureToError_NexusOperationExecution_TokenFallbackToId(t *testing.T) 
 			Endpoint:         "ep",
 			Service:          "svc",
 			Operation:        "op",
-			OperationId:      "legacy-id",
-			OperationToken:   "",
+			//lint:ignore SA1019 construct a legacy failure to verify operation ID fallback
+			OperationId:    "legacy-id",
+			OperationToken: "",
 		}},
 		Message: "failed",
 	}

--- a/internal/failure_converter.go
+++ b/internal/failure_converter.go
@@ -160,8 +160,9 @@ func (dfc *DefaultFailureConverter) ErrorToFailure(err error) *failurepb.Failure
 			Endpoint:         err.Endpoint,
 			Service:          err.Service,
 			Operation:        err.Operation,
-			OperationId:      token,
-			OperationToken:   token,
+			//lint:ignore SA1019 populate the legacy operation ID for backwards-compatible failure decoding
+			OperationId:    token,
+			OperationToken: token,
 		}
 		failure.FailureInfo = &failurepb.Failure_NexusOperationExecutionFailureInfo{NexusOperationExecutionFailureInfo: failureInfo}
 	case *nexus.HandlerError:

--- a/internal/internal_command_state_machine.go
+++ b/internal/internal_command_state_machine.go
@@ -1457,9 +1457,11 @@ func (h *commandsHelper) requestCancelExternalWorkflowExecution(namespace, workf
 		panic("cancellation on external workflow should use cancellation ID")
 	}
 	attributes := &commandpb.RequestCancelExternalWorkflowExecutionCommandAttributes{
-		Namespace:         namespace,
-		WorkflowId:        workflowID,
-		RunId:             runID,
+		//lint:ignore SA1019 preserve cross-namespace command compatibility
+		Namespace:  namespace,
+		WorkflowId: workflowID,
+		RunId:      runID,
+		//lint:ignore SA1019 control correlates command state with initiated history
 		Control:           cancellationID,
 		ChildWorkflowOnly: false,
 	}
@@ -1523,13 +1525,15 @@ func (h *commandsHelper) signalExternalWorkflowExecution(
 	childWorkflowOnly bool,
 ) commandStateMachine {
 	attributes := &commandpb.SignalExternalWorkflowExecutionCommandAttributes{
+		//lint:ignore SA1019 preserve cross-namespace command compatibility
 		Namespace: namespace,
 		Execution: &commonpb.WorkflowExecution{
 			WorkflowId: workflowID,
 			RunId:      runID,
 		},
-		SignalName:        signalName,
-		Input:             input,
+		SignalName: signalName,
+		Input:      input,
+		//lint:ignore SA1019 control correlates command state with initiated history
 		Control:           signalID,
 		ChildWorkflowOnly: childWorkflowOnly,
 		Header:            header,

--- a/internal/internal_command_state_machine_test.go
+++ b/internal/internal_command_state_machine_test.go
@@ -636,9 +636,11 @@ func Test_CancelExternalWorkflowStateMachine_Succeed(t *testing.T) {
 	require.Equal(
 		t,
 		&commandpb.RequestCancelExternalWorkflowExecutionCommandAttributes{
-			Namespace:         namespace,
-			WorkflowId:        workflowID,
-			RunId:             runID,
+			//lint:ignore SA1019 verify legacy command compatibility fields
+			Namespace:  namespace,
+			WorkflowId: workflowID,
+			RunId:      runID,
+			//lint:ignore SA1019 verify legacy command compatibility fields
 			Control:           cancellationID,
 			ChildWorkflowOnly: false,
 		},
@@ -682,9 +684,11 @@ func Test_CancelExternalWorkflowStateMachine_Failed(t *testing.T) {
 	require.Equal(
 		t,
 		&commandpb.RequestCancelExternalWorkflowExecutionCommandAttributes{
-			Namespace:         namespace,
-			WorkflowId:        workflowID,
-			RunId:             runID,
+			//lint:ignore SA1019 verify legacy command compatibility fields
+			Namespace:  namespace,
+			WorkflowId: workflowID,
+			RunId:      runID,
+			//lint:ignore SA1019 verify legacy command compatibility fields
 			Control:           cancellationID,
 			ChildWorkflowOnly: false,
 		},

--- a/internal/internal_nexus_task_handler.go
+++ b/internal/internal_nexus_task_handler.go
@@ -509,6 +509,7 @@ func (h *nexusTaskHandler) fillInCompletion(taskToken []byte, res *nexuspb.Respo
 		res.Variant = &nexuspb.Response_StartOperation{
 			StartOperation: &nexuspb.StartOperationResponse{
 				Variant: &nexuspb.StartOperationResponse_OperationError{
+					//lint:ignore SA1019 servers without Temporal failure responses require the legacy operation error variant
 					OperationError: &nexuspb.UnsuccessfulOperationError{
 						OperationState: state,
 						Failure:        failure,

--- a/internal/internal_nexus_task_poller.go
+++ b/internal/internal_nexus_task_poller.go
@@ -84,6 +84,7 @@ func (ntp *nexusTaskPoller) poll(ctx context.Context) (taskForWorker, error) {
 		Namespace: ntp.namespace,
 		TaskQueue: &taskqueuepb.TaskQueue{Name: ntp.taskQueueName, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		Identity:  ntp.identity,
+		//lint:ignore SA1019 retain legacy Build ID versioning metadata for older servers
 		WorkerVersionCapabilities: &commonpb.WorkerVersionCapabilities{
 			BuildId:              ntp.workerBuildID,
 			UseVersioning:        ntp.useBuildIDVersioning,

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -1913,16 +1913,17 @@ func (wth *workflowTaskHandlerImpl) completeWorkflow(
 			backoffStartInterval = durationpb.New(contErr.BackoffStartInterval)
 		}
 		closeCommand.Attributes = &commandpb.Command_ContinueAsNewWorkflowExecutionCommandAttributes{ContinueAsNewWorkflowExecutionCommandAttributes: &commandpb.ContinueAsNewWorkflowExecutionCommandAttributes{
-			WorkflowType:              &commonpb.WorkflowType{Name: contErr.WorkflowType.Name},
-			Input:                     contErr.Input,
-			TaskQueue:                 &taskqueuepb.TaskQueue{Name: contErr.TaskQueueName, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
-			WorkflowRunTimeout:        durationpb.New(contErr.WorkflowRunTimeout),
-			WorkflowTaskTimeout:       durationpb.New(contErr.WorkflowTaskTimeout),
-			BackoffStartInterval:      backoffStartInterval,
-			Header:                    contErr.Header,
-			Memo:                      workflowContext.workflowInfo.Memo,
-			SearchAttributes:          sanitizeSearchAttributesForStart(workflowContext.workflowInfo.SearchAttributes),
-			RetryPolicy:               convertToPBRetryPolicy(retryPolicy),
+			WorkflowType:         &commonpb.WorkflowType{Name: contErr.WorkflowType.Name},
+			Input:                contErr.Input,
+			TaskQueue:            &taskqueuepb.TaskQueue{Name: contErr.TaskQueueName, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+			WorkflowRunTimeout:   durationpb.New(contErr.WorkflowRunTimeout),
+			WorkflowTaskTimeout:  durationpb.New(contErr.WorkflowTaskTimeout),
+			BackoffStartInterval: backoffStartInterval,
+			Header:               contErr.Header,
+			Memo:                 workflowContext.workflowInfo.Memo,
+			SearchAttributes:     sanitizeSearchAttributesForStart(workflowContext.workflowInfo.SearchAttributes),
+			RetryPolicy:          convertToPBRetryPolicy(retryPolicy),
+			//lint:ignore SA1019 preserve deprecated build-ID versioning behavior
 			InheritBuildId:            useCompat,
 			InitialVersioningBehavior: continueAsNewVersioningBehaviorToProto(contErr.InitialVersioningBehavior),
 		}}
@@ -1994,15 +1995,17 @@ func (wth *workflowTaskHandlerImpl) completeWorkflow(
 		Identity:                   wth.identity,
 		ReturnNewWorkflowTask:      true,
 		ForceCreateNewWorkflowTask: forceNewWorkflowTask,
-		BinaryChecksum:             wth.workerBuildID,
-		QueryResults:               queryResults,
-		Namespace:                  wth.namespace,
-		MeteringMetadata:           &commonpb.MeteringMetadata{NonfirstLocalActivityExecutionAttempts: nonfirstLAAttempts},
+		//lint:ignore SA1019 support servers without build-ID versioning
+		BinaryChecksum:   wth.workerBuildID,
+		QueryResults:     queryResults,
+		Namespace:        wth.namespace,
+		MeteringMetadata: &commonpb.MeteringMetadata{NonfirstLocalActivityExecutionAttempts: nonfirstLAAttempts},
 		SdkMetadata: &sdk.WorkflowTaskCompletedMetadata{
 			LangUsedFlags: langUsedFlags,
 			SdkName:       eventHandler.getNewSdkNameAndReset(),
 			SdkVersion:    eventHandler.getNewSdkVersionAndReset(),
 		},
+		//lint:ignore SA1019 preserve deprecated build-ID versioning behavior
 		WorkerVersionStamp: &commonpb.WorkerVersionStamp{
 			BuildId:       wth.workerBuildID,
 			UseVersioning: wth.useBuildIDForVersioning,
@@ -2010,6 +2013,7 @@ func (wth *workflowTaskHandlerImpl) completeWorkflow(
 		Capabilities: &workflowservice.RespondWorkflowTaskCompletedRequest_Capabilities{
 			DiscardSpeculativeWorkflowTaskWithEvents: true,
 		},
+		//lint:ignore SA1019 support legacy worker deployment APIs
 		Deployment: &deploymentpb.Deployment{
 			BuildId:    wth.workerBuildID,
 			SeriesName: seriesName,
@@ -2551,11 +2555,13 @@ func (ath *activityTaskHandlerImpl) visitorErrorToActivityFailure(msgPrefix stri
 	ath.logger.Error(msgPrefix+err.Error(), keyvals...)
 
 	return &workflowservice.RespondActivityTaskFailedRequest{
-		TaskToken:         t.TaskToken,
-		Failure:           ath.failureConverter.ErrorToFailure(err),
-		Identity:          ath.identity,
-		Namespace:         ath.namespace,
-		WorkerVersion:     ath.versionStamp,
+		TaskToken: t.TaskToken,
+		Failure:   ath.failureConverter.ErrorToFailure(err),
+		Identity:  ath.identity,
+		Namespace: ath.namespace,
+		//lint:ignore SA1019 preserve deprecated build-ID versioning behavior
+		WorkerVersion: ath.versionStamp,
+		//lint:ignore SA1019 support legacy worker deployment APIs
 		Deployment:        ath.deployment,
 		DeploymentOptions: ath.workerDeploymentOptions,
 	}

--- a/internal/internal_task_handlers_test.go
+++ b/internal/internal_task_handlers_test.go
@@ -584,11 +584,13 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_BinaryChecksum() {
 		createTestEventWorkflowExecutionStarted(1, &historypb.WorkflowExecutionStartedEventAttributes{TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue}}),
 		createTestEventWorkflowTaskScheduled(2, &historypb.WorkflowTaskScheduledEventAttributes{TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue}}),
 		createTestEventWorkflowTaskStarted(3),
+		//lint:ignore SA1019 construct legacy history for replay compatibility
 		createTestEventWorkflowTaskCompleted(4, &historypb.WorkflowTaskCompletedEventAttributes{ScheduledEventId: 2, BinaryChecksum: checksum1}),
 		createTestEventTimerStarted(5, 5),
 		createTestEventTimerFired(6, 5),
 		createTestEventWorkflowTaskScheduled(7, &historypb.WorkflowTaskScheduledEventAttributes{TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue}}),
 		createTestEventWorkflowTaskStarted(8),
+		//lint:ignore SA1019 construct legacy history for replay compatibility
 		createTestEventWorkflowTaskCompleted(9, &historypb.WorkflowTaskCompletedEventAttributes{ScheduledEventId: 7, BinaryChecksum: checksum2}),
 		createTestEventTimerStarted(10, 10),
 		createTestEventTimerFired(11, 10),
@@ -1253,7 +1255,6 @@ func (t *TaskHandlersTestSuite) TestConsistentQuery_InvalidQueryTask() {
 }
 
 func (t *TaskHandlersTestSuite) TestConsistentQuery_Success() {
-	checksum1 := "chck1"
 	numberOfSignalsToComplete, err := converter.GetDefaultDataConverter().ToPayloads(2)
 	t.NoError(err)
 	signal, err := converter.GetDefaultDataConverter().ToPayloads("signal data")
@@ -1266,7 +1267,7 @@ func (t *TaskHandlersTestSuite) TestConsistentQuery_Success() {
 		createTestEventWorkflowTaskScheduled(2, &historypb.WorkflowTaskScheduledEventAttributes{}),
 		createTestEventWorkflowTaskStarted(3),
 		createTestEventWorkflowTaskCompleted(4, &historypb.WorkflowTaskCompletedEventAttributes{
-			ScheduledEventId: 2, BinaryChecksum: checksum1,
+			ScheduledEventId: 2,
 		}),
 		createTestEventWorkflowExecutionSignaledWithPayload(5, signalCh, signal),
 		createTestEventWorkflowTaskScheduled(6, &historypb.WorkflowTaskScheduledEventAttributes{}),

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -845,16 +845,19 @@ func (wtp *workflowTaskProcessor) errorToFailWorkflowTask(taskToken []byte, err 
 
 func (wtp *workflowTaskProcessor) errorToFailWorkflowTaskWithCause(taskToken []byte, err error, cause enumspb.WorkflowTaskFailedCause) *workflowservice.RespondWorkflowTaskFailedRequest {
 	builtRequest := &workflowservice.RespondWorkflowTaskFailedRequest{
-		TaskToken:      taskToken,
-		Cause:          cause,
-		Failure:        wtp.failureConverter.ErrorToFailure(err),
-		Identity:       wtp.identity,
+		TaskToken: taskToken,
+		Cause:     cause,
+		Failure:   wtp.failureConverter.ErrorToFailure(err),
+		Identity:  wtp.identity,
+		//lint:ignore SA1019 retain the checksum used by servers without Build ID versioning support
 		BinaryChecksum: wtp.workerBuildID,
 		Namespace:      wtp.namespace,
+		//lint:ignore SA1019 retain legacy Build ID versioning metadata for older servers
 		WorkerVersion: &commonpb.WorkerVersionStamp{
 			BuildId:       wtp.workerBuildID,
 			UseVersioning: wtp.useBuildIDVersioning,
 		},
+		//lint:ignore SA1019 retain legacy deployment metadata for servers predating deployment options
 		Deployment: &deploymentpb.Deployment{
 			BuildId:    wtp.workerBuildID,
 			SeriesName: wtp.getDeploymentName(),
@@ -1145,10 +1148,12 @@ func (wtp *workflowTaskPoller) getNextPollRequest() (request *workflowservice.Po
 	}
 
 	builtRequest := &workflowservice.PollWorkflowTaskQueueRequest{
-		Namespace:      wtp.namespace,
-		TaskQueue:      taskQueue,
-		Identity:       wtp.identity,
+		Namespace: wtp.namespace,
+		TaskQueue: taskQueue,
+		Identity:  wtp.identity,
+		//lint:ignore SA1019 retain the checksum used by servers without Build ID versioning support
 		BinaryChecksum: wtp.workerBuildID,
+		//lint:ignore SA1019 retain legacy Build ID versioning metadata for older servers
 		WorkerVersionCapabilities: &commonpb.WorkerVersionCapabilities{
 			BuildId:              wtp.workerBuildID,
 			UseVersioning:        wtp.useBuildIDVersioning,
@@ -1408,6 +1413,7 @@ func (atp *activityTaskPoller) poll(ctx context.Context) (taskForWorker, error) 
 		TaskQueue:         &taskqueuepb.TaskQueue{Name: atp.taskQueueName, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		Identity:          atp.identity,
 		TaskQueueMetadata: &taskqueuepb.TaskQueueMetadata{MaxTasksPerSecond: wrapperspb.Double(atp.activitiesPerSecond)},
+		//lint:ignore SA1019 retain legacy Build ID versioning metadata for older servers
 		WorkerVersionCapabilities: &commonpb.WorkerVersionCapabilities{
 			BuildId:              atp.workerBuildID,
 			UseVersioning:        atp.useBuildIDVersioning,
@@ -1602,11 +1608,13 @@ func convertActivityResultToRespondRequest(
 
 	if err == nil {
 		return &workflowservice.RespondActivityTaskCompletedRequest{
-			TaskToken:         taskToken,
-			Result:            result,
-			Identity:          identity,
-			Namespace:         namespace,
-			WorkerVersion:     versionStamp,
+			TaskToken: taskToken,
+			Result:    result,
+			Identity:  identity,
+			Namespace: namespace,
+			//lint:ignore SA1019 retain legacy Build ID versioning metadata for older servers
+			WorkerVersion: versionStamp,
+			//lint:ignore SA1019 retain legacy deployment metadata for servers predating deployment options
 			Deployment:        deployment,
 			DeploymentOptions: workerDeploymentOptions,
 		}
@@ -1617,21 +1625,25 @@ func convertActivityResultToRespondRequest(
 		var canceledErr *CanceledError
 		if errors.As(err, &canceledErr) {
 			return &workflowservice.RespondActivityTaskCanceledRequest{
-				TaskToken:         taskToken,
-				Details:           convertErrDetailsToPayloads(canceledErr.details, dataConverter),
-				Identity:          identity,
-				Namespace:         namespace,
-				WorkerVersion:     versionStamp,
+				TaskToken: taskToken,
+				Details:   convertErrDetailsToPayloads(canceledErr.details, dataConverter),
+				Identity:  identity,
+				Namespace: namespace,
+				//lint:ignore SA1019 retain legacy Build ID versioning metadata for older servers
+				WorkerVersion: versionStamp,
+				//lint:ignore SA1019 retain legacy deployment metadata for servers predating deployment options
 				Deployment:        deployment,
 				DeploymentOptions: workerDeploymentOptions,
 			}
 		}
 		if errors.Is(err, context.Canceled) {
 			return &workflowservice.RespondActivityTaskCanceledRequest{
-				TaskToken:         taskToken,
-				Identity:          identity,
-				Namespace:         namespace,
-				WorkerVersion:     versionStamp,
+				TaskToken: taskToken,
+				Identity:  identity,
+				Namespace: namespace,
+				//lint:ignore SA1019 retain legacy Build ID versioning metadata for older servers
+				WorkerVersion: versionStamp,
+				//lint:ignore SA1019 retain legacy deployment metadata for servers predating deployment options
 				Deployment:        deployment,
 				DeploymentOptions: workerDeploymentOptions,
 			}
@@ -1645,11 +1657,13 @@ func convertActivityResultToRespondRequest(
 	}
 
 	return &workflowservice.RespondActivityTaskFailedRequest{
-		TaskToken:         taskToken,
-		Failure:           failureConverter.ErrorToFailure(err),
-		Identity:          identity,
-		Namespace:         namespace,
-		WorkerVersion:     versionStamp,
+		TaskToken: taskToken,
+		Failure:   failureConverter.ErrorToFailure(err),
+		Identity:  identity,
+		Namespace: namespace,
+		//lint:ignore SA1019 retain legacy Build ID versioning metadata for older servers
+		WorkerVersion: versionStamp,
+		//lint:ignore SA1019 retain legacy deployment metadata for servers predating deployment options
 		Deployment:        deployment,
 		DeploymentOptions: workerDeploymentOptions,
 	}

--- a/internal/internal_versioning_client.go
+++ b/internal/internal_versioning_client.go
@@ -308,10 +308,15 @@ func (o *DescribeTaskQueueEnhancedOptions) validateAndConvertToProto(namespace s
 			// Sticky queues not supported
 			Name: o.TaskQueue,
 		},
-		ApiMode:                enumspb.DESCRIBE_TASK_QUEUE_MODE_ENHANCED,
-		Versions:               taskQueueVersionSelectionToProto(o.Versions),
-		TaskQueueTypes:         taskQueueTypes,
-		ReportPollers:          o.ReportPollers,
+		//lint:ignore SA1019 DescribeTaskQueueEnhanced requires the deprecated enhanced API mode
+		ApiMode: enumspb.DESCRIBE_TASK_QUEUE_MODE_ENHANCED,
+		//lint:ignore SA1019 DescribeTaskQueueEnhanced requires enhanced-mode version selection
+		Versions: taskQueueVersionSelectionToProto(o.Versions),
+		//lint:ignore SA1019 DescribeTaskQueueEnhanced requires enhanced-mode task queue types
+		TaskQueueTypes: taskQueueTypes,
+		//lint:ignore SA1019 DescribeTaskQueueEnhanced requires enhanced-mode poller reporting
+		ReportPollers: o.ReportPollers,
+		//lint:ignore SA1019 DescribeTaskQueueEnhanced requires enhanced-mode reachability reporting
 		ReportTaskReachability: o.ReportTaskReachability,
 		ReportStats:            o.ReportStats,
 	}

--- a/internal/internal_versioning_client_test.go
+++ b/internal/internal_versioning_client_test.go
@@ -21,6 +21,7 @@ func Test_DetectEnhancedNotSupported_fromProtoResponse(t *testing.T) {
 		{
 			name: "enhanced task queue info",
 			response: &workflowservice.DescribeTaskQueueResponse{
+				//lint:ignore SA1019 exercise enhanced-mode response detection
 				VersionsInfo: map[string]*taskqueuepb.TaskQueueVersionInfo{
 					"one": {
 						TypesInfo:        map[int32]*taskqueuepb.TaskQueueTypeInfo{},
@@ -33,6 +34,7 @@ func Test_DetectEnhancedNotSupported_fromProtoResponse(t *testing.T) {
 		{
 			name: "legacy task queue info",
 			response: &workflowservice.DescribeTaskQueueResponse{
+				//lint:ignore SA1019 exercise detection of pre-enhanced server responses
 				TaskQueueStatus: &taskqueuepb.TaskQueueStatus{},
 			},
 			want: errors.New("server does not support `DescribeTaskQueueEnhanced`"),
@@ -67,6 +69,7 @@ func Test_TaskQueueDescription_fromProtoResponse(t *testing.T) {
 		{
 			name: "normal task queue info",
 			response: &workflowservice.DescribeTaskQueueResponse{
+				//lint:ignore SA1019 exercise enhanced-mode response conversion
 				VersionsInfo: map[string]*taskqueuepb.TaskQueueVersionInfo{
 					"one": {
 						TypesInfo: map[int32]*taskqueuepb.TaskQueueTypeInfo{
@@ -80,7 +83,9 @@ func Test_TaskQueueDescription_fromProtoResponse(t *testing.T) {
 					},
 				},
 				VersioningInfo: &taskqueuepb.TaskQueueVersioningInfo{
-					CurrentVersion:           "foo.build1",
+					//lint:ignore SA1019 exercise fallback conversion of legacy string versions
+					CurrentVersion: "foo.build1",
+					//lint:ignore SA1019 exercise fallback conversion of legacy string versions
 					RampingVersion:           "foo.build2",
 					RampingVersionPercentage: 3.0,
 					UpdateTime:               nowProto,

--- a/internal/internal_worker_deployment_client.go
+++ b/internal/internal_worker_deployment_client.go
@@ -206,8 +206,9 @@ func (h *workerDeploymentHandleImpl) SetCurrentVersion(ctx context.Context, opti
 	}
 
 	request := &workflowservice.SetWorkerDeploymentCurrentVersionRequest{
-		Namespace:               h.workflowClient.namespace,
-		DeploymentName:          h.Name,
+		Namespace:      h.workflowClient.namespace,
+		DeploymentName: h.Name,
+		//lint:ignore SA1019 retain the canonical version string for older servers
 		Version:                 h.buildIdToVersionStr(options.BuildID),
 		BuildId:                 options.BuildID,
 		ConflictToken:           options.ConflictToken,
@@ -245,8 +246,9 @@ func (h *workerDeploymentHandleImpl) SetRampingVersion(ctx context.Context, opti
 	}
 
 	request := &workflowservice.SetWorkerDeploymentRampingVersionRequest{
-		Namespace:               h.workflowClient.namespace,
-		DeploymentName:          h.Name,
+		Namespace:      h.workflowClient.namespace,
+		DeploymentName: h.Name,
+		//lint:ignore SA1019 retain the canonical version string for older servers
 		Version:                 h.buildIdToVersionStr(options.BuildID),
 		BuildId:                 options.BuildID,
 		Percentage:              options.Percentage,
@@ -376,7 +378,8 @@ func (h *workerDeploymentHandleImpl) DescribeVersion(ctx context.Context, option
 
 	request := &workflowservice.DescribeWorkerDeploymentVersionRequest{
 		Namespace: h.workflowClient.namespace,
-		Version:   h.buildIdToVersionStr(options.BuildID),
+		//lint:ignore SA1019 retain the canonical version string for older servers
+		Version: h.buildIdToVersionStr(options.BuildID),
 		DeploymentVersion: &deployment.WorkerDeploymentVersion{
 			BuildId:        options.BuildID,
 			DeploymentName: h.Name,
@@ -413,7 +416,8 @@ func (h *workerDeploymentHandleImpl) DeleteVersion(ctx context.Context, options 
 
 	request := &workflowservice.DeleteWorkerDeploymentVersionRequest{
 		Namespace: h.workflowClient.namespace,
-		Version:   h.buildIdToVersionStr(options.BuildID),
+		//lint:ignore SA1019 retain the canonical version string for older servers
+		Version: h.buildIdToVersionStr(options.BuildID),
 		DeploymentVersion: &deployment.WorkerDeploymentVersion{
 			BuildId:        options.BuildID,
 			DeploymentName: h.Name,
@@ -466,7 +470,8 @@ func (h *workerDeploymentHandleImpl) UpdateVersionMetadata(ctx context.Context, 
 	}
 
 	request := &workflowservice.UpdateWorkerDeploymentVersionMetadataRequest{
-		Namespace:         h.workflowClient.namespace,
+		Namespace: h.workflowClient.namespace,
+		//lint:ignore SA1019 retain the canonical version string for older servers
 		Version:           options.Version.toCanonicalString(),
 		DeploymentVersion: options.Version.toProto(),
 		UpsertEntries:     workerDeploymentUpsertEntriesMetadataToProto(h.workflowClient.dataConverter, options.MetadataUpdate),

--- a/internal/internal_worker_heartbeat.go
+++ b/internal/internal_worker_heartbeat.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/uuid"
 	commonpb "go.temporal.io/api/common/v1"
+	deploymentpb "go.temporal.io/api/deployment/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	nexuspb "go.temporal.io/api/nexus/v1"
 	workerservicepb "go.temporal.io/api/nexusservices/workerservice/v1"
@@ -296,8 +297,9 @@ func (hw *sharedNamespaceWorker) pollWorkerCommandTask() (*workflowservice.PollN
 		},
 		Identity:          hw.client.identity,
 		WorkerInstanceKey: hw.workerInstanceKey,
-		WorkerVersionCapabilities: &commonpb.WorkerVersionCapabilities{
-			BuildId: "1.0",
+		DeploymentOptions: &deploymentpb.WorkerDeploymentOptions{
+			BuildId:              "1.0",
+			WorkerVersioningMode: enumspb.WORKER_VERSIONING_MODE_UNVERSIONED,
 		},
 	})
 }

--- a/internal/internal_worker_heartbeat_test.go
+++ b/internal/internal_worker_heartbeat_test.go
@@ -104,6 +104,12 @@ func TestWorkerCommandPollUsesWorkerCommandsQueue(t *testing.T) {
 			if req.TaskQueue.GetKind() != enumspb.TASK_QUEUE_KIND_WORKER_COMMANDS {
 				t.Fatalf("task queue kind = %v, want worker commands", req.TaskQueue.GetKind())
 			}
+			if req.DeploymentOptions.GetBuildId() != "1.0" {
+				t.Fatalf("build ID = %q, want %q", req.DeploymentOptions.GetBuildId(), "1.0")
+			}
+			if req.DeploymentOptions.GetWorkerVersioningMode() != enumspb.WORKER_VERSIONING_MODE_UNVERSIONED {
+				t.Fatalf("worker versioning mode = %v, want unversioned", req.DeploymentOptions.GetWorkerVersioningMode())
+			}
 			return &workflowservice.PollNexusTaskQueueResponse{}, nil
 		})
 

--- a/internal/internal_workflow_execution_options.go
+++ b/internal/internal_workflow_execution_options.go
@@ -145,8 +145,11 @@ func versioningOverrideToProto(versioningOverride VersioningOverride) *workflowp
 	switch v := versioningOverride.(type) {
 	case *PinnedVersioningOverride:
 		return &workflowpb.VersioningOverride{
-			Behavior:      versioningBehaviorToProto(v.behavior()),
+			//lint:ignore SA1019 populate legacy versioning fields for compatibility with servers that do not support the override oneof
+			Behavior: versioningBehaviorToProto(v.behavior()),
+			//lint:ignore SA1019 populate legacy versioning fields for compatibility with servers that do not support the override oneof
 			PinnedVersion: v.Version.toCanonicalString(),
+			//lint:ignore SA1019 populate legacy versioning fields for compatibility with servers that do not support the override oneof
 			Deployment: &deploymentpb.Deployment{
 				SeriesName: v.Version.DeploymentName,
 				BuildId:    v.Version.BuildID,
@@ -160,6 +163,7 @@ func versioningOverrideToProto(versioningOverride VersioningOverride) *workflowp
 		}
 	case *AutoUpgradeVersioningOverride:
 		return &workflowpb.VersioningOverride{
+			//lint:ignore SA1019 populate legacy versioning fields for compatibility with servers that do not support the override oneof
 			Behavior: versioningBehaviorToProto(v.behavior()),
 			Override: &workflowpb.VersioningOverride_AutoUpgrade{AutoUpgrade: true},
 		}

--- a/internal/internal_workflow_execution_options_test.go
+++ b/internal/internal_workflow_execution_options_test.go
@@ -27,8 +27,11 @@ func Test_WorkflowExecutionOptions_fromProtoResponse(t *testing.T) {
 			response: &workflowservice.UpdateWorkflowExecutionOptionsResponse{
 				WorkflowExecutionOptions: &workflowpb.WorkflowExecutionOptions{
 					VersioningOverride: &workflowpb.VersioningOverride{
-						Behavior:      enumspb.VersioningBehavior(VersioningBehaviorPinned),
+						//lint:ignore SA1019 construct a legacy versioning response to verify backwards-compatible decoding
+						Behavior: enumspb.VersioningBehavior(VersioningBehaviorPinned),
+						//lint:ignore SA1019 construct a legacy versioning response to verify backwards-compatible decoding
 						PinnedVersion: "my series.v1",
+						//lint:ignore SA1019 construct a legacy versioning response to verify backwards-compatible decoding
 						Deployment: &deploymentpb.Deployment{
 							SeriesName: "my series",
 							BuildId:    "v1",

--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -2821,6 +2821,7 @@ func (env *testWorkflowEnvironmentImpl) ExecuteNexusOperation(
 		response, failure, err := taskHandler.Execute(task)
 		if err != nil {
 			// No retries for operations, fail the operation immediately.
+			//lint:ignore SA4006 fillInFailure cannot fail for a handler error without a cause.
 			failure, err = taskHandler.fillInFailure(task.TaskToken, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeInternal, "%s", err.Error()), false)
 		}
 		if failure != nil {

--- a/internal/nexus_operations.go
+++ b/internal/nexus_operations.go
@@ -327,7 +327,8 @@ func nexusOperationFailure(params ExecuteNexusOperationParams, token string, cau
 				Service:        params.client.Service(),
 				Operation:      params.operation,
 				OperationToken: token,
-				OperationId:    token, // Also populate ID for backwards compatibility.
+				//lint:ignore SA1019 preserve legacy operation ID behavior in the test environment
+				OperationId: token, // Also populate ID for backwards compatibility.
 			},
 		},
 		Cause: cause,


### PR DESCRIPTION
## What was changed

- Bumped `honnef.co/go/tools` from `v0.6.0` to `v0.8.0`, the first release supporting Go 1.27.
- Kept every analyzer enabled and added narrow reasons for compatibility code that must still populate deprecated server API fields.
- Replaced the worker-command poll request deprecated version field with `DeploymentOptions` and strengthened its unit test.
- Removed an unused legacy checksum fixture.
- Made the compression example assert the stable property that compression reduces payload size instead of a Go-version-specific zlib byte count.

## Findings surfaced by Staticcheck 0.8.0

- 59 `SA1019` deprecated-field findings:
  - 57 intentional older-server or legacy-fixture uses now have field-local compatibility reasons.
  - 1 stale test fixture was removed.
  - 1 worker-command request was migrated to its modern replacement.
- 1 `SA4006` finding is explicitly documented at the conversion invariant where the generated handler error has no cause.
- 2 `SA5008` diagnostics on the same Go 1.26 JSON-tag compatibility fixture are covered by one field-local reason.
- No analyzer is globally disabled.

## Why?

The CI check follows `go-version: stable`, which now resolves to Go 1.27. Staticcheck `v0.6.0` crashes on the Go 1.27 AST before reporting diagnostics. Staticcheck `v0.8.0` supports Go 1.27 and makes the remaining compatibility debt explicit without hiding future findings.

## Checklist

1. Closes: N/A

2. How was this tested:

- `GOTOOLCHAIN=go1.27.0 go run . check`
- `GOTOOLCHAIN=go1.26.5 go run . check`
- `GOTOOLCHAIN=go1.27.0 go run . unit-test`
- `GOTOOLCHAIN=go1.26.5 go run . unit-test -run "^ExampleCodecDataConverter_compression$"`
- `GOTOOLCHAIN=go1.27.0 go run . integration-test -dev-server -run "TestWorkerHeartbeatSuite/TestActivityCancelDeliveredWithoutHeartbeat"`
- Focused compatibility, Nexus timeout, worker-command, and Google ADK tests

3. Any docs updates needed?

No. This is build tooling and internal compatibility maintenance. A maintainer should apply `skip-changelog` rather than add a user-facing release note.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 3bacbb43c0c2c3aa9b0eed34d19a6a13e2eeeade. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->