### PR TITLE
Add SDK Sentinel PR responder

### DIFF
--- a/.github/workflows/sdk-sentinel-pr-responder.yml
+++ b/.github/workflows/sdk-sentinel-pr-responder.yml
@@ -1,0 +1,57 @@
+name: SDK Sentinel PR responder relay
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions: {}
+
+jobs:
+  relay:
+    if: >-
+      github.event.issue.pull_request &&
+      github.event.comment.user.login != 'sdk-sentinel-bot' &&
+      contains(github.event.comment.body, '@sdk-sentinel-bot') &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Mint a Sentinel-only dispatch token from the Relay App
+        id: dispatch-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        with:
+          app-id: ${{ vars.SDK_SENTINEL_RELAY_APP_ID }}
+          private-key: ${{ secrets.SDK_SENTINEL_RELAY_PRIVATE_KEY }}
+          owner: temporalio
+          repositories: sdk-sentinel
+          permission-actions: write
+          permission-metadata: read
+      - name: Verify the Sentinel Relay installation
+        env:
+          ACTUAL_APP_SLUG: ${{ steps.dispatch-token.outputs.app-slug }}
+          ACTUAL_INSTALLATION_ID: ${{ steps.dispatch-token.outputs.installation-id }}
+          EXPECTED_INSTALLATION_ID: ${{ vars.SDK_SENTINEL_RELAY_INSTALLATION_ID }}
+        run: |
+          test "$ACTUAL_APP_SLUG" = sdk-sentinel-relay
+          test "$ACTUAL_INSTALLATION_ID" = "$EXPECTED_INSTALLATION_ID"
+      - name: Dispatch the trusted central responder
+        env:
+          COMMENT_ID: ${{ github.event.comment.id }}
+          DISPATCH_TOKEN: ${{ steps.dispatch-token.outputs.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          TARGET_ID: go
+        run: |
+          payload="$(
+            jq -cn \
+              --arg target "$TARGET_ID" \
+              --arg pr_number "$PR_NUMBER" \
+              --arg comment_id "$COMMENT_ID" \
+              '{ref:"main",inputs:{target:$target,pr_number:$pr_number,comment_id:$comment_id}}'
+          )"
+          curl --fail --silent --show-error \
+            --request POST \
+            --header "Accept: application/vnd.github+json" \
+            --header "Authorization: Bearer $DISPATCH_TOKEN" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            --data "$payload" \
+            https://api.github.com/repos/temporalio/sdk-sentinel/actions/workflows/sdk-pr-responder.yml/dispatches


### PR DESCRIPTION
## What changed?

Added the SDK Sentinel PR responder relay workflow with the manifest target ID set to go.

## Why?

This lets authorized PR participants dispatch the trusted central SDK Sentinel responder by mentioning the Sentinel bot in a pull request comment.

## Breaking changes

None.

## Server PR

N/A.

## Validation

- Verified the workflow matches the SDK Sentinel relay template and the deployed Rust SDK workflow, apart from the target ID.
- Ran actionlint successfully (ignoring its unsupported vars context warning).
- Ran git diff --check.