### PR TITLE
fix(metrics): label payload limit failures as PayloadsTooLarge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,8 @@ to docs, or any other relevant information.
 - Added Go 1.27+ generic methods on the experimental `temporalnexus.NexusClient` for starting
   workflow-, activity-, and workflow-update-backed Nexus operations.
 - The `temporal_activity_execution_failed` and `temporal_local_activity_execution_failed` worker
-  metrics now carry a `failure_reason` attribute, currently always `ActivityError`. Each is now
-  split into one time series per reason, which may affect existing dashboards.
+  metrics now carry a `failure_reason` attribute. Each is now split into one time series per
+  reason, which may affect existing dashboards.
 
 ### Changed
 

--- a/internal/internal_public.go
+++ b/internal/internal_public.go
@@ -87,7 +87,9 @@ type (
 		//  - RespondActivityTaskCompletedRequest
 		//  - RespondActivityTaskFailedRequest
 		//  - RespondActivityTaskCanceledRequest
-		Execute(taskQueue string, task *workflowservice.PollActivityTaskQueueResponse) (any, error)
+		// The second return is the error that produced a failed response, when the worker itself
+		// produced it; it does not mean Execute failed. The third does.
+		Execute(taskQueue string, task *workflowservice.PollActivityTaskQueueResponse) (any, error, error)
 	}
 )
 

--- a/internal/internal_public.go
+++ b/internal/internal_public.go
@@ -80,16 +80,23 @@ type (
 		) (*workflowExecutionContextImpl, error)
 	}
 
-	// ActivityTaskHandler represents activity task handlers.
-	ActivityTaskHandler interface {
-		// Executes the activity task
-		// The response is one of the types:
+	// activityTaskResult is the outcome of handling an activity task, as opposed to a failure to
+	// handle it at all, which Execute reports through its error return.
+	activityTaskResult struct {
+		// response is one of the types:
 		//  - RespondActivityTaskCompletedRequest
 		//  - RespondActivityTaskFailedRequest
 		//  - RespondActivityTaskCanceledRequest
-		// The second return is the error that produced a failed response, when the worker itself
-		// produced it; it does not mean Execute failed. The third does.
-		Execute(taskQueue string, task *workflowservice.PollActivityTaskQueueResponse) (any, error, error)
+		response any
+		// failureErr is the error behind a failed response when the worker produced the failure
+		// itself, so callers can classify it. Nil when the activity reported the failure.
+		failureErr error
+	}
+
+	// ActivityTaskHandler represents activity task handlers.
+	ActivityTaskHandler interface {
+		// Executes the activity task
+		Execute(taskQueue string, task *workflowservice.PollActivityTaskQueueResponse) (activityTaskResult, error)
 	}
 )
 

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -2357,7 +2357,7 @@ func newServiceInvoker(
 }
 
 // Execute executes an implementation of the activity.
