### PR TITLE
Restore tests skipped for flakiness

### DIFF
--- a/internal/internal_task_handlers_test.go
+++ b/internal/internal_task_handlers_test.go
@@ -978,12 +978,10 @@ func (t *TaskHandlersTestSuite) TestWithTruncatedHistory() {
 }
 
 func (t *TaskHandlersTestSuite) TestSideEffectDefer() {
-	t.T().Skip("issue-1650: SideEffectDefer test is flaky")
 	t.testSideEffectDeferHelper(1)
 }
 
 func (t *TaskHandlersTestSuite) TestSideEffectDefer_NoCache() {
-	t.T().Skip("issue-1650: SideEffectDefer test is flaky")
 	t.testSideEffectDeferHelper(0)
 }
 
@@ -1957,48 +1955,47 @@ func (t *TaskHandlersTestSuite) TestLocalActivityRetry_WorkflowTaskHeartbeatFail
 	<-doneCh
 }
 
-func (t *TaskHandlersTestSuite) TestHeartBeat_NoError() {
-	t.T().Skip("issue-1650: TestHeartBeat_NoError is flaky")
-	mockCtrl := gomock.NewController(t.T())
-	mockService := workflowservicemock.NewMockWorkflowServiceClient(mockCtrl)
-	invocationChannel := make(chan int, 2)
-	heartbeatResponse := workflowservice.RecordActivityTaskHeartbeatResponse{CancelRequested: false}
-	mockService.EXPECT().
-		RecordActivityTaskHeartbeat(gomock.Any(), gomock.Any(), gomock.Any()).
-		Do(func(_ any, _ any, _ ...any) { invocationChannel <- 1 }).
-		Return(&heartbeatResponse, nil).
-		Times(2)
+func TestHeartBeat_NoError(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		const heartbeatThrottleInterval = time.Second
 
-	temporalInvoker := &temporalInvoker{
-		identity:                  "Test_Temporal_Invoker",
-		service:                   mockService,
-		taskToken:                 nil,
-		heartbeatThrottleInterval: time.Second,
-	}
+		mockCtrl := gomock.NewController(t)
+		mockService := workflowservicemock.NewMockWorkflowServiceClient(mockCtrl)
+		invocationChannel := make(chan int, 2)
+		heartbeatResponse := workflowservice.RecordActivityTaskHeartbeatResponse{CancelRequested: false}
+		mockService.EXPECT().
+			RecordActivityTaskHeartbeat(gomock.Any(), gomock.Any(), gomock.Any()).
+			Do(func(_ any, _ any, _ ...any) { invocationChannel <- 1 }).
+			Return(&heartbeatResponse, nil).
+			Times(2)
 
-	heartbeatErr := temporalInvoker.Heartbeat(context.Background(), nil, false)
-	t.NoError(heartbeatErr)
+		temporalInvoker := newServiceInvoker(
+			nil, "Test_Temporal_Invoker", mockService, metrics.NopHandler, func(error) {}, heartbeatThrottleInterval,
+			make(chan struct{}), testNamespace, &atomic.Bool{}, nil, nil,
+		)
+		defer temporalInvoker.Close(t.Context(), false)
 
-	select {
-	case <-invocationChannel:
-	case <-time.After(3 * time.Second):
-		t.Fail("did not get expected 1st call to record heartbeat")
-	}
+		firstHeartbeatTime := time.Now()
+		heartbeatErr := temporalInvoker.Heartbeat(t.Context(), nil, false)
+		require.NoError(t, heartbeatErr)
+		<-invocationChannel
+		require.Zero(t, time.Since(firstHeartbeatTime))
 
-	heartbeatErr = temporalInvoker.Heartbeat(context.Background(), nil, false)
-	t.NoError(heartbeatErr)
+		secondHeartbeatTime := time.Now()
+		heartbeatErr = temporalInvoker.Heartbeat(t.Context(), nil, false)
+		require.NoError(t, heartbeatErr)
+		synctest.Wait()
 
-	select {
-	case <-invocationChannel:
-		t.Fail("got unexpected call to record heartbeat. 2nd call should come via batch timer")
-	default:
-	}
+		select {
+		case <-invocationChannel:
+			t.Fatal("second heartbeat was not batched")
+		default:
+		}
 
-	select {
-	case <-invocationChannel:
-	case <-time.After(3 * time.Second):
-		t.Fail("did not get expected 2nd call to record heartbeat via batch timer")
-	}
+		<-invocationChannel
+		require.Equal(t, heartbeatThrottleInterval, time.Since(secondHeartbeatTime))
+		synctest.Wait()
+	})
 }
 
 func (t *TaskHandlersTestSuite) TestHeartBeat_NilResponseWithError() {

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -3454,17 +3454,14 @@ func (ts *IntegrationTestSuite) TestStandaloneActivityStartLinks() {
 }
 
 func (ts *IntegrationTestSuite) TestOpenTelemetryTracing() {
-	ts.T().Skip("issue-1650: Otel Tracing intergation tests are flaky")
 	ts.testOpenTelemetryTracing(true, false)
 }
 
 func (ts *IntegrationTestSuite) TestOpenTelemetryTracingWithUpdateWithStart() {
-	ts.T().Skip("issue-1650: Otel Tracing intergation tests are flaky")
 	ts.testOpenTelemetryTracing(true, true)
 }
 
 func (ts *IntegrationTestSuite) TestOpenTelemetryTracingWithoutMessages() {
-	ts.T().Skip("issue-1650: Otel Tracing intergation tests are flaky")
 	ts.testOpenTelemetryTracing(false, false)
 }
 

--- a/test/nexus_test.go
+++ b/test/nexus_test.go
@@ -3439,7 +3439,6 @@ func (t *otelTracer) spanChildren(spans []sdktrace.ReadOnlySpan, parentID trace.
 }
 
 func TestNexusTracingInterceptor(t *testing.T) {
-	t.Skip("this test is flaky in CI and needs to be restructured")
 	cases := []struct {
 		name   string
 		tracer func(t *testing.T) interceptortest.TestTracer
@@ -3514,11 +3513,8 @@ func TestNexusTracingInterceptor(t *testing.T) {
 						interceptortest.Span("StartNexusOperation:test/workflow-op",
 							interceptortest.Span("RunStartNexusOperationHandler:test/workflow-op",
 								interceptortest.Span("StartWorkflow:waitForCancelWorkflow",
-									interceptortest.Span("RunWorkflow:waitForCancelWorkflow")))))),
-				// Note that the span is not attached since the server as of 1.27 does not propagate headers to the cancel
-				// request.  This assertion will have to change once the server fixes this behavior. It's left here as a
-				// reminder.
-				interceptortest.Span("RunCancelNexusOperationHandler:test/workflow-op"),
+									interceptortest.Span("RunWorkflow:waitForCancelWorkflow"))),
+							interceptortest.Span("RunCancelNexusOperationHandler:test/workflow-op")))),
 			}, tracer.FinishedSpans())
 		})
 	}

