### PR TITLE
Cache all Go module dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: stable
+          cache-dependency-path: '**/go.sum'
 
       - name: Check
         run: go run . check
@@ -62,6 +63,7 @@ jobs:
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: ${{ matrix.go-version }}
+          cache-dependency-path: '**/go.sum'
 
       - name: Unit test
         run: go run . unit-test
@@ -112,6 +114,7 @@ jobs:
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: ${{ matrix.go-version }}
+          cache-dependency-path: '**/go.sum'
 
       - name: Integration tests (without cache)
         run: go run . integration-test -dev-server
@@ -163,6 +166,7 @@ jobs:
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: ${{ matrix.go-version }}
+          cache-dependency-path: '**/go.sum'
 
       - name: Integration tests (with cache)
         run: go run . integration-test -dev-server
@@ -203,6 +207,7 @@ jobs:
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: stable
+          cache-dependency-path: '**/go.sum'
 
       - name: Docker compose - checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -280,6 +285,7 @@ jobs:
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: ${{ matrix.go-version }}
+          cache-dependency-path: '**/go.sum'
       - name: Selected integration tests against cloud
         # Keep this list intentionally small. Add cloud-safe tests here when
         # they cover behavior that cannot be validated against the local dev server.

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -13,4 +13,5 @@ jobs:
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version-file: go.mod
+          cache-dependency-path: '**/go.sum'
       - uses: temporalio/public-actions/golang/govulncheck@main


### PR DESCRIPTION
## What was changed

Configure `setup-go` to hash every module's `go.sum` in CI and govulncheck.

## Why?

The default key only covers the root `go.mod`. Dependency changes in nested
modules did not invalidate the cache.

## Checklist

1. Closes: N/A

2. How was this tested: Parsed both workflow files, confirmed all seven
   `setup-go` steps use the glob, and ran `git diff --check`.

3. Any docs updates needed? No.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow configuration with no runtime or application code changes.
> 
> **Overview**
> Adds **`cache-dependency-path: '**/go.sum'`** to every **`actions/setup-go`** step in **`ci.yml`** (check, unit/integration/docker/cloud jobs) and **`govulncheck.yml`**.
> 
> That changes how the Go module cache is keyed: dependency updates in **nested modules** (not only the root **`go.mod`**) now invalidate or refresh the cache, avoiding stale module downloads in CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef4f5c6b3c1c28bad6df9429069aae1133fc1acf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->