-func (ath *activityTaskHandlerImpl) Execute(taskQueue string, t *workflowservice.PollActivityTaskQueueResponse) (result any, err error) {
+func (ath *activityTaskHandlerImpl) Execute(taskQueue string, t *workflowservice.PollActivityTaskQueueResponse) (result any, failureErr error, err error) {
 	traceLog(func() {
 		if t.WorkflowExecution.GetWorkflowId() == "" {
 			ath.logger.Debug("Processing new standalone activity task",
@@ -2399,7 +2399,7 @@ func (ath *activityTaskHandlerImpl) Execute(taskQueue string, t *workflowservice
 	}
 
 	if err := visitProtoPayloads(canCtx, ath.inboundPayloadVisitor, t, ath.payloadVisitorConcurrency); err != nil {
-		return ath.visitorErrorToActivityFailure("Activity task preprocess error: ", t, err), nil
+		return ath.visitorErrorToActivityFailure("Activity task preprocess error: ", t, err), err, nil
 	}
 
 	heartbeatThrottleInterval := ath.getHeartbeatThrottleInterval(t.GetHeartbeatTimeout().AsDuration())
@@ -2413,7 +2413,7 @@ func (ath *activityTaskHandlerImpl) Execute(taskQueue string, t *workflowservice
 	ctx, err := WithActivityTask(canCtx, t, taskQueue, invoker, ath.logger, metricsHandler,
 		ath.dataConverter, ath.workerStopCh, ath.contextPropagators, ath.registry.interceptors, ath.client)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// We must capture the context here because it is changed later to one that is
@@ -2430,7 +2430,7 @@ func (ath *activityTaskHandlerImpl) Execute(taskQueue string, t *workflowservice
 		metricsHandler.Counter(metrics.UnregisteredActivityInvocationCounter).Inc(1)
 		return convertActivityResultToRespondRequest(ath.identity, t.TaskToken, nil,
 			NewActivityNotRegisteredError(activityType, ath.getRegisteredActivityNames()),
-			dataConverter, failureConverter, ath.namespace, false, ath.versionStamp, ath.deployment, ath.workerDeploymentOptions), nil
+			dataConverter, failureConverter, ath.namespace, false, ath.versionStamp, ath.deployment, ath.workerDeploymentOptions), nil, nil
 	}
 
 	// panic handler
@@ -2455,7 +2455,7 @@ func (ath *activityTaskHandlerImpl) Execute(taskQueue string, t *workflowservice
 	// propagate context information into the activity context from the headers
 	ctx, err = contextWithHeaderPropagated(ctx, t.Header, ath.contextPropagators)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	info := getActivityEnv(ctx)
@@ -2469,7 +2469,7 @@ func (ath *activityTaskHandlerImpl) Execute(taskQueue string, t *workflowservice
 	// skip sending another response regardless of what the activity returned.
 	var hbVisitorErr heartbeatVisitorError
 	if errors.As(context.Cause(canCtx), &hbVisitorErr) {
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	// Cancels that don't originate from the server will have separate cancel reasons, like
@@ -2486,7 +2486,7 @@ func (ath *activityTaskHandlerImpl) Execute(taskQueue string, t *workflowservice
 			tagResult, output,
 			tagError, err,
 		)
-		return nil, ctx.Err()
+		return nil, nil, ctx.Err()
 	}
 	if err != nil && err != ErrActivityResultPending {
 		logFunc := ath.logger.Error // Default to Error
@@ -2530,11 +2530,11 @@ func (ath *activityTaskHandlerImpl) Execute(taskQueue string, t *workflowservice
 		}
 		outboundCtx := extstore.WithStorageTarget(outboundBase, storageTarget)
 		if err := visitProtoPayloads(outboundCtx, ath.outboundPayloadVisitor, msg, ath.payloadVisitorConcurrency); err != nil {
-			return ath.visitorErrorToActivityFailure("Activity task postprocess error: ", t, err), nil
+			return ath.visitorErrorToActivityFailure("Activity task postprocess error: ", t, err), err, nil
 		}
 	}
 
-	return response, nil
+	return response, nil, nil
 }
 
 func (ath *activityTaskHandlerImpl) visitorErrorToActivityFailure(msgPrefix string, t *workflowservice.PollActivityTaskQueueResponse, err error) *workflowservice.RespondActivityTaskFailedRequest {

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -2357,7 +2357,7 @@ func newServiceInvoker(
 }
 
 // Execute executes an implementation of the activity.
-func (ath *activityTaskHandlerImpl) Execute(taskQueue string, t *workflowservice.PollActivityTaskQueueResponse) (result any, failureErr error, err error) {
+func (ath *activityTaskHandlerImpl) Execute(taskQueue string, t *workflowservice.PollActivityTaskQueueResponse) (result activityTaskResult, err error) {
 	traceLog(func() {
 		if t.WorkflowExecution.GetWorkflowId() == "" {
 			ath.logger.Debug("Processing new standalone activity task",
@@ -2399,7 +2399,10 @@ func (ath *activityTaskHandlerImpl) Execute(taskQueue string, t *workflowservice
 	}
 
 	if err := visitProtoPayloads(canCtx, ath.inboundPayloadVisitor, t, ath.payloadVisitorConcurrency); err != nil {
-		return ath.visitorErrorToActivityFailure("Activity task preprocess error: ", t, err), err, nil
+		return activityTaskResult{
+			response:   ath.visitorErrorToActivityFailure("Activity task preprocess error: ", t, err),
+			failureErr: err,
+		}, nil
 	}
 
 	heartbeatThrottleInterval := ath.getHeartbeatThrottleInterval(t.GetHeartbeatTimeout().AsDuration())
@@ -2413,13 +2416,13 @@ func (ath *activityTaskHandlerImpl) Execute(taskQueue string, t *workflowservice
 	ctx, err := WithActivityTask(canCtx, t, taskQueue, invoker, ath.logger, metricsHandler,
 		ath.dataConverter, ath.workerStopCh, ath.contextPropagators, ath.registry.interceptors, ath.client)
 	if err != nil {
-		return nil, nil, err
+		return activityTaskResult{}, err
 	}
 
 	// We must capture the context here because it is changed later to one that is
 	// cancelled when the activity is done
 	defer func(ctx context.Context) {
-		_, activityCompleted := result.(*workflowservice.RespondActivityTaskCompletedRequest)
+		_, activityCompleted := result.response.(*workflowservice.RespondActivityTaskCompletedRequest)
 		invoker.Close(ctx, !activityCompleted) // flush buffered heartbeat if activity was not successfully completed.
 	}(ctx)
 
@@ -2428,9 +2431,9 @@ func (ath *activityTaskHandlerImpl) Execute(taskQueue string, t *workflowservice
 		// In case if activity is not registered we should report a failure to the server to allow activity retry
 		// instead of making it stuck on the same attempt.
 		metricsHandler.Counter(metrics.UnregisteredActivityInvocationCounter).Inc(1)
-		return convertActivityResultToRespondRequest(ath.identity, t.TaskToken, nil,
+		return activityTaskResult{response: convertActivityResultToRespondRequest(ath.identity, t.TaskToken, nil,
 			NewActivityNotRegisteredError(activityType, ath.getRegisteredActivityNames()),
-			dataConverter, failureConverter, ath.namespace, false, ath.versionStamp, ath.deployment, ath.workerDeploymentOptions), nil, nil
+			dataConverter, failureConverter, ath.namespace, false, ath.versionStamp, ath.deployment, ath.workerDeploymentOptions)}, nil
 	}
 
 	// panic handler
@@ -2447,15 +2450,17 @@ func (ath *activityTaskHandlerImpl) Execute(taskQueue string, t *workflowservice
 				tagPanicStack, st)
 			metricsHandler.Counter(metrics.ActivityTaskErrorCounter).Inc(1)
 			panicErr := newPanicError(p, st)
-			result = convertActivityResultToRespondRequest(ath.identity, t.TaskToken, nil, panicErr,
-				dataConverter, failureConverter, ath.namespace, false, ath.versionStamp, ath.deployment, ath.workerDeploymentOptions)
+			result = activityTaskResult{
+				response: convertActivityResultToRespondRequest(ath.identity, t.TaskToken, nil, panicErr,
+					dataConverter, failureConverter, ath.namespace, false, ath.versionStamp, ath.deployment, ath.workerDeploymentOptions),
+			}
 		}
 	}()
 
 	// propagate context information into the activity context from the headers
 	ctx, err = contextWithHeaderPropagated(ctx, t.Header, ath.contextPropagators)
 	if err != nil {
-		return nil, nil, err
+		return activityTaskResult{}, err
 	}
 
 	info := getActivityEnv(ctx)
@@ -2469,7 +2474,7 @@ func (ath *activityTaskHandlerImpl) Execute(taskQueue string, t *workflowservice
 	// skip sending another response regardless of what the activity returned.
 	var hbVisitorErr heartbeatVisitorError
 	if errors.As(context.Cause(canCtx), &hbVisitorErr) {
-		return nil, nil, nil
+		return activityTaskResult{}, nil
 	}
 
 	// Cancels that don't originate from the server will have separate cancel reasons, like
@@ -2486,7 +2491,7 @@ func (ath *activityTaskHandlerImpl) Execute(taskQueue string, t *workflowservice
 			tagResult, output,
 			tagError, err,
 		)
-		return nil, nil, ctx.Err()
+		return activityTaskResult{}, ctx.Err()
 	}
 	if err != nil && err != ErrActivityResultPending {
 		logFunc := ath.logger.Error // Default to Error
@@ -2530,11 +2535,14 @@ func (ath *activityTaskHandlerImpl) Execute(taskQueue string, t *workflowservice
 		}
 		outboundCtx := extstore.WithStorageTarget(outboundBase, storageTarget)
 		if err := visitProtoPayloads(outboundCtx, ath.outboundPayloadVisitor, msg, ath.payloadVisitorConcurrency); err != nil {
-			return ath.visitorErrorToActivityFailure("Activity task postprocess error: ", t, err), err, nil
+			return activityTaskResult{
+				response:   ath.visitorErrorToActivityFailure("Activity task postprocess error: ", t, err),
+				failureErr: err,
+			}, nil
 		}
 	}
 
-	return response, nil, nil
+	return activityTaskResult{response: response}, nil
 }
 
 func (ath *activityTaskHandlerImpl) visitorErrorToActivityFailure(msgPrefix string, t *workflowservice.PollActivityTaskQueueResponse, err error) *workflowservice.RespondActivityTaskFailedRequest {

--- a/internal/internal_task_handlers_interfaces_test.go
+++ b/internal/internal_task_handlers_interfaces_test.go
@@ -66,7 +66,7 @@ func newSampleActivityTaskHandler() *sampleActivityTaskHandler {
 	return &sampleActivityTaskHandler{}
 }
 
-func (ath sampleActivityTaskHandler) Execute(_ string, task *workflowservice.PollActivityTaskQueueResponse) (any, error) {
+func (ath sampleActivityTaskHandler) Execute(_ string, task *workflowservice.PollActivityTaskQueueResponse) (any, error, error) {
 	activityImplementation := &greeterActivity{}
 	result, err := activityImplementation.Execute(context.Background(), task.Input)
 	fc := GetDefaultFailureConverter()
@@ -75,12 +75,12 @@ func (ath sampleActivityTaskHandler) Execute(_ string, task *workflowservice.Pol
 		return &workflowservice.RespondActivityTaskFailedRequest{
 			TaskToken: task.TaskToken,
 			Failure:   failure,
-		}, nil
+		}, nil, nil
 	}
 	return &workflowservice.RespondActivityTaskCompletedRequest{
 		TaskToken: task.TaskToken,
 		Result:    result,
-	}, nil
+	}, nil, nil
 }
 
 // Test suite.
@@ -131,7 +131,7 @@ func (s *PollLayerInterfacesTestSuite) TestProcessActivityTaskInterface() {
 
 	// Execute activity task and respond to the service.
 	taskHandler := newSampleActivityTaskHandler()
-	request, err := taskHandler.Execute(taskqueue, response)
+	request, _, err := taskHandler.Execute(taskqueue, response)
 	s.NoError(err)
 	switch request := request.(type) {
 	case *workflowservice.RespondActivityTaskCompletedRequest:

--- a/internal/internal_task_handlers_interfaces_test.go
+++ b/internal/internal_task_handlers_interfaces_test.go
@@ -66,21 +66,21 @@ func newSampleActivityTaskHandler() *sampleActivityTaskHandler {
 	return &sampleActivityTaskHandler{}
 }
 
-func (ath sampleActivityTaskHandler) Execute(_ string, task *workflowservice.PollActivityTaskQueueResponse) (any, error, error) {
+func (ath sampleActivityTaskHandler) Execute(_ string, task *workflowservice.PollActivityTaskQueueResponse) (activityTaskResult, error) {
 	activityImplementation := &greeterActivity{}
 	result, err := activityImplementation.Execute(context.Background(), task.Input)
 	fc := GetDefaultFailureConverter()
 	if err != nil {
 		failure := fc.ErrorToFailure(NewApplicationError(err.Error(), getErrType(err), false, nil))
-		return &workflowservice.RespondActivityTaskFailedRequest{
+		return activityTaskResult{response: &workflowservice.RespondActivityTaskFailedRequest{
 			TaskToken: task.TaskToken,
 			Failure:   failure,
-		}, nil, nil
+		}}, nil
 	}
-	return &workflowservice.RespondActivityTaskCompletedRequest{
+	return activityTaskResult{response: &workflowservice.RespondActivityTaskCompletedRequest{
 		TaskToken: task.TaskToken,
 		Result:    result,
-	}, nil, nil
+	}}, nil
 }
 
 // Test suite.
@@ -131,7 +131,8 @@ func (s *PollLayerInterfacesTestSuite) TestProcessActivityTaskInterface() {
 
 	// Execute activity task and respond to the service.
 	taskHandler := newSampleActivityTaskHandler()
-	request, _, err := taskHandler.Execute(taskqueue, response)
+	taskResult, err := taskHandler.Execute(taskqueue, response)
+	request := taskResult.response
 	s.NoError(err)
 	switch request := request.(type) {
 	case *workflowservice.RespondActivityTaskCompletedRequest:

--- a/internal/internal_task_handlers_test.go
+++ b/internal/internal_task_handlers_test.go
@@ -2118,7 +2118,7 @@ func (t *TaskHandlersTestSuite) TestActivityExecutionDeadline() {
 			WorkflowNamespace: "namespace",
 		}
 		td := fmt.Sprintf("testIndex: %v, testDetails: %v", i, d)
-		r, err := activityHandler.Execute(taskqueue, pats)
+		r, _, err := activityHandler.Execute(taskqueue, pats)
 		t.logger.Info(fmt.Sprintf("test: %v, result: %v err: %v", td, r, err))
 		t.Equal(d.err, err, td)
 		if err != nil {
@@ -2177,7 +2177,7 @@ func (t *TaskHandlersTestSuite) TestActivityExecutionWorkerStop() {
 		WorkflowNamespace: "namespace",
 	}
 	close(workerStopCh)
-	r, err := activityHandler.Execute(taskqueue, pats)
+	r, _, err := activityHandler.Execute(taskqueue, pats)
 	t.NoError(err)
 	t.NotNil(r)
 }
@@ -2224,7 +2224,7 @@ func (t *TaskHandlersTestSuite) TestActivityCancellationUsesIsCanceledError() {
 		WorkflowNamespace: wep.Namespace,
 	}
 
-	result, err := activityHandler.Execute(taskqueue, pats)
+	result, _, err := activityHandler.Execute(taskqueue, pats)
 	t.Require().NoError(err)
 
 	canceledReq, ok := result.(*workflowservice.RespondActivityTaskCanceledRequest)

--- a/internal/internal_task_handlers_test.go
+++ b/internal/internal_task_handlers_test.go
@@ -2118,7 +2118,8 @@ func (t *TaskHandlersTestSuite) TestActivityExecutionDeadline() {
 			WorkflowNamespace: "namespace",
 		}
 		td := fmt.Sprintf("testIndex: %v, testDetails: %v", i, d)
-		r, _, err := activityHandler.Execute(taskqueue, pats)
+		res, err := activityHandler.Execute(taskqueue, pats)
+		r := res.response
 		t.logger.Info(fmt.Sprintf("test: %v, result: %v err: %v", td, r, err))
 		t.Equal(d.err, err, td)
 		if err != nil {
@@ -2177,7 +2178,8 @@ func (t *TaskHandlersTestSuite) TestActivityExecutionWorkerStop() {
 		WorkflowNamespace: "namespace",
 	}
 	close(workerStopCh)
-	r, _, err := activityHandler.Execute(taskqueue, pats)
+	res, err := activityHandler.Execute(taskqueue, pats)
+	r := res.response
 	t.NoError(err)
 	t.NotNil(r)
 }
@@ -2224,7 +2226,8 @@ func (t *TaskHandlersTestSuite) TestActivityCancellationUsesIsCanceledError() {
 		WorkflowNamespace: wep.Namespace,
 	}
 
-	result, _, err := activityHandler.Execute(taskqueue, pats)
+	res, err := activityHandler.Execute(taskqueue, pats)
+	result := res.response
 	t.Require().NoError(err)
 
 	canceledReq, ok := result.(*workflowservice.RespondActivityTaskCanceledRequest)

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -1487,7 +1487,7 @@ func (atp *activityTaskPoller) ProcessTask(task any) error {
 	executionStartTime := time.Now()
 
 	// Process the activity task.
-	request, err := atp.taskHandler.Execute(atp.taskQueueName, activityTask.task)
+	request, failureErr, err := atp.taskHandler.Execute(atp.taskQueueName, activityTask.task)
 
 	// err is returned in case of internal failure, such as unable to propagate context or context timeout.
 	if err != nil {
@@ -1500,8 +1500,12 @@ func (atp *activityTaskPoller) ProcessTask(task any) error {
 	// in case if activity execution failed, request should be of type RespondActivityTaskFailedRequest
 	if req, ok := request.(*workflowservice.RespondActivityTaskFailedRequest); ok {
 		if !isBenignProtoApplicationFailure(req.Failure) {
+			failureReason := metrics.FailureReasonActivityError
+			if errors.As(failureErr, new(payloadSizeError)) {
+				failureReason = metrics.FailureReasonPayloadsTooLarge
+			}
 			activityMetricsHandler.
-				WithTags(metrics.ActivityTaskFailedTags(metrics.FailureReasonActivityError)).
+				WithTags(metrics.ActivityTaskFailedTags(failureReason)).
 				Counter(metrics.ActivityExecutionFailedCounter).Inc(1)
 		}
 	}

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -1487,7 +1487,8 @@ func (atp *activityTaskPoller) ProcessTask(task any) error {
 	executionStartTime := time.Now()
 
 	// Process the activity task.
-	request, failureErr, err := atp.taskHandler.Execute(atp.taskQueueName, activityTask.task)
+	result, err := atp.taskHandler.Execute(atp.taskQueueName, activityTask.task)
+	request := result.response
 
 	// err is returned in case of internal failure, such as unable to propagate context or context timeout.
 	if err != nil {
@@ -1501,7 +1502,7 @@ func (atp *activityTaskPoller) ProcessTask(task any) error {
 	if req, ok := request.(*workflowservice.RespondActivityTaskFailedRequest); ok {
 		if !isBenignProtoApplicationFailure(req.Failure) {
 			failureReason := metrics.FailureReasonActivityError
-			if errors.As(failureErr, new(payloadSizeError)) {
+			if errors.As(result.failureErr, new(payloadSizeError)) {
 				failureReason = metrics.FailureReasonPayloadsTooLarge
 			}
 			activityMetricsHandler.

--- a/internal/internal_task_pollers_test.go
+++ b/internal/internal_task_pollers_test.go
@@ -652,9 +652,9 @@ type pendingActivityTaskHandler struct {
 	executed chan struct{}
 }
 
-func (h *pendingActivityTaskHandler) Execute(string, *workflowservice.PollActivityTaskQueueResponse) (any, error) {
+func (h *pendingActivityTaskHandler) Execute(string, *workflowservice.PollActivityTaskQueueResponse) (any, error, error) {
 	close(h.executed)
-	return ErrActivityResultPending, nil
+	return ErrActivityResultPending, nil, nil
 }
 
 func TestDoPollGracefulShutdown(t *testing.T) {

--- a/internal/internal_task_pollers_test.go
+++ b/internal/internal_task_pollers_test.go
@@ -652,9 +652,9 @@ type pendingActivityTaskHandler struct {
 	executed chan struct{}
 }
 
-func (h *pendingActivityTaskHandler) Execute(string, *workflowservice.PollActivityTaskQueueResponse) (any, error, error) {
+func (h *pendingActivityTaskHandler) Execute(string, *workflowservice.PollActivityTaskQueueResponse) (activityTaskResult, error) {
 	close(h.executed)
-	return ErrActivityResultPending, nil, nil
+	return activityTaskResult{response: ErrActivityResultPending}, nil
 }
 
 func TestDoPollGracefulShutdown(t *testing.T) {

--- a/internal/internal_workers_test.go
+++ b/internal/internal_workers_test.go
@@ -35,11 +35,11 @@ func newNoResponseActivityTaskHandler() *noResponseActivityTaskHandler {
 	return &noResponseActivityTaskHandler{isExecuteCalled: make(chan struct{})}
 }
 
-func (ath noResponseActivityTaskHandler) Execute(string, *workflowservice.PollActivityTaskQueueResponse) (any, error) {
+func (ath noResponseActivityTaskHandler) Execute(string, *workflowservice.PollActivityTaskQueueResponse) (any, error, error) {
 	close(ath.isExecuteCalled)
 	c := make(chan struct{})
 	<-c
-	return nil, nil
+	return nil, nil, nil
 }
 
 func (ath noResponseActivityTaskHandler) BlockedOnExecuteCalled() error {

--- a/internal/internal_workers_test.go
+++ b/internal/internal_workers_test.go
@@ -35,11 +35,11 @@ func newNoResponseActivityTaskHandler() *noResponseActivityTaskHandler {
 	return &noResponseActivityTaskHandler{isExecuteCalled: make(chan struct{})}
 }
 
-func (ath noResponseActivityTaskHandler) Execute(string, *workflowservice.PollActivityTaskQueueResponse) (any, error, error) {
+func (ath noResponseActivityTaskHandler) Execute(string, *workflowservice.PollActivityTaskQueueResponse) (activityTaskResult, error) {
 	close(ath.isExecuteCalled)
 	c := make(chan struct{})
 	<-c
-	return nil, nil, nil
+	return activityTaskResult{}, nil
 }
 
 func (ath noResponseActivityTaskHandler) BlockedOnExecuteCalled() error {

--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -849,7 +849,7 @@ func (env *testWorkflowEnvironmentImpl) executeActivity(
 	env.addNewActivityHandle(task, func(result *commonpb.Payloads, err error) {}, env.GetDataConverter(), env.GetFailureConverter())
 	activityID := ActivityID{id: task.ActivityId}
 
-	result, err := taskHandler.Execute(defaultTestTaskQueue, task)
+	result, _, err := taskHandler.Execute(defaultTestTaskQueue, task)
 	if err != nil {
 		if err == context.DeadlineExceeded {
 			env.logger.Debug(fmt.Sprintf("Activity %v timed out", task.ActivityType.Name))
@@ -1754,7 +1754,7 @@ func (env *testWorkflowEnvironmentImpl) executeActivityWithRetryForTest(
 
 	for {
 		var err error
-		result, err = taskHandler.Execute(parameters.TaskQueueName, task)
+		result, _, err = taskHandler.Execute(parameters.TaskQueueName, task)
 		if err != nil {
 			if err == context.DeadlineExceeded {
 				return err

--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -849,7 +849,8 @@ func (env *testWorkflowEnvironmentImpl) executeActivity(
 	env.addNewActivityHandle(task, func(result *commonpb.Payloads, err error) {}, env.GetDataConverter(), env.GetFailureConverter())
 	activityID := ActivityID{id: task.ActivityId}
 
-	result, _, err := taskHandler.Execute(defaultTestTaskQueue, task)
+	taskResult, err := taskHandler.Execute(defaultTestTaskQueue, task)
+	result := taskResult.response
 	if err != nil {
 		if err == context.DeadlineExceeded {
 			env.logger.Debug(fmt.Sprintf("Activity %v timed out", task.ActivityType.Name))
@@ -1754,7 +1755,9 @@ func (env *testWorkflowEnvironmentImpl) executeActivityWithRetryForTest(
 
 	for {
 		var err error
-		result, _, err = taskHandler.Execute(parameters.TaskQueueName, task)
+		var taskResult activityTaskResult
+		taskResult, err = taskHandler.Execute(parameters.TaskQueueName, task)
+		result = taskResult.response
 		if err != nil {
 			if err == context.DeadlineExceeded {
 				return err

--- a/test/payload_limits_test.go
+++ b/test/payload_limits_test.go
@@ -17,6 +17,7 @@ import (
 	workflowservice "go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/sdk/activity"
 	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/internal/common/metrics"
 	ilog "go.temporal.io/sdk/internal/log"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/testsuite"
@@ -387,8 +388,10 @@ func (ts *PayloadLimitsTestSuite) TestPayloadSizeErrorActivityResult() {
 	defer cancel()
 
 	logger := ilog.NewMemoryLogger()
+	metricsHandler := metrics.NewCapturingHandler()
 	ts.ResetClientAndWorker(func(opts *client.Options) {
 		opts.Logger = logger
+		opts.MetricsHandler = metricsHandler
 	}, nil)
 
 	wfName := "payload-size-error-activity-result"
@@ -446,6 +449,16 @@ func (ts *PayloadLimitsTestSuite) TestPayloadSizeErrorActivityResult() {
 
 	// Verify failure is logged
 	ts.assertLogContains(logger, payloadErrorMessage)
+
+	// The worker turns the oversized result into an activity task failure, so it must be counted
+	// under its own reason rather than the generic activity one.
+	var reasons []string
+	for _, counter := range metricsHandler.Counters() {
+		if counter.Name == metrics.ActivityExecutionFailedCounter {
+			reasons = append(reasons, counter.Tags[metrics.FailureReasonTagName])
+		}
+	}
+	ts.Contains(reasons, metrics.FailureReasonPayloadsTooLarge)
 }
 
 func (ts *PayloadLimitsTestSuite) TestPayloadSizeErrorDisabledWorkflowResult() {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

- Plumb activity failure causing errors from the activity task handler to the activity task poller.
- Associate `PayloadsTooLarge` failure reason with `payloadSizeError` error type.

## Why?

Better observability of failure reason for payload size errors.

## Checklist
<!--- add/delete as needed --->

1. How was this tested: Updated integration test.

3. Any docs updates needed? Yes
