### PR TITLE
Group unit tests by module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,7 @@ jobs:
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: ${{ matrix.go-version }}
+          cache-dependency-path: '**/go.sum'
 
       - name: Unit test
         run: go run . unit-test

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ If you omit `-dev-server`, integration tests connect to a server already running
 By default, the internal build tool only reports test failures. Full test output is written to `.build/test-logs` at 
 the repository root.
 
-To stream full test and dev-server output to the console while still saving the log files, use `-console-output full`:
+To show full test and dev-server output in the console while still saving the log files, use `-console-output full`:
 
 ```bash
 go run . unit-test -console-output full

--- a/internal/cmd/build/main.go
+++ b/internal/cmd/build/main.go
@@ -38,6 +38,7 @@ func main() {
 
 const coverageDir = ".build/coverage"
 const defaultTestLogDir = ".build/test-logs"
+const integrationTestModuleDir = "test"
 const unitTestPackageConcurrency = "1"
 const unitTestWorkers = 2
 
@@ -216,6 +217,23 @@ func findModuleDirs(root fs.FS) ([]string, error) {
 	}
 	sort.Strings(moduleDirs)
 	return moduleDirs, nil
+}
+
+func findUnitModuleDirs(root fs.FS) ([]string, error) {
+	moduleDirs, err := findModuleDirs(root)
+	if err != nil {
+		return nil, err
+	}
+
+	// Integration tests have their own command and server setup.
+	unitModuleDirs := make([]string, 0, len(moduleDirs))
+	for _, moduleDir := range moduleDirs {
+		if moduleDir == integrationTestModuleDir || strings.HasPrefix(moduleDir, integrationTestModuleDir+"/") {
+			continue
+		}
+		unitModuleDirs = append(unitModuleDirs, moduleDir)
+	}
+	return unitModuleDirs, nil
 }
 
 func (b *builder) integrationTest() error {
@@ -453,9 +471,13 @@ func (b *builder) unitTest() error {
 	}
 	testOutput.rerunCommand = "go run . unit-test"
 
-	moduleDirs, err := b.checkModuleDirs()
+	moduleNames, err := findUnitModuleDirs(os.DirFS(b.rootDir))
 	if err != nil {
 		return fmt.Errorf("failed finding modules to test: %w", err)
+	}
+	moduleDirs := make([]string, 0, len(moduleNames))
+	for _, moduleName := range moduleNames {
+		moduleDirs = append(moduleDirs, filepath.Join(b.rootDir, filepath.FromSlash(moduleName)))
 	}
 
 	// Create coverage dir if doing coverage

--- a/internal/cmd/build/main.go
+++ b/internal/cmd/build/main.go
@@ -16,6 +16,7 @@ import (
 	"runtime"
 	"sort"
 	"strings"
+	"sync"
 
 	_ "github.com/Antonboom/testifylint/analyzer"
 	_ "github.com/BurntSushi/toml"
@@ -37,6 +38,17 @@ func main() {
 
 const coverageDir = ".build/coverage"
 const defaultTestLogDir = ".build/test-logs"
+const unitTestPackageConcurrency = "1"
+const unitTestWorkers = 2
+
+type unitCoverage int
+
+const (
+	unitCoverageDisabled unitCoverage = iota
+	unitCoverageEnabled
+)
+
+var testFailureReportMu sync.Mutex
 
 const (
 	testConsoleOutputFull     = "full"
@@ -441,23 +453,10 @@ func (b *builder) unitTest() error {
 	}
 	testOutput.rerunCommand = "go run . unit-test"
 
-	// Find every non ./test-prefixed package that has a test file
-	testDirMap := map[string]struct{}{}
-	var testDirs []string
-	err = fs.WalkDir(os.DirFS(b.rootDir), ".", func(p string, d fs.DirEntry, err error) error {
-		if (!strings.HasPrefix(p, "test") || strings.HasPrefix(p, "testsuite")) && strings.HasSuffix(p, "_test.go") {
-			dir := path.Dir(p)
-			if _, ok := testDirMap[dir]; !ok {
-				testDirMap[dir] = struct{}{}
-				testDirs = append(testDirs, dir)
-			}
-		}
-		return nil
-	})
+	moduleDirs, err := b.checkModuleDirs()
 	if err != nil {
-		return fmt.Errorf("failed walking test dirs: %w", err)
+		return fmt.Errorf("failed finding modules to test: %w", err)
 	}
-	sort.Strings(testDirs)
 
 	// Create coverage dir if doing coverage
 	if *coverageFlag {
@@ -466,30 +465,166 @@ func (b *builder) unitTest() error {
 		}
 	}
 
-	// Run unit test for each dir
-	log.Printf("Running unit tests in dirs: %v", testDirs)
-	for _, testDir := range testDirs {
-		// Run unit test
-		args := []string{"go", "test", "-json", "-count", "1", "-race", "-v", "-timeout", "5m"}
-		if *runFlag != "" {
-			args = append(args, "-run", *runFlag)
+	// Run modules concurrently while keeping package output sequential.
+	log.Printf("Running unit tests in modules with %d workers: %v", unitTestWorkers, moduleDirs)
+	coverage := unitCoverageDisabled
+	if *coverageFlag {
+		coverage = unitCoverageEnabled
+	}
+	return b.runUnitModules(moduleDirs, *runFlag, coverage, testOutput)
+}
+
+type unitWorker struct {
+	output   testOutput
+	stdout   bytes.Buffer
+	stderr   bytes.Buffer
+	failures []unitFailure
+}
+
+type unitFailure struct {
+	moduleDir string
+	err       error
+}
+
+func (b *builder) runUnitModules(
+	moduleDirs []string,
+	run string,
+	coverage unitCoverage,
+	output testOutput,
+) error {
+	tempDir, err := os.MkdirTemp(filepath.Dir(output.logPath), ".unit-test-")
+	if err != nil {
+		return fmt.Errorf("failed creating unit test log directory: %w", err)
+	}
+	defer func() {
+		if err := os.RemoveAll(tempDir); err != nil {
+			log.Printf("Failed removing temporary unit test logs: %v", err)
 		}
-		if *coverageFlag {
-			args = append(
-				args,
-				"-coverprofile="+filepath.Join(b.rootDir, coverageDir, "unit-test-"+strings.ReplaceAll(testDir, "/", "-")+".out"),
-				"-coverpkg=./...",
-			)
-		}
-		args = append(args, ".")
-		cmd := b.cmdFromRoot(args...)
-		// Need to run inside directory
-		cmd.Dir = filepath.Join(b.rootDir, testDir)
-		if err := b.runTestCmd(cmd, testOutput); err != nil {
-			return fmt.Errorf("unit test failed in %v: %w", testDir, err)
+	}()
+
+	workers := make([]unitWorker, unitTestWorkers)
+	for i := range workers {
+		if err := b.prepareUnitWorker(tempDir, i, output, &workers[i]); err != nil {
+			return err
 		}
 	}
 
+	jobs := make(chan string)
+	var wait sync.WaitGroup
+	for i := range workers {
+		wait.Add(1)
+		go func(worker *unitWorker) {
+			defer wait.Done()
+			for moduleDir := range jobs {
+				if err := b.runUnitModule(moduleDir, run, coverage, worker.output); err != nil {
+					worker.failures = append(worker.failures, unitFailure{moduleDir: moduleDir, err: err})
+				}
+			}
+		}(&workers[i])
+	}
+	for _, moduleDir := range moduleDirs {
+		jobs <- moduleDir
+	}
+	close(jobs)
+	wait.Wait()
+
+	for i := range workers {
+		if err := mergeWorkerOutput(output, &workers[i]); err != nil {
+			return err
+		}
+	}
+	for i := range workers {
+		if len(workers[i].failures) > 0 {
+			failure := workers[i].failures[0]
+			return fmt.Errorf("unit test failed in %v: %w", failure.moduleDir, failure.err)
+		}
+	}
+	return nil
+}
+
+func (b *builder) prepareUnitWorker(tempDir string, index int, output testOutput, worker *unitWorker) error {
+	prefix := filepath.Join(tempDir, fmt.Sprintf("%03d", index))
+	workerOutput := output
+	workerOutput.logPath = prefix + ".log"
+	workerOutput.jsonLogPath = prefix + ".json"
+	for _, path := range []string{workerOutput.logPath, workerOutput.jsonLogPath} {
+		file, err := os.Create(path)
+		if err != nil {
+			return fmt.Errorf("failed preparing worker output %q: %w", path, err)
+		}
+		if err := file.Close(); err != nil {
+			return fmt.Errorf("failed closing worker output %q: %w", path, err)
+		}
+	}
+	workerOutput.stdout = &worker.stdout
+	workerOutput.stderr = &worker.stderr
+	worker.output = workerOutput
+	return nil
+}
+
+func (b *builder) runUnitModule(moduleDir string, run string, coverage unitCoverage, output testOutput) error {
+	args := []string{
+		"go", "test", "-json", "-count", "1", "-race", "-v", "-timeout", "5m",
+		"-p", unitTestPackageConcurrency,
+	}
+	if run != "" {
+		args = append(args, "-run", run)
+	}
+	if coverage == unitCoverageEnabled {
+		moduleName, err := filepath.Rel(b.rootDir, moduleDir)
+		if err != nil {
+			return fmt.Errorf("failed resolving module %q: %w", moduleDir, err)
+		}
+		if moduleName == "." {
+			moduleName = "root"
+		}
+		moduleName = strings.ReplaceAll(moduleName, string(filepath.Separator), "-")
+		coverageFile := filepath.Join(b.rootDir, coverageDir, "unit-test-"+moduleName+".out")
+		args = append(args, "-coverprofile="+coverageFile, "-coverpkg=./...")
+	}
+	args = append(args, "./...")
+
+	cmd := b.cmdFromRoot(args...)
+	cmd.Dir = moduleDir
+	return b.runTestCmd(cmd, output)
+}
+
+func mergeWorkerOutput(output testOutput, worker *unitWorker) error {
+	for _, pair := range [][2]string{
+		{output.logPath, worker.output.logPath},
+		{output.jsonLogPath, worker.output.jsonLogPath},
+	} {
+		if err := appendFile(pair[0], pair[1]); err != nil {
+			return err
+		}
+	}
+	if _, err := worker.stdout.WriteTo(output.stdout); err != nil {
+		return fmt.Errorf("failed writing worker stdout: %w", err)
+	}
+	if _, err := worker.stderr.WriteTo(output.stderr); err != nil {
+		return fmt.Errorf("failed writing worker stderr: %w", err)
+	}
+	return nil
+}
+
+func appendFile(destination, source string) error {
+	file, err := os.OpenFile(destination, os.O_WRONLY|os.O_APPEND, 0666)
+	if err != nil {
+		return fmt.Errorf("failed opening merged test log %q: %w", destination, err)
+	}
+	defer file.Close()
+	return writeFile(file, source)
+}
+
+func writeFile(writer io.Writer, source string) error {
+	file, err := os.Open(source)
+	if err != nil {
+		return fmt.Errorf("failed opening module output %q: %w", source, err)
+	}
+	defer file.Close()
+	if _, err := io.Copy(writer, file); err != nil {
+		return fmt.Errorf("failed merging module output %q: %w", source, err)
+	}
 	return nil
 }
 
@@ -531,6 +666,8 @@ func addTestOutputFlags(flagSet *flag.FlagSet) *testOutputFlags {
 type testOutput struct {
 	logPath         string
 	jsonLogPath     string
+	finalLogPath    string
+	finalJSONPath   string
 	combinedLogPath string
 	serverLogPath   string
 	rerunCommand    string
@@ -590,6 +727,8 @@ func (b *builder) prepareTestOutput(flags testOutputFlags, logName string) (test
 	return testOutput{
 		logPath:       logPath,
 		jsonLogPath:   jsonLogPath,
+		finalLogPath:  logPath,
+		finalJSONPath: jsonLogPath,
 		consoleOutput: flags.consoleOutput,
 		stdout:        os.Stdout,
 		stderr:        os.Stderr,
@@ -658,6 +797,8 @@ func (b *builder) runTestCmd(cmd *exec.Cmd, testOutput testOutput) error {
 	jsonCloseErr := jsonLogFile.Close()
 	rows := results.failures()
 	if runErr != nil {
+		testFailureReportMu.Lock()
+		defer testFailureReportMu.Unlock()
 		summaryErr := appendTestFailureRows(os.Getenv("GITHUB_STEP_SUMMARY"), rows)
 		if summaryErr != nil {
 			log.Printf("Failed writing test failure summary: %v", summaryErr)

--- a/internal/cmd/build/main_test.go
+++ b/internal/cmd/build/main_test.go
@@ -66,6 +66,25 @@ func TestFindModuleDirs(t *testing.T) {
 	}
 }
 
+func TestFindUnitModuleDirs(t *testing.T) {
+	moduleDirs, err := findUnitModuleDirs(fstest.MapFS{
+		"go.mod":                    {},
+		"contrib/example/go.mod":    {},
+		"internal/cmd/build/go.mod": {},
+		"test/go.mod":               {},
+		"test/nested/go.mod":        {},
+		"testdata/fixture/go.mod":   {},
+		"vendor/dependency/go.mod":  {},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{".", "contrib/example", "internal/cmd/build"}
+	if !slices.Equal(want, moduleDirs) {
+		t.Fatalf("expected unit module directories %v, got %v", want, moduleDirs)
+	}
+}
+
 func TestTestOutputFlagsDefaultToFailures(t *testing.T) {
 	flags := addTestOutputFlags(flag.NewFlagSet("test", flag.ContinueOnError))
 	if flags.consoleOutput != testConsoleOutputFailures {

--- a/internal/cmd/build/test_output.go
+++ b/internal/cmd/build/test_output.go
@@ -316,8 +316,16 @@ func writeTestRerunCommands(sb *strings.Builder, rows []testFailureSummaryRow, r
 
 func writeCompleteTestLogLocations(sb *strings.Builder, output testOutput) {
 	startTestReportSection(sb, "Complete logs")
-	fmt.Fprintf(sb, "- Go test: %s\n", output.logPath)
-	fmt.Fprintf(sb, "- Go test JSON: %s\n", output.jsonLogPath)
+	logPath := output.finalLogPath
+	if logPath == "" {
+		logPath = output.logPath
+	}
+	jsonLogPath := output.finalJSONPath
+	if jsonLogPath == "" {
+		jsonLogPath = output.jsonLogPath
+	}
+	fmt.Fprintf(sb, "- Go test: %s\n", logPath)
+	fmt.Fprintf(sb, "- Go test JSON: %s\n", jsonLogPath)
 	if output.combinedLogPath != "" {
 		fmt.Fprintf(sb, "- Combined Go and dev server: %s\n", output.combinedLogPath)
 	}


### PR DESCRIPTION
## What was changed

Run every non-integration module through two unit-test workers, including `internal/cmd/build`. Each module uses `-p 1`. Buffer each worker's output and merge complete worker logs after both finish.

Key unit-test caches with every module's `go.sum`. Keep that key exclusive to unit jobs so check and integration jobs cannot save partial contents first.

## Why?

One process per package repeats build and process overhead. Sequential modules leave a long contrib tail on macOS and Windows. Two workers overlap modules without interleaving package logs.

The first two-worker CI run still downloaded 136 dependencies on macOS Intel despite an exact cache hit. The scoped key tests whether complete unit caches remove that overhead.

## CI experiment

The first run populated the new unit-specific caches. A rerun of the same commit restored them with zero dependency downloads.

| Job | Before | Warm cache |
| --- | ---: | ---: |
| macOS Intel stable | 13:55 | 4:53 |
| macOS Intel oldstable | 10:37 | 6:23 |
| Windows stable | 10:47 | 5:27 |
| Windows oldstable | 7:50 | 5:34 |

The warm macOS ARM oldstable row hit an unrelated 5 ms timing-tolerance flake in `TestWaitServerReady_respectsTimeout`.

## Checklist

1. Closes: N/A

2. How was this tested:

- `go test ./...`
- `go run . unit-test`
- Regression coverage for build-module discovery
- Focused coverage and full-console runs
- Parsed the merged JSON and checked package output remains contiguous
- Workflow diff and whitespace validation
- `go run . check` passes through testifylint; doclink still hits the deferred Go 1.26 generic-method issue

3. Any docs updates needed?

No.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how all unit tests are discovered and executed (including `internal/cmd/build`), which can affect CI timing, coverage layout, and log ordering; CI cache key behavior also changes for unit jobs.
> 
> **Overview**
> **Unit tests now run one `go test ./...` per Go module** (excluding the integration `test/` tree) instead of spawning a separate test run for every directory that contains a `*_test.go` file. Two worker goroutines process modules in parallel; each module uses **`-p 1`** so package output stays sequential within a module. Per-worker logs are written to temp files and **merged** into the main test log/JSON paths; failure reports and “complete logs” sections use those **final** paths.
> 
> Adds **`findUnitModuleDirs`** (with a unit test) and coverage profiles keyed by **module name** rather than per-directory paths. GitHub failure summary writes are guarded with a **mutex** when workers report failures concurrently.
> 
> **CI:** `setup-go` for unit jobs sets **`cache-dependency-path: '**/go.sum'`** so module caches are populated from a full unit run and not partially warmed by other jobs.
> 
> **Docs:** README wording for `-console-output full` changes from “stream” to “show”.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15e539402679478dc2fed277405a6ef1ea8f3437. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->