### PR TITLE
Transition fixed pollers with runtime poller groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,12 @@ to docs, or any other relevant information.
   corrected span parenting and span directions for span-kind mapping. It backs the new
   `contrib/opentelemetry-v2` module and is not span-compatible with the tracing interceptor
   used by `contrib/opentelemetry` (v1).
+- Simple-maximum task pollers now switch to poller-group-aware autoscaling when runtime poll
+  responses introduce poller groups.
+- Task pollers originally configured with `SimpleMaximum` now switch to poller-group-aware
+  autoscaling when runtime poll responses introduce poller groups, and return to their original
+  `SimpleMaximum` configuration when a newer response clears the groups. Task pollers configured
+  with autoscaling remain autoscaling when groups are cleared.
 
 ### Changed
 

--- a/internal/internal_nexus_worker.go
+++ b/internal/internal_nexus_worker.go
@@ -86,13 +86,42 @@ func newNexusWorker(opts nexusWorkerOptions) (*nexusWorker, error) {
 	}
 
 	baseWorker := newBaseWorker(bwo)
-
-	return &nexusWorker{
+	w := &nexusWorker{
 		executionParameters: opts.executionParameters,
 		workflowService:     opts.workflowService,
 		worker:              baseWorker,
 		stopC:               workerStopChannel,
-	}, nil
+	}
+	// Only originally fixed pollers need runtime transition configuration.
+	if _, ok := params.NexusTaskPollerBehavior.(*pollerBehaviorSimpleMaximum); ok {
+		baseWorker.setPollerTransition(
+			params.pollerGroupInfoStore,
+			[]string{metrics.PollerTypeNexusTask},
+			func() []scalableTaskPoller {
+				params.serverSupportsAutoscaling.Store(true)
+				autoscaling := NewPollerBehaviorAutoscaling(PollerBehaviorAutoscalingOptions{})
+				groups := newPollerGroupManager(pollerGroupModeNonWorkflow, params.pollerGroupInfoStore)
+				groupedPoller := *poller
+				groupedPoller.pollerGroups = groups
+				params.pollerBehaviorState.set(metrics.PollerTypeNexusTask, autoscaling)
+				return []scalableTaskPoller{
+					newScalableTaskPoller(
+						&groupedPoller,
+						params.Logger,
+						autoscaling,
+						metrics.PollerTypeNexusTask,
+						params.serverSupportsAutoscaling,
+						groups,
+					),
+				}
+			},
+			func() {
+				params.pollerBehaviorState.set(metrics.PollerTypeNexusTask, params.NexusTaskPollerBehavior)
+			},
+		)
+	}
+
+	return w, nil
 }
 
 // Start the worker.

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -107,6 +107,10 @@ type (
 		poller              taskPoller
 		worker              *baseWorker
 		identity            string
+		// allowPollerTransition is false only for the internal session-creation
+		// worker; ordinary and resource-specific session Activity workers follow
+		// runtime poller-group state.
+		allowPollerTransition bool
 		// stopC is created by newActivityWorker, exposed through WorkerStopChannel
 		// to activity task polling/handling, and closed by activityWorker.Stop().
 		stopC chan struct{}
@@ -125,6 +129,16 @@ type (
 		workflowTaskHandler WorkflowTaskHandler
 		activityTaskHandler ActivityTaskHandler
 		slotSupplier        SlotSupplier
+	}
+
+	// workerPollerBehaviorState is the shared runtime view of poller behavior.
+	// Worker components update it when their polling mode changes, and heartbeat
+	// generation reads a consistent snapshot.
+	workerPollerBehaviorState struct {
+		mu       sync.RWMutex
+		workflow PollerBehavior
+		activity PollerBehavior
+		nexus    PollerBehavior
 	}
 
 	// workerExecutionParameters defines worker configure/execution options.
@@ -222,6 +236,10 @@ type (
 		// NexusTaskPollerBehavior defines the behavior of the nexus task poller.
 		NexusTaskPollerBehavior PollerBehavior
 
+		// pollerBehaviorState is shared by execution-parameter copies and tracks
+		// the effective runtime behaviors reported in worker heartbeats.
+		pollerBehaviorState *workerPollerBehaviorState
+
 		// pollerAutoEnrollEligibility records, per poller type, whether the poller
 		// was left at its default and is therefore eligible for poller-autoscaling
 		// auto-enrollment when the namespace advertises the
@@ -274,6 +292,33 @@ type (
 		BuildID string
 	}
 )
+
+func (s *workerPollerBehaviorState) set(pollerType string, behavior PollerBehavior) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	switch pollerType {
+	case metrics.PollerTypeWorkflowTask:
+		s.workflow = behavior
+	case metrics.PollerTypeActivityTask:
+		s.activity = behavior
+	case metrics.PollerTypeNexusTask:
+		s.nexus = behavior
+	default:
+		panic(fmt.Sprintf("unknown poller type %q", pollerType))
+	}
+}
+
+func (s *workerPollerBehaviorState) snapshot() (workflow, activity, nexus PollerBehavior) {
+	if s == nil {
+		return nil, nil, nil
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.workflow, s.activity, s.nexus
+}
 
 var debugMode = os.Getenv("TEMPORAL_DEBUG") != ""
 
@@ -533,6 +578,33 @@ func (ww *workflowWorker) initializeTaskPollers(behavior PollerBehavior) {
 	ww.executionParameters.WorkflowTaskPollerBehavior = behavior
 	taskPollers := buildWorkflowScalableTaskPollers(taskProcessor, behavior, ww.executionParameters)
 	ww.worker.initializeTaskPollers(taskPollers)
+
+	// Only originally fixed pollers need runtime transition configuration.
+	if _, ok := behavior.(*pollerBehaviorSimpleMaximum); !ok {
+		return
+	}
+	taskPollerTypes := []string{metrics.PollerTypeWorkflowTask}
+	if taskProcessor.stickyCacheSize > 0 {
+		taskPollerTypes = append(taskPollerTypes, metrics.PollerTypeWorkflowStickyTask)
+	}
+	ww.worker.setPollerTransition(
+		ww.executionParameters.pollerGroupInfoStore,
+		taskPollerTypes,
+		func() []scalableTaskPoller {
+			ww.executionParameters.serverSupportsAutoscaling.Store(true)
+			autoscaling := NewPollerBehaviorAutoscaling(PollerBehaviorAutoscalingOptions{})
+			taskPollers := buildWorkflowScalableTaskPollers(
+				taskProcessor,
+				autoscaling,
+				ww.executionParameters,
+			)
+			ww.executionParameters.pollerBehaviorState.set(metrics.PollerTypeWorkflowTask, autoscaling)
+			return taskPollers
+		},
+		func() {
+			ww.executionParameters.pollerBehaviorState.set(metrics.PollerTypeWorkflowTask, behavior)
+		},
+	)
 }
 
 func newSessionWorker(client *WorkflowClient, params workerExecutionParameters, env *registry, maxConcurrentSessionExecutionSize int) *sessionWorker {
@@ -573,6 +645,9 @@ func newSessionWorker(client *WorkflowClient, params workerExecutionParameters, 
 	overrides := &workerOverrides{}
 	overrides.slotSupplier, _ = NewFixedSizeSlotSupplier(maxConcurrentSessionExecutionSize)
 	creationWorker := newActivityWorker(client, params, overrides, env, sessionEnvironment.GetTokenBucket())
+	// The internal global session-creation queue remains fixed. The resource-specific
+	// session Activity worker created above still follows runtime poller-group state.
+	creationWorker.allowPollerTransition = false
 
 	return &sessionWorker{
 		creationWorker: creationWorker,
@@ -665,12 +740,13 @@ func newActivityWorker(
 
 	base := newBaseWorker(bwo)
 	return &activityWorker{
-		executionParameters: params,
-		workflowService:     service,
-		worker:              base,
-		poller:              poller,
-		identity:            params.Identity,
-		stopC:               workerStopChannel,
+		executionParameters:   params,
+		workflowService:       service,
+		worker:                base,
+		poller:                poller,
+		identity:              params.Identity,
+		stopC:                 workerStopChannel,
+		allowPollerTransition: true,
 	}
 }
 
@@ -710,6 +786,43 @@ func (aw *activityWorker) initializeTaskPollers(behavior PollerBehavior) {
 			pollerGroups,
 		),
 	})
+
+	// Only eligible, originally fixed pollers need runtime transition configuration.
+	if !aw.allowPollerTransition {
+		return
+	}
+	if _, ok := behavior.(*pollerBehaviorSimpleMaximum); !ok {
+		return
+	}
+	poller, ok := aw.poller.(*activityTaskPoller)
+	if !ok {
+		return
+	}
+	aw.worker.setPollerTransition(
+		aw.executionParameters.pollerGroupInfoStore,
+		[]string{metrics.PollerTypeActivityTask},
+		func() []scalableTaskPoller {
+			aw.executionParameters.serverSupportsAutoscaling.Store(true)
+			autoscaling := NewPollerBehaviorAutoscaling(PollerBehaviorAutoscalingOptions{})
+			groups := newPollerGroupManager(pollerGroupModeNonWorkflow, aw.executionParameters.pollerGroupInfoStore)
+			groupedPoller := *poller
+			groupedPoller.pollerGroups = groups
+			aw.executionParameters.pollerBehaviorState.set(metrics.PollerTypeActivityTask, autoscaling)
+			return []scalableTaskPoller{
+				newScalableTaskPoller(
+					&groupedPoller,
+					aw.executionParameters.Logger,
+					autoscaling,
+					metrics.PollerTypeActivityTask,
+					aw.executionParameters.serverSupportsAutoscaling,
+					groups,
+				),
+			}
+		},
+		func() {
+			aw.executionParameters.pollerBehaviorState.set(metrics.PollerTypeActivityTask, behavior)
+		},
+	)
 }
 
 type registry struct {
@@ -1462,13 +1575,16 @@ func (aw *AggregatedWorker) start() error {
 		autoscaling := NewPollerBehaviorAutoscaling(PollerBehaviorAutoscalingOptions{})
 		if aw.executionParams.pollerAutoEnrollEligibility.nexusTask {
 			aw.executionParams.NexusTaskPollerBehavior = autoscaling
+			aw.executionParams.pollerBehaviorState.set(metrics.PollerTypeNexusTask, autoscaling)
 		}
 		if aw.executionParams.pollerAutoEnrollEligibility.workflowTask && !util.IsInterfaceNil(aw.workflowWorker) {
 			aw.executionParams.WorkflowTaskPollerBehavior = autoscaling
+			aw.executionParams.pollerBehaviorState.set(metrics.PollerTypeWorkflowTask, autoscaling)
 		}
 		if aw.executionParams.pollerAutoEnrollEligibility.activityTask {
 			if !util.IsInterfaceNil(aw.activityWorker) {
 				aw.executionParams.ActivityTaskPollerBehavior = autoscaling
+				aw.executionParams.pollerBehaviorState.set(metrics.PollerTypeActivityTask, autoscaling)
 			}
 		}
 	}
@@ -2510,6 +2626,11 @@ func NewAggregatedWorker(client *WorkflowClient, taskQueue string, options Worke
 	} else {
 		panic("must set either MaxConcurrentNexusTaskPollers or NexusTaskPollerBehavior")
 	}
+	workerParams.pollerBehaviorState = &workerPollerBehaviorState{
+		workflow: workerParams.WorkflowTaskPollerBehavior,
+		activity: workerParams.ActivityTaskPollerBehavior,
+		nexus:    workerParams.NexusTaskPollerBehavior,
+	}
 
 	// Carry through which poller types are eligible for auto-enrollment so that
 	// start() can enroll them into autoscaling when the namespace advertises the
@@ -2620,11 +2741,11 @@ func NewAggregatedWorker(client *WorkflowClient, taskQueue string, options Worke
 
 			mu.Lock()
 			defer mu.Unlock()
-			// Read the poller behaviors live so heartbeats reflect any
-			// auto-enrollment into poller autoscaling done during start().
-			populateOpts.workflowPollerBehavior = aw.executionParams.WorkflowTaskPollerBehavior
-			populateOpts.activityPollerBehavior = aw.executionParams.ActivityTaskPollerBehavior
-			populateOpts.nexusPollerBehavior = aw.executionParams.NexusTaskPollerBehavior
+			// Snapshot the shared runtime behaviors so heartbeats reflect startup
+			// auto-enrollment and later poller-group-driven mode changes.
+			populateOpts.workflowPollerBehavior,
+				populateOpts.activityPollerBehavior,
+				populateOpts.nexusPollerBehavior = aw.executionParams.pollerBehaviorState.snapshot()
 			if aw.workflowWorker != nil {
 				populateOpts.workflowSlotSupplierKind = aw.workflowWorker.worker.slotSupplier.GetSlotSupplierKind()
 				populateOpts.localActivitySlotSupplierKind = aw.workflowWorker.localActivityWorker.slotSupplier.GetSlotSupplierKind()

--- a/internal/internal_worker_base.go
+++ b/internal/internal_worker_base.go
@@ -257,6 +257,21 @@ type (
 
 		noRepoll atomic.Bool
 		pollerWG sync.WaitGroup
+
+		pollerTransition *pollerTransition
+	}
+
+	// pollerTransition stores what an originally fixed worker needs to follow
+	// runtime poller-group state after it starts.
+	pollerTransition struct {
+		// groupInfos is the shared source of truth for whether this originally
+		// fixed worker currently needs grouped autoscaling.
+		groupInfos      *pollerGroupInfoStore
+		taskPollerTypes []string
+		// These callbacks construct grouped pollers or restore externally visible
+		// state when the controller returns to the original fixed pollers.
+		buildAutoscaling func() []scalableTaskPoller
+		restoreFixed     func()
 	}
 
 	eagerOrPolledTask interface {
@@ -436,6 +451,30 @@ func (bw *baseWorker) initializeTaskPollers(taskPollers []scalableTaskPoller) {
 	}
 }
 
+// setPollerTransition records what a fixed worker needs to switch
+// to grouped autoscaling if poller-group information appears, and to restore its
+// fixed mode if that information later clears. It only configures the transition;
+// runPollerTransitionController performs any mode changes after the worker starts.
+func (bw *baseWorker) setPollerTransition(
+	groupInfos *pollerGroupInfoStore,
+	taskPollerTypes []string,
+	buildAutoscaling func() []scalableTaskPoller,
+	restoreFixed func(),
+) {
+	if bw.isWorkerStarted {
+		panic("cannot configure poller transition after worker start")
+	}
+	if bw.pollerTransition != nil {
+		panic("poller transition already configured")
+	}
+	bw.pollerTransition = &pollerTransition{
+		groupInfos:       groupInfos,
+		taskPollerTypes:  taskPollerTypes,
+		buildAutoscaling: buildAutoscaling,
+		restoreFixed:     restoreFixed,
+	}
+}
+
 // Start creates the fixed control goroutines for polling, autoscaling, and
 // dispatch. Autoscaling poll-attempt and task-processing goroutines are created
 // dynamically while the worker is running.
@@ -452,27 +491,12 @@ func (bw *baseWorker) Start() {
 		}
 	}
 
-	for _, taskWorker := range bw.options.taskPollers {
-		if taskWorker.autoscalingRunner != nil {
-			// Autoscaling pollers are created with both a runner and an autoscaler.
-			// The runner's manager opens polls under the current target.
-			bw.stopWG.Add(1)
-			bw.pollerWG.Add(1)
-			go bw.runAutoscalingPoller(taskWorker)
-
-			// The autoscaler's separate loop periodically refreshes scaling signals.
-			bw.stopWG.Add(1)
-			go func() {
-				defer bw.stopWG.Done()
-				taskWorker.pollerAutoscaler.run(bw.stopCh)
-			}()
-		} else {
-			for i := 0; i < taskWorker.pollerCount; i++ {
-				bw.stopWG.Add(1)
-				bw.pollerWG.Add(1)
-				go bw.runPoller(taskWorker)
-			}
-		}
+	if bw.pollerTransition == nil {
+		bw.startPollers(bw.options.taskPollers, nil, bw.pollerBalancer)
+	} else {
+		bw.stopWG.Add(1)
+		bw.pollerWG.Add(1)
+		go bw.runPollerTransitionController()
 	}
 
 	// When all pollers have exited, close taskQueueCh so the dispatcher
@@ -496,6 +520,105 @@ func (bw *baseWorker) Start() {
 	})
 }
 
+func (bw *baseWorker) startPollers(
+	taskPollers []scalableTaskPoller,
+	loopStop <-chan struct{},
+	balancer *pollerBalancer,
+) {
+	// loopStop belongs to one polling mode. Unlike bw.stopCh, closing it retires
+	// only that mode during a runtime transition and does not stop the worker.
+	for _, taskWorker := range taskPollers {
+		if taskWorker.autoscalingRunner != nil {
+			// Autoscaling pollers are created with both a runner and an autoscaler.
+			// The runner's manager opens polls under the current target.
+			bw.stopWG.Add(1)
+			bw.pollerWG.Add(1)
+			go bw.runAutoscalingPoller(taskWorker, loopStop, balancer)
+
+			// The autoscaler's separate loop periodically refreshes scaling signals.
+			autoscalerStop := loopStop
+			if autoscalerStop == nil {
+				autoscalerStop = bw.stopCh
+			}
+			bw.stopWG.Add(1)
+			go func(stop <-chan struct{}) {
+				defer bw.stopWG.Done()
+				taskWorker.pollerAutoscaler.run(stop)
+			}(autoscalerStop)
+		} else {
+			for i := 0; i < taskWorker.pollerCount; i++ {
+				bw.stopWG.Add(1)
+				bw.pollerWG.Add(1)
+				go bw.runPoller(taskWorker, loopStop, balancer)
+			}
+		}
+	}
+}
+
+// runPollerTransitionController keeps an originally fixed worker's polling mode
+// aligned with the latest poller-group snapshot until the worker stops.
+func (bw *baseWorker) runPollerTransitionController() {
+	defer bw.stopWG.Done()
+	defer bw.pollerWG.Done()
+
+	var grouped bool
+	var modeStarted bool
+	// modeStop is owned by this controller and shared by all loops in the active
+	// mode. Closing it retires those loops after their replacement has started.
+	var modeStop chan struct{}
+	defer func() {
+		if modeStop != nil {
+			close(modeStop)
+		}
+	}()
+
+	for {
+		changed := bw.pollerTransition.groupInfos.changed()
+		wantGrouped := bw.pollerTransition.groupInfos.len() > 0
+		if !modeStarted || grouped != wantGrouped {
+			// Give the replacement its own stop channel before retiring the current
+			// mode, avoiding a gap where neither mode can open polls.
+			nextStop := make(chan struct{})
+			if wantGrouped {
+				bw.startPollers(
+					bw.pollerTransition.buildAutoscaling(),
+					nextStop,
+					newPollerBalancer(bw.pollerTransition.taskPollerTypes),
+				)
+			} else {
+				bw.pollerTransition.restoreFixed()
+				bw.startPollers(bw.options.taskPollers, nextStop, bw.pollerBalancer)
+			}
+			if modeStop != nil {
+				close(modeStop)
+			}
+			modeStop = nextStop
+			grouped = wantGrouped
+			modeStarted = true
+		}
+
+		select {
+		case <-bw.stopCh:
+			return
+		case <-changed:
+		}
+	}
+}
+
+func newPollerBalancer(taskPollerTypes []string) *pollerBalancer {
+	if len(taskPollerTypes) <= 1 {
+		return nil
+	}
+	balancer := &pollerBalancer{
+		pollerCount:   make(map[string]int),
+		pollerBarrier: make(map[string]barrier),
+	}
+	for _, taskPollerType := range taskPollerTypes {
+		balancer.registerPollerType(taskPollerType)
+	}
+	return balancer
+}
+
 func (bw *baseWorker) isStop() bool {
 	select {
 	case <-bw.stopCh:
@@ -509,7 +632,11 @@ func (bw *baseWorker) shouldDrainOnShutdown() bool {
 	return bw.options.workerPollCompleteOnShutdown != nil && bw.options.workerPollCompleteOnShutdown.Load()
 }
 
-func (bw *baseWorker) runPoller(taskWorker scalableTaskPoller) {
+func (bw *baseWorker) runPoller(
+	taskWorker scalableTaskPoller,
+	loopStop <-chan struct{},
+	balancer *pollerBalancer,
+) {
 	defer bw.stopWG.Done()
 	defer bw.pollerWG.Done()
 	bw.metricsHandler.Counter(metrics.PollerStartCounter).Inc(1)
@@ -522,9 +649,14 @@ func (bw *baseWorker) runPoller(taskWorker scalableTaskPoller) {
 		if bw.noRepoll.Load() {
 			return
 		}
+		select {
+		case <-loopStop:
+			return
+		default:
+		}
 		// Call the balancer to make sure one poller type doesn't starve the others of slots.
-		if bw.pollerBalancer != nil {
-			if bw.pollerBalancer.balance(bw.limiterContext, taskWorker.taskPollerType) != nil {
+		if balancer != nil {
+			if balancer.balance(bw.limiterContext, taskWorker.taskPollerType) != nil {
 				return
 			}
 		}
@@ -533,6 +665,8 @@ func (bw *baseWorker) runPoller(taskWorker scalableTaskPoller) {
 
 		select {
 		case <-bw.stopCh:
+			return
+		case <-loopStop:
 			return
 		case permit := <-reserveChan:
 			if permit == nil { // There was an error reserving a slot
@@ -546,12 +680,21 @@ func (bw *baseWorker) runPoller(taskWorker scalableTaskPoller) {
 				bw.releaseSlot(permit, SlotReleaseReasonUnused)
 				return
 			}
-			if bw.pollerBalancer != nil {
-				bw.pollerBalancer.incrementPoller(taskWorker.taskPollerType)
+			if balancer != nil {
+				balancer.incrementPoller(taskWorker.taskPollerType)
+			}
+			select {
+			case <-loopStop:
+				if balancer != nil {
+					balancer.decrementPoller(taskWorker.taskPollerType)
+				}
+				bw.releaseSlot(permit, SlotReleaseReasonUnused)
+				return
+			default:
 			}
 			bw.pollTask(taskWorker, permit, pollerGroupLease{})
-			if bw.pollerBalancer != nil {
-				bw.pollerBalancer.decrementPoller(taskWorker.taskPollerType)
+			if balancer != nil {
+				balancer.decrementPoller(taskWorker.taskPollerType)
 			}
 		}
 	}
@@ -562,14 +705,31 @@ func (bw *baseWorker) runPoller(taskWorker scalableTaskPoller) {
 // synchronously, and loops. The autoscaling path instead uses this goroutine as
 // a manager: it waits for runner admission, reserves a slot, then spawns one
 // short-lived goroutine per logical poll. The configured poller limit bounds
-// logical active polls, not the supporting goroutine count.
-func (bw *baseWorker) runAutoscalingPoller(taskWorker scalableTaskPoller) {
+// logical active polls, not the supporting goroutine count. Closing loopStop
+// retires this polling mode by stopping new admission and slot reservations;
+// logical polls already in flight finish before the manager returns.
+func (bw *baseWorker) runAutoscalingPoller(
+	taskWorker scalableTaskPoller,
+	loopStop <-chan struct{},
+	balancer *pollerBalancer,
+) {
 	defer bw.stopWG.Done()
 	defer bw.pollerWG.Done()
 
-	ctx, cancelfn := context.WithCancel(context.Background())
+	ctx, cancelfn := context.WithCancel(bw.limiterContext)
 	reserveChan := make(chan *SlotPermit)
 	var pollWG sync.WaitGroup
+	if loopStop != nil {
+		// Convert the mode-scoped stop channel into the context used by admission,
+		// balancing, and slot reservation. In-flight poll RPCs still finish below.
+		go func() {
+			select {
+			case <-loopStop:
+				cancelfn()
+			case <-ctx.Done():
+			}
+		}()
+	}
 
 	defer pollWG.Wait()
 	defer cancelfn()
@@ -580,13 +740,13 @@ func (bw *baseWorker) runAutoscalingPoller(taskWorker scalableTaskPoller) {
 		}
 		// Call the balancer before reserving a slot so one poller type cannot
 		// hold slots while waiting for another type to start polling.
-		if bw.pollerBalancer != nil {
-			if bw.pollerBalancer.balance(bw.limiterContext, taskWorker.taskPollerType) != nil {
+		if balancer != nil {
+			if balancer.balance(ctx, taskWorker.taskPollerType) != nil {
 				return
 			}
 		}
 
-		lease, releaseActive, err := taskWorker.autoscalingRunner.acquire(bw.limiterContext)
+		lease, releaseActive, err := taskWorker.autoscalingRunner.acquire(ctx)
 		if err != nil {
 			return
 		}
@@ -595,7 +755,7 @@ func (bw *baseWorker) runAutoscalingPoller(taskWorker scalableTaskPoller) {
 
 		var permit *SlotPermit
 		select {
-		case <-bw.stopCh:
+		case <-ctx.Done():
 			lease.release()
 			releaseActive()
 			return
@@ -610,6 +770,16 @@ func (bw *baseWorker) runAutoscalingPoller(taskWorker scalableTaskPoller) {
 			}
 			continue
 		}
+		// A slot and cancellation can become ready together. If the slot won the
+		// select after this mode stopped, release its reservations without polling.
+		select {
+		case <-ctx.Done():
+			bw.releaseSlot(permit, SlotReleaseReasonUnused)
+			lease.release()
+			releaseActive()
+			return
+		default:
+		}
 
 		if bw.sessionTokenBucket != nil && !bw.sessionTokenBucket.waitForAvailableToken() {
 			bw.releaseSlot(permit, SlotReleaseReasonUnused)
@@ -617,8 +787,8 @@ func (bw *baseWorker) runAutoscalingPoller(taskWorker scalableTaskPoller) {
 			releaseActive()
 			return
 		}
-		if bw.pollerBalancer != nil {
-			bw.pollerBalancer.incrementPoller(taskWorker.taskPollerType)
+		if balancer != nil {
+			balancer.incrementPoller(taskWorker.taskPollerType)
 		}
 
 		pollWG.Add(1)
@@ -628,8 +798,8 @@ func (bw *baseWorker) runAutoscalingPoller(taskWorker scalableTaskPoller) {
 			defer pollWG.Done()
 			defer releaseActive()
 			defer lease.release()
-			if bw.pollerBalancer != nil {
-				defer bw.pollerBalancer.decrementPoller(taskWorker.taskPollerType)
+			if balancer != nil {
+				defer balancer.decrementPoller(taskWorker.taskPollerType)
 			}
 			bw.pollTask(taskWorker, slotPermit, lease)
 		}(permit)
@@ -1048,6 +1218,7 @@ func (prh *pollerAutoscaler) handleError(err error) {
 
 func (prh *pollerAutoscaler) run(stopCh <-chan struct{}) {
 	ticker := time.NewTicker(pollerAutoscalingReportInterval)
+	defer ticker.Stop()
 	// Here we periodically check if we should permit increasing the
 	// poller count further. We do this by comparing the number of ingested items in the
 	// current period with the number of ingested items in the previous period. If we

--- a/internal/internal_worker_base_test.go
+++ b/internal/internal_worker_base_test.go
@@ -869,6 +869,39 @@ func (s *ScalableTaskPollerSuite) TestAutoscalingDoesNotHoldSlotWhileWaitingForP
 	})
 }
 
+func (s *ScalableTaskPollerSuite) TestAutoscalingModeStopDoesNotPollWithConcurrentSlot() {
+	// Repeat the cancellation race: ReserveSlot completes because its context was
+	// canceled, just as the manager is deciding between that permit and ctx.Done.
+	for range 100 {
+		behavior := &pollerBehaviorAutoscaling{
+			initialNumberOfPollers: 1,
+			maximumNumberOfPollers: 1,
+			minimumNumberOfPollers: 1,
+		}
+		taskPoller := &countingProbeTaskPoller{}
+		poller := newScalableTaskPoller(taskPoller, ilog.NewNopLogger(), behavior, "", nil, nil)
+		slotSupplier := &permitAfterCancellationSlotSupplier{reserveStarted: make(chan struct{})}
+		bw := newBaseWorker(baseWorkerOptions{
+			slotSupplier:     slotSupplier,
+			maxTaskPerSecond: 1000,
+			taskProcessor:    noopTaskProcessor{},
+			workerType:       "AutoscalingModeStopSlotRaceTest",
+			logger:           ilog.NewNopLogger(),
+			stopTimeout:      time.Second,
+			metricsHandler:   metrics.NopHandler,
+		})
+
+		modeStop := make(chan struct{})
+		bw.startPollers([]scalableTaskPoller{poller}, modeStop, nil)
+		<-slotSupplier.reserveStarted
+		close(modeStop)
+		bw.stopWG.Wait()
+
+		require.Zero(s.T(), taskPoller.started.Load(), "retired mode opened a poll")
+		require.Equal(s.T(), int32(1), slotSupplier.releases.Load(), "unused permit was not released")
+	}
+}
+
 func (s *ScalableTaskPollerSuite) TestAutoscalingBalancerDoesNotHoldSlotsWhileBlocked() {
 	synctest.Test(s.T(), func(t *testing.T) {
 		behavior := &pollerBehaviorAutoscaling{
@@ -915,6 +948,38 @@ type blockingProbeTaskPoller struct {
 	started atomic.Int32
 }
 
+type countingProbeTaskPoller struct {
+	started atomic.Int32
+}
+
+func (p *countingProbeTaskPoller) PollTask(pollerGroupLease) (taskForWorker, error) {
+	p.started.Add(1)
+	return nil, nil
+}
+
+type transitionProbePoller struct {
+	groupInfos *pollerGroupInfoStore
+	published  chan struct{}
+	returnTask chan struct{}
+	task       taskForWorker
+	once       sync.Once
+	started    atomic.Int32
+}
+
+func (p *transitionProbePoller) PollTask(pollerGroupLease) (taskForWorker, error) {
+	p.started.Add(1)
+	var task taskForWorker
+	p.once.Do(func() {
+		p.groupInfos.updateGroups(testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{
+			{Id: "runtime-group", Weight: 1},
+		}))
+		close(p.published)
+		<-p.returnTask
+		task = p.task
+	})
+	return task, nil
+}
+
 func newBlockingProbeTaskPoller() *blockingProbeTaskPoller {
 	return &blockingProbeTaskPoller{
 		signals: make(chan struct{}, 32),
@@ -950,6 +1015,301 @@ func (p *blockingProbeTaskPoller) startedPolls() int32 {
 func (p *blockingProbeTaskPoller) Close() {
 	if p.closed.CompareAndSwap(false, true) {
 		close(p.done)
+	}
+}
+
+func TestRuntimePollerTransitionLifecycle(t *testing.T) {
+	groupInfos := newPollerGroupInfoStore()
+	fixed := &transitionProbePoller{
+		groupInfos: groupInfos,
+		published:  make(chan struct{}),
+		returnTask: make(chan struct{}),
+		task:       &testTask{},
+	}
+	replacement := newBlockingProbeTaskPoller()
+	processed := make(chan struct{}, 1)
+	processor := &recordingTaskProcessor{processed: processed}
+	var builds atomic.Int32
+	var restores atomic.Int32
+
+	bw := newBaseWorker(baseWorkerOptions{
+		slotSupplier:     &testSlotSupplier{},
+		maxTaskPerSecond: 1000,
+		taskPollers: []scalableTaskPoller{
+			newScalableTaskPoller(
+				fixed,
+				ilog.NewNopLogger(),
+				NewPollerBehaviorSimpleMaximum(PollerBehaviorSimpleMaximumOptions{MaximumNumberOfPollers: 1}),
+				metrics.PollerTypeActivityTask,
+				&atomic.Bool{},
+				nil,
+			),
+		},
+		taskProcessor:  processor,
+		workerType:     "RuntimePollerTransitionTest",
+		logger:         ilog.NewNopLogger(),
+		stopTimeout:    time.Second,
+		metricsHandler: metrics.NopHandler,
+	})
+	bw.setPollerTransition(groupInfos, []string{metrics.PollerTypeActivityTask}, func() []scalableTaskPoller {
+		builds.Add(1)
+		groups := newPollerGroupManager(pollerGroupModeNonWorkflow, groupInfos)
+		return []scalableTaskPoller{
+			newScalableTaskPoller(
+				replacement,
+				ilog.NewNopLogger(),
+				NewPollerBehaviorAutoscaling(PollerBehaviorAutoscalingOptions{}),
+				metrics.PollerTypeActivityTask,
+				&atomic.Bool{},
+				groups,
+			),
+		}
+	}, func() {
+		restores.Add(1)
+	})
+
+	bw.Start()
+	defer func() {
+		replacement.Close()
+		bw.Stop()
+	}()
+
+	select {
+	case <-fixed.published:
+	case <-time.After(time.Second):
+		t.Fatal("fixed poll did not publish poller groups")
+	}
+	require.Eventually(t, func() bool {
+		return replacement.startedPolls() > 0
+	}, time.Second, 10*time.Millisecond, "replacement should start before the triggering poll returns")
+
+	var updates sync.WaitGroup
+	for version := int64(2); version <= 10; version++ {
+		updates.Add(1)
+		go func(version int64) {
+			defer updates.Done()
+			groupInfos.updateGroups(testPollerGroupsInfo(version, []*taskqueuepb.PollerGroupInfo{
+				{Id: "runtime-group", Weight: 1},
+			}))
+		}(version)
+	}
+	updates.Wait()
+	require.Equal(t, int32(1), builds.Load())
+
+	close(fixed.returnTask)
+	select {
+	case <-processed:
+	case <-time.After(time.Second):
+		t.Fatal("task from triggering poll was not processed")
+	}
+
+	groupInfos.updateGroups(testPollerGroupsInfo(11, nil))
+	require.Eventually(t, func() bool {
+		return fixed.started.Load() > 1
+	}, time.Second, 10*time.Millisecond, "fixed polling should resume after groups clear")
+	require.Equal(t, int32(1), builds.Load())
+	require.Equal(t, int32(2), restores.Load())
+
+	previousReplacementPolls := replacement.startedPolls()
+	groupInfos.updateGroups(testPollerGroupsInfo(12, []*taskqueuepb.PollerGroupInfo{
+		{Id: "runtime-group", Weight: 1},
+	}))
+	require.Eventually(t, func() bool {
+		return builds.Load() == 2 && replacement.startedPolls() > previousReplacementPolls
+	}, time.Second, 10*time.Millisecond, "autoscaling polling should resume when groups return")
+
+	groupInfos.updateGroups(testPollerGroupsInfo(13, nil))
+	require.Eventually(t, func() bool {
+		return restores.Load() == 3
+	}, time.Second, 10*time.Millisecond, "fixed polling should resume after groups clear again")
+
+	previousReplacementPolls = replacement.startedPolls()
+	groupInfos.updateGroups(testPollerGroupsInfo(14, []*taskqueuepb.PollerGroupInfo{
+		{Id: "runtime-group", Weight: 1},
+	}))
+	require.Eventually(t, func() bool {
+		return builds.Load() == 3 && replacement.startedPolls() > previousReplacementPolls
+	}, time.Second, 10*time.Millisecond, "autoscaling polling should resume after a second re-entry")
+}
+
+func TestPollerTransitionKeepsFixedPollersIndependent(t *testing.T) {
+	groupInfos := newPollerGroupInfoStore()
+	fixed := newBlockingProbeTaskPoller()
+	bw := newBaseWorker(baseWorkerOptions{
+		slotSupplier:     &testSlotSupplier{},
+		maxTaskPerSecond: 1000,
+		taskPollers: []scalableTaskPoller{
+			newScalableTaskPoller(
+				fixed,
+				ilog.NewNopLogger(),
+				NewPollerBehaviorSimpleMaximum(PollerBehaviorSimpleMaximumOptions{MaximumNumberOfPollers: 2}),
+				metrics.PollerTypeWorkflowTask,
+				&atomic.Bool{},
+				nil,
+			),
+		},
+		taskProcessor:  noopTaskProcessor{},
+		workerType:     "FixedPollerTransitionTest",
+		logger:         ilog.NewNopLogger(),
+		stopTimeout:    time.Second,
+		metricsHandler: metrics.NopHandler,
+	})
+	bw.setPollerTransition(
+		groupInfos,
+		[]string{metrics.PollerTypeWorkflowTask, metrics.PollerTypeWorkflowStickyTask},
+		func() []scalableTaskPoller { return nil },
+		func() {},
+	)
+
+	bw.Start()
+	defer func() {
+		fixed.Close()
+		bw.Stop()
+	}()
+
+	require.Eventually(t, func() bool {
+		return fixed.startedPolls() == 2
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestPollerTransitionUsesLatestSnapshotAtStart(t *testing.T) {
+	groupInfos := newPollerGroupInfoStore()
+	groupInfos.updateGroups(testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{
+		{Id: "runtime-group", Weight: 1},
+	}))
+	groupInfos.updateGroups(testPollerGroupsInfo(2, nil))
+
+	fixed := newBlockingProbeTaskPoller()
+	replacement := newBlockingProbeTaskPoller()
+	var builds atomic.Int32
+	bw := newBaseWorker(baseWorkerOptions{
+		slotSupplier:     &testSlotSupplier{},
+		maxTaskPerSecond: 1000,
+		taskPollers: []scalableTaskPoller{
+			newScalableTaskPoller(
+				fixed,
+				ilog.NewNopLogger(),
+				NewPollerBehaviorSimpleMaximum(PollerBehaviorSimpleMaximumOptions{MaximumNumberOfPollers: 1}),
+				metrics.PollerTypeActivityTask,
+				&atomic.Bool{},
+				nil,
+			),
+		},
+		taskProcessor:  noopTaskProcessor{},
+		workerType:     "RememberedPollerTransitionTest",
+		logger:         ilog.NewNopLogger(),
+		stopTimeout:    time.Second,
+		metricsHandler: metrics.NopHandler,
+	})
+	bw.setPollerTransition(groupInfos, []string{metrics.PollerTypeActivityTask}, func() []scalableTaskPoller {
+		builds.Add(1)
+		groups := newPollerGroupManager(pollerGroupModeNonWorkflow, groupInfos)
+		return []scalableTaskPoller{
+			newScalableTaskPoller(
+				replacement,
+				ilog.NewNopLogger(),
+				NewPollerBehaviorAutoscaling(PollerBehaviorAutoscalingOptions{}),
+				metrics.PollerTypeActivityTask,
+				&atomic.Bool{},
+				groups,
+			),
+		}
+	}, func() {})
+
+	bw.Start()
+	defer func() {
+		fixed.Close()
+		replacement.Close()
+		bw.Stop()
+	}()
+
+	require.Eventually(t, func() bool {
+		return fixed.startedPolls() > 0
+	}, time.Second, 10*time.Millisecond)
+	require.Equal(t, int32(0), builds.Load())
+}
+
+func TestShutdownDuringPollerTransition(t *testing.T) {
+	groupInfos := newPollerGroupInfoStore()
+	fixed := &transitionProbePoller{
+		groupInfos: groupInfos,
+		published:  make(chan struct{}),
+		returnTask: make(chan struct{}),
+		task:       &testTask{},
+	}
+	replacement := newBlockingProbeTaskPoller()
+	processed := make(chan struct{}, 1)
+	buildEntered := make(chan struct{})
+	releaseBuild := make(chan struct{})
+	drain := &atomic.Bool{}
+	drain.Store(true)
+
+	bw := newBaseWorker(baseWorkerOptions{
+		slotSupplier:     &testSlotSupplier{},
+		maxTaskPerSecond: 1000,
+		taskPollers: []scalableTaskPoller{
+			newScalableTaskPoller(
+				fixed,
+				ilog.NewNopLogger(),
+				NewPollerBehaviorSimpleMaximum(PollerBehaviorSimpleMaximumOptions{MaximumNumberOfPollers: 1}),
+				metrics.PollerTypeActivityTask,
+				&atomic.Bool{},
+				nil,
+			),
+		},
+		taskProcessor:                &recordingTaskProcessor{processed: processed},
+		workerType:                   "ShutdownPollerTransitionTest",
+		logger:                       ilog.NewNopLogger(),
+		stopTimeout:                  time.Second,
+		metricsHandler:               metrics.NopHandler,
+		workerPollCompleteOnShutdown: drain,
+	})
+	bw.setPollerTransition(groupInfos, []string{metrics.PollerTypeActivityTask}, func() []scalableTaskPoller {
+		close(buildEntered)
+		<-releaseBuild
+		groups := newPollerGroupManager(pollerGroupModeNonWorkflow, groupInfos)
+		return []scalableTaskPoller{
+			newScalableTaskPoller(
+				replacement,
+				ilog.NewNopLogger(),
+				NewPollerBehaviorAutoscaling(PollerBehaviorAutoscalingOptions{}),
+				metrics.PollerTypeActivityTask,
+				&atomic.Bool{},
+				groups,
+			),
+		}
+	}, func() {})
+
+	bw.Start()
+	select {
+	case <-fixed.published:
+	case <-time.After(time.Second):
+		t.Fatal("fixed poll did not publish poller groups")
+	}
+	select {
+	case <-buildEntered:
+	case <-time.After(time.Second):
+		t.Fatal("transition did not start")
+	}
+
+	stopDone := make(chan struct{})
+	go func() {
+		bw.Stop()
+		close(stopDone)
+	}()
+	replacement.Close()
+	close(fixed.returnTask)
+	close(releaseBuild)
+
+	select {
+	case <-stopDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("shutdown blocked during poller transition")
+	}
+	select {
+	case <-processed:
+	case <-time.After(time.Second):
+		t.Fatal("triggering task was not drained during shutdown")
 	}
 }
 
@@ -1065,6 +1425,32 @@ func (s *limitedSlotSupplier) ReleaseSlot(SlotReleaseInfo) {
 }
 
 func (s *limitedSlotSupplier) MaxSlots() int { return cap(s.slots) }
+
+// permitAfterCancellationSlotSupplier models a slot reservation completing at
+// the same time its context is canceled.
+type permitAfterCancellationSlotSupplier struct {
+	reserveStarted chan struct{}
+	startOnce      sync.Once
+	releases       atomic.Int32
+}
+
+func (s *permitAfterCancellationSlotSupplier) ReserveSlot(ctx context.Context, _ SlotReservationInfo) (*SlotPermit, error) {
+	s.startOnce.Do(func() { close(s.reserveStarted) })
+	<-ctx.Done()
+	return &SlotPermit{}, nil
+}
+
+func (s *permitAfterCancellationSlotSupplier) TryReserveSlot(SlotReservationInfo) *SlotPermit {
+	return nil
+}
+
+func (s *permitAfterCancellationSlotSupplier) MarkSlotUsed(SlotMarkUsedInfo) {}
+
+func (s *permitAfterCancellationSlotSupplier) ReleaseSlot(SlotReleaseInfo) {
+	s.releases.Add(1)
+}
+
+func (s *permitAfterCancellationSlotSupplier) MaxSlots() int { return 0 }
 
 type noopTaskProcessor struct{}
 

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -2296,6 +2296,148 @@ func (s *internalWorkerTestSuite) TestDescribeNamespacePollerGroupsSeedWorkflowN
 	releaseNormalPollOnce.Do(func() { close(releaseNormalPoll) })
 }
 
+func (s *internalWorkerTestSuite) TestWorkflowSimpleMaximumTransitionsToGroupedAutoscaling() {
+	namespace := "testNamespace"
+	taskQueue := "runtime-workflow-transition-tq"
+	groupID := "runtime-group"
+	service := workflowservicemock.NewMockWorkflowServiceClient(s.mockCtrl)
+	service.EXPECT().GetSystemInfo(gomock.Any(), gomock.Any(), gomock.Any()).Return(&workflowservice.GetSystemInfoResponse{}, nil).AnyTimes()
+	service.EXPECT().DescribeNamespace(gomock.Any(), gomock.Any(), gomock.Any()).Return(&workflowservice.DescribeNamespaceResponse{
+		NamespaceInfo: &namespacepb.NamespaceInfo{
+			Name:  namespace,
+			State: enumspb.NAMESPACE_STATE_REGISTERED,
+		},
+	}, nil).AnyTimes()
+	service.EXPECT().ShutdownWorker(gomock.Any(), gomock.Any(), gomock.Any()).Return(&workflowservice.ShutdownWorkerResponse{}, nil).AnyTimes()
+	service.EXPECT().PollActivityTaskQueue(gomock.Any(), gomock.Any(), gomock.Any()).Return(&workflowservice.PollActivityTaskQueueResponse{}, nil).AnyTimes()
+
+	polls := make(chan *workflowservice.PollWorkflowTaskQueueRequest, 20)
+	var publishGroups sync.Once
+	var transitionStage atomic.Int32
+	var publishEmptyGroups sync.Once
+	var republishGroups sync.Once
+	service.EXPECT().PollWorkflowTaskQueue(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, req *workflowservice.PollWorkflowTaskQueueRequest, opts ...grpc.CallOption) (*workflowservice.PollWorkflowTaskQueueResponse, error) {
+			select {
+			case polls <- proto.Clone(req).(*workflowservice.PollWorkflowTaskQueueRequest):
+			default:
+			}
+
+			response := &workflowservice.PollWorkflowTaskQueueResponse{}
+			publishGroups.Do(func() {
+				response.PollerGroupsInfo = testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{
+					{Id: groupID, Weight: 1},
+				})
+			})
+			switch transitionStage.Load() {
+			case 1:
+				if req.GetPollerGroupId() == groupID {
+					publishEmptyGroups.Do(func() {
+						response.PollerGroupsInfo = testPollerGroupsInfo(2, nil)
+					})
+				}
+			case 2:
+				if req.GetPollerGroupId() == "" {
+					republishGroups.Do(func() {
+						response.PollerGroupsInfo = testPollerGroupsInfo(3, []*taskqueuepb.PollerGroupInfo{
+							{Id: groupID, Weight: 1},
+						})
+					})
+				}
+			}
+			return response, nil
+		},
+	).AnyTimes()
+
+	client := NewServiceClient(service, nil, ClientOptions{
+		Namespace:               namespace,
+		WorkerHeartbeatInterval: time.Minute,
+	})
+	worker := NewAggregatedWorker(client, taskQueue, WorkerOptions{
+		WorkflowTaskPollerBehavior: NewPollerBehaviorSimpleMaximum(PollerBehaviorSimpleMaximumOptions{MaximumNumberOfPollers: 2}),
+		ActivityTaskPollerBehavior: NewPollerBehaviorSimpleMaximum(PollerBehaviorSimpleMaximumOptions{MaximumNumberOfPollers: 1}),
+		NexusTaskPollerBehavior:    NewPollerBehaviorSimpleMaximum(PollerBehaviorSimpleMaximumOptions{MaximumNumberOfPollers: 1}),
+	})
+	require.NoError(s.T(), worker.Start())
+	defer worker.Stop()
+
+	stickyEnabled := worker.workflowWorker.taskProcessor.stickyCacheSize > 0
+	var sawNormal, sawSticky bool
+	require.Eventually(s.T(), func() bool {
+		for {
+			select {
+			case req := <-polls:
+				if req.GetPollerGroupId() != groupID {
+					continue
+				}
+				switch req.GetTaskQueue().GetKind() {
+				case enumspb.TASK_QUEUE_KIND_NORMAL:
+					sawNormal = true
+				case enumspb.TASK_QUEUE_KIND_STICKY:
+					sawSticky = true
+				}
+			default:
+				return sawNormal && (sawSticky || !stickyEnabled)
+			}
+		}
+	}, 2*time.Second, 10*time.Millisecond)
+
+	heartbeat := worker.heartbeatCallback()
+	require.True(s.T(), heartbeat.GetWorkflowPollerInfo().GetIsAutoscaling())
+
+	for len(polls) > 0 {
+		<-polls
+	}
+	transitionStage.Store(1)
+	require.Eventually(s.T(), func() bool {
+		workflowBehavior, _, _ := worker.executionParams.pollerBehaviorState.snapshot()
+		_, isSimpleMaximum := workflowBehavior.(*pollerBehaviorSimpleMaximum)
+		if !isSimpleMaximum {
+			return false
+		}
+		heartbeat = worker.heartbeatCallback()
+		if heartbeat.GetWorkflowPollerInfo().GetIsAutoscaling() {
+			return false
+		}
+		select {
+		case req := <-polls:
+			return req.GetPollerGroupId() == ""
+		default:
+			return false
+		}
+	}, 2*time.Second, 10*time.Millisecond)
+
+	for len(polls) > 0 {
+		<-polls
+	}
+	transitionStage.Store(2)
+	sawNormal, sawSticky = false, false
+	require.Eventually(s.T(), func() bool {
+		for {
+			select {
+			case req := <-polls:
+				if req.GetPollerGroupId() != groupID {
+					continue
+				}
+				switch req.GetTaskQueue().GetKind() {
+				case enumspb.TASK_QUEUE_KIND_NORMAL:
+					sawNormal = true
+				case enumspb.TASK_QUEUE_KIND_STICKY:
+					sawSticky = true
+				}
+			default:
+				if !sawNormal || (!sawSticky && stickyEnabled) {
+					return false
+				}
+				workflowBehavior, _, _ := worker.executionParams.pollerBehaviorState.snapshot()
+				_, isAutoscaling := workflowBehavior.(*pollerBehaviorAutoscaling)
+				heartbeat = worker.heartbeatCallback()
+				return isAutoscaling && heartbeat.GetWorkflowPollerInfo().GetIsAutoscaling()
+			}
+		}
+	}, 2*time.Second, 10*time.Millisecond)
+}
+
 func (s *internalWorkerTestSuite) TestDescribeNamespacePollerGroupsSeedActivityPolls() {
 	namespace := "testNamespace"
 	taskQueue := "seeded-activity-tq"
@@ -2316,7 +2458,10 @@ func (s *internalWorkerTestSuite) TestDescribeNamespacePollerGroupsSeedActivityP
 		},
 	).AnyTimes()
 
-	client := NewServiceClient(service, nil, ClientOptions{Namespace: namespace})
+	client := NewServiceClient(service, nil, ClientOptions{
+		Namespace:               namespace,
+		WorkerHeartbeatInterval: time.Minute,
+	})
 	worker := NewAggregatedWorker(client, taskQueue, WorkerOptions{
 		DisableWorkflowWorker:      true,
 		WorkflowTaskPollerBehavior: NewPollerBehaviorSimpleMaximum(PollerBehaviorSimpleMaximumOptions{MaximumNumberOfPollers: 2}),
@@ -2335,6 +2480,201 @@ func (s *internalWorkerTestSuite) TestDescribeNamespacePollerGroupsSeedActivityP
 				}
 			default:
 				return false
+			}
+		}
+	}, 2*time.Second, 10*time.Millisecond)
+
+	require.Nil(s.T(), worker.activityWorker.worker.pollerTransition)
+	worker.executionParams.pollerGroupInfoStore.updateGroups(testPollerGroupsInfo(2, nil))
+	heartbeat := worker.heartbeatCallback()
+	require.True(s.T(), heartbeat.GetActivityPollerInfo().GetIsAutoscaling())
+}
+
+func (s *internalWorkerTestSuite) TestActivitySimpleMaximumTransitionsToGroupedAutoscaling() {
+	namespace := "testNamespace"
+	taskQueue := "runtime-activity-transition-tq"
+	groupID := "runtime-group"
+	service := workflowservicemock.NewMockWorkflowServiceClient(s.mockCtrl)
+	service.EXPECT().GetSystemInfo(gomock.Any(), gomock.Any(), gomock.Any()).Return(&workflowservice.GetSystemInfoResponse{}, nil).AnyTimes()
+	service.EXPECT().DescribeNamespace(gomock.Any(), gomock.Any(), gomock.Any()).Return(&workflowservice.DescribeNamespaceResponse{
+		NamespaceInfo: &namespacepb.NamespaceInfo{
+			Name:  namespace,
+			State: enumspb.NAMESPACE_STATE_REGISTERED,
+		},
+	}, nil).AnyTimes()
+	service.EXPECT().ShutdownWorker(gomock.Any(), gomock.Any(), gomock.Any()).Return(&workflowservice.ShutdownWorkerResponse{}, nil).AnyTimes()
+
+	polls := make(chan string, 20)
+	var publishGroups sync.Once
+	var transitionStage atomic.Int32
+	var publishEmptyGroups sync.Once
+	var republishGroups sync.Once
+	service.EXPECT().PollActivityTaskQueue(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, req *workflowservice.PollActivityTaskQueueRequest, opts ...grpc.CallOption) (*workflowservice.PollActivityTaskQueueResponse, error) {
+			select {
+			case polls <- req.GetPollerGroupId():
+			default:
+			}
+
+			response := &workflowservice.PollActivityTaskQueueResponse{}
+			publishGroups.Do(func() {
+				response.PollerGroupsInfo = testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{
+					{Id: groupID, Weight: 1},
+				})
+			})
+			switch transitionStage.Load() {
+			case 1:
+				if req.GetPollerGroupId() == groupID {
+					publishEmptyGroups.Do(func() {
+						response.PollerGroupsInfo = testPollerGroupsInfo(2, nil)
+					})
+				}
+			case 2:
+				if req.GetPollerGroupId() == "" {
+					republishGroups.Do(func() {
+						response.PollerGroupsInfo = testPollerGroupsInfo(3, []*taskqueuepb.PollerGroupInfo{
+							{Id: groupID, Weight: 1},
+						})
+					})
+				}
+			}
+			return response, nil
+		},
+	).AnyTimes()
+
+	client := NewServiceClient(service, nil, ClientOptions{
+		Namespace:               namespace,
+		WorkerHeartbeatInterval: time.Minute,
+	})
+	worker := NewAggregatedWorker(client, taskQueue, WorkerOptions{
+		DisableWorkflowWorker:      true,
+		WorkflowTaskPollerBehavior: NewPollerBehaviorSimpleMaximum(PollerBehaviorSimpleMaximumOptions{MaximumNumberOfPollers: 1}),
+		ActivityTaskPollerBehavior: NewPollerBehaviorSimpleMaximum(PollerBehaviorSimpleMaximumOptions{MaximumNumberOfPollers: 2}),
+		NexusTaskPollerBehavior:    NewPollerBehaviorSimpleMaximum(PollerBehaviorSimpleMaximumOptions{MaximumNumberOfPollers: 1}),
+	})
+	require.NoError(s.T(), worker.Start())
+	defer worker.Stop()
+
+	require.Eventually(s.T(), func() bool {
+		for {
+			select {
+			case id := <-polls:
+				if id == groupID {
+					return true
+				}
+			default:
+				return false
+			}
+		}
+	}, 2*time.Second, 10*time.Millisecond)
+
+	heartbeat := worker.heartbeatCallback()
+	require.True(s.T(), heartbeat.GetActivityPollerInfo().GetIsAutoscaling())
+
+	for len(polls) > 0 {
+		<-polls
+	}
+	transitionStage.Store(1)
+	require.Eventually(s.T(), func() bool {
+		_, activityBehavior, _ := worker.executionParams.pollerBehaviorState.snapshot()
+		_, isSimpleMaximum := activityBehavior.(*pollerBehaviorSimpleMaximum)
+		if !isSimpleMaximum {
+			return false
+		}
+		heartbeat = worker.heartbeatCallback()
+		if heartbeat.GetActivityPollerInfo().GetIsAutoscaling() {
+			return false
+		}
+		select {
+		case id := <-polls:
+			return id == ""
+		default:
+			return false
+		}
+	}, 2*time.Second, 10*time.Millisecond)
+
+	for len(polls) > 0 {
+		<-polls
+	}
+	transitionStage.Store(2)
+	require.Eventually(s.T(), func() bool {
+		for {
+			select {
+			case id := <-polls:
+				if id == groupID {
+					_, activityBehavior, _ := worker.executionParams.pollerBehaviorState.snapshot()
+					_, isAutoscaling := activityBehavior.(*pollerBehaviorAutoscaling)
+					heartbeat = worker.heartbeatCallback()
+					if isAutoscaling && heartbeat.GetActivityPollerInfo().GetIsAutoscaling() {
+						return true
+					}
+				}
+			default:
+				return false
+			}
+		}
+	}, 2*time.Second, 10*time.Millisecond)
+}
+
+func (s *internalWorkerTestSuite) TestSessionActivityTransitionsButCreationStaysFixed() {
+	namespace := "testNamespace"
+	taskQueue := "runtime-session-transition-tq"
+	groupID := "runtime-group"
+	service := workflowservicemock.NewMockWorkflowServiceClient(s.mockCtrl)
+	service.EXPECT().GetSystemInfo(gomock.Any(), gomock.Any(), gomock.Any()).Return(&workflowservice.GetSystemInfoResponse{}, nil).AnyTimes()
+	service.EXPECT().DescribeNamespace(gomock.Any(), gomock.Any(), gomock.Any()).Return(&workflowservice.DescribeNamespaceResponse{
+		NamespaceInfo: &namespacepb.NamespaceInfo{
+			Name:  namespace,
+			State: enumspb.NAMESPACE_STATE_REGISTERED,
+		},
+	}, nil).AnyTimes()
+	service.EXPECT().ShutdownWorker(gomock.Any(), gomock.Any(), gomock.Any()).Return(&workflowservice.ShutdownWorkerResponse{}, nil).AnyTimes()
+	service.EXPECT().PollWorkflowTaskQueue(gomock.Any(), gomock.Any(), gomock.Any()).Return(&workflowservice.PollWorkflowTaskQueueResponse{}, nil).AnyTimes()
+
+	client := NewServiceClient(service, nil, ClientOptions{Namespace: namespace})
+	worker := NewAggregatedWorker(client, taskQueue, WorkerOptions{
+		EnableSessionWorker: true,
+	})
+	worker.RegisterActivity(testActivityNoResult)
+	sessionTaskQueue := worker.sessionWorker.getActivityWorkerTaskQueue()
+	creationTaskQueue := worker.sessionWorker.getCreationWorkerTaskQueue()
+
+	polls := make(chan *workflowservice.PollActivityTaskQueueRequest, 50)
+	var publishGroups sync.Once
+	service.EXPECT().PollActivityTaskQueue(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, req *workflowservice.PollActivityTaskQueueRequest, opts ...grpc.CallOption) (*workflowservice.PollActivityTaskQueueResponse, error) {
+			select {
+			case polls <- proto.Clone(req).(*workflowservice.PollActivityTaskQueueRequest):
+			default:
+			}
+
+			response := &workflowservice.PollActivityTaskQueueResponse{}
+			publishGroups.Do(func() {
+				response.PollerGroupsInfo = testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{
+					{Id: groupID, Weight: 1},
+				})
+			})
+			return response, nil
+		},
+	).AnyTimes()
+
+	require.NoError(s.T(), worker.Start())
+	defer worker.Stop()
+
+	var sawSessionGrouped, sawCreationUngrouped bool
+	require.Eventually(s.T(), func() bool {
+		for {
+			select {
+			case req := <-polls:
+				switch req.GetTaskQueue().GetName() {
+				case sessionTaskQueue:
+					sawSessionGrouped = sawSessionGrouped || req.GetPollerGroupId() == groupID
+				case creationTaskQueue:
+					require.Empty(s.T(), req.GetPollerGroupId())
+					sawCreationUngrouped = true
+				}
+			default:
+				return sawSessionGrouped && sawCreationUngrouped
 			}
 		}
 	}, 2*time.Second, 10*time.Millisecond)
@@ -2383,6 +2723,139 @@ func (s *internalWorkerTestSuite) TestDescribeNamespacePollerGroupsSeedNexusPoll
 			case id := <-polls:
 				if id == groupID {
 					return true
+				}
+			default:
+				return false
+			}
+		}
+	}, 2*time.Second, 10*time.Millisecond)
+}
+
+func (s *internalWorkerTestSuite) TestNexusSimpleMaximumTransitionsToGroupedAutoscaling() {
+	namespace := "testNamespace"
+	taskQueue := "runtime-nexus-transition-tq"
+	groupID := "runtime-group"
+	service := workflowservicemock.NewMockWorkflowServiceClient(s.mockCtrl)
+	service.EXPECT().GetSystemInfo(gomock.Any(), gomock.Any(), gomock.Any()).Return(&workflowservice.GetSystemInfoResponse{}, nil).AnyTimes()
+	service.EXPECT().DescribeNamespace(gomock.Any(), gomock.Any(), gomock.Any()).Return(&workflowservice.DescribeNamespaceResponse{
+		NamespaceInfo: &namespacepb.NamespaceInfo{
+			Name:  namespace,
+			State: enumspb.NAMESPACE_STATE_REGISTERED,
+		},
+	}, nil).AnyTimes()
+	service.EXPECT().ShutdownWorker(gomock.Any(), gomock.Any(), gomock.Any()).Return(&workflowservice.ShutdownWorkerResponse{}, nil).AnyTimes()
+
+	polls := make(chan string, 20)
+	var publishGroups sync.Once
+	var transitionStage atomic.Int32
+	var publishEmptyGroups sync.Once
+	var republishGroups sync.Once
+	service.EXPECT().PollNexusTaskQueue(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, req *workflowservice.PollNexusTaskQueueRequest, opts ...grpc.CallOption) (*workflowservice.PollNexusTaskQueueResponse, error) {
+			select {
+			case polls <- req.GetPollerGroupId():
+			default:
+			}
+
+			response := &workflowservice.PollNexusTaskQueueResponse{}
+			publishGroups.Do(func() {
+				response.PollerGroupsInfo = testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{
+					{Id: groupID, Weight: 1},
+				})
+			})
+			switch transitionStage.Load() {
+			case 1:
+				if req.GetPollerGroupId() == groupID {
+					publishEmptyGroups.Do(func() {
+						response.PollerGroupsInfo = testPollerGroupsInfo(2, nil)
+					})
+				}
+			case 2:
+				if req.GetPollerGroupId() == "" {
+					republishGroups.Do(func() {
+						response.PollerGroupsInfo = testPollerGroupsInfo(3, []*taskqueuepb.PollerGroupInfo{
+							{Id: groupID, Weight: 1},
+						})
+					})
+				}
+			}
+			return response, nil
+		},
+	).AnyTimes()
+
+	client := NewServiceClient(service, nil, ClientOptions{
+		Namespace:               namespace,
+		WorkerHeartbeatInterval: time.Minute,
+	})
+	worker := NewAggregatedWorker(client, taskQueue, WorkerOptions{
+		DisableWorkflowWorker:      true,
+		LocalActivityWorkerOnly:    true,
+		WorkflowTaskPollerBehavior: NewPollerBehaviorSimpleMaximum(PollerBehaviorSimpleMaximumOptions{MaximumNumberOfPollers: 1}),
+		ActivityTaskPollerBehavior: NewPollerBehaviorSimpleMaximum(PollerBehaviorSimpleMaximumOptions{MaximumNumberOfPollers: 1}),
+		NexusTaskPollerBehavior:    NewPollerBehaviorSimpleMaximum(PollerBehaviorSimpleMaximumOptions{MaximumNumberOfPollers: 2}),
+	})
+	nexusService := nexus.NewService("runtime-transition-service")
+	require.NoError(s.T(), nexusService.Register(nexus.NewSyncOperation("op", func(ctx context.Context, input string, opts nexus.StartOperationOptions) (string, error) {
+		return "", nil
+	})))
+	worker.RegisterNexusService(nexusService)
+
+	require.NoError(s.T(), worker.Start())
+	defer worker.Stop()
+
+	require.Eventually(s.T(), func() bool {
+		for {
+			select {
+			case id := <-polls:
+				if id == groupID {
+					return true
+				}
+			default:
+				return false
+			}
+		}
+	}, 2*time.Second, 10*time.Millisecond)
+
+	heartbeat := worker.heartbeatCallback()
+	require.True(s.T(), heartbeat.GetNexusPollerInfo().GetIsAutoscaling())
+
+	for len(polls) > 0 {
+		<-polls
+	}
+	transitionStage.Store(1)
+	require.Eventually(s.T(), func() bool {
+		_, _, nexusBehavior := worker.executionParams.pollerBehaviorState.snapshot()
+		_, isSimpleMaximum := nexusBehavior.(*pollerBehaviorSimpleMaximum)
+		if !isSimpleMaximum {
+			return false
+		}
+		heartbeat = worker.heartbeatCallback()
+		if heartbeat.GetNexusPollerInfo().GetIsAutoscaling() {
+			return false
+		}
+		select {
+		case id := <-polls:
+			return id == ""
+		default:
+			return false
+		}
+	}, 2*time.Second, 10*time.Millisecond)
+
+	for len(polls) > 0 {
+		<-polls
+	}
+	transitionStage.Store(2)
+	require.Eventually(s.T(), func() bool {
+		for {
+			select {
+			case id := <-polls:
+				if id == groupID {
+					_, _, nexusBehavior := worker.executionParams.pollerBehaviorState.snapshot()
+					_, isAutoscaling := nexusBehavior.(*pollerBehaviorAutoscaling)
+					heartbeat = worker.heartbeatCallback()
+					if isAutoscaling && heartbeat.GetNexusPollerInfo().GetIsAutoscaling() {
+						return true
+					}
 				}
 			default:
 				return false


### PR DESCRIPTION


## Summary

Workers originally configured with `SimpleMaximum` now follow runtime poller-group availability. Pollers originally configured to SimpleMax can now switch to autoscaling and back to SimpleMax, based off of server providing poller group info or not.

Worker heartbeating also picks up this dynamic configuration, for accurate reporting.

Session Activity polling can transition, while the session-creation polling remains fixed.

## Lifecycle

Each eligible worker runs a new transition controller that observes the sahred `pollerGroupInfoStore`. 

When the desired mode changes, the controller starts the replacement polling topology before stopping the current topology from repolling. Polls already in flight may complete and dispatch their tasks normally; their existing slot, lease, and shutdown ownership is unchanged.

For Workflow polling:

- Fixed mode restores the original mixed normal/sticky poller.
- Grouped mode creates separate normal and sticky autoscaling runners that share the Workflow poller-group manager and use a topology-local balancer.

Each transition receives a new mode-specific stop channel, allowing the worker to switch repeatedly without stopping the worker itself.

## Testing

- `TestWorkflowSimpleMaximumTransitionsToGroupedAutoscaling`
- `TestActivitySimpleMaximumTransitionsToGroupedAutoscaling`
- `TestNexusSimpleMaximumTransitionsToGroupedAutoscaling`
- `TestSessionActivityTransitionsButCreationStaysFixed`
- `TestRuntimePollerTransitionLifecycle`
- `TestPollerTransitionRemembersNonEmptySnapshot`
- `TestShutdownDuringPollerTransition`

## Limitations

The embedded dev server cannot deterministically inject a new non-empty poller-group snapshot after worker startup. Runtime topology changes therefore use deterministic mock-service coverage; existing worker shutdown integration tests cover the surrounding server lifecycle in both cache modes.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core worker polling lifecycle and goroutine handoff during runtime mode switches; mistakes could cause polling gaps, duplicate polls, or incorrect heartbeat reporting, though coverage is extensive.
> 
> **Overview**
> Workers that start with **`SimpleMaximum`** polling can now **switch at runtime** to poller-group-aware autoscaling when poll responses advertise poller groups, and **switch back** when a later response clears them. Workers already on autoscaling are unchanged when groups disappear.
> 
> A **`pollerTransition` controller** in `baseWorker` watches the shared `pollerGroupInfoStore`, starts the replacement polling topology before stopping the old one (per-mode `loopStop` channels), and updates **`workerPollerBehaviorState`** so worker heartbeats report the effective mode after auto-enrollment or these transitions.
> 
> Workflow, activity, and Nexus fixed pollers register transition callbacks; the **session creation** activity worker stays fixed (`allowPollerTransition: false`) while the resource-specific session activity worker can still transition. Autoscaling shutdown paths also avoid polling after mode stop when slot reservation races with cancellation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f5c1cb0da377b45e198697bde1f25e27e70d78c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->