### PR TITLE
feat: workflow command pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ to docs, or any other relevant information.
   optional structured details for payload validation failures. Passing `nil` omits details.
 - Added Go 1.27+ generic methods on the experimental `temporalnexus.NexusClient` for starting
   workflow-, activity-, and workflow-update-backed Nexus operations.
+- Workflow task completions larger than the gRPC request size limit are now paginated automatically
+  when the namespace supports it. Paginated workflow task completions require Temporal Server 1.32.0
+  or later.
 - The `temporal_activity_execution_failed` and `temporal_local_activity_execution_failed` worker
   metrics now carry a `failure_reason` attribute. Each is now split into one time series per
   reason, which may affect existing dashboards.

--- a/internal/cmd/build/main.go
+++ b/internal/cmd/build/main.go
@@ -375,6 +375,10 @@ func (b *builder) integrationTest() error {
 				"--dynamic-config-value", "activity.startDelayEnabled=true",
 				"--dynamic-config-value", "history.enableUpdateCallbacks=true",
 				"--dynamic-config-value", "activity.enableCallbacks=true",
+				"--dynamic-config-value", "history.enableWorkflowTaskCompletionPagination=true",
+				// Pagination clears the gRPC request limit, but the recombined completion still
+				// persists as one transaction, so raise the persistence limit above it.
+				"--dynamic-config-value", "system.transactionSizeLimit=33554432",
 			},
 		})
 		if err != nil {

--- a/internal/common/metrics/constants.go
+++ b/internal/common/metrics/constants.go
@@ -100,4 +100,5 @@ const (
 	FailureReasonNonDeterminismError = "NonDeterminismError"
 	FailureReasonPayloadsTooLarge    = "PayloadsTooLarge"
 	FailureReasonGrpcMessageTooLarge = "GrpcMessageTooLarge"
+	FailureReasonRequestTooLarge     = "RequestTooLarge"
 )

--- a/internal/common/retry/interceptor.go
+++ b/internal/common/retry/interceptor.go
@@ -11,6 +11,7 @@ import (
 	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/retry"
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/util/backoffutils"
 	errordetailspb "go.temporal.io/api/errordetails/v1"
+	"go.temporal.io/api/serviceerror"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -173,8 +174,13 @@ func IsRetryable(err error, excludeInternalFromRetry *atomic.Bool) bool {
 // IsWorkflowTaskCompletionBufferLost reports whether err carries the server's
 // WorkflowTaskCompletionBufferLostFailure detail, meaning it dropped the buffered pages of a
 // paginated RespondWorkflowTaskCompleted and they must be resent from page 0.
+//
+// serviceerror.ToStatus (not status.Convert) is required because the client's errorInterceptor has
+// already converted the error into a *serviceerror.WorkflowTaskCompletionBufferLost by the time it
+// reaches the resend loop; that type carries the detail on its Status() but not via gRPC's
+// GRPCStatus(), so status.Convert would drop it and report codes.Unknown.
 func IsWorkflowTaskCompletionBufferLost(err error) bool {
-	grpcStatus := status.Convert(err)
+	grpcStatus := serviceerror.ToStatus(err)
 	if grpcStatus == nil {
 		return false
 	}

--- a/internal/common/retry/interceptor.go
+++ b/internal/common/retry/interceptor.go
@@ -10,6 +10,7 @@ import (
 
 	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/retry"
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/util/backoffutils"
+	errordetailspb "go.temporal.io/api/errordetails/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -150,6 +151,11 @@ func IsRetryable(err error, excludeInternalFromRetry *atomic.Bool) bool {
 	if _, ok := err.(*GrpcMessageTooLargeError); ok {
 		return false
 	}
+	// Buffer loss on a paginated completion is recovered by resending every page from page 0, not by
+	// retrying the single failed request, so it must never be retried at the gRPC layer.
+	if IsWorkflowTaskCompletionBufferLost(err) {
+		return false
+	}
 	grpcStatus := status.Convert(err)
 	if grpcStatus == nil {
 		return false
@@ -160,6 +166,22 @@ func IsRetryable(err error, excludeInternalFromRetry *atomic.Bool) bool {
 	}
 	if errCode == codes.Internal {
 		return !excludeInternalFromRetry.Load()
+	}
+	return false
+}
+
+// IsWorkflowTaskCompletionBufferLost reports whether err carries the server's
+// WorkflowTaskCompletionBufferLostFailure detail, meaning it dropped the buffered pages of a
+// paginated RespondWorkflowTaskCompleted and they must be resent from page 0.
+func IsWorkflowTaskCompletionBufferLost(err error) bool {
+	grpcStatus := status.Convert(err)
+	if grpcStatus == nil {
+		return false
+	}
+	for _, detail := range grpcStatus.Details() {
+		if _, ok := detail.(*errordetailspb.WorkflowTaskCompletionBufferLostFailure); ok {
+			return true
+		}
 	}
 	return false
 }

--- a/internal/common/retry/interceptor.go
+++ b/internal/common/retry/interceptor.go
@@ -174,12 +174,11 @@ func IsRetryable(err error, excludeInternalFromRetry *atomic.Bool) bool {
 // IsWorkflowTaskCompletionBufferLost reports whether err carries the server's
 // WorkflowTaskCompletionBufferLostFailure detail, meaning it dropped the buffered pages of a
 // paginated RespondWorkflowTaskCompleted and they must be resent from page 0.
-//
-// serviceerror.ToStatus (not status.Convert) is required because the client's errorInterceptor has
-// already converted the error into a *serviceerror.WorkflowTaskCompletionBufferLost by the time it
-// reaches the resend loop; that type carries the detail on its Status() but not via gRPC's
-// GRPCStatus(), so status.Convert would drop it and report codes.Unknown.
 func IsWorkflowTaskCompletionBufferLost(err error) bool {
+	// serviceerror.ToStatus (not status.Convert) is required because the client's errorInterceptor has
+	// already converted the error into a *serviceerror.WorkflowTaskCompletionBufferLost by the time it
+	// reaches the resend loop; that type carries the detail on its Status() but not via gRPC's
+	// GRPCStatus(), so status.Convert would drop it and report codes.Unknown.
 	grpcStatus := serviceerror.ToStatus(err)
 	if grpcStatus == nil {
 		return false

--- a/internal/common/retry/interceptor_test.go
+++ b/internal/common/retry/interceptor_test.go
@@ -1,0 +1,26 @@
+package retry
+
+import (
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	errordetailspb "go.temporal.io/api/errordetails/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestIsWorkflowTaskCompletionBufferLost(t *testing.T) {
+	st, err := status.New(codes.Aborted, "buffer lost").WithDetails(&errordetailspb.WorkflowTaskCompletionBufferLostFailure{})
+	require.NoError(t, err)
+	bufferLostErr := st.Err()
+
+	require.True(t, IsWorkflowTaskCompletionBufferLost(bufferLostErr))
+	// A plain Aborted without the detail is not buffer loss.
+	require.False(t, IsWorkflowTaskCompletionBufferLost(status.Error(codes.Aborted, "other")))
+	require.False(t, IsWorkflowTaskCompletionBufferLost(nil))
+
+	// Buffer loss must not be retried at the gRPC layer, though plain Aborted still is.
+	require.False(t, IsRetryable(bufferLostErr, &atomic.Bool{}))
+	require.True(t, IsRetryable(status.Error(codes.Aborted, "other"), &atomic.Bool{}))
+}

--- a/internal/common/retry/interceptor_test.go
+++ b/internal/common/retry/interceptor_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	errordetailspb "go.temporal.io/api/errordetails/v1"
+	"go.temporal.io/api/serviceerror"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -16,6 +17,10 @@ func TestIsWorkflowTaskCompletionBufferLost(t *testing.T) {
 	bufferLostErr := st.Err()
 
 	require.True(t, IsWorkflowTaskCompletionBufferLost(bufferLostErr))
+	// The client's errorInterceptor converts the server status into a typed serviceerror before the
+	// resend loop sees it, so detection must handle that form, not just the raw status.
+	require.True(t, IsWorkflowTaskCompletionBufferLost(serviceerror.FromStatus(st)))
+	require.False(t, IsWorkflowTaskCompletionBufferLost(serviceerror.NewUnavailable("nope")))
 	// A plain Aborted without the detail is not buffer loss.
 	require.False(t, IsWorkflowTaskCompletionBufferLost(status.Error(codes.Aborted, "other")))
 	require.False(t, IsWorkflowTaskCompletionBufferLost(nil))

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"go.temporal.io/sdk/internal/common/retry"
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
@@ -161,6 +162,8 @@ type (
 		inboundPayloadVisitor     PayloadVisitor
 		outboundPayloadVisitor    PayloadVisitor
 		payloadVisitorConcurrency int
+
+		workflowTaskCompletionPagination *workflowTaskCompletionPaginationConfig
 	}
 
 	// activityTaskPoller implements polling/processing a workflow task
@@ -374,24 +377,25 @@ func newWorkflowTaskProcessor(
 			workerControlTaskQueue:       params.workerControlTaskQueue,
 			workerPollCompleteOnShutdown: params.workerPollCompleteOnShutdown,
 		},
-		service:                      service,
-		namespace:                    params.Namespace,
-		taskQueueName:                params.TaskQueue,
-		identity:                     params.Identity,
-		taskHandler:                  taskHandler,
-		contextManager:               contextManager,
-		logger:                       params.Logger,
-		dataConverter:                params.DataConverter,
-		failureConverter:             params.FailureConverter,
-		stickyUUID:                   stickyUUID,
-		StickyScheduleToStartTimeout: params.StickyScheduleToStartTimeout,
-		stickyCacheSize:              params.cache.MaxWorkflowCacheSize(),
-		eagerActivityExecutor:        params.eagerActivityExecutor,
-		numNormalPollerMetric:        newNumPollerMetric(params.MetricsHandler, metrics.PollerTypeWorkflowTask),
-		numStickyPollerMetric:        newNumPollerMetric(params.MetricsHandler, metrics.PollerTypeWorkflowStickyTask),
-		inboundPayloadVisitor:        params.inboundPayloadVisitor,
-		outboundPayloadVisitor:       params.outboundPayloadVisitor,
-		payloadVisitorConcurrency:    params.payloadVisitorConcurrency,
+		service:                          service,
+		namespace:                        params.Namespace,
+		taskQueueName:                    params.TaskQueue,
+		identity:                         params.Identity,
+		taskHandler:                      taskHandler,
+		contextManager:                   contextManager,
+		logger:                           params.Logger,
+		dataConverter:                    params.DataConverter,
+		failureConverter:                 params.FailureConverter,
+		stickyUUID:                       stickyUUID,
+		StickyScheduleToStartTimeout:     params.StickyScheduleToStartTimeout,
+		stickyCacheSize:                  params.cache.MaxWorkflowCacheSize(),
+		eagerActivityExecutor:            params.eagerActivityExecutor,
+		numNormalPollerMetric:            newNumPollerMetric(params.MetricsHandler, metrics.PollerTypeWorkflowTask),
+		numStickyPollerMetric:            newNumPollerMetric(params.MetricsHandler, metrics.PollerTypeWorkflowStickyTask),
+		inboundPayloadVisitor:            params.inboundPayloadVisitor,
+		outboundPayloadVisitor:           params.outboundPayloadVisitor,
+		payloadVisitorConcurrency:        params.payloadVisitorConcurrency,
+		workflowTaskCompletionPagination: params.workflowTaskCompletionPagination,
 	}
 }
 
@@ -631,6 +635,32 @@ func (wtp *workflowTaskProcessor) RespondTaskCompletedWithMetrics(
 		taskCompletion = &workflowTaskCompletion{rawRequest: wtp.errorToFailWorkflowTask(task.TaskToken, taskErr)}
 	}
 
+	// A completion whose recombined command bytes exceed the namespace limit would be rejected and
+	// the workflow terminated by the server, so fail it proactively rather than sending doomed
+	// pages. Only buffered command bytes count toward that limit, not messages or metadata.
+	if req, ok := taskCompletion.rawRequest.(*workflowservice.RespondWorkflowTaskCompletedRequest); ok && wtp.workflowTaskCompletionPagination != nil {
+		if limit := wtp.workflowTaskCompletionPagination.sizeLimit.Load(); limit > 0 {
+			var commandBytes int64
+			for _, command := range req.Commands {
+				commandBytes += int64(proto.Size(command))
+			}
+			if commandBytes > limit {
+				taskErr := fmt.Errorf("workflow task completion command size %d exceeds the namespace limit of %d bytes", commandBytes, limit)
+				wtp.logger.Warn("Workflow task completion exceeds namespace size limit.",
+					tagWorkflowType, task.WorkflowType.GetName(),
+					tagWorkflowID, task.WorkflowExecution.GetWorkflowId(),
+					tagRunID, task.WorkflowExecution.GetRunId(),
+					tagAttempt, task.Attempt,
+					tagError, taskErr)
+				emitFailMetric = true
+				failureReason = metrics.FailureReasonRequestTooLarge
+				taskCompletion = &workflowTaskCompletion{
+					rawRequest: wtp.errorToFailWorkflowTaskWithCause(task.TaskToken, taskErr, enumspb.WORKFLOW_TASK_FAILED_CAUSE_REQUEST_TOO_LARGE),
+				}
+			}
+		}
+	}
+
 	taskDuration := time.Since(startTime)
 	metricsHandler.Timer(metrics.WorkflowTaskExecutionLatency).Record(taskDuration)
 
@@ -701,10 +731,7 @@ func (wtp *workflowTaskProcessor) sendTaskCompletedRequest(
 ) (response *workflowservice.RespondWorkflowTaskCompletedResponse, err error) {
 	ctx := context.Background()
 	// Respond task completion.
-	grpcCtx, cancel := newGRPCContext(ctx, grpcMetricsHandler(
-		wtp.metricsHandler.WithTags(metrics.RPCTags(task.GetWorkflowType().GetName(),
-			metrics.NoneTagValue, metrics.NoneTagValue))),
-		defaultGrpcRetryParameters(ctx))
+	grpcCtx, cancel := wtp.newWorkflowTaskReportGRPCContext(ctx, task)
 	defer cancel()
 	if taskCompletion == nil {
 		// should not happen
@@ -736,7 +763,7 @@ func (wtp *workflowTaskProcessor) sendTaskCompletedRequest(
 			}
 		}
 		eagerReserved := wtp.eagerActivityExecutor.applyToRequest(request)
-		response, err = wtp.service.RespondWorkflowTaskCompleted(grpcCtx, request)
+		response, err = wtp.respondWorkflowTaskCompleted(ctx, grpcCtx, request, task)
 		if err != nil {
 			traceLog(func() {
 				wtp.logger.Debug("RespondWorkflowTaskCompleted failed.", tagError, err)
@@ -759,6 +786,97 @@ func (wtp *workflowTaskProcessor) sendTaskCompletedRequest(
 		panic("unknown request type from ProcessWorkflowTask()")
 	}
 	return
+}
+
+// respondWorkflowTaskCompleted sends a workflow task completion, paginating it across multiple
+// requests sharing one task token when the namespace supports it and the completion would otherwise
+// exceed the gRPC request size limit.
+func (wtp *workflowTaskProcessor) respondWorkflowTaskCompleted(
+	ctx context.Context,
+	grpcCtx context.Context,
+	request *workflowservice.RespondWorkflowTaskCompletedRequest,
+	task *workflowservice.PollWorkflowTaskQueueResponse,
+) (*workflowservice.RespondWorkflowTaskCompletedResponse, error) {
+	if wtp.workflowTaskCompletionPagination == nil || !wtp.workflowTaskCompletionPagination.enabled.Load() {
+		return wtp.service.RespondWorkflowTaskCompleted(grpcCtx, request)
+	}
+	intermediatePages, finalPage := paginateWorkflowTaskCompletion(request, maxWorkflowTaskCompletionPageBytes)
+	if len(intermediatePages) == 0 {
+		return wtp.service.RespondWorkflowTaskCompleted(grpcCtx, finalPage)
+	}
+	return wtp.sendPaginatedWorkflowTaskCompletion(ctx, intermediatePages, finalPage, task)
+}
+
+// sendPaginatedWorkflowTaskCompletion sends a paginated completion, resending every page from page 0
+// on buffer loss. Buffer loss — the server dropping the pages it had buffered for this token — is
+// transient, so it backs off exponentially and retries. The server bounds the loop by eventually
+// timing the task out, after which the stale token fails with a different, non-buffer-lost error;
+// worker shutdown ends it sooner. The gRPC retry layer does not retry buffer loss
+// (see retry.IsWorkflowTaskCompletionBufferLost), so this loop is its sole handler.
+func (wtp *workflowTaskProcessor) sendPaginatedWorkflowTaskCompletion(
+	ctx context.Context,
+	intermediatePages []*workflowservice.RespondWorkflowTaskCompletedRequest,
+	finalPage *workflowservice.RespondWorkflowTaskCompletedRequest,
+	task *workflowservice.PollWorkflowTaskQueueResponse,
+) (*workflowservice.RespondWorkflowTaskCompletedResponse, error) {
+	backoff := workflowTaskCompletionPageResendInitialBackoff
+	for {
+		response, err := wtp.sendWorkflowTaskCompletionPages(ctx, intermediatePages, finalPage, task)
+		if err == nil {
+			return response, nil
+		}
+		if !retry.IsWorkflowTaskCompletionBufferLost(err) {
+			return nil, err
+		}
+		timer := time.NewTimer(backoff)
+		select {
+		case <-wtp.stopC:
+			timer.Stop()
+			return nil, err
+		case <-timer.C:
+		}
+		if backoff *= 2; backoff > workflowTaskCompletionPageResendMaxBackoff {
+			backoff = workflowTaskCompletionPageResendMaxBackoff
+		}
+	}
+}
+
+// sendWorkflowTaskCompletionPages sends the intermediate pages concurrently, then the final page; a
+// failed page cancels the rest, since any failure resends the whole set or fails the task.
+func (wtp *workflowTaskProcessor) sendWorkflowTaskCompletionPages(
+	ctx context.Context,
+	intermediatePages []*workflowservice.RespondWorkflowTaskCompletedRequest,
+	finalPage *workflowservice.RespondWorkflowTaskCompletedRequest,
+	task *workflowservice.PollWorkflowTaskQueueResponse,
+) (*workflowservice.RespondWorkflowTaskCompletedResponse, error) {
+	group, groupCtx := errgroup.WithContext(ctx)
+	group.SetLimit(maxConcurrentWorkflowTaskCompletionPages)
+	for _, page := range intermediatePages {
+		group.Go(func() error {
+			grpcCtx, cancel := wtp.newWorkflowTaskReportGRPCContext(groupCtx, task)
+			defer cancel()
+			_, err := wtp.service.RespondWorkflowTaskCompleted(grpcCtx, page)
+			return err
+		})
+	}
+	if err := group.Wait(); err != nil {
+		return nil, err
+	}
+	grpcCtx, cancel := wtp.newWorkflowTaskReportGRPCContext(ctx, task)
+	defer cancel()
+	return wtp.service.RespondWorkflowTaskCompleted(grpcCtx, finalPage)
+}
+
+// newWorkflowTaskReportGRPCContext builds the gRPC context for reporting a workflow task
+// (completion, failure, or query result), shared by the single-request and per-page send paths.
+func (wtp *workflowTaskProcessor) newWorkflowTaskReportGRPCContext(
+	ctx context.Context,
+	task *workflowservice.PollWorkflowTaskQueueResponse,
+) (context.Context, context.CancelFunc) {
+	return newGRPCContext(ctx, grpcMetricsHandler(
+		wtp.metricsHandler.WithTags(metrics.RPCTags(task.GetWorkflowType().GetName(),
+			metrics.NoneTagValue, metrics.NoneTagValue))),
+		defaultGrpcRetryParameters(ctx))
 }
 
 func (wtp *workflowTaskProcessor) reportGrpcMessageTooLarge(

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -635,10 +635,16 @@ func (wtp *workflowTaskProcessor) RespondTaskCompletedWithMetrics(
 		taskCompletion = &workflowTaskCompletion{rawRequest: wtp.errorToFailWorkflowTask(task.TaskToken, taskErr)}
 	}
 
-	// A completion whose recombined command bytes exceed the namespace limit would be rejected and
-	// the workflow terminated by the server, so fail it proactively rather than sending doomed
-	// pages. Only buffered command bytes count toward that limit, not messages or metadata.
-	if req, ok := taskCompletion.rawRequest.(*workflowservice.RespondWorkflowTaskCompletedRequest); ok && wtp.workflowTaskCompletionPagination != nil {
+	// The namespace limit governs the server's recombined page buffer, so it only applies to a
+	// completion large enough to be paginated; a completion that fits in a single request is never
+	// buffered and is left for the server to accept. A paginated completion whose buffered command
+	// bytes would exceed the limit is rejected and the workflow terminated by the server, so fail it
+	// proactively rather than sending doomed pages. Only buffered command bytes count toward the
+	// limit, not messages or metadata.
+	if req, ok := taskCompletion.rawRequest.(*workflowservice.RespondWorkflowTaskCompletedRequest); ok &&
+		wtp.workflowTaskCompletionPagination != nil &&
+		wtp.workflowTaskCompletionPagination.enabled.Load() &&
+		proto.Size(req) > maxWorkflowTaskCompletionPageBytes {
 		if limit := wtp.workflowTaskCompletionPagination.sizeLimit.Load(); limit > 0 {
 			var commandBytes int64
 			for _, command := range req.Commands {

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -248,6 +248,9 @@ type (
 		// Set to true during start() when the namespace has the poller_autoscaling capability.
 		serverSupportsAutoscaling *atomic.Bool
 
+		// Resolved during start() from the namespace's pagination capability and size limit.
+		workflowTaskCompletionPagination *workflowTaskCompletionPaginationConfig
+
 		inboundPayloadVisitor PayloadVisitor
 
 		outboundPayloadVisitor PayloadVisitor
@@ -1424,6 +1427,11 @@ func (aw *AggregatedWorker) start() error {
 		aw.workerPollCompleteOnShutdown.Store(true)
 	}
 
+	if nsData.capabilities.GetWorkflowTaskCompletionPagination() {
+		aw.executionParams.workflowTaskCompletionPagination.enabled.Store(true)
+		aw.executionParams.workflowTaskCompletionPagination.sizeLimit.Store(nsData.limits.GetWorkflowTaskCompletionSizeLimitError())
+	}
+
 	if nsData.capabilities.GetPollerAutoscaling() {
 		aw.executionParams.serverSupportsAutoscaling.Store(true)
 	}
@@ -2432,14 +2440,15 @@ func NewAggregatedWorker(client *WorkflowClient, taskQueue string, options Worke
 			maxConcurrent: options.MaxConcurrentEagerActivityExecutionSize,
 			maxPerTask:    *options.MaxEagerActivityReservationsPerWorkflowTask,
 		}),
-		capabilities:                  &capabilities,
-		pollTimeTracker:               &pollTimeTracker{},
-		workerInstanceKey:             workerInstanceKey,
-		workerControlTaskQueue:        workerControlTaskQueue(client.namespace, client.workerGroupingKey),
-		activityCancellationCallbacks: activityCancellationCallbacks,
-		workerPollCompleteOnShutdown:  workerPollCompleteOnShutdown,
-		serverSupportsAutoscaling:     &atomic.Bool{},
-		inboundPayloadVisitor:         extstore.NewExternalRetrievalVisitor(client.storageParams),
+		capabilities:                     &capabilities,
+		pollTimeTracker:                  &pollTimeTracker{},
+		workerInstanceKey:                workerInstanceKey,
+		workerControlTaskQueue:           workerControlTaskQueue(client.namespace, client.workerGroupingKey),
+		activityCancellationCallbacks:    activityCancellationCallbacks,
+		workerPollCompleteOnShutdown:     workerPollCompleteOnShutdown,
+		serverSupportsAutoscaling:        &atomic.Bool{},
+		workflowTaskCompletionPagination: &workflowTaskCompletionPaginationConfig{},
+		inboundPayloadVisitor:            extstore.NewExternalRetrievalVisitor(client.storageParams),
 		outboundPayloadVisitor: newCompositePayloadVisitor(
 			extstore.NewExternalStorageVisitor(client.storageParams),
 			payloadLimitVisitor,

--- a/internal/internal_workflow_task_pagination.go
+++ b/internal/internal_workflow_task_pagination.go
@@ -1,0 +1,102 @@
+package internal
+
+import (
+	"sync/atomic"
+	"time"
+
+	commandpb "go.temporal.io/api/command/v1"
+	"go.temporal.io/api/workflowservice/v1"
+	"google.golang.org/protobuf/proto"
+)
+
+// workflowTaskCompletionPaginationConfig holds the namespace-resolved settings governing pagination
+// of oversized workflow task completions. It is resolved once when the worker starts and read while
+// completing tasks, so the worker and its pollers share it by pointer.
+type workflowTaskCompletionPaginationConfig struct {
+	// enabled is true when the namespace advertises the workflow_task_completion_pagination capability.
+	enabled atomic.Bool
+	// sizeLimit is the namespace's limit on the recombined completion size; a completion over it is
+	// rejected server-side, so the worker fails it proactively. Zero means no limit was advertised.
+	sizeLimit atomic.Int64
+}
+
+const (
+	// maxWorkflowTaskCompletionPageBytes is the maximum encoded size of a single completion page,
+	// kept below the ~4 MiB gRPC frame limit. This per-page cap is distinct from the namespace's
+	// limit on the recombined completion size.
+	//
+	// Pages are packed by summing command body sizes only; the 512 KiB of headroom below 4 MiB
+	// absorbs everything that sum omits: the per-request overhead (task token, identity, namespace)
+	// and the per-command wire framing (a field tag plus a length varint, up to 6 bytes each). At the
+	// server's default per-workflow history-count limit (~51,200 events), worst-case framing is
+	// ~300 KiB, so this headroom covers even a page of many tiny commands and lets us skip
+	// per-command accounting.
+	maxWorkflowTaskCompletionPageBytes = 4*1024*1024 - 512*1024
+	// Conservative heuristic, not a tuned value: caps the client-side burst (concurrent request
+	// bodies and streams); the cost is only extra serial rounds for completions over this many pages.
+	maxConcurrentWorkflowTaskCompletionPages = 3
+
+	workflowTaskCompletionPageResendInitialBackoff = 100 * time.Millisecond
+	workflowTaskCompletionPageResendMaxBackoff     = 5 * time.Second
+)
+
+// paginateWorkflowTaskCompletion splits a completion that exceeds maxPageBytes into intermediate
+// pages that each stay under it, by distributing its commands across them in order. The server
+// buffers only the commands of intermediate pages, so all messages and metadata ride on the
+// returned final page, whose PageNumber is the count of intermediate pages.
+//
+// It returns (nil, request) — meaning send the request as-is — when the request already fits, has
+// no commands to distribute, or has a single command that alone exceeds a page (which the server
+// then rejects).
+func paginateWorkflowTaskCompletion(
+	request *workflowservice.RespondWorkflowTaskCompletedRequest,
+	maxPageBytes int,
+) (intermediatePages []*workflowservice.RespondWorkflowTaskCompletedRequest, finalPage *workflowservice.RespondWorkflowTaskCompletedRequest) {
+	if proto.Size(request) <= maxPageBytes {
+		return nil, request
+	}
+
+	newIntermediatePage := func(commands []*commandpb.Command, pageNumber int) *workflowservice.RespondWorkflowTaskCompletedRequest {
+		return &workflowservice.RespondWorkflowTaskCompletedRequest{
+			TaskToken:        request.TaskToken,
+			Identity:         request.Identity,
+			Namespace:        request.Namespace,
+			IntermediatePage: true,
+			PageNumber:       int32(pageNumber),
+			Commands:         commands,
+		}
+	}
+
+	// Pages are packed purely by command body size; maxPageBytes reserves headroom for the
+	// per-request and per-command overhead this ignores. Only commands can be split across pages, so
+	// pagination cannot help when there are none, or when a single command alone exceeds a page.
+	if len(request.Commands) == 0 {
+		return nil, request
+	}
+	for _, command := range request.Commands {
+		if proto.Size(command) > maxPageBytes {
+			return nil, request
+		}
+	}
+
+	var current []*commandpb.Command
+	currentLen := 0
+	for _, command := range request.Commands {
+		commandLen := proto.Size(command)
+		if len(current) > 0 && currentLen+commandLen > maxPageBytes {
+			intermediatePages = append(intermediatePages, newIntermediatePage(current, len(intermediatePages)))
+			current = nil
+			currentLen = 0
+		}
+		currentLen += commandLen
+		current = append(current, command)
+	}
+	if len(current) > 0 {
+		intermediatePages = append(intermediatePages, newIntermediatePage(current, len(intermediatePages)))
+	}
+
+	request.Commands = nil
+	request.PageNumber = int32(len(intermediatePages))
+	request.IntermediatePage = false
+	return intermediatePages, request
+}

--- a/internal/internal_workflow_task_pagination_test.go
+++ b/internal/internal_workflow_task_pagination_test.go
@@ -1,0 +1,92 @@
+package internal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	commandpb "go.temporal.io/api/command/v1"
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	protocolpb "go.temporal.io/api/protocol/v1"
+	"go.temporal.io/api/workflowservice/v1"
+	"google.golang.org/protobuf/proto"
+)
+
+func paginationTestCommand(payloadSize int) *commandpb.Command {
+	return &commandpb.Command{
+		CommandType: enumspb.COMMAND_TYPE_RECORD_MARKER,
+		Attributes: &commandpb.Command_RecordMarkerCommandAttributes{
+			RecordMarkerCommandAttributes: &commandpb.RecordMarkerCommandAttributes{
+				MarkerName: "test",
+				Details: map[string]*commonpb.Payloads{
+					"data": {Payloads: []*commonpb.Payload{{Data: make([]byte, payloadSize)}}},
+				},
+			},
+		},
+	}
+}
+
+func paginationTestRequest(commands []*commandpb.Command) *workflowservice.RespondWorkflowTaskCompletedRequest {
+	return &workflowservice.RespondWorkflowTaskCompletedRequest{
+		TaskToken: []byte("task-token"),
+		Namespace: "namespace",
+		Identity:  "identity",
+		Commands:  commands,
+	}
+}
+
+func TestPaginateWorkflowTaskCompletion_FitsInSinglePage(t *testing.T) {
+	request := paginationTestRequest([]*commandpb.Command{paginationTestCommand(16)})
+	intermediate, final := paginateWorkflowTaskCompletion(request, 4096)
+	require.Empty(t, intermediate)
+	require.Same(t, request, final)
+	require.False(t, final.IntermediatePage)
+	require.EqualValues(t, 0, final.PageNumber)
+}
+
+func TestPaginateWorkflowTaskCompletion_SplitsCommandsAcrossPages(t *testing.T) {
+	const maxPageBytes = 1024
+	const commandCount = 6
+	var commands []*commandpb.Command
+	for i := 0; i < commandCount; i++ {
+		commands = append(commands, paginationTestCommand(400))
+	}
+	request := paginationTestRequest(commands)
+	require.Greater(t, proto.Size(request), maxPageBytes)
+
+	intermediate, final := paginateWorkflowTaskCompletion(request, maxPageBytes)
+	require.NotEmpty(t, intermediate)
+
+	// The final page carries no commands and is numbered after every intermediate page.
+	require.False(t, final.IntermediatePage)
+	require.Empty(t, final.Commands)
+	require.EqualValues(t, len(intermediate), final.PageNumber)
+	require.LessOrEqual(t, proto.Size(final), maxPageBytes)
+
+	totalCommands := 0
+	for i, page := range intermediate {
+		require.True(t, page.IntermediatePage)
+		require.EqualValues(t, i, page.PageNumber)
+		require.Equal(t, []byte("task-token"), page.TaskToken)
+		require.LessOrEqual(t, proto.Size(page), maxPageBytes, "intermediate page %d over limit", i)
+		totalCommands += len(page.Commands)
+	}
+	// Every command is preserved exactly once across the intermediate pages.
+	require.Equal(t, commandCount, totalCommands)
+}
+
+func TestPaginateWorkflowTaskCompletion_SingleCommandLargerThanPageIsNotSplit(t *testing.T) {
+	request := paginationTestRequest([]*commandpb.Command{paginationTestCommand(4096)})
+	intermediate, final := paginateWorkflowTaskCompletion(request, 1024)
+	require.Empty(t, intermediate)
+	require.Same(t, request, final)
+}
+
+func TestPaginateWorkflowTaskCompletion_NoCommandsIsNotSplit(t *testing.T) {
+	// Over the limit because of messages, but with no commands there is nothing to distribute.
+	request := paginationTestRequest(nil)
+	request.Messages = []*protocolpb.Message{{Id: string(make([]byte, 2048))}}
+	intermediate, final := paginateWorkflowTaskCompletion(request, 1024)
+	require.Empty(t, intermediate)
+	require.Same(t, request, final)
+}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -228,6 +228,12 @@ func (ts *IntegrationTestSuite) SetupTest() {
 		options.LocalActivityWorkerOnly = true
 	}
 
+	if strings.Contains(ts.T().Name(), "WorkflowTaskCompletionPagination") {
+		// This workflow serializes a large (~5 MiB) completion in a single workflow task; on slow CI
+		// hardware that can exceed the default 1s deadlock-detection window.
+		options.DeadlockDetectionTimeout = 10 * time.Second
+	}
+
 	if strings.Contains(ts.T().Name(), "CancelTimerViaDeferAfterWFTFailure") ||
 		strings.Contains(ts.T().Name(), "TestNonDeterminismFailureCause") {
 		options.WorkflowPanicPolicy = worker.BlockWorkflow

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -291,6 +291,24 @@ func (ts *IntegrationTestSuite) TearDownTest() {
 	}
 }
 
+func (ts *IntegrationTestSuite) TestWorkflowTaskCompletionPagination() {
+	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
+	defer cancel()
+
+	resp, err := ts.client.WorkflowService().DescribeNamespace(ctx, &workflowservice.DescribeNamespaceRequest{
+		Namespace: ts.config.Namespace,
+	})
+	ts.NoError(err)
+	if !resp.GetNamespaceInfo().GetCapabilities().GetWorkflowTaskCompletionPagination() {
+		ts.T().Skip("server does not support workflow_task_completion_pagination namespace capability")
+	}
+
+	// The completion is larger than the gRPC request size limit, so it succeeds only if it is
+	// paginated.
+	err = ts.executeWorkflow("test-wft-completion-pagination", ts.workflows.WorkflowTaskCompletionPagination, nil)
+	ts.NoError(err)
+}
+
 func (ts *IntegrationTestSuite) TestBasic() {
 	var expected []string
 	err := ts.executeWorkflow("test-basic", ts.workflows.Basic, &expected)

--- a/test/workflow_test.go
+++ b/test/workflow_test.go
@@ -4302,6 +4302,27 @@ func (w *Workflows) TemporalOpTerminateCallerCaller(ctx workflow.Context, _ stri
 	return result, err
 }
 
+// WorkflowTaskCompletionPagination schedules many activities in a single workflow task so the
+// completion (~5 MiB across the commands) exceeds the gRPC request size limit and must be
+// paginated. Each input is well under the per-blob size limit, so it is the aggregate completion
+// size that drives pagination.
+func (w *Workflows) WorkflowTaskCompletionPagination(ctx workflow.Context) error {
+	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		StartToCloseTimeout: 30 * time.Second,
+	})
+	input := strings.Repeat("a", 400*1024)
+	var futures []workflow.Future
+	for i := 0; i < 13; i++ {
+		futures = append(futures, workflow.ExecuteActivity(ctx, "EchoString", input))
+	}
+	for _, future := range futures {
+		if err := future.Get(ctx, nil); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (w *Workflows) register(worker worker.Worker) {
 	worker.RegisterWorkflow(w.TemporalOpEcho)
 	worker.RegisterWorkflow(w.TemporalOpWaitForCancel)
@@ -4466,6 +4487,7 @@ func (w *Workflows) register(worker worker.Worker) {
 	worker.RegisterWorkflow(w.AwaitWithOptions)
 	worker.RegisterWorkflow(w.WorkflowWithRejectableUpdate)
 	worker.RegisterWorkflow(w.WorkflowWithUpdate)
+	worker.RegisterWorkflow(w.WorkflowTaskCompletionPagination)
 
 	worker.RegisterWorkflow(w.child)
 	worker.RegisterWorkflow(w.childWithRetryPolicy)


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

- Add support for paginating workflow task completions when the namespace advertises support.
- Retry pagination with exponential backoff when server report buffer loss.
- Proactively fail workflow task completion on first attempt if commands size is known to be larger than configured namespace command buffer size limit.

## Why?

Enable submitting large batches of workflow commands that would otherwise fail the gRPC data size limit.

## Checklist
<!--- add/delete as needed --->

1. How was this tested: Unit tests, integration tests.

1. Any docs updates needed? No