### PR TITLE
Skip newer Go syntax in doclink

### DIFF
--- a/internal/cmd/tools/doclink/doclink.go
+++ b/internal/cmd/tools/doclink/doclink.go
@@ -5,9 +5,12 @@ import (
 	"flag"
 	"fmt"
 	"go/ast"
+	"go/build"
+	"go/build/constraint"
 	"go/format"
 	"go/parser"
 	"go/token"
+	"go/version"
 	"log"
 	"os"
 	"path/filepath"
@@ -23,6 +26,8 @@ type (
 		fix     bool
 	}
 )
+
+const goBuildPrefix = "//go:build "
 
 var changesNeeded = false
 
@@ -56,6 +61,14 @@ func run() error {
 			return nil
 		}
 		if strings.HasSuffix(path, ".go") && !strings.HasSuffix(path, "_test.go") {
+			supported, err := supportsGoSyntax(path, build.Default.ReleaseTags[len(build.Default.ReleaseTags)-1])
+			if err != nil {
+				return fmt.Errorf("failed to inspect build constraint in %s: %v", path, err)
+			}
+			if !supported {
+				return nil
+			}
+
 			file, err := os.Open(path)
 			if err != nil {
 				return fmt.Errorf("failed to read file %s: %v", path, err)
@@ -141,6 +154,36 @@ func run() error {
 		return fmt.Errorf("error walking the path %s: %v", cfg.rootDir, err)
 	}
 	return nil
+}
+
+// supportsGoSyntax skips files requiring syntax newer than this toolchain.
+func supportsGoSyntax(path, toolchain string) (supported bool, retErr error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return false, err
+	}
+	defer func() {
+		if err := file.Close(); retErr == nil {
+			retErr = err
+		}
+	}()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if !strings.HasPrefix(line, goBuildPrefix) {
+			continue
+		}
+
+		expr, err := constraint.Parse(line)
+		if err != nil {
+			return false, err
+		}
+		minimum := constraint.GoVersion(expr)
+		return minimum == "" || version.Compare(toolchain, minimum) >= 0, nil
+	}
+
+	return true, scanner.Err()
 }
 
 // Traverse the AST of public packages to identify wrappers for internal objects

--- a/internal/cmd/tools/doclink/doclink.go
+++ b/internal/cmd/tools/doclink/doclink.go
@@ -170,11 +170,10 @@ func supportsGoSyntax(path, toolchain string) (supported bool, retErr error) {
 
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if !strings.HasPrefix(line, goBuildPrefix) {
+		line := scanner.Text()
+		if !constraint.IsGoBuild(line) {
 			continue
 		}
-
 		expr, err := constraint.Parse(line)
 		if err != nil {
 			return false, err

--- a/internal/cmd/tools/doclink/doclink.go
+++ b/internal/cmd/tools/doclink/doclink.go
@@ -27,8 +27,6 @@ type (
 	}
 )
 
-const goBuildPrefix = "//go:build "
-
 var changesNeeded = false
 
 func main() {

--- a/internal/cmd/tools/doclink/doclink_test.go
+++ b/internal/cmd/tools/doclink/doclink_test.go
@@ -15,6 +15,24 @@ func TestIsValidDefinitionWithMatchGroupedInterface(t *testing.T) {
 	}
 }
 
+func TestSupportsGoSyntax(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "future.go")
+	if err := os.WriteFile(path, []byte("//go:build go1.27\n\npackage future\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	supported, err := supportsGoSyntax(path, "go1.26")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if supported {
+		t.Fatal("expected future Go syntax to be skipped")
+	}
+}
+
 func TestIsValidDefinitionWithMatchGroupedNamedType(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What was changed

Skip files requiring newer Go syntax during doclink checks.

## Why?

Doclink ignored Go version build constraints. Go 1.26 therefore tried to parse generic methods guarded by `//go:build go1.27`.

## Checklist

1. Closes N/A

2. How was this tested:

- `go test ./internal/cmd/tools/doclink -count=1`
- Doclink check with Go 1.26 and Go 1.27
- `go run . check`

3. Any docs updates needed?

No.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only the internal doclink maintenance tool; no runtime SDK, auth, or data-handling impact.
> 
> **Overview**
> **Doclink** no longer parses public `.go` files whose `//go:build` constraints require a **Go version newer than the running toolchain**, which avoids parse failures on Go 1.26 when sources are gated for Go 1.27 (e.g. generic methods).
> 
> Before `processPublic` runs, each file is checked via new **`supportsGoSyntax`**, which scans build constraint lines, derives the minimum Go version with `constraint.GoVersion`, and compares it to the latest release tag from **`build.Default`**. Unsupported files are skipped like other excluded paths. A unit test asserts a `go1.27`-gated file is skipped when the toolchain is `go1.26`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6b23294f5eee95ec1f48a7ac3d21311f79a4306. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->