--- a/test/nexus_test.go
+++ b/test/nexus_test.go
@@ -3407,14 +3407,61 @@ type opentracingTracer struct {
 	mock *mocktracer.MockTracer
 }
 
+const (
+	traceWorkflowIDTag = "temporalWorkflowID"
+	traceRunIDTag      = "temporalRunID"
+)
+
+type replaySpanKey struct {
+	name       string
+	workflowID string
+	runID      string
+}
+
 func (t *opentracingTracer) FinishedSpans() []*interceptortest.SpanInfo {
 	return t.spanChildren(t.mock.FinishedSpans(), 0)
 }
 
+func newReplaySpanKey(name, workflowID, runID string) *replaySpanKey {
+	if !strings.HasPrefix(name, "RunWorkflow:") || workflowID == "" || runID == "" {
+		return nil
+	}
+
+	return &replaySpanKey{name: name, workflowID: workflowID, runID: runID}
+}
+
+func appendReplaySpan(
+	spans []*interceptortest.SpanInfo,
+	span *interceptortest.SpanInfo,
+	key *replaySpanKey,
+	replays map[replaySpanKey]*interceptortest.SpanInfo,
+) []*interceptortest.SpanInfo {
+	if key == nil {
+		return append(spans, span)
+	}
+
+	// Replay emits another RunWorkflow span for the same execution.
+	if existing := replays[*key]; existing != nil {
+		existing.Children = append(existing.Children, span.Children...)
+		return spans
+	}
+
+	replays[*key] = span
+	return append(spans, span)
+}
+
 func (t *opentracingTracer) spanChildren(spans []*mocktracer.MockSpan, parentID int) (ret []*interceptortest.SpanInfo) {
+	replays := make(map[replaySpanKey]*interceptortest.SpanInfo)
 	for _, s := range spans {
 		if s.ParentID == parentID {
-			ret = append(ret, interceptortest.Span(s.OperationName, t.spanChildren(spans, s.SpanContext.SpanID)...))
+			workflowID, _ := s.Tag(traceWorkflowIDTag).(string)
+			runID, _ := s.Tag(traceRunIDTag).(string)
+			ret = appendReplaySpan(
+				ret,
+				interceptortest.Span(s.OperationName, t.spanChildren(spans, s.SpanContext.SpanID)...),
+				newReplaySpanKey(s.OperationName, workflowID, runID),
+				replays,
+			)
 		}
 	}
 	return
@@ -3430,9 +3477,24 @@ func (t *otelTracer) FinishedSpans() []*interceptortest.SpanInfo {
 }
 
 func (t *otelTracer) spanChildren(spans []sdktrace.ReadOnlySpan, parentID trace.SpanID) (ret []*interceptortest.SpanInfo) {
+	replays := make(map[replaySpanKey]*interceptortest.SpanInfo)
 	for _, s := range spans {
 		if s.Parent().SpanID() == parentID {
-			ret = append(ret, interceptortest.Span(s.Name(), t.spanChildren(spans, s.SpanContext().SpanID())...))
+			var workflowID, runID string
+			for _, attr := range s.Attributes() {
+				switch string(attr.Key) {
+				case traceWorkflowIDTag:
+					workflowID = attr.Value.AsString()
+				case traceRunIDTag:
+					runID = attr.Value.AsString()
+				}
+			}
+			ret = appendReplaySpan(
+				ret,
+				interceptortest.Span(s.Name(), t.spanChildren(spans, s.SpanContext().SpanID())...),
+				newReplaySpanKey(s.Name(), workflowID, runID),
+				replays,
+			)
 		}
 	}
 	return

--- a/test/worker_deployment_test.go
+++ b/test/worker_deployment_test.go
@@ -104,8 +104,23 @@ func sameTaskQueues(a, b []client.WorkerDeploymentTaskQueueInfo) bool {
 	return true
 }
 
+func taskQueuesReady(queues []client.WorkerDeploymentTaskQueueInfo, name string) bool {
+	expected := []client.WorkerDeploymentTaskQueueInfo{
+		{Name: name, Type: client.TaskQueueTypeWorkflow},
+		{Name: name, Type: client.TaskQueueTypeActivity},
+	}
+
+	return sameTaskQueues(queues, expected)
+}
+
 func TestSameTaskQueuesRequiresQueues(t *testing.T) {
 	require.False(t, sameTaskQueues(nil, nil))
+}
+
+func TestTaskQueuesReadyRequiresBothTypes(t *testing.T) {
+	require.False(t, taskQueuesReady([]client.WorkerDeploymentTaskQueueInfo{
+		{Name: "task-queue", Type: client.TaskQueueTypeWorkflow},
+	}, "task-queue"))
 }
 
 func (ts *WorkerDeploymentTestSuite) waitForWorkerDeploymentRoutingConfigPropagation(
@@ -253,6 +268,18 @@ func (ts *WorkerDeploymentTestSuite) TestBuildIDChangesOverWorkflowLifetime() {
 		ts.NoError(res.Get(&didRun))
 		return didRun
 	}, time.Second*10, time.Millisecond*100)
+
+	ts.Eventually(func() bool {
+		v1Description, err := dHandle.DescribeVersion(ctx, client.WorkerDeploymentDescribeVersionOptions{
+			BuildID: v1.BuildID,
+		})
+		if err != nil {
+			return false
+		}
+
+		return taskQueuesReady(v1Description.Info.TaskQueuesInfos, ts.taskQueueName)
+	}, 5*time.Second, 100*time.Millisecond)
+
 	worker1.Stop()
 
 	worker2 := worker.New(ts.client, ts.taskQueueName, worker.Options{
@@ -272,24 +299,10 @@ func (ts *WorkerDeploymentTestSuite) TestBuildIDChangesOverWorkflowLifetime() {
 
 	ts.waitForWorkerDeploymentVersion(ctx, dHandle, v2)
 	ts.Eventually(func() bool {
-		v1Description, err := dHandle.DescribeVersion(ctx, client.WorkerDeploymentDescribeVersionOptions{
-			BuildID: v1.BuildID,
-		})
-		if err != nil {
-			return false
-		}
-
 		v2Description, err := dHandle.DescribeVersion(ctx, client.WorkerDeploymentDescribeVersionOptions{
 			BuildID: v2.BuildID,
 		})
-		if err != nil {
-			return false
-		}
-
-		return sameTaskQueues(
-			v1Description.Info.TaskQueuesInfos,
-			v2Description.Info.TaskQueuesInfos,
-		)
+		return err == nil && taskQueuesReady(v2Description.Info.TaskQueuesInfos, ts.taskQueueName)
 	}, 5*time.Second, 100*time.Millisecond)
 
 	_, err = dHandle.SetCurrentVersion(ctx, client.WorkerDeploymentSetCurrentVersionOptions{

--- a/test/worker_deployment_test.go
+++ b/test/worker_deployment_test.go
@@ -87,6 +87,23 @@ func (ts *WorkerDeploymentTestSuite) waitForWorkerDeploymentVersion(
 	}, 5*time.Second, 100*time.Millisecond)
 }
 
+func sameTaskQueues(a, b []client.WorkerDeploymentTaskQueueInfo) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	queues := make(map[client.WorkerDeploymentTaskQueueInfo]struct{}, len(a))
+	for _, queue := range a {
+		queues[queue] = struct{}{}
+	}
+	for _, queue := range b {
+		if _, ok := queues[queue]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
 func (ts *WorkerDeploymentTestSuite) waitForWorkerDeploymentRoutingConfigPropagation(
 	ctx context.Context,
 	deploymentName string,
@@ -165,7 +182,6 @@ func (ts *WorkerDeploymentTestSuite) runWorkflowAndCheckV1(ctx context.Context, 
 }
 
 func (ts *WorkerDeploymentTestSuite) TestBuildIDChangesOverWorkflowLifetime() {
-	ts.T().Skip("issue-1650: Build ID integration tests are flaky")
 	if os.Getenv("DISABLE_SERVER_1_27_TESTS") != "" {
 		ts.T().Skip("temporal server 1.27+ required")
 	}
@@ -233,6 +249,10 @@ func (ts *WorkerDeploymentTestSuite) TestBuildIDChangesOverWorkflowLifetime() {
 		ts.NoError(res.Get(&didRun))
 		return didRun
 	}, time.Second*10, time.Millisecond*100)
+	v1Description, err := dHandle.DescribeVersion(ctx, client.WorkerDeploymentDescribeVersionOptions{
+		BuildID: v1.BuildID,
+	})
+	ts.NoError(err)
 	worker1.Stop()
 
 	worker2 := worker.New(ts.client, ts.taskQueueName, worker.Options{
@@ -251,6 +271,15 @@ func (ts *WorkerDeploymentTestSuite) TestBuildIDChangesOverWorkflowLifetime() {
 	defer worker2.Stop()
 
 	ts.waitForWorkerDeploymentVersion(ctx, dHandle, v2)
+	ts.Eventually(func() bool {
+		v2Description, err := dHandle.DescribeVersion(ctx, client.WorkerDeploymentDescribeVersionOptions{
+			BuildID: v2.BuildID,
+		})
+		return err == nil && sameTaskQueues(
+			v1Description.Info.TaskQueuesInfos,
+			v2Description.Info.TaskQueuesInfos,
+		)
+	}, 5*time.Second, 100*time.Millisecond)
 
 	_, err = dHandle.SetCurrentVersion(ctx, client.WorkerDeploymentSetCurrentVersionOptions{
 		BuildID:       v2.BuildID,

--- a/test/worker_deployment_test.go
+++ b/test/worker_deployment_test.go
@@ -88,7 +88,7 @@ func (ts *WorkerDeploymentTestSuite) waitForWorkerDeploymentVersion(
 }
 
 func sameTaskQueues(a, b []client.WorkerDeploymentTaskQueueInfo) bool {
-	if len(a) != len(b) {
+	if len(a) == 0 || len(a) != len(b) {
 		return false
 	}
 
@@ -102,6 +102,10 @@ func sameTaskQueues(a, b []client.WorkerDeploymentTaskQueueInfo) bool {
 		}
 	}
 	return true
+}
+
+func TestSameTaskQueuesRequiresQueues(t *testing.T) {
+	require.False(t, sameTaskQueues(nil, nil))
 }
 
 func (ts *WorkerDeploymentTestSuite) waitForWorkerDeploymentRoutingConfigPropagation(
@@ -249,10 +253,6 @@ func (ts *WorkerDeploymentTestSuite) TestBuildIDChangesOverWorkflowLifetime() {
 		ts.NoError(res.Get(&didRun))
 		return didRun
 	}, time.Second*10, time.Millisecond*100)
-	v1Description, err := dHandle.DescribeVersion(ctx, client.WorkerDeploymentDescribeVersionOptions{
-		BuildID: v1.BuildID,
-	})
-	ts.NoError(err)
 	worker1.Stop()
 
 	worker2 := worker.New(ts.client, ts.taskQueueName, worker.Options{
@@ -272,10 +272,21 @@ func (ts *WorkerDeploymentTestSuite) TestBuildIDChangesOverWorkflowLifetime() {
 
 	ts.waitForWorkerDeploymentVersion(ctx, dHandle, v2)
 	ts.Eventually(func() bool {
+		v1Description, err := dHandle.DescribeVersion(ctx, client.WorkerDeploymentDescribeVersionOptions{
+			BuildID: v1.BuildID,
+		})
+		if err != nil {
+			return false
+		}
+
 		v2Description, err := dHandle.DescribeVersion(ctx, client.WorkerDeploymentDescribeVersionOptions{
 			BuildID: v2.BuildID,
 		})
-		return err == nil && sameTaskQueues(
+		if err != nil {
+			return false
+		}
+
+		return sameTaskQueues(
 			v1Description.Info.TaskQueuesInfos,
 			v2Description.Info.TaskQueuesInfos,
 		)

--- a/test/worker_deployment_test.go
+++ b/test/worker_deployment_test.go
@@ -205,7 +205,7 @@ func (ts *WorkerDeploymentTestSuite) TestBuildIDChangesOverWorkflowLifetime() {
 		ts.T().Skip("temporal server 1.27+ required")
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
 	deploymentName := "deploy-test-" + uuid.NewString()


### PR DESCRIPTION
## What was changed
  - `TestHeartBeat_NoError`: Preserve heartbeat batching checks using deterministic virtual time with `synctest`.
  - `TestBuildIDChangesOverWorkflowLifetime`: Wait for deployment task queues before promoting a version.
  - `TestNexusTracingInterceptor`: Update cancellation tracing for [server header propagation](https://github.com/temporalio/temporal/pull/8335) and merge only replayed `RunWorkflow` spans with matching identities.

The tests were re-enabled, their original flakes are no longer available, will monitor CI:
  - `TestSideEffectDefer`
  - `TestSideEffectDefer_NoCache`
  - `TestOpenTelemetryTracing`
  - `TestOpenTelemetryTracingWithUpdateWithStart`
  - `TestOpenTelemetryTracingWithoutMessages`

## Why?
Tests were "temporary" skipped, but forgot to unskip and fix

## Checklist
<!--- add/delete as needed --->

1. Closes #1650

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to test code and expectations; production behavior is unchanged.
> 
> **Overview**
> Re-enables several tests that were skipped under issue #1650 and adjusts the ones that needed deterministic or stricter synchronization.
> 
> **Heartbeat batching** — `TestHeartBeat_NoError` is now a standalone test wrapped in `synctest` so the first heartbeat is immediate, the second is batched until the throttle interval elapses, without wall-clock sleeps.
> 
> **Worker deployment build ID** — `TestBuildIDChangesOverWorkflowLifetime` waits until each deployment version reports both workflow and activity task queues before stopping workers or promoting versions; helpers `taskQueuesReady` / `sameTaskQueues` back that check.
> 
> **Nexus tracing** — Test harness merges duplicate replay `RunWorkflow` spans by workflow/run ID, and expected traces now nest `RunCancelNexusOperationHandler` under the Nexus operation span to match server header propagation.
> 
> **Re-enabled without structural changes** (CI will be watched): side-effect defer tests, OpenTelemetry integration tracing variants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7241d362bd6ce56b919b10eb4c7131c225ff28fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->