### PR TITLE
Route Workflow polls by per-cell sticky backlog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,8 @@ to docs, or any other relevant information.
 
 ### Changed
 
+- Workflow poller autoscaling now uses each selected poller group's sticky backlog to allocate
+  floating polling capacity between normal and sticky task queues after required group coverage.
 - Improved the performance of yield-heavy workloads by eliminating unnecessary computation and heap allocations.
 - Replaced the internal `OnceCell` implementation with `sync.OnceValue` for lazy workflow run ID lookup.
 

--- a/internal/internal_poller_groups.go
+++ b/internal/internal_poller_groups.go
@@ -33,13 +33,18 @@ type (
 
 	// pollerGroupSnapshot is immutable after publication.
 	pollerGroupSnapshot struct {
-		weights    map[string]float32
-		version    int64
-		versionSet bool
+		weights map[string]float32
+		// generations identifies the current incarnation of each group ID. A
+		// group keeps its generation across weight updates, but receives a new one
+		// when removed and re-added.
+		generations map[string]int64
+		version     int64
+		versionSet  bool
 	}
 
-	// pollerGroupManager is owned by a polling path and combines shared routing
-	// state with its local coverage tracker.
+	// pollerGroupManager combines shared routing state with local poll coverage.
+	// For Workflow polling, it also selects whether normal or sticky may poll
+	// next; workflowPollAdmission enforces their shared admission budget.
 	pollerGroupManager struct {
 		groupInfos *pollerGroupInfoStore
 		tracker    *pollerGroupTracker
@@ -63,14 +68,24 @@ type (
 
 	// pollerGroupTracker is the manager-owned pending-poll coverage accounting.
 	pollerGroupTracker struct {
-		mode   pollerGroupMode
-		mu     sync.Mutex
-		groups map[string]*pollerGroupState
+		mode             pollerGroupMode
+		mu               sync.Mutex
+		groups           map[string]*pollerGroupState
+		workflowDecision workflowPollDecision
+	}
+
+	workflowPollDecision struct {
+		group     *pollerGroupState
+		queueKind enumspb.TaskQueueKind
+		version   int64
 	}
 
 	// pollerGroupState is the tracker-owned pending-poll state for one group.
 	pollerGroupState struct {
 		groupID string
+		// generation prevents a re-added group from inheriting pending counts or
+		// sticky backlog when this tracker did not observe the removal snapshot.
+		generation int64
 
 		// Activity/Nexus use total pending
 		pendingPollCount int
@@ -78,6 +93,7 @@ type (
 		// Workflow uses queue-kind-specific pending counts
 		workflowPendingNormal int
 		workflowPendingSticky int
+		stickyBacklog         int64
 	}
 )
 
@@ -89,7 +105,10 @@ const (
 
 func newPollerGroupInfoStore() *pollerGroupInfoStore {
 	return &pollerGroupInfoStore{
-		current: pollerGroupSnapshot{weights: make(map[string]float32)},
+		current: pollerGroupSnapshot{
+			weights:     make(map[string]float32),
+			generations: make(map[string]int64),
+		},
 		changedCh: make(chan struct{}),
 	}
 }
@@ -118,7 +137,8 @@ func (m *pollerGroupManager) reserve() pollerGroupLease {
 	if m == nil || m.groupInfos == nil || m.tracker == nil {
 		return pollerGroupLease{}
 	}
-	group := m.tracker.reserve(m.groupInfos.snapshot().weights)
+	snapshot := m.groupInfos.snapshot()
+	group := m.tracker.reserve(snapshot.weights, snapshot.generations)
 	return pollerGroupLease{
 		manager: m,
 		group:   group,
@@ -134,7 +154,8 @@ func (m *pollerGroupManager) tryReserveRequired(
 	if m == nil || m.groupInfos == nil || m.tracker == nil {
 		return pollerGroupLease{}, false
 	}
-	group := m.tracker.tryReserveRequired(m.groupInfos.snapshot().weights, queueKind)
+	snapshot := m.groupInfos.snapshot()
+	group := m.tracker.tryReserveRequired(snapshot.weights, snapshot.generations, queueKind)
 	if group == nil {
 		return pollerGroupLease{}, false
 	}
@@ -153,8 +174,15 @@ func (m *pollerGroupManager) tryReserveWorkflowPoll(
 	if m == nil || m.groupInfos == nil || m.tracker == nil {
 		return pollerGroupLease{queueKind: queueKind}, true
 	}
-	group, ok := m.tracker.tryReserveWorkflowPoll(m.groupInfos.snapshot().weights, queueKind)
-	if !ok {
+	snapshot := m.groupInfos.snapshot()
+	if len(snapshot.weights) == 0 {
+		return pollerGroupLease{manager: m, queueKind: queueKind}, true
+	}
+	group, wakeWaiters := m.tracker.tryReserveWorkflowPoll(snapshot, queueKind)
+	if wakeWaiters {
+		m.signalWaiters()
+	}
+	if group == nil {
 		return pollerGroupLease{}, false
 	}
 	lease := pollerGroupLease{
@@ -162,8 +190,21 @@ func (m *pollerGroupManager) tryReserveWorkflowPoll(
 		group:     group,
 		queueKind: queueKind,
 	}
-	m.signalWaiters()
 	return lease, true
+}
+
+func (m *pollerGroupManager) updateWorkflowStickyBacklog(groupID string, backlog int64) {
+	if m == nil || m.tracker == nil || groupID == "" {
+		return
+	}
+	snapshot := m.groupInfos.snapshot()
+	if m.tracker.updateWorkflowStickyBacklog(
+		snapshot,
+		groupID,
+		backlog,
+	) {
+		m.signalWaiters()
+	}
 }
 
 func (m *pollerGroupManager) updateGroups(info *taskqueuepb.PollerGroupsInfo) {
@@ -209,13 +250,13 @@ func (l pollerGroupLease) release() {
 	l.manager.signalWaiters()
 }
 
-func (t *pollerGroupTracker) reserve(weights map[string]float32) *pollerGroupState {
+func (t *pollerGroupTracker) reserve(weights map[string]float32, generations map[string]int64) *pollerGroupState {
 	if t == nil {
 		return nil
 	}
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	t.syncGroups(weights)
+	t.syncGroups(weights, generations)
 
 	if len(t.groups) == 0 {
 		return nil
@@ -242,6 +283,7 @@ func (t *pollerGroupTracker) reserve(weights map[string]float32) *pollerGroupSta
 
 func (t *pollerGroupTracker) tryReserveRequired(
 	weights map[string]float32,
+	generations map[string]int64,
 	queueKind enumspb.TaskQueueKind,
 ) *pollerGroupState {
 	if t == nil {
@@ -249,7 +291,7 @@ func (t *pollerGroupTracker) tryReserveRequired(
 	}
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	t.syncGroups(weights)
+	t.syncGroups(weights, generations)
 
 	var candidates map[string]float32
 	if t.mode == pollerGroupModeNonWorkflow {
@@ -275,40 +317,70 @@ func (t *pollerGroupTracker) tryReserveRequired(
 	return group
 }
 
-// tryReserveWorkflowPoll first satisfies per-group coverage for queueKind. It
-// blocks additional polls for that kind while the other required workflow kind
-// still has a coverage gap. Once both kinds are covered, it selects additional
-// polls using the server-provided weights.
+// tryReserveWorkflowPoll first satisfies normal and sticky coverage. Once
+// coverage is complete, it retains one weighted group decision until the
+// runner selected by that group's sticky backlog claims it. The manager handles
+// empty snapshots, so a nil group means the requested runner must wait.
+// wakeWaiters reports whether another runner should recheck admission.
 func (t *pollerGroupTracker) tryReserveWorkflowPoll(
-	weights map[string]float32,
+	snapshot pollerGroupSnapshot,
 	queueKind enumspb.TaskQueueKind,
-) (*pollerGroupState, bool) {
+) (selectedGroup *pollerGroupState, wakeWaiters bool) {
 	if t == nil {
-		return nil, true
+		return nil, false
 	}
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	t.syncGroups(weights)
+	wakeWaiters = t.syncWorkflowSnapshot(snapshot)
 
 	if len(t.groups) == 0 {
-		return nil, true
+		return nil, wakeWaiters
 	}
 
-	candidates := t.workflowCoverageCandidates(weights, queueKind)
-	if len(candidates) == 0 {
-		// The requested kind already covers every group. Do not admit an
-		// additional poll while another required workflow kind remains uncovered.
-		if t.workflowCoverageMissing() {
-			return nil, false
+	if t.workflowCoverageMissing() {
+		if t.workflowDecision.group != nil {
+			t.workflowDecision = workflowPollDecision{}
+			wakeWaiters = true
 		}
-		candidates = weights
+		candidates := t.workflowCoverageCandidates(snapshot.weights, queueKind)
+		if len(candidates) == 0 {
+			return nil, wakeWaiters
+		}
+		groupID := choosePollerGroup(candidates)
+		if groupID == "" {
+			return nil, wakeWaiters
+		}
+		group := t.groups[groupID]
+		t.incrementWorkflowPending(group, queueKind)
+		return group, true
 	}
 
-	groupID := choosePollerGroup(candidates)
-	if groupID == "" {
+	if t.workflowDecision.group == nil {
+		groupID := choosePollerGroup(snapshot.weights)
+		if groupID == "" {
+			return nil, wakeWaiters
+		}
+		group := t.groups[groupID]
+		decisionKind := enumspb.TASK_QUEUE_KIND_NORMAL
+		if t.mode == pollerGroupModeWorkflowWithSticky && group.stickyBacklog > 0 {
+			decisionKind = enumspb.TASK_QUEUE_KIND_STICKY
+		}
+		t.workflowDecision = workflowPollDecision{
+			group:     group,
+			queueKind: decisionKind,
+			version:   snapshot.version,
+		}
+		wakeWaiters = true
+	}
+
+	if t.workflowDecision.queueKind != queueKind {
+		return nil, wakeWaiters
+	}
+	group := t.workflowDecision.group
+	t.workflowDecision = workflowPollDecision{}
+	if t.groups[group.groupID] != group {
 		return nil, true
 	}
-	group := t.groups[groupID]
 	t.incrementWorkflowPending(group, queueKind)
 	return group, true
 }
@@ -319,16 +391,58 @@ func (t *pollerGroupTracker) release(group *pollerGroupState, queueKind enumspb.
 	}
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	t.decrementPending(group, queueKind)
+	if current := t.groups[group.groupID]; current != group {
+		return
+	}
+	becameUncovered := t.decrementPending(group, queueKind)
+	if t.mode != pollerGroupModeNonWorkflow && becameUncovered {
+		t.workflowDecision = workflowPollDecision{}
+	}
 }
 
-func (t *pollerGroupTracker) syncGroups(weights map[string]float32) {
+func (t *pollerGroupTracker) updateWorkflowStickyBacklog(
+	snapshot pollerGroupSnapshot,
+	groupID string,
+	backlog int64,
+) bool {
+	if t == nil || t.mode == pollerGroupModeNonWorkflow || groupID == "" {
+		return false
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	wakeWaiters := t.syncWorkflowSnapshot(snapshot)
+	group := t.groups[groupID]
+	if group == nil || group.stickyBacklog == backlog {
+		return wakeWaiters
+	}
+	group.stickyBacklog = backlog
+	t.workflowDecision = workflowPollDecision{}
+	return true
+}
+
+func (t *pollerGroupTracker) syncWorkflowSnapshot(snapshot pollerGroupSnapshot) bool {
+	t.syncGroups(snapshot.weights, snapshot.generations)
+	// Discard decisions made with stale routing data.
+	if t.workflowDecision.group == nil ||
+		t.workflowDecision.version == snapshot.version {
+		return false
+	}
+
+	t.workflowDecision = workflowPollDecision{}
+	return true
+}
+
+func (t *pollerGroupTracker) syncGroups(weights map[string]float32, generations map[string]int64) {
 	if t.groups == nil {
 		t.groups = make(map[string]*pollerGroupState)
 	}
 	for groupID := range weights {
-		if _, ok := t.groups[groupID]; !ok {
-			t.groups[groupID] = &pollerGroupState{groupID: groupID}
+		group, ok := t.groups[groupID]
+		if !ok || group.generation != generations[groupID] {
+			t.groups[groupID] = &pollerGroupState{
+				groupID:    groupID,
+				generation: generations[groupID],
+			}
 		}
 	}
 	for groupID := range t.groups {
@@ -373,23 +487,26 @@ func (t *pollerGroupTracker) incrementWorkflowPending(group *pollerGroupState, q
 	}
 }
 
-func (t *pollerGroupTracker) decrementPending(group *pollerGroupState, queueKind enumspb.TaskQueueKind) {
+func (t *pollerGroupTracker) decrementPending(group *pollerGroupState, queueKind enumspb.TaskQueueKind) bool {
 	if group == nil {
-		return
+		return false
 	}
 	if t.mode == pollerGroupModeNonWorkflow {
 		if group.pendingPollCount > 0 {
 			group.pendingPollCount--
 		}
-		return
+		return false
 	}
 	if queueKind == enumspb.TASK_QUEUE_KIND_STICKY {
 		if group.workflowPendingSticky > 0 {
 			group.workflowPendingSticky--
 		}
-	} else if group.workflowPendingNormal > 0 {
+		return group.workflowPendingSticky == 0
+	}
+	if group.workflowPendingNormal > 0 {
 		group.workflowPendingNormal--
 	}
+	return group.workflowPendingNormal == 0
 }
 
 // choosePollerGroup picks a random group using the configured weights.
@@ -476,16 +593,23 @@ func (s *pollerGroupInfoStore) updateGroups(info *taskqueuepb.PollerGroupsInfo) 
 	}
 
 	weights := make(map[string]float32, len(info.GetPollerGroups()))
+	generations := make(map[string]int64, len(info.GetPollerGroups()))
 	for _, group := range info.GetPollerGroups() {
 		if groupID := group.GetId(); groupID != "" {
 			weights[groupID] = group.GetWeight()
+			generation, ok := s.current.generations[groupID]
+			if !ok {
+				generation = info.GetVersion()
+			}
+			generations[groupID] = generation
 		}
 	}
 
 	s.current = pollerGroupSnapshot{
-		weights:    weights,
-		version:    info.GetVersion(),
-		versionSet: true,
+		weights:     weights,
+		generations: generations,
+		version:     info.GetVersion(),
+		versionSet:  true,
 	}
 	close(s.changedCh)
 	s.changedCh = make(chan struct{})

--- a/internal/internal_poller_groups_test.go
+++ b/internal/internal_poller_groups_test.go
@@ -202,7 +202,7 @@ func TestPollerGroupManagerReserveWorkflowPollFillsCoverageBeforeWeights(t *test
 	require.Equal(t, enumspb.TASK_QUEUE_KIND_NORMAL, lease.queueKind)
 }
 
-func TestPollerGroupManagerReserveWorkflowPollKeepsRunnerQueueKind(t *testing.T) {
+func TestPollerGroupManagerReserveWorkflowPollUsesSelectedGroupBacklog(t *testing.T) {
 	manager := newPollerGroupManager(pollerGroupModeWorkflowWithSticky, nil)
 	manager.updateGroups(testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{{Id: "group-a", Weight: 1}}))
 
@@ -212,8 +212,115 @@ func TestPollerGroupManagerReserveWorkflowPollKeepsRunnerQueueKind(t *testing.T)
 	normalLease := requireWorkflowPollLease(t, manager, enumspb.TASK_QUEUE_KIND_NORMAL)
 	require.Equal(t, enumspb.TASK_QUEUE_KIND_NORMAL, normalLease.queueKind)
 
+	manager.updateWorkflowStickyBacklog("group-a", 1)
 	extraStickyLease := requireWorkflowPollLease(t, manager, enumspb.TASK_QUEUE_KIND_STICKY)
 	require.Equal(t, enumspb.TASK_QUEUE_KIND_STICKY, extraStickyLease.queueKind)
+}
+
+func TestPollerGroupManagerFloatingPollSelectsGroupBeforeQueueKind(t *testing.T) {
+	manager := newPollerGroupManager(pollerGroupModeWorkflowWithSticky, nil)
+	manager.updateGroups(testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{
+		{Id: "normal-group", Weight: 0},
+		{Id: "sticky-group", Weight: 100},
+	}))
+
+	for range 2 {
+		requireWorkflowPollLease(t, manager, enumspb.TASK_QUEUE_KIND_NORMAL)
+		requireWorkflowPollLease(t, manager, enumspb.TASK_QUEUE_KIND_STICKY)
+	}
+	manager.updateWorkflowStickyBacklog("sticky-group", 5)
+
+	_, ok := manager.tryReserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_NORMAL)
+	require.False(t, ok, "the normal runner must not reroll a selected group with sticky backlog")
+
+	manager.tracker.mu.Lock()
+	decision := manager.tracker.workflowDecision
+	manager.tracker.mu.Unlock()
+	require.NotNil(t, decision.group)
+	require.Equal(t, "sticky-group", decision.group.groupID)
+	require.Equal(t, enumspb.TASK_QUEUE_KIND_STICKY, decision.queueKind)
+	require.Equal(t, int64(1), decision.version)
+
+	lease := requireWorkflowPollLease(t, manager, enumspb.TASK_QUEUE_KIND_STICKY)
+	require.Equal(t, "sticky-group", lease.groupIDOrEmpty())
+}
+
+func TestPollerGroupManagerWorkflowCoverageOverridesStickyBacklog(t *testing.T) {
+	manager := newPollerGroupManager(pollerGroupModeWorkflowWithSticky, nil)
+	manager.updateGroups(testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{
+		{Id: "group-a", Weight: 0},
+		{Id: "group-b", Weight: 100},
+	}))
+
+	normalB := requireWorkflowPollLease(t, manager, enumspb.TASK_QUEUE_KIND_NORMAL)
+	require.Equal(t, "group-b", normalB.groupIDOrEmpty())
+	requireWorkflowPollLease(t, manager, enumspb.TASK_QUEUE_KIND_NORMAL)
+	requireWorkflowPollLease(t, manager, enumspb.TASK_QUEUE_KIND_STICKY)
+	requireWorkflowPollLease(t, manager, enumspb.TASK_QUEUE_KIND_STICKY)
+	manager.updateWorkflowStickyBacklog("group-b", 5)
+	require.Equal(t, "group-b", requireWorkflowPollLease(t, manager, enumspb.TASK_QUEUE_KIND_STICKY).groupIDOrEmpty())
+
+	normalB.release()
+	_, ok := manager.tryReserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_STICKY)
+	require.False(t, ok, "floating sticky capacity must wait for missing normal coverage")
+	require.Equal(t, "group-b", requireWorkflowPollLease(t, manager, enumspb.TASK_QUEUE_KIND_NORMAL).groupIDOrEmpty())
+}
+
+func TestPollerGroupManagerZeroBacklogChoosesNormalFloatingPoll(t *testing.T) {
+	manager := newPollerGroupManager(pollerGroupModeWorkflowWithSticky, nil)
+	manager.updateGroups(testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{{Id: "group-a", Weight: 1}}))
+	requireWorkflowPollLease(t, manager, enumspb.TASK_QUEUE_KIND_NORMAL)
+	requireWorkflowPollLease(t, manager, enumspb.TASK_QUEUE_KIND_STICKY)
+	manager.updateWorkflowStickyBacklog("group-a", 3)
+	requireWorkflowPollLease(t, manager, enumspb.TASK_QUEUE_KIND_STICKY)
+
+	manager.updateWorkflowStickyBacklog("group-a", 0)
+	_, ok := manager.tryReserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_STICKY)
+	require.False(t, ok)
+	require.Equal(t, "group-a", requireWorkflowPollLease(t, manager, enumspb.TASK_QUEUE_KIND_NORMAL).groupIDOrEmpty())
+}
+
+func TestPollerGroupManagerRemovedAndReaddedGroupLosesBacklog(t *testing.T) {
+	manager := newPollerGroupManager(pollerGroupModeWorkflowWithSticky, nil)
+	manager.updateGroups(testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{{Id: "group-a", Weight: 1}}))
+	oldNormal := requireWorkflowPollLease(t, manager, enumspb.TASK_QUEUE_KIND_NORMAL)
+	oldSticky := requireWorkflowPollLease(t, manager, enumspb.TASK_QUEUE_KIND_STICKY)
+	manager.updateWorkflowStickyBacklog("group-a", 3)
+
+	manager.updateGroups(testPollerGroupsInfo(2, nil))
+	manager.updateGroups(testPollerGroupsInfo(3, []*taskqueuepb.PollerGroupInfo{{Id: "group-a", Weight: 1}}))
+	requireWorkflowPollLease(t, manager, enumspb.TASK_QUEUE_KIND_NORMAL)
+	requireWorkflowPollLease(t, manager, enumspb.TASK_QUEUE_KIND_STICKY)
+
+	_, ok := manager.tryReserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_STICKY)
+	require.False(t, ok, "a re-added group must not inherit sticky backlog")
+	requireWorkflowPollLease(t, manager, enumspb.TASK_QUEUE_KIND_NORMAL)
+
+	oldNormal.release()
+	oldSticky.release()
+}
+
+func TestPollerGroupManagerWeightUpdateReconsidersPendingDecision(t *testing.T) {
+	manager := newPollerGroupManager(pollerGroupModeWorkflowWithSticky, nil)
+	manager.updateGroups(testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{
+		{Id: "normal-group", Weight: 0},
+		{Id: "sticky-group", Weight: 100},
+	}))
+	for range 2 {
+		requireWorkflowPollLease(t, manager, enumspb.TASK_QUEUE_KIND_NORMAL)
+		requireWorkflowPollLease(t, manager, enumspb.TASK_QUEUE_KIND_STICKY)
+	}
+	manager.updateWorkflowStickyBacklog("sticky-group", 5)
+	_, ok := manager.tryReserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_NORMAL)
+	require.False(t, ok)
+
+	manager.updateGroups(testPollerGroupsInfo(2, []*taskqueuepb.PollerGroupInfo{
+		{Id: "normal-group", Weight: 100},
+		{Id: "sticky-group", Weight: 0},
+	}))
+	_, ok = manager.tryReserveWorkflowPoll(enumspb.TASK_QUEUE_KIND_STICKY)
+	require.False(t, ok, "a newer weight snapshot must invalidate the pending sticky decision")
+	require.Equal(t, "normal-group", requireWorkflowPollLease(t, manager, enumspb.TASK_QUEUE_KIND_NORMAL).groupIDOrEmpty())
 }
 
 func TestPollerGroupManagerBlocksExtraNormalUntilAllStickyGroupsCovered(t *testing.T) {
@@ -284,6 +391,7 @@ func TestPollerGroupManagerReserveWorkflowPollFallsBackBeforeGroupsKnown(t *test
 
 	lease := requireWorkflowPollLease(t, manager, enumspb.TASK_QUEUE_KIND_STICKY)
 	require.Empty(t, lease.groupIDOrEmpty())
+	require.Same(t, manager, lease.manager)
 	require.Equal(t, enumspb.TASK_QUEUE_KIND_STICKY, lease.queueKind)
 }
 
@@ -349,4 +457,97 @@ func TestPollerGroupManagersConcurrentSharedUpdatesAndReservations(t *testing.T)
 
 	require.Equal(t, 2, activity.requiredMin())
 	require.Equal(t, 2, workflow.requiredMin())
+}
+
+func TestPollerGroupManagerConcurrentStickyRoutingChurn(t *testing.T) {
+	const (
+		groupA           = "group-a"
+		groupB           = "group-b"
+		stressIterations = 1000
+	)
+	groupInfos := newPollerGroupInfoStore()
+	manager := newPollerGroupManager(pollerGroupModeWorkflowWithSticky, groupInfos)
+	manager.updateGroups(testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{
+		{Id: groupA, Weight: 1},
+		{Id: groupB, Weight: 1},
+	}))
+
+	start := make(chan struct{})
+	reserved := make(chan int, 2)
+	var wg sync.WaitGroup
+	wg.Add(4)
+
+	go func() {
+		defer wg.Done()
+		<-start
+
+		for i := range stressIterations {
+			var groups []*taskqueuepb.PollerGroupInfo
+			switch i % 4 {
+			case 0:
+				groups = []*taskqueuepb.PollerGroupInfo{{Id: groupA, Weight: 100}, {Id: groupB, Weight: 0}}
+			case 1:
+				groups = []*taskqueuepb.PollerGroupInfo{{Id: groupA, Weight: 0}, {Id: groupB, Weight: 100}}
+			case 2:
+				groups = []*taskqueuepb.PollerGroupInfo{{Id: groupA, Weight: 1}}
+			case 3:
+				groups = []*taskqueuepb.PollerGroupInfo{{Id: groupB, Weight: 1}}
+			}
+			manager.updateGroups(testPollerGroupsInfo(int64(i+2), groups))
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		<-start
+
+		for i := range stressIterations {
+			manager.updateWorkflowStickyBacklog(groupA, int64(i%3))
+			manager.updateWorkflowStickyBacklog(groupB, int64((i+1)%3))
+		}
+	}()
+
+	reserve := func(queueKind enumspb.TaskQueueKind) {
+		defer wg.Done()
+		<-start
+
+		count := 0
+		for range stressIterations {
+			lease, ok := manager.tryReserveWorkflowPoll(queueKind)
+			if !ok {
+				continue
+			}
+			lease.release()
+			count++
+		}
+		reserved <- count
+	}
+	go reserve(enumspb.TASK_QUEUE_KIND_NORMAL)
+	go reserve(enumspb.TASK_QUEUE_KIND_STICKY)
+
+	close(start)
+	wg.Wait()
+	close(reserved)
+	for count := range reserved {
+		require.Positive(t, count)
+	}
+
+	finalVersion := int64(stressIterations + 2)
+	manager.updateGroups(testPollerGroupsInfo(finalVersion, []*taskqueuepb.PollerGroupInfo{
+		{Id: groupA, Weight: 1},
+		{Id: groupB, Weight: 1},
+	}))
+	manager.updateWorkflowStickyBacklog(groupA, 0)
+	manager.updateWorkflowStickyBacklog(groupB, 0)
+	require.Equal(t, finalVersion, groupInfos.snapshot().version)
+
+	manager.tracker.mu.Lock()
+	defer manager.tracker.mu.Unlock()
+	require.Nil(t, manager.tracker.workflowDecision.group)
+	require.Len(t, manager.tracker.groups, 2)
+	for _, group := range manager.tracker.groups {
+		require.Zero(t, group.workflowPendingNormal)
+		require.Zero(t, group.workflowPendingSticky)
+		require.Zero(t, group.stickyBacklog)
+	}
 }

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -1148,13 +1148,32 @@ func (wtp *workflowTaskPoller) release(kind enumspb.TaskQueueKind) {
 	wtp.requestLock.Unlock()
 }
 
-func (wtp *workflowTaskPoller) updateBacklog(taskQueueKind enumspb.TaskQueueKind, backlogCountHint int64) {
+func (wtp *workflowTaskPoller) updateBacklog(
+	taskQueueKind enumspb.TaskQueueKind,
+	responseGroupID string,
+	backlogCountHint int64,
+) {
 	if taskQueueKind == enumspb.TASK_QUEUE_KIND_NORMAL || wtp.stickyCacheSize <= 0 {
 		// we only care about sticky backlog for now.
 		return
 	}
+	if wtp.pollerGroups != nil {
+		wtp.pollerGroups.updateWorkflowStickyBacklog(responseGroupID, backlogCountHint)
+		return
+	}
 	wtp.requestLock.Lock()
 	wtp.stickyBacklog = backlogCountHint
+	wtp.requestLock.Unlock()
+}
+
+// resetUngroupedBacklog clears the task-queue-wide hint after a poll error.
+func (wtp *workflowTaskPoller) resetUngroupedBacklog(taskQueueKind enumspb.TaskQueueKind) {
+	if taskQueueKind == enumspb.TASK_QUEUE_KIND_NORMAL || wtp.stickyCacheSize <= 0 || wtp.pollerGroups != nil {
+		return
+	}
+
+	wtp.requestLock.Lock()
+	wtp.stickyBacklog = 0
 	wtp.requestLock.Unlock()
 }
 
@@ -1283,7 +1302,7 @@ func (wtp *workflowTaskPoller) pollWithLease(
 
 	response, err := wtp.pollWorkflowTaskQueue(ctx, request)
 	if err != nil {
-		wtp.updateBacklog(queueKind, 0)
+		wtp.resetUngroupedBacklog(queueKind)
 		return nil, err
 	}
 
@@ -1294,7 +1313,7 @@ func (wtp *workflowTaskPoller) pollWithLease(
 	if response == nil || len(response.TaskToken) == 0 {
 		// Emit using base scope as no workflow type information is available in the case of empty poll
 		wtp.metricsHandler.Counter(metrics.WorkflowTaskQueuePollEmptyCounter).Inc(1)
-		wtp.updateBacklog(queueKind, 0)
+		wtp.updateBacklog(queueKind, response.GetPollerGroupId(), response.GetBacklogCountHint())
 		return &workflowTask{}, nil
 	}
 
@@ -1304,7 +1323,7 @@ func (wtp *workflowTaskPoller) pollWithLease(
 		wtp.pollTimeTracker.recordPollSuccess(metrics.PollerTypeWorkflowTask)
 	}
 
-	wtp.updateBacklog(queueKind, response.GetBacklogCountHint())
+	wtp.updateBacklog(queueKind, response.GetPollerGroupId(), response.GetBacklogCountHint())
 
 	task := wtp.toWorkflowTask(response)
 	traceLog(func() {

--- a/internal/internal_task_pollers_test.go
+++ b/internal/internal_task_pollers_test.go
@@ -590,6 +590,78 @@ func TestWorkflowPollerGroupUpdateFromOnePollerAffectsAnotherPoller(t *testing.T
 	require.NoError(t, err)
 }
 
+func TestWorkflowStickyBacklogUsesResponsePollerGroupID(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	service := workflowservicemock.NewMockWorkflowServiceClient(ctrl)
+	const (
+		namespace       = "test-ns"
+		taskQueue       = "test-task-queue"
+		identity        = "test-worker"
+		requestGroupID  = "request-group"
+		responseGroupID = "response-group"
+	)
+	pollerGroups := newPollerGroupManager(pollerGroupModeWorkflowWithSticky, nil)
+	pollerGroups.updateGroups(testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{
+		{Id: requestGroupID, Weight: 100},
+	}))
+
+	gomock.InOrder(
+		service.EXPECT().PollWorkflowTaskQueue(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, req *workflowservice.PollWorkflowTaskQueueRequest, _ ...grpc.CallOption) (*workflowservice.PollWorkflowTaskQueueResponse, error) {
+				require.Equal(t, requestGroupID, req.GetPollerGroupId())
+				return &workflowservice.PollWorkflowTaskQueueResponse{
+					PollerGroupId: responseGroupID,
+					PollerGroupsInfo: testPollerGroupsInfo(2, []*taskqueuepb.PollerGroupInfo{
+						{Id: responseGroupID, Weight: 1},
+					}),
+					BacklogCountHint: 7,
+				}, nil
+			}),
+		service.EXPECT().PollWorkflowTaskQueue(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, req *workflowservice.PollWorkflowTaskQueueRequest, _ ...grpc.CallOption) (*workflowservice.PollWorkflowTaskQueueResponse, error) {
+				require.Equal(t, responseGroupID, req.GetPollerGroupId())
+				return &workflowservice.PollWorkflowTaskQueueResponse{
+					PollerGroupId: responseGroupID,
+				}, nil
+			}),
+	)
+
+	wtp := &workflowTaskPoller{
+		basePoller: basePoller{
+			metricsHandler:  metrics.NopHandler,
+			workerBuildID:   "test-build-id",
+			pollTimeTracker: &pollTimeTracker{},
+		},
+		mode:                  Sticky,
+		namespace:             namespace,
+		taskQueueName:         taskQueue,
+		identity:              identity,
+		service:               service,
+		logger:                ilog.NewDefaultLogger(),
+		stickyCacheSize:       1,
+		pollerGroups:          pollerGroups,
+		numNormalPollerMetric: newNumPollerMetric(metrics.NopHandler, metrics.PollerTypeWorkflowTask),
+		numStickyPollerMetric: newNumPollerMetric(metrics.NopHandler, metrics.PollerTypeWorkflowStickyTask),
+	}
+
+	firstLease := requireWorkflowPollLease(t, pollerGroups, enumspb.TASK_QUEUE_KIND_STICKY)
+	defer firstLease.release()
+	task, err := wtp.pollWithLease(t.Context(), firstLease)
+	require.NoError(t, err)
+	require.True(t, task.isEmpty())
+	require.NotContains(t, pollerGroups.tracker.groups, requestGroupID)
+	require.Equal(t, int64(7), pollerGroups.tracker.groups[responseGroupID].stickyBacklog)
+
+	secondLease := requireWorkflowPollLease(t, pollerGroups, enumspb.TASK_QUEUE_KIND_STICKY)
+	defer secondLease.release()
+	task, err = wtp.pollWithLease(t.Context(), secondLease)
+	require.NoError(t, err)
+	require.True(t, task.isEmpty())
+	require.Equal(t, int64(0), pollerGroups.tracker.groups[responseGroupID].stickyBacklog)
+}
+
 func TestWFTRacePrevention(t *testing.T) {
 	params := workerExecutionParameters{cache: NewWorkerCache()}
 	ensureRequiredParams(&params)

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -558,6 +558,7 @@ func buildWorkflowScalableTaskPollers(
 				),
 			)
 		}
+		configureWorkflowPollAdmission(scalableTaskPollers, pollerGroups)
 		return scalableTaskPollers
 	default: // *pollerBehaviorSimpleMaximum
 		return []scalableTaskPoller{

--- a/internal/internal_worker_base.go
+++ b/internal/internal_worker_base.go
@@ -315,13 +315,26 @@ type (
 	barrier chan struct{}
 
 	autoscalingTaskPollerRunner struct {
-		autoscaler   *pollerAutoscaler
-		pollerGroups *pollerGroupManager
-		queueKind    enumspb.TaskQueueKind
-		wakeCh       chan struct{}
-		activeMu     sync.Mutex
+		autoscaler        *pollerAutoscaler
+		pollerGroups      *pollerGroupManager
+		workflowAdmission *workflowPollAdmission
+		queueKind         enumspb.TaskQueueKind
+		wakeCh            chan struct{}
+		activeMu          sync.Mutex
 		// active counts admitted logical poll attempts, not supporting goroutines.
 		active int
+	}
+
+	// workflowPollAdmission shares an admission budget between normal and
+	// sticky Workflow poll runners. pollerGroupManager owns per-group coverage
+	// and selects which runner may claim each group-routed poll.
+	workflowPollAdmission struct {
+		mu               sync.Mutex
+		pollerGroups     *pollerGroupManager
+		normalAutoscaler *pollerAutoscaler
+		stickyAutoscaler *pollerAutoscaler
+		activeNormal     int
+		activeSticky     int
 	}
 
 	// pollerBalancer is used to balance the number of poll requests from different poller types
@@ -1257,6 +1270,9 @@ func newAutoscalingTaskPollerRunner(
 }
 
 func (r *autoscalingTaskPollerRunner) acquire(ctx context.Context) (pollerGroupLease, func(), error) {
+	if r.workflowAdmission != nil {
+		return r.workflowAdmission.acquire(ctx, r)
+	}
 	for {
 		// Capture the store notification before evaluating admission. If the
 		// snapshot changes during the evaluation, this channel is closed and the
@@ -1291,6 +1307,83 @@ func (r *autoscalingTaskPollerRunner) acquire(ctx context.Context) (pollerGroupL
 		case <-pollerGroupsChanged:
 		}
 	}
+}
+
+func (c *workflowPollAdmission) acquire(
+	ctx context.Context,
+	runner *autoscalingTaskPollerRunner,
+) (pollerGroupLease, func(), error) {
+	for {
+		pollerGroupsChanged := c.pollerGroups.groupInfos.changed()
+		c.mu.Lock()
+		canAcquire := c.activeNormal+c.activeSticky < c.effectiveTarget()
+		if canAcquire && c.pollerGroups.requiredMin() == 0 {
+			canAcquire = c.activeForKind(runner.queueKind) < runner.effectiveTarget()
+		}
+		var lease pollerGroupLease
+		var ok bool
+		if canAcquire {
+			lease, ok = c.pollerGroups.tryReserveWorkflowPoll(runner.queueKind)
+		} else {
+			// Current normal and sticky coverage may temporarily exceed the
+			// aggregate target while stale or ungrouped polls drain.
+			lease, ok = c.pollerGroups.tryReserveRequired(runner.queueKind)
+		}
+		if ok {
+			if runner.queueKind == enumspb.TASK_QUEUE_KIND_STICKY {
+				c.activeSticky++
+			} else {
+				c.activeNormal++
+			}
+			c.mu.Unlock()
+			return lease, func() { c.release(runner.queueKind) }, nil
+		}
+		c.mu.Unlock()
+
+		select {
+		case <-ctx.Done():
+			return pollerGroupLease{}, nil, ctx.Err()
+		case <-runner.wakeCh:
+		case <-pollerGroupsChanged:
+		}
+	}
+}
+
+// activeForKind expects c.mu to be held.
+func (c *workflowPollAdmission) activeForKind(queueKind enumspb.TaskQueueKind) int {
+	if queueKind == enumspb.TASK_QUEUE_KIND_STICKY {
+		return c.activeSticky
+	}
+	return c.activeNormal
+}
+
+// effectiveTarget expects c.mu to be held.
+func (c *workflowPollAdmission) effectiveTarget() int {
+	groups := c.pollerGroups.requiredMin()
+	normal := effectivePollerTarget(
+		int(c.normalAutoscaler.target.Load()),
+		c.normalAutoscaler.minPollerCount,
+		c.normalAutoscaler.maxPollerCount,
+		groups,
+	)
+	sticky := effectivePollerTarget(
+		int(c.stickyAutoscaler.target.Load()),
+		c.stickyAutoscaler.minPollerCount,
+		c.stickyAutoscaler.maxPollerCount,
+		groups,
+	)
+	return normal + sticky
+}
+
+func (c *workflowPollAdmission) release(queueKind enumspb.TaskQueueKind) {
+	c.mu.Lock()
+	if queueKind == enumspb.TASK_QUEUE_KIND_STICKY {
+		c.activeSticky--
+	} else {
+		c.activeNormal--
+	}
+	c.mu.Unlock()
+	c.pollerGroups.signalWaiters()
 }
 
 func (r *autoscalingTaskPollerRunner) tryReservePollerGroup() (pollerGroupLease, bool) {
@@ -1342,9 +1435,43 @@ func (r *autoscalingTaskPollerRunner) signal() {
 }
 
 func (r *autoscalingTaskPollerRunner) activePolls() int {
+	if r.workflowAdmission != nil {
+		r.workflowAdmission.mu.Lock()
+		defer r.workflowAdmission.mu.Unlock()
+		return r.workflowAdmission.activeForKind(r.queueKind)
+	}
 	r.activeMu.Lock()
 	defer r.activeMu.Unlock()
 	return r.active
+}
+
+// configureWorkflowPollAdmission gives normal and sticky Workflow runners a
+// shared admission budget while preserving their separate autoscalers.
+func configureWorkflowPollAdmission(taskPollers []scalableTaskPoller, pollerGroups *pollerGroupManager) {
+	var normal, sticky *autoscalingTaskPollerRunner
+	for _, taskPoller := range taskPollers {
+		runner := taskPoller.autoscalingRunner
+		if runner == nil {
+			continue
+		}
+		if runner.queueKind == enumspb.TASK_QUEUE_KIND_STICKY {
+			sticky = runner
+		} else if _, ok := taskPoller.taskPoller.(*workflowTaskPoller); ok {
+			normal = runner
+		}
+	}
+	if normal == nil || sticky == nil {
+		return
+	}
+	admission := &workflowPollAdmission{
+		pollerGroups:     pollerGroups,
+		normalAutoscaler: normal.autoscaler,
+		stickyAutoscaler: sticky.autoscaler,
+	}
+	normal.workflowAdmission = admission
+	sticky.workflowAdmission = admission
+	normal.autoscaler.targetChangedCallback = pollerGroups.signalWaiters
+	sticky.autoscaler.targetChangedCallback = pollerGroups.signalWaiters
 }
 
 func newScalableTaskPoller(

--- a/internal/internal_worker_base_test.go
+++ b/internal/internal_worker_base_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -714,6 +715,392 @@ func (s *ScalableTaskPollerSuite) TestAutoscalingWorkflowRunnerBlocksExtraNormal
 	}
 }
 
+func (s *ScalableTaskPollerSuite) TestAutoscalingWorkflowAdmissionUsesAggregateCapacityForSelectedKind() {
+	pollerGroups := newPollerGroupManager(pollerGroupModeWorkflowWithSticky, nil)
+	pollerGroups.updateGroups(testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{
+		{Id: "normal-group", Weight: 0},
+		{Id: "sticky-group", Weight: 100},
+	}))
+	normalAutoscaler := newPollerAutoscaler(pollerAutoscalerOptions{
+		initialPollerCount: 3,
+		maxPollerCount:     3,
+		minPollerCount:     1,
+	})
+	stickyAutoscaler := newPollerAutoscaler(pollerAutoscalerOptions{
+		initialPollerCount: 2,
+		maxPollerCount:     2,
+		minPollerCount:     1,
+	})
+	normalRunner := newAutoscalingTaskPollerRunner(
+		normalAutoscaler,
+		pollerGroups,
+		enumspb.TASK_QUEUE_KIND_NORMAL,
+	)
+	stickyRunner := newAutoscalingTaskPollerRunner(
+		stickyAutoscaler,
+		pollerGroups,
+		enumspb.TASK_QUEUE_KIND_STICKY,
+	)
+	admission := &workflowPollAdmission{
+		pollerGroups:     pollerGroups,
+		normalAutoscaler: normalAutoscaler,
+		stickyAutoscaler: stickyAutoscaler,
+	}
+	normalRunner.workflowAdmission = admission
+	stickyRunner.workflowAdmission = admission
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	type heldPoll struct {
+		lease   pollerGroupLease
+		release func()
+	}
+	var coverage []heldPoll
+	for range 2 {
+		lease, release, err := normalRunner.acquire(ctx)
+		require.NoError(s.T(), err)
+		coverage = append(coverage, heldPoll{lease: lease, release: release})
+	}
+	for range 2 {
+		lease, release, err := stickyRunner.acquire(ctx)
+		require.NoError(s.T(), err)
+		coverage = append(coverage, heldPoll{lease: lease, release: release})
+	}
+	defer func() {
+		for _, poll := range coverage {
+			poll.lease.release()
+			poll.release()
+		}
+	}()
+	pollerGroups.updateWorkflowStickyBacklog("sticky-group", 5)
+
+	type acquireResult struct {
+		lease   pollerGroupLease
+		release func()
+		err     error
+	}
+	normalResult := make(chan acquireResult, 1)
+	normalCtx, cancelNormal := context.WithCancel(ctx)
+	defer cancelNormal()
+	go func() {
+		lease, release, err := normalRunner.acquire(normalCtx)
+		normalResult <- acquireResult{lease: lease, release: release, err: err}
+	}()
+	require.Eventually(s.T(), func() bool {
+		pollerGroups.tracker.mu.Lock()
+		defer pollerGroups.tracker.mu.Unlock()
+		decision := pollerGroups.tracker.workflowDecision
+		return decision.group != nil &&
+			decision.group.groupID == "sticky-group" &&
+			decision.queueKind == enumspb.TASK_QUEUE_KIND_STICKY
+	}, time.Second, time.Millisecond, "normal runner did not retain the decision for the sticky runner")
+
+	floatingLease, floatingRelease, err := stickyRunner.acquire(ctx)
+	require.NoError(s.T(), err)
+	defer floatingRelease()
+	defer floatingLease.release()
+	require.Equal(s.T(), "sticky-group", floatingLease.groupIDOrEmpty())
+	require.Equal(s.T(), 3, stickyRunner.activePolls(), "sticky should borrow unused aggregate capacity")
+	require.Equal(s.T(), 2, stickyRunner.effectiveTarget(), "the sticky component target remains unchanged")
+
+	cancelNormal()
+	result := <-normalResult
+	require.ErrorIs(s.T(), result.err, context.Canceled)
+}
+
+func (s *ScalableTaskPollerSuite) TestAutoscalingWorkflowAdmissionReplacesStaleCoverageAboveTarget() {
+	pollerGroups := newPollerGroupManager(pollerGroupModeWorkflowWithSticky, nil)
+	pollerGroups.updateGroups(testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{
+		{Id: "old-a", Weight: 1},
+		{Id: "old-b", Weight: 1},
+	}))
+	normalAutoscaler := newPollerAutoscaler(pollerAutoscalerOptions{
+		initialPollerCount: 2,
+		maxPollerCount:     2,
+		minPollerCount:     2,
+	})
+	stickyAutoscaler := newPollerAutoscaler(pollerAutoscalerOptions{
+		initialPollerCount: 2,
+		maxPollerCount:     2,
+		minPollerCount:     2,
+	})
+	normalRunner := newAutoscalingTaskPollerRunner(normalAutoscaler, pollerGroups, enumspb.TASK_QUEUE_KIND_NORMAL)
+	stickyRunner := newAutoscalingTaskPollerRunner(stickyAutoscaler, pollerGroups, enumspb.TASK_QUEUE_KIND_STICKY)
+	sharedAdmission := &workflowPollAdmission{
+		pollerGroups:     pollerGroups,
+		normalAutoscaler: normalAutoscaler,
+		stickyAutoscaler: stickyAutoscaler,
+	}
+	normalRunner.workflowAdmission = sharedAdmission
+	stickyRunner.workflowAdmission = sharedAdmission
+
+	type heldAdmission struct {
+		lease   pollerGroupLease
+		release func()
+	}
+	acquire := func(runner *autoscalingTaskPollerRunner) []heldAdmission {
+		admissions := make([]heldAdmission, 0, 2)
+		for range 2 {
+			lease, release, err := runner.acquire(s.T().Context())
+			require.NoError(s.T(), err)
+			admissions = append(admissions, heldAdmission{lease: lease, release: release})
+		}
+		return admissions
+	}
+	release := func(admissions []heldAdmission) {
+		for _, admission := range admissions {
+			admission.lease.release()
+			admission.release()
+		}
+	}
+
+	oldNormal := acquire(normalRunner)
+	oldSticky := acquire(stickyRunner)
+	pollerGroups.updateGroups(testPollerGroupsInfo(2, []*taskqueuepb.PollerGroupInfo{
+		{Id: "new-a", Weight: 1},
+		{Id: "new-b", Weight: 1},
+	}))
+
+	newNormal := acquire(normalRunner)
+	newSticky := acquire(stickyRunner)
+	for _, admissions := range [][]heldAdmission{newNormal, newSticky} {
+		groups := make(map[string]struct{}, len(admissions))
+		for _, admission := range admissions {
+			groups[admission.lease.groupIDOrEmpty()] = struct{}{}
+		}
+		require.Equal(s.T(), map[string]struct{}{"new-a": {}, "new-b": {}}, groups)
+	}
+	require.Equal(s.T(), 4, normalRunner.activePolls())
+	require.Equal(s.T(), 4, stickyRunner.activePolls())
+
+	release(oldNormal)
+	release(oldSticky)
+	_, normalMissing := pollerGroups.tryReserveRequired(enumspb.TASK_QUEUE_KIND_NORMAL)
+	_, stickyMissing := pollerGroups.tryReserveRequired(enumspb.TASK_QUEUE_KIND_STICKY)
+	require.False(s.T(), normalMissing)
+	require.False(s.T(), stickyMissing)
+	release(newNormal)
+	release(newSticky)
+}
+
+func (s *ScalableTaskPollerSuite) TestAutoscalingWorkflowAdmissionTargetReductionWaitsForCapacity() {
+	pollerGroups := newPollerGroupManager(pollerGroupModeWorkflowWithSticky, nil)
+	pollerGroups.updateGroups(testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{{Id: "group-a", Weight: 1}}))
+	normalAutoscaler := newPollerAutoscaler(pollerAutoscalerOptions{
+		initialPollerCount: 2,
+		maxPollerCount:     2,
+		minPollerCount:     1,
+	})
+	stickyAutoscaler := newPollerAutoscaler(pollerAutoscalerOptions{
+		initialPollerCount: 1,
+		maxPollerCount:     1,
+		minPollerCount:     1,
+	})
+	normalRunner := newAutoscalingTaskPollerRunner(normalAutoscaler, pollerGroups, enumspb.TASK_QUEUE_KIND_NORMAL)
+	stickyRunner := newAutoscalingTaskPollerRunner(stickyAutoscaler, pollerGroups, enumspb.TASK_QUEUE_KIND_STICKY)
+	admission := &workflowPollAdmission{
+		pollerGroups:     pollerGroups,
+		normalAutoscaler: normalAutoscaler,
+		stickyAutoscaler: stickyAutoscaler,
+	}
+	normalRunner.workflowAdmission = admission
+	stickyRunner.workflowAdmission = admission
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	normalLease, normalRelease, err := normalRunner.acquire(ctx)
+	require.NoError(s.T(), err)
+	stickyLease, stickyRelease, err := stickyRunner.acquire(ctx)
+	require.NoError(s.T(), err)
+	floatingLease, floatingRelease, err := normalRunner.acquire(ctx)
+	require.NoError(s.T(), err)
+
+	normalAutoscaler.updateTarget(func(int64) int64 { return 1 })
+	blockedCtx, cancelBlocked := context.WithTimeout(ctx, 20*time.Millisecond)
+	_, _, err = normalRunner.acquire(blockedCtx)
+	require.ErrorIs(s.T(), err, context.DeadlineExceeded,
+		"poll acquired while aggregate activity exceeded the reduced target")
+	cancelBlocked()
+
+	floatingLease.release()
+	floatingRelease()
+	normalLease.release()
+	normalRelease()
+	stickyLease.release()
+	stickyRelease()
+}
+
+func (s *ScalableTaskPollerSuite) TestAutoscalingWorkflowAdmissionBacklogUpdateWakesSelectedRunner() {
+	pollerGroups := newPollerGroupManager(pollerGroupModeWorkflowWithSticky, nil)
+	pollerGroups.updateGroups(testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{{Id: "group-a", Weight: 1}}))
+	normalAutoscaler := newPollerAutoscaler(pollerAutoscalerOptions{
+		initialPollerCount: 2,
+		maxPollerCount:     2,
+		minPollerCount:     1,
+	})
+	stickyAutoscaler := newPollerAutoscaler(pollerAutoscalerOptions{
+		initialPollerCount: 1,
+		maxPollerCount:     1,
+		minPollerCount:     1,
+	})
+	normalRunner := newAutoscalingTaskPollerRunner(normalAutoscaler, pollerGroups, enumspb.TASK_QUEUE_KIND_NORMAL)
+	stickyRunner := newAutoscalingTaskPollerRunner(stickyAutoscaler, pollerGroups, enumspb.TASK_QUEUE_KIND_STICKY)
+	admission := &workflowPollAdmission{
+		pollerGroups:     pollerGroups,
+		normalAutoscaler: normalAutoscaler,
+		stickyAutoscaler: stickyAutoscaler,
+	}
+	normalRunner.workflowAdmission = admission
+	stickyRunner.workflowAdmission = admission
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	normalLease, normalRelease, err := normalRunner.acquire(ctx)
+	require.NoError(s.T(), err)
+	defer normalRelease()
+	defer normalLease.release()
+	stickyLease, stickyRelease, err := stickyRunner.acquire(ctx)
+	require.NoError(s.T(), err)
+	defer stickyRelease()
+	defer stickyLease.release()
+	pollerGroups.updateWorkflowStickyBacklog("group-a", 2)
+
+	type acquireResult struct {
+		lease   pollerGroupLease
+		release func()
+		err     error
+	}
+	resultCh := make(chan acquireResult, 1)
+	go func() {
+		lease, release, err := normalRunner.acquire(ctx)
+		resultCh <- acquireResult{lease: lease, release: release, err: err}
+	}()
+	require.Eventually(s.T(), func() bool {
+		pollerGroups.tracker.mu.Lock()
+		defer pollerGroups.tracker.mu.Unlock()
+		decision := pollerGroups.tracker.workflowDecision
+		return decision.group != nil && decision.queueKind == enumspb.TASK_QUEUE_KIND_STICKY
+	}, time.Second, time.Millisecond)
+
+	pollerGroups.updateWorkflowStickyBacklog("group-a", 0)
+	select {
+	case result := <-resultCh:
+		require.NoError(s.T(), result.err)
+		defer result.release()
+		defer result.lease.release()
+		require.Equal(s.T(), enumspb.TASK_QUEUE_KIND_NORMAL, result.lease.queueKind)
+	case <-time.After(time.Second):
+		s.T().Fatal("normal runner did not wake after the selected group's backlog cleared")
+	}
+}
+
+func (s *ScalableTaskPollerSuite) TestAutoscalingWorkflowAdmissionKeepsPerKindTargetsWithoutGroups() {
+	pollerGroups := newPollerGroupManager(pollerGroupModeWorkflowWithSticky, nil)
+	normalAutoscaler := newPollerAutoscaler(pollerAutoscalerOptions{
+		initialPollerCount: 2,
+		maxPollerCount:     2,
+		minPollerCount:     1,
+	})
+	stickyAutoscaler := newPollerAutoscaler(pollerAutoscalerOptions{
+		initialPollerCount: 1,
+		maxPollerCount:     1,
+		minPollerCount:     1,
+	})
+	normalRunner := newAutoscalingTaskPollerRunner(normalAutoscaler, pollerGroups, enumspb.TASK_QUEUE_KIND_NORMAL)
+	stickyRunner := newAutoscalingTaskPollerRunner(stickyAutoscaler, pollerGroups, enumspb.TASK_QUEUE_KIND_STICKY)
+	admission := &workflowPollAdmission{
+		pollerGroups:     pollerGroups,
+		normalAutoscaler: normalAutoscaler,
+		stickyAutoscaler: stickyAutoscaler,
+	}
+	normalRunner.workflowAdmission = admission
+	stickyRunner.workflowAdmission = admission
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	stickyLease, stickyRelease, err := stickyRunner.acquire(ctx)
+	require.NoError(s.T(), err)
+	defer stickyRelease()
+	defer stickyLease.release()
+
+	blockedCtx, cancelBlocked := context.WithTimeout(ctx, 20*time.Millisecond)
+	_, _, err = stickyRunner.acquire(blockedCtx)
+	require.ErrorIs(s.T(), err, context.DeadlineExceeded,
+		"sticky must not borrow normal capacity before groups are known")
+	cancelBlocked()
+
+	for range 2 {
+		lease, release, err := normalRunner.acquire(ctx)
+		require.NoError(s.T(), err)
+		defer release()
+		defer lease.release()
+	}
+	require.Equal(s.T(), 2, normalRunner.activePolls())
+	require.Equal(s.T(), 1, stickyRunner.activePolls())
+}
+
+func (s *ScalableTaskPollerSuite) TestAutoscalingWorkflowAdmissionSlotFailureAndShutdownReleaseAdmission() {
+	behavior := &pollerBehaviorAutoscaling{
+		initialNumberOfPollers: 1,
+		maximumNumberOfPollers: 1,
+		minimumNumberOfPollers: 1,
+	}
+	pollerGroups := newPollerGroupManager(pollerGroupModeWorkflowWithSticky, nil)
+	pollerGroups.updateGroups(testPollerGroupsInfo(1, []*taskqueuepb.PollerGroupInfo{
+		{Id: "group-a", Weight: 1},
+	}))
+
+	poller := newScalableTaskPoller(
+		newBlockingProbeTaskPoller(),
+		ilog.NewNopLogger(),
+		behavior,
+		metrics.PollerTypeWorkflowTask,
+		&atomic.Bool{},
+		pollerGroups,
+	)
+	stickyAutoscaler := newPollerAutoscaler(pollerAutoscalerOptions{
+		initialPollerCount: 1,
+		maxPollerCount:     1,
+		minPollerCount:     1,
+	})
+	poller.autoscalingRunner.workflowAdmission = &workflowPollAdmission{
+		pollerGroups:     pollerGroups,
+		normalAutoscaler: poller.pollerAutoscaler,
+		stickyAutoscaler: stickyAutoscaler,
+	}
+	slotSupplier := &failThenBlockSlotSupplier{failed: make(chan struct{})}
+	bw := newBaseWorker(baseWorkerOptions{
+		slotSupplier:     slotSupplier,
+		maxTaskPerSecond: 1000,
+		taskPollers:      []scalableTaskPoller{poller},
+		taskProcessor:    noopTaskProcessor{},
+		workerType:       "AutoscalingWorkflowAdmissionSlotFailureTest",
+		logger:           ilog.NewNopLogger(),
+		stopTimeout:      2 * time.Second,
+		metricsHandler:   metrics.NopHandler,
+	})
+
+	bw.Start()
+	select {
+	case <-slotSupplier.failed:
+	case <-time.After(time.Second):
+		s.T().Fatal("slot reservation did not fail")
+	}
+	require.Eventually(s.T(), func() bool {
+		pollerGroups.tracker.mu.Lock()
+		pendingNormal := pollerGroups.tracker.groups["group-a"].workflowPendingNormal
+		pollerGroups.tracker.mu.Unlock()
+		return poller.autoscalingRunner.activePolls() == 0 && pendingNormal == 0
+	}, time.Second, time.Millisecond, "slot failure retained workflow admission")
+
+	bw.Stop()
+	pollerGroups.tracker.mu.Lock()
+	pendingNormal := pollerGroups.tracker.groups["group-a"].workflowPendingNormal
+	pollerGroups.tracker.mu.Unlock()
+	require.Equal(s.T(), 0, poller.autoscalingRunner.activePolls())
+	require.Equal(s.T(), 0, pendingNormal, "shutdown retained normal coverage")
+}
+
 func (s *ScalableTaskPollerSuite) TestAutoscalingEffectiveTargetUsesMCNRequiredMinimumAsFloor() {
 	tests := []struct {
 		name          string
@@ -1351,6 +1738,25 @@ func (s *testSlotSupplier) MarkSlotUsed(SlotMarkUsedInfo) {}
 func (s *testSlotSupplier) ReleaseSlot(SlotReleaseInfo) {}
 
 func (s *testSlotSupplier) MaxSlots() int { return 0 }
+
+type failThenBlockSlotSupplier struct {
+	failed chan struct{}
+	calls  atomic.Int32
+}
+
+func (s *failThenBlockSlotSupplier) ReserveSlot(ctx context.Context, _ SlotReservationInfo) (*SlotPermit, error) {
+	if s.calls.Add(1) == 1 {
+		close(s.failed)
+		return nil, errors.New("test slot reservation failure")
+	}
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func (s *failThenBlockSlotSupplier) TryReserveSlot(SlotReservationInfo) *SlotPermit { return nil }
+func (s *failThenBlockSlotSupplier) MarkSlotUsed(SlotMarkUsedInfo)                  {}
+func (s *failThenBlockSlotSupplier) ReleaseSlot(SlotReleaseInfo)                    {}
+func (s *failThenBlockSlotSupplier) MaxSlots() int                                  { return 0 }
 
 type captureReservationInfoSlotSupplier struct {
 	taskQueue     string

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -1862,10 +1862,17 @@ func (s *internalWorkerTestSuite) TestPollerAutoscalingAutoEnrollWithDefaults() 
 	workflowGroups := workflowPollers[0].autoscalingRunner.pollerGroups
 	require.NotNil(s.T(), workflowGroups)
 	require.Same(s.T(), worker.client.pollerGroupInfoStore, workflowGroups.groupInfos)
+	var workflowAdmission *workflowPollAdmission
 	for _, p := range workflowPollers {
 		require.NotNil(s.T(), p.autoscalingRunner)
 		require.Same(s.T(), workflowGroups, p.autoscalingRunner.pollerGroups)
+		if workflowAdmission == nil {
+			workflowAdmission = p.autoscalingRunner.workflowAdmission
+		} else {
+			require.Same(s.T(), workflowAdmission, p.autoscalingRunner.workflowAdmission)
+		}
 	}
+	require.NotNil(s.T(), workflowAdmission)
 	activityPollers := worker.activityWorker.worker.options.taskPollers
 	require.NotEmpty(s.T(), activityPollers)
 	require.NotNil(s.T(), activityPollers[0].autoscalingRunner)


### PR DESCRIPTION
## Summary

This adds per-cell sticky-backlog-aware scheduling for floating Workflow polls. Required MCN coverage remains authoritative; backlog only decides normal versus sticky after every group has its required normal and sticky poll.

## Scheduling policy

1. Fill missing normal and sticky coverage for every poller group.
2. For floating capacity, select a group using the latest server weights.
3. Poll sticky when that selected group has positive `backlog_count_hint`; otherwise poll normal.

Normal and sticky keep separate `workflowTaskPoller` RPC objects and separate autoscaler feedback. Their manager loops share one admission coordinator whose budget is:

```text
aggregate target = effective normal target + effective sticky target
```

The component targets contribute to the shared budget rather than cap floating capacity by queue kind. Before poller groups are known, the existing per-kind targets remain in force. `pollerBalancer` still runs before Workflow admission, preserving cross-type balancing without holding a slot while the coordinator waits.

Sticky backlog is stored per group and attributed using the response group ID. A zero hint clears it, and group removal/re-addition creates a fresh group incarnation so stale backlog and pending leases cannot leak across it. A shared pending decision prevents one manager goroutine from discarding or rerolling a decision intended for the other queue kind.

## Key tests

- `TestPollerGroupManagerWorkflowCoverageOverridesStickyBacklog`: missing normal coverage wins even when sticky has excess capacity and backlog.
- `TestPollerGroupManagerFloatingPollSelectsGroupBeforeQueueKind`: group selection happens first and the decision is retained for the matching runner.
- `TestPollerGroupManagerZeroBacklogChoosesNormalFloatingPoll`: zero clears a previous sticky hint.
- `TestPollerGroupManagerRemovedAndReaddedGroupLosesBacklog`: re-added groups do not inherit stale backlog or lease state.
- `TestPollerGroupManagerWeightUpdateReconsidersPendingDecision`: weight changes invalidate an unclaimed floating decision.
- `TestWorkflowStickyBacklogUsesResponsePollerGroupID`: hints use the response group when it differs from the request group.
- `TestAutoscalingWorkflowCoordinatorUsesAggregateCapacityForSelectedKind`: separate targets combine into a shared budget and floating capacity can move to the selected kind.
- `TestAutoscalingWorkflowCoordinatorBacklogUpdateWakesSelectedRunner`: backlog changes wake and reconsider blocked admission.
- `TestAutoscalingWorkflowCoordinatorTargetReductionWaitsForCapacity`: reduced targets do not admit excess polls.
- `TestAutoscalingWorkflowCoordinatorSlotFailureAndShutdownReleaseAdmission`: slot failure and shutdown release both admission and group coverage.

## Validation

- `go run . unit-test -run 'Test(PollerGroupManager|WorkflowStickyBacklog)|TestScalableTaskPollerSuite/TestAutoscalingWorkflowCoordinator|TestWorkerTestSuite/TestWorkerAutoEnrollsDefaultPollersWhenGroupsBecomeKnown'` from `internal/cmd/build` (race enabled)
- `go test ./internal -count=1` (1,186 tests)
- `go run . check` from `internal/cmd/build`

## Current limitation

The repository dev-server fixtures cannot emit MCN poller-group updates or per-cell sticky backlog hints, so the routing behavior is covered with deterministic mocked poll responses and coordinator tests rather than a dev-server integration test. The hint is treated as a binary latest observation for the selected cell; positive chooses sticky and zero chooses normal.
