### PR TITLE
Use shared changelog workflow

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -6,8 +6,9 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   changelog-check:
     name: Changelog checkpoint
-    uses: temporalio/.github/.github/workflows/changelog.yml@6f052b395a527ab62ec33e5e0d7d1faf551bb8b7
+    uses: temporalio/.github/.github/workflows/changelog.yml@d8129c755fbd1d3f18c5a7a5420d5754acc63e3f

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -2,41 +2,12 @@ name: Changelog
 
 on:
   pull_request:
-    # `labeled`/`unlabeled` are included so applying the `skip-changelog`
-    # label re-runs this check. They are not in the default set of activity
-    # types, and this lives in its own workflow so a label change re-runs only
-    # this cheap check rather than the full CI matrix.
     types: [opened, synchronize, reopened, labeled, unlabeled]
 
 permissions:
   contents: read
-  pull-requests: read
 
 jobs:
   changelog-check:
     name: Changelog checkpoint
-    runs-on: ubuntu-latest
-    steps:
-      # Reminds contributors to record user-facing changes. Passes when the PR
-      # touches any CHANGELOG.md, or when a maintainer applies the
-      # `skip-changelog` label to confirm no entry is needed. Otherwise
-      # fails with guidance. It does not judge whether the entry is meaningful,
-      # it is purely a nudge.
-      - name: Require a CHANGELOG.md update or override label
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
-        run: |
-          if echo "$LABELS" | grep -q '"skip-changelog"'; then
-            echo "Found 'skip-changelog' label; no CHANGELOG.md entry required."
-            exit 0
-          fi
-          if gh api "repos/$REPO/pulls/$PR_NUMBER/files" --paginate --jq '.[].filename' \
-            | grep -Eq '(^|/)CHANGELOG\.md$'; then
-            echo "A CHANGELOG.md was updated."
-            exit 0
-          fi
-          echo "::error::This PR does not update a CHANGELOG.md. If it includes a user-facing change, add an entry under [Unreleased] in the affected module's CHANGELOG.md. If no changelog entry is needed, a maintainer can apply the 'skip-changelog' label."
-          exit 1
+    uses: temporalio/.github/.github/workflows/changelog.yml@6f052b395a527ab62ec33e5e0d7d1faf551bb8b7


### PR DESCRIPTION
## What was changed

Replaced the repository-local changelog implementation with the reusable workflow from temporalio/.github. The caller pins merged commit 6f052b395a527ab62ec33e5e0d7d1faf551bb8b7 and retains the local pull request triggers needed to rerun when skip-changelog is added or removed.

## Why?

This centralizes the check across SDK repositories and verifies that every changelog addition is under an Unreleased section, including after an intervening release changes the pull request merge result. The shared workflow was introduced by temporalio/.github#20.

## Checklist

1. Closes: N/A

2. How was this tested:

- actionlint
- git diff --check
- The shared workflow was exercised against mocked pass, failure, and label-override cases
- The shared workflow was verified against recent Go, Rust, and TypeScript changelog history

3. Any docs updates needed?

No repository documentation changes are needed. The shared workflow is documented in temporalio/.github.