### PR TITLE
Stabilize waitServerReady timeout test

### DIFF
--- a/testsuite/devserver_internal_test.go
+++ b/testsuite/devserver_internal_test.go
@@ -33,7 +33,7 @@ func TestWaitServerReady_respectsTimeout(t *testing.T) {
 		// Even though the timeout is only a millisecond,
 		// we'll allow for a slack of up to 10 milliseconds
 		// to account for slow CI machines.
-		// Keep this below the retry interval so an extra retry fails.
+		// Anything smaller than 1 second is fine to use here.
 		// Increase only if CI scheduler jitter exceeds this allowance.
 	)
 }

--- a/testsuite/devserver_internal_test.go
+++ b/testsuite/devserver_internal_test.go
@@ -29,10 +29,25 @@ func TestWaitServerReady_respectsTimeout(t *testing.T) {
 	assert.WithinDuration(t,
 		startTime.Add(time.Millisecond),
 		time.Now(),
-		5*time.Millisecond,
+		10*time.Millisecond,
 		// Even though the timeout is only a millisecond,
-		// we'll allow for a slack of up to 5 milliseconds
+		// we'll allow for a slack of up to 10 milliseconds
 		// to account for slow CI machines.
-		// Anything smaller than 1 second is fine to use here.
+		// Keep this below the retry interval so an extra retry fails.
+		// Increase only if CI scheduler jitter exceeds this allowance.
 	)
+}
+
+func TestRetryFor_respectsCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	attempts := 0
+	err := retryFor(ctx, 2, 100*time.Millisecond, func() error {
+		attempts++
+		return assert.AnError
+	})
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, attempts)
 }


### PR DESCRIPTION
## What was changed

- Increase the timeout assertion allowance from 5 ms to 10 ms.
- Verify context cancellation stops retries after one attempt.

## Why?

Allow observed CI scheduler jitter without weakening the assertion to one
second. The attempt assertion preserves cancellation coverage without relying
on wall-clock precision.

## Checklist

1. Supersedes #2611.

2. How was this tested:

   `go test -race -count=100 -run 'Test(WaitServerReady_respectsTimeout|RetryFor_respectsCancellation)' ./testsuite`

3. Any docs updates needed?

   No.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no production code paths affected.
> 
> **Overview**
> Relaxes the **`TestWaitServerReady_respectsTimeout`** timing slack from **5 ms to 10 ms** so the 1 ms deadline assertion is less flaky on slow or jittery CI, with comments noting when to widen it further.
> 
> Adds **`TestRetryFor_respectsCancellation`**, which cancels the context up front and asserts **`retryFor`** returns **`context.Canceled`** after a **single** callback attempt instead of sleeping through further retries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 325244be0c587cfc463ebde247fa15755fe2c978. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->