### PR TITLE
Add generic methods to NexusClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ to docs, or any other relevant information.
 
 - Added `temporal.NewPayloadValidationError` to create non-retryable application errors with
   optional structured details for payload validation failures. Passing `nil` omits details.
+- Added Go 1.27+ generic methods on the experimental `temporalnexus.NexusClient` for starting
+  workflow-, activity-, and workflow-update-backed Nexus operations.
 
 ### Changed
 

--- a/temporalnexus/temporal_operation.go
+++ b/temporalnexus/temporal_operation.go
@@ -145,7 +145,8 @@ func (nc NexusClient) GetWorkflowClient() client.Client {
 // The workflow parameter must have the signature func(workflow.Context, I) (O, error).
 // For workflows that don't follow this signature, use [StartUntypedWorkflow].
 //
-// These are free functions because Go does not allow generic methods on non-generic structs.
+// Use this package-level function for compatibility with Go versions before 1.27. When building
+// with Go 1.27 or later, the same operation is also available as a method on [NexusClient].
 //
 // NOTE: Experimental
 func StartWorkflow[I, O any, WF func(workflow.Context, I) (O, error)](
@@ -196,7 +197,8 @@ func StartUntypedWorkflow[R any](
 // It returns either an async result with a workflow update operation token for pending
 // operations or a sync response if the update is already completed.
 //
-// These are free functions because Go does not allow generic methods on non-generic structs.
+// Use this package-level function for compatibility with Go versions before 1.27. When building
+// with Go 1.27 or later, the same operation is also available as a method on [NexusClient].
 //
 // NOTE: Experimental
 func StartUpdateWorkflow[R any](
@@ -347,7 +349,8 @@ func validateUpdateWorkflowNexusOperation(u client.UpdateWorkflowOptions) error 
 // activityOpts must specify an ID and at least one of StartToCloseTimeout
 // or ScheduleToCloseTimeout. TaskQueue defaults to the current worker's task queue when empty.
 //
-// These are free functions because Go does not allow generic methods on non-generic structs.
+// Use this package-level function for compatibility with Go versions before 1.27. When building
+// with Go 1.27 or later, the same operation is also available as a method on [NexusClient].
 func StartActivity[I, O any, AF func(context.Context, I) (O, error)](
 	ctx context.Context,
 	nc NexusClient,

--- a/temporalnexus/temporal_operation_go1.27.go
+++ b/temporalnexus/temporal_operation_go1.27.go
@@ -1,0 +1,104 @@
+//go:build go1.27
+
+package temporalnexus
+
+import (
+	"context"
+
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/workflow"
+)
+
+// StartWorkflow starts a type-safe workflow run for a Nexus operation.
+//
+// The workflow parameter must have the signature func(workflow.Context, I) (O, error).
+// For workflows that don't follow this signature, use [StartUntypedWorkflow].
+//
+// This method is available when building with Go 1.27 or later. The package-level
+// [StartWorkflow] function provides the same behavior for earlier Go versions.
+//
+// Example:
+//
+//	op := MustNewTemporalOperation(TemporalOperationOptions[MyInput, MyOutput]{
+//		Name: "my-workflow-operation",
+//		Start: func(ctx context.Context, nc NexusClient, input MyInput, _ StartTemporalOperationOptions) (TemporalOperationResult[MyOutput], error) {
+//			return nc.StartWorkflow(
+//				ctx,
+//				client.StartWorkflowOptions{ID: "workflow-" + input.ID},
+//				MyWorkflow,
+//				input,
+//			)
+//		},
+//	})
+//
+// NOTE: Experimental
+func (nc NexusClient) StartWorkflow[I, O any, WF func(workflow.Context, I) (O, error)](
+	ctx context.Context,
+	workflowOpts client.StartWorkflowOptions,
+	workflow WF,
+	arg I,
+) (TemporalOperationResult[O], error) {
+	return StartWorkflow(ctx, nc, workflowOpts, workflow, arg)
+}
+
+// StartUpdateWorkflow starts a type-safe workflow update run for a Nexus operation.
+//
+// This method is available when building with Go 1.27 or later. The package-level
+// [StartUpdateWorkflow] function provides the same behavior for earlier Go versions.
+//
+// Example:
+//
+//	op := MustNewTemporalOperation(TemporalOperationOptions[MyInput, MyOutput]{
+//		Name: "my-update-operation",
+//		Start: func(ctx context.Context, nc NexusClient, input MyInput, _ StartTemporalOperationOptions) (TemporalOperationResult[MyOutput], error) {
+//			return nc.StartUpdateWorkflow[MyOutput](ctx, client.UpdateWorkflowOptions{
+//				WorkflowID:   input.ID,
+//				UpdateName:   "MyUpdate",
+//				Args:         []any{input},
+//				WaitForStage: client.WorkflowUpdateStageAccepted,
+//			})
+//		},
+//	})
+//
+// NOTE: Experimental
+func (nc NexusClient) StartUpdateWorkflow[R any](
+	ctx context.Context,
+	updateWorkflowOptions client.UpdateWorkflowOptions,
+) (TemporalOperationResult[R], error) {
+	return StartUpdateWorkflow[R](ctx, nc, updateWorkflowOptions)
+}
+
+// StartActivity starts a type-safe stand-alone activity execution for a Nexus operation.
+//
+// The activity parameter must have the signature func(context.Context, I) (O, error).
+// For activities that don't follow this signature, use [StartUntypedActivity].
+//
+// This method is available when building with Go 1.27 or later. The package-level
+// [StartActivity] function provides the same behavior for earlier Go versions.
+//
+// Example:
+//
+//	op := MustNewTemporalOperation(TemporalOperationOptions[MyInput, MyOutput]{
+//		Name: "my-activity-operation",
+//		Start: func(ctx context.Context, nc NexusClient, input MyInput, _ StartTemporalOperationOptions) (TemporalOperationResult[MyOutput], error) {
+//			return nc.StartActivity(
+//				ctx,
+//				client.StartActivityOptions{
+//					ID:                  "activity-" + input.ID,
+//					StartToCloseTimeout: time.Minute,
+//				},
+//				MyActivity,
+//				input,
+//			)
+//		},
+//	})
+//
+// NOTE: Experimental
+func (nc NexusClient) StartActivity[I, O any, AF func(context.Context, I) (O, error)](
+	ctx context.Context,
+	activityOpts client.StartActivityOptions,
+	activity AF,
+	arg I,
+) (TemporalOperationResult[O], error) {
+	return StartActivity(ctx, nc, activityOpts, activity, arg)
+}

--- a/temporalnexus/temporal_operation_go1.27_test.go
+++ b/temporalnexus/temporal_operation_go1.27_test.go
@@ -1,0 +1,166 @@
+//go:build go1.27
+
+package temporalnexus
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/nexus-rpc/sdk-go/nexus"
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/internal"
+	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/workflow"
+)
+
+func TestNexusClientStartWorkflowSmoke(t *testing.T) {
+	backingWorkflow := func(_ workflow.Context, input string) (string, error) {
+		return "workflow:" + input, nil
+	}
+	op := MustNewTemporalOperation(TemporalOperationOptions[string, string]{
+		Name: "workflow-op",
+		Start: func(ctx context.Context, nc NexusClient, input string, _ StartTemporalOperationOptions) (TemporalOperationResult[string], error) {
+			return nc.StartWorkflow(
+				ctx,
+				client.StartWorkflowOptions{ID: "workflow-" + input},
+				backingWorkflow,
+				input,
+			)
+		},
+	})
+	callerWorkflow := func(ctx workflow.Context, input string) (string, error) {
+		nc := workflow.NewNexusClient("endpoint", "service")
+		var result string
+		err := nc.ExecuteOperation(ctx, op, input, workflow.NexusOperationOptions{}).Get(ctx, &result)
+		return result, err
+	}
+	service := nexus.NewService("service")
+	require.NoError(t, service.Register(op))
+
+	suite := testsuite.WorkflowTestSuite{}
+	env := suite.NewTestWorkflowEnvironment()
+	env.RegisterWorkflow(backingWorkflow)
+	env.RegisterNexusService(service)
+	env.ExecuteWorkflow(callerWorkflow, "input")
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+	var result string
+	require.NoError(t, env.GetWorkflowResult(&result))
+	require.Equal(t, "workflow:input", result)
+}
+
+func TestNexusClientStartUpdateWorkflowSmoke(t *testing.T) {
+	op := MustNewTemporalOperation(TemporalOperationOptions[string, string]{
+		Name: "update-op",
+		Start: func(ctx context.Context, nc NexusClient, input string, _ StartTemporalOperationOptions) (TemporalOperationResult[string], error) {
+			return nc.StartUpdateWorkflow[string](ctx, client.UpdateWorkflowOptions{
+				WorkflowID:   input,
+				UpdateName:   "update",
+				WaitForStage: client.WorkflowUpdateStageAccepted,
+			})
+		},
+	})
+
+	require.Equal(t, "update-op", op.Name())
+}
+
+func TestNexusClientStartActivitySmoke(t *testing.T) {
+	backingActivity := func(_ context.Context, input string) (string, error) {
+		return "activity:" + input, nil
+	}
+	op := MustNewTemporalOperation(TemporalOperationOptions[string, string]{
+		Name: "activity-op",
+		Start: func(ctx context.Context, nc NexusClient, input string, _ StartTemporalOperationOptions) (TemporalOperationResult[string], error) {
+			return nc.StartActivity(
+				ctx,
+				client.StartActivityOptions{
+					ID:                  "activity-" + input,
+					StartToCloseTimeout: time.Minute,
+				},
+				backingActivity,
+				input,
+			)
+		},
+	})
+	callerWorkflow := func(ctx workflow.Context, input string) (string, error) {
+		nc := workflow.NewNexusClient("endpoint", "service")
+		var result string
+		err := nc.ExecuteOperation(ctx, op, input, workflow.NexusOperationOptions{}).Get(ctx, &result)
+		return result, err
+	}
+	service := nexus.NewService("service")
+	require.NoError(t, service.Register(op))
+
+	suite := testsuite.WorkflowTestSuite{}
+	env := suite.NewTestWorkflowEnvironment()
+	env.RegisterActivity(backingActivity)
+	env.RegisterNexusService(service)
+	env.ExecuteWorkflow(callerWorkflow, "input")
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+	var result string
+	require.NoError(t, env.GetWorkflowResult(&result))
+	require.Equal(t, "activity:input", result)
+}
+
+func TestNexusClientStartWorkflow(t *testing.T) {
+	var started atomic.Bool
+	started.Store(true)
+	nc := NexusClient{asyncStarted: &started}
+
+	_, err := nc.StartWorkflow(
+		t.Context(),
+		client.StartWorkflowOptions{},
+		func(workflow.Context, string) (string, error) { return "", nil },
+		"ignored",
+	)
+
+	var handlerErr *nexus.HandlerError
+	require.ErrorAs(t, err, &handlerErr)
+	require.Equal(t, nexus.HandlerErrorTypeBadRequest, handlerErr.Type)
+	require.ErrorContains(t, err, errMultipleAsyncOperationsMsg)
+}
+
+func TestNexusClientStartUpdateWorkflow(t *testing.T) {
+	var started atomic.Bool
+	started.Store(true)
+	nc := NexusClient{
+		asyncStarted:          &started,
+		startOperationOptions: nexus.StartOperationOptions{CallbackURL: "temporal://dummy"},
+	}
+	ctx := internal.ContextWithNexusOperationContext(t.Context(), &internal.NexusOperationContext{})
+
+	_, err := nc.StartUpdateWorkflow[string](ctx, client.UpdateWorkflowOptions{
+		WorkflowID:   "workflow-id",
+		UpdateName:   "update-name",
+		WaitForStage: client.WorkflowUpdateStageAccepted,
+	})
+
+	var handlerErr *nexus.HandlerError
+	require.ErrorAs(t, err, &handlerErr)
+	require.Equal(t, nexus.HandlerErrorTypeBadRequest, handlerErr.Type)
+	require.ErrorContains(t, err, errMultipleAsyncOperationsMsg)
+}
+
+func TestNexusClientStartActivity(t *testing.T) {
+	var started atomic.Bool
+	started.Store(true)
+	nc := NexusClient{asyncStarted: &started}
+
+	_, err := nc.StartActivity(
+		t.Context(),
+		client.StartActivityOptions{},
+		func(context.Context, string) (string, error) { return "", nil },
+		"ignored",
+	)
+
+	var handlerErr *nexus.HandlerError
+	require.ErrorAs(t, err, &handlerErr)
+	require.Equal(t, nexus.HandlerErrorTypeBadRequest, handlerErr.Type)
+	require.ErrorContains(t, err, errMultipleAsyncOperationsMsg)
+}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Add generic methods to `NexusClient`

## Why?

Expose generic methods on `NexusClient` without needing to use functions.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive, build-tag-gated API sugar that forwards to existing implementations; no change to runtime behavior for callers still using package-level functions.
> 
> **Overview**
> Adds **Go 1.27+** generic methods on experimental `temporalnexus.NexusClient` so Nexus operation handlers can call `nc.StartWorkflow`, `nc.StartUpdateWorkflow`, and `nc.StartActivity` instead of passing `nc` into package-level helpers.
> 
> The new methods live in `temporal_operation_go1.27.go` (`//go:build go1.27`) and delegate to the existing `StartWorkflow` / `StartUpdateWorkflow` / `StartActivity` functions, so behavior is unchanged on older toolchains. Package-level function docs now point to the methods when building with Go 1.27+.
> 
> Includes Go 1.27-only smoke tests (workflow/activity via test env) and tests that the methods still enforce the single-async-operation rule. **CHANGELOG** documents the addition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 432ccd2124ad266dae32e8787f56fba300f486f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->