### PR TITLE
feat: Expose workflow cancellation reason

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,14 @@ to docs, or any other relevant information.
 - The `temporal_activity_execution_failed` and `temporal_local_activity_execution_failed` worker
   metrics now carry a `failure_reason` attribute. Each is now split into one time series per
   reason, which may affect existing dashboards.
+- Workflow cancellation now carries a reason. A workflow reads why it was asked to cancel with
+  `workflow.GetCancellationReason(ctx)` and sets one when cancelling another workflow with
+  `workflow.RequestCancelExternalWorkflowWithOptions`. In the test environment,
+  `TestWorkflowEnvironment.CancelWorkflowWithReason` and `CancelWorkflowByIDWithReason` set the
+  reason the workflow observes, and `OnRequestCancelExternalWorkflowWithOptions` mocks external
+  cancellations with the reason as a matchable argument.
+  `interceptor.WorkflowOutboundInterceptor` gained the corresponding
+  `RequestCancelExternalWorkflowWithOptions` and `GetCancellationReason` methods.
 
 ### Changed
 
@@ -49,6 +57,10 @@ to docs, or any other relevant information.
   from both the workflow and the activity context) now sees only the activity or child workflow
   context, and one whose `WithSerializationContext` returned a converter that is no longer
   context-aware now receives the activity or child workflow context it previously never saw.
+- `WorkflowEnvironment` gained `GetCancellationReason() string`, `RequestCancelExternalWorkflow`
+  gained a `reason` parameter before the callback, and `RequestCancelChildWorkflow` gained a
+  trailing `reason` parameter. The interface is aliased publicly as
+  `internalbindings.WorkflowEnvironment`, so out-of-tree implementations must be updated.
 
 ### Fixed
 

--- a/internal/cancel_reason_test.go
+++ b/internal/cancel_reason_test.go
@@ -1,0 +1,218 @@
+package internal
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func recordCancellationReason(ctx Context) (string, error) {
+	ctx.Done().Receive(ctx, nil)
+	return GetCancellationReason(ctx), nil
+}
+
+func TestCancellationReason_FromTestEnvironment(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		cancel func(env *TestWorkflowEnvironment)
+		want   string
+	}{
+		{
+			name:   "with reason",
+			cancel: func(env *TestWorkflowEnvironment) { env.CancelWorkflowWithReason("because") },
+			want:   "because",
+		},
+		{
+			name:   "without reason",
+			cancel: func(env *TestWorkflowEnvironment) { env.CancelWorkflow() },
+			want:   "",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var suite WorkflowTestSuite
+			env := suite.NewTestWorkflowEnvironment()
+			env.RegisterWorkflow(recordCancellationReason)
+			env.RegisterDelayedCallback(func() { tc.cancel(env) }, time.Millisecond)
+
+			env.ExecuteWorkflow(recordCancellationReason)
+
+			require.True(t, env.IsWorkflowCompleted())
+			var reason string
+			require.NoError(t, env.GetWorkflowResult(&reason))
+			require.Equal(t, tc.want, reason)
+		})
+	}
+}
+
+func selfCancelWithReason(ctx Context) (string, error) {
+	info := GetWorkflowInfo(ctx)
+	RequestCancelExternalWorkflowWithOptions(ctx, RequestCancelExternalWorkflowOptions{
+		WorkflowID: info.WorkflowExecution.ID,
+		RunID:      info.WorkflowExecution.RunID,
+		Reason:     "because",
+	})
+	ctx.Done().Receive(ctx, nil)
+	return GetCancellationReason(ctx), nil
+}
+
+func TestCancellationReason_FromRequestCancelExternalWorkflowWithOptions(t *testing.T) {
+	var suite WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+	env.RegisterWorkflow(selfCancelWithReason)
+
+	env.ExecuteWorkflow(selfCancelWithReason)
+
+	require.True(t, env.IsWorkflowCompleted())
+	var reason string
+	require.NoError(t, env.GetWorkflowResult(&reason))
+	require.Equal(t, "because", reason)
+}
+
+func cancelChildThroughContext(ctx Context) (string, error) {
+	ctx = WithChildWorkflowOptions(ctx, ChildWorkflowOptions{WorkflowID: "child-1", WaitForCancellation: true})
+	var reason string
+	err := ExecuteChildWorkflow(ctx, recordCancellationReason).Get(ctx, &reason)
+	return reason, err
+}
+
+func TestCancellationReason_ChildCancelCarriesNoInventedReason(t *testing.T) {
+	var suite WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+	env.RegisterWorkflow(cancelChildThroughContext)
+	env.RegisterWorkflow(recordCancellationReason)
+	env.RegisterDelayedCallback(func() { env.CancelWorkflowWithReason("because") }, time.Millisecond)
+
+	env.ExecuteWorkflow(cancelChildThroughContext)
+
+	require.True(t, env.IsWorkflowCompleted())
+	var reason string
+	require.NoError(t, env.GetWorkflowResult(&reason))
+	require.Empty(t, reason)
+}
+
+type cancelCountingInterceptor struct {
+	WorkflowOutboundInterceptorBase
+	legacyCalls  *int
+	optionsCalls *int
+}
+
+func (i *cancelCountingInterceptor) RequestCancelExternalWorkflow(ctx Context, workflowID, runID string) Future {
+	*i.legacyCalls++
+	return i.Next.RequestCancelExternalWorkflow(ctx, workflowID, runID)
+}
+
+func (i *cancelCountingInterceptor) RequestCancelExternalWorkflowWithOptions(ctx Context, options RequestCancelExternalWorkflowOptions) Future {
+	*i.optionsCalls++
+	return i.Next.RequestCancelExternalWorkflowWithOptions(ctx, options)
+}
+
+func (i *cancelCountingInterceptor) GetCancellationReason(ctx Context) string {
+	return "intercepted"
+}
+
+type cancelCountingWorkerInterceptor struct {
+	WorkerInterceptorBase
+	legacyCalls  *int
+	optionsCalls *int
+}
+
+func (i *cancelCountingWorkerInterceptor) InterceptWorkflow(ctx Context, next WorkflowInboundInterceptor) WorkflowInboundInterceptor {
+	return &cancelCountingInboundInterceptor{
+		WorkflowInboundInterceptorBase: WorkflowInboundInterceptorBase{Next: next},
+		legacyCalls:                    i.legacyCalls,
+		optionsCalls:                   i.optionsCalls,
+	}
+}
+
+type cancelCountingInboundInterceptor struct {
+	WorkflowInboundInterceptorBase
+	legacyCalls  *int
+	optionsCalls *int
+}
+
+func (i *cancelCountingInboundInterceptor) Init(outbound WorkflowOutboundInterceptor) error {
+	return i.Next.Init(&cancelCountingInterceptor{
+		WorkflowOutboundInterceptorBase: WorkflowOutboundInterceptorBase{Next: outbound},
+		legacyCalls:                     i.legacyCalls,
+		optionsCalls:                    i.optionsCalls,
+	})
+}
+
+func cancelBothWays(ctx Context) (string, error) {
+	info := GetWorkflowInfo(ctx)
+	RequestCancelExternalWorkflow(ctx, "other-1", "")
+	RequestCancelExternalWorkflowWithOptions(ctx, RequestCancelExternalWorkflowOptions{
+		WorkflowID: info.WorkflowExecution.ID,
+		Reason:     "because",
+	})
+	ctx.Done().Receive(ctx, nil)
+	return GetCancellationReason(ctx), nil
+}
+
+func TestCancellationReason_InterceptorSeesBothPaths(t *testing.T) {
+	var legacyCalls, optionsCalls int
+
+	var suite WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+	env.SetWorkerOptions(WorkerOptions{Interceptors: []WorkerInterceptor{
+		&cancelCountingWorkerInterceptor{legacyCalls: &legacyCalls, optionsCalls: &optionsCalls},
+	}})
+	env.RegisterWorkflow(cancelBothWays)
+	env.OnRequestCancelExternalWorkflow(mock.Anything, "other-1", mock.Anything).Return(nil).Once()
+
+	env.ExecuteWorkflow(cancelBothWays)
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.Equal(t, 1, legacyCalls, "legacy cancel must reach the legacy interceptor method")
+	require.Equal(t, 1, optionsCalls, "options cancel must reach the options interceptor method")
+
+	var reason string
+	require.NoError(t, env.GetWorkflowResult(&reason))
+	require.Equal(t, "intercepted", reason, "GetCancellationReason must go through the interceptor chain")
+}
+
+func cancelChildByIDWithReason(ctx Context) (string, error) {
+	ctx = WithChildWorkflowOptions(ctx, ChildWorkflowOptions{WorkflowID: "child-by-id", WaitForCancellation: true})
+	var reason string
+	err := ExecuteChildWorkflow(ctx, recordCancellationReason).Get(ctx, &reason)
+	return reason, err
+}
+
+func TestCancellationReason_CancelWorkflowByIDWithReason(t *testing.T) {
+	var suite WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+	env.RegisterWorkflow(cancelChildByIDWithReason)
+	env.RegisterWorkflow(recordCancellationReason)
+	env.RegisterDelayedCallback(func() {
+		env.CancelWorkflowByIDWithReason("child-by-id", "", "because")
+	}, time.Millisecond)
+
+	env.ExecuteWorkflow(cancelChildByIDWithReason)
+
+	require.True(t, env.IsWorkflowCompleted())
+	var reason string
+	require.NoError(t, env.GetWorkflowResult(&reason))
+	require.Equal(t, "because", reason)
+}
+
+func cancelExternalWithReason(ctx Context) error {
+	return RequestCancelExternalWorkflowWithOptions(ctx, RequestCancelExternalWorkflowOptions{
+		WorkflowID: "external-1",
+		Reason:     "because",
+	}).Get(ctx, nil)
+}
+
+func TestCancellationReason_MockMatchesReason(t *testing.T) {
+	var suite WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+	env.RegisterWorkflow(cancelExternalWithReason)
+	env.OnRequestCancelExternalWorkflowWithOptions(mock.Anything, "external-1", mock.Anything, "because").Return(nil).Once()
+
+	env.ExecuteWorkflow(cancelExternalWithReason)
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+	env.AssertExpectations(t)
+}

--- a/internal/interceptor.go
+++ b/internal/interceptor.go
@@ -275,6 +275,13 @@ type WorkflowOutboundInterceptor interface {
 	// workflow.RequestCancelExternalWorkflow.
 	RequestCancelExternalWorkflow(ctx Context, workflowID, runID string) Future
 
+	// RequestCancelExternalWorkflowWithOptions intercepts
+	// workflow.RequestCancelExternalWorkflowWithOptions.
+	RequestCancelExternalWorkflowWithOptions(ctx Context, options RequestCancelExternalWorkflowOptions) Future
+
+	// GetCancellationReason intercepts workflow.GetCancellationReason.
+	GetCancellationReason(ctx Context) string
+
 	// SignalExternalWorkflow intercepts workflow.SignalExternalWorkflow.
 	// interceptor.WorkflowHeader will return a non-nil map for this context.
 	SignalExternalWorkflow(ctx Context, workflowID, runID, signalName string, arg any) Future

--- a/internal/interceptor_base.go
+++ b/internal/interceptor_base.go
@@ -304,6 +304,21 @@ func (w *WorkflowOutboundInterceptorBase) RequestCancelExternalWorkflow(
 	return w.Next.RequestCancelExternalWorkflow(ctx, workflowID, runID)
 }
 
+// RequestCancelExternalWorkflowWithOptions implements
+// WorkflowOutboundInterceptor.RequestCancelExternalWorkflowWithOptions.
+func (w *WorkflowOutboundInterceptorBase) RequestCancelExternalWorkflowWithOptions(
+	ctx Context,
+	options RequestCancelExternalWorkflowOptions,
+) Future {
+	return w.Next.RequestCancelExternalWorkflowWithOptions(ctx, options)
+}
+
+// GetCancellationReason implements
+// WorkflowOutboundInterceptor.GetCancellationReason.
+func (w *WorkflowOutboundInterceptorBase) GetCancellationReason(ctx Context) string {
+	return w.Next.GetCancellationReason(ctx)
+}
+
 // SignalExternalWorkflow implements
 // WorkflowOutboundInterceptor.SignalExternalWorkflow.
 func (w *WorkflowOutboundInterceptorBase) SignalExternalWorkflow(

--- a/internal/interceptortest/proxy.go
+++ b/internal/interceptortest/proxy.go
@@ -357,6 +357,19 @@ func (p *proxyWorkflowOutbound) RequestCancelExternalWorkflow(
 	return
 }
 
+func (p *proxyWorkflowOutbound) RequestCancelExternalWorkflowWithOptions(
+	ctx workflow.Context,
+	options workflow.RequestCancelExternalWorkflowOptions,
+) (ret workflow.Future) {
+	ret, _ = p.invoke(ctx, options)[0].Interface().(workflow.Future)
+	return
+}
+
+func (p *proxyWorkflowOutbound) GetCancellationReason(ctx workflow.Context) (ret string) {
+	ret, _ = p.invoke(ctx)[0].Interface().(string)
+	return
+}
+
 func (p *proxyWorkflowOutbound) SignalExternalWorkflow(
 	ctx workflow.Context,
 	workflowID string,

--- a/internal/internal_command_state_machine.go
+++ b/internal/internal_command_state_machine.go
@@ -78,8 +78,9 @@ type (
 
 	childWorkflowCommandStateMachine struct {
 		*commandStateMachineBase
-		attributes    *commandpb.StartChildWorkflowExecutionCommandAttributes
-		startMetadata *sdk.UserMetadata
+		attributes         *commandpb.StartChildWorkflowExecutionCommandAttributes
+		startMetadata      *sdk.UserMetadata
+		cancellationReason string
 	}
 
 	naiveCommandStateMachine struct {
@@ -722,6 +723,7 @@ func (d *childWorkflowCommandStateMachine) getCommand() *commandpb.Command {
 			Namespace:         d.attributes.Namespace, //lint:ignore SA1019 deprecated namespace field
 			WorkflowId:        d.attributes.WorkflowId,
 			ChildWorkflowOnly: true,
+			Reason:            d.cancellationReason,
 		}}
 		return command
 	default:
@@ -1424,7 +1426,7 @@ func (h *commandsHelper) handleStartChildWorkflowExecutionFailed(workflowID stri
 	return command
 }
 
-func (h *commandsHelper) requestCancelExternalWorkflowExecution(namespace, workflowID, runID string, cancellationID string, childWorkflowOnly bool) commandStateMachine {
+func (h *commandsHelper) requestCancelExternalWorkflowExecution(namespace, workflowID, runID string, cancellationID, reason string, childWorkflowOnly bool) commandStateMachine {
 	if childWorkflowOnly {
 		// For cancellation of child workflow only, we do not use cancellation ID
 		// since the child workflow cancellation go through the existing child workflow
@@ -1443,6 +1445,7 @@ func (h *commandsHelper) requestCancelExternalWorkflowExecution(namespace, workf
 		}
 		// targeting child workflow
 		command := h.getCommand(makeCommandID(commandTypeChildWorkflow, workflowID))
+		command.(*childWorkflowCommandStateMachine).cancellationReason = reason
 		command.cancel()
 		return command
 	}
@@ -1464,6 +1467,7 @@ func (h *commandsHelper) requestCancelExternalWorkflowExecution(namespace, workf
 		//lint:ignore SA1019 control correlates command state with initiated history
 		Control:           cancellationID,
 		ChildWorkflowOnly: false,
+		Reason:            reason,
 	}
 	command := h.newCancelExternalWorkflowStateMachine(attributes, cancellationID)
 	h.addCommand(command)

--- a/internal/internal_command_state_machine_test.go
+++ b/internal/internal_command_state_machine_test.go
@@ -401,7 +401,7 @@ func Test_ChildWorkflowStateMachine_CancelSucceed(t *testing.T) {
 	h.handleChildWorkflowExecutionStarted(workflowID)
 
 	// cancel child workflow
-	h.requestCancelExternalWorkflowExecution(namespace, workflowID, runID, cancellationID, true)
+	h.requestCancelExternalWorkflowExecution(namespace, workflowID, runID, cancellationID, "", true)
 	require.Equal(t, commandStateCanceledAfterStarted, d.getState())
 
 	// send cancel request
@@ -470,7 +470,7 @@ func Test_ChildWorkflowStateMachine_InvalidStates(t *testing.T) {
 	require.NotNil(t, err)
 
 	// cancel child workflow after child workflow is started
-	h.requestCancelExternalWorkflowExecution(namespace, workflowID, runID, cancellationID, true)
+	h.requestCancelExternalWorkflowExecution(namespace, workflowID, runID, cancellationID, "", true)
 	require.Equal(t, commandStateCanceledAfterStarted, d.getState())
 
 	// send cancel request
@@ -521,7 +521,7 @@ func Test_ChildWorkflow_UnusualCancelationOrdering(t *testing.T) {
 	h.handleStartChildWorkflowExecutionInitiated(workflowID)
 	h.handleChildWorkflowExecutionStarted(workflowID)
 	// cancel child workflow after child workflow is started
-	h.requestCancelExternalWorkflowExecution(namespace, workflowID, runID, cancellationID, true)
+	h.requestCancelExternalWorkflowExecution(namespace, workflowID, runID, cancellationID, "", true)
 	// send cancel request
 	h.getCommands(true)
 	h.handleRequestCancelExternalWorkflowExecutionInitiated(initiatedEventID, workflowID, cancellationID)
@@ -556,7 +556,7 @@ func Test_ChildWorkflowStateMachine_CancelFailed(t *testing.T) {
 	// child workflow started
 	h.handleChildWorkflowExecutionStarted(workflowID)
 	// cancel child workflow
-	h.requestCancelExternalWorkflowExecution(namespace, workflowID, runID, cancellationID, true)
+	h.requestCancelExternalWorkflowExecution(namespace, workflowID, runID, cancellationID, "", true)
 	// send cancel request
 	h.getCommands(true)
 	// cancel request initiated
@@ -624,7 +624,7 @@ func Test_CancelExternalWorkflowStateMachine_Succeed(t *testing.T) {
 	h := newCommandsHelper()
 
 	// request cancel external workflow
-	command := h.requestCancelExternalWorkflowExecution(namespace, workflowID, runID, cancellationID, false)
+	command := h.requestCancelExternalWorkflowExecution(namespace, workflowID, runID, cancellationID, "", false)
 	require.False(t, command.isDone())
 	d := h.getCommand(makeCommandID(commandTypeCancellation, cancellationID))
 	require.Equal(t, commandStateCreated, d.getState())
@@ -672,7 +672,7 @@ func Test_CancelExternalWorkflowStateMachine_Failed(t *testing.T) {
 	h := newCommandsHelper()
 
 	// request cancel external workflow
-	command := h.requestCancelExternalWorkflowExecution(namespace, workflowID, runID, cancellationID, false)
+	command := h.requestCancelExternalWorkflowExecution(namespace, workflowID, runID, cancellationID, "", false)
 	require.False(t, command.isDone())
 	d := h.getCommand(makeCommandID(commandTypeCancellation, cancellationID))
 	require.Equal(t, commandStateCreated, d.getState())
@@ -763,4 +763,47 @@ func runAndCatchPanic(f func()) (err error) {
 
 	f()
 	return nil
+}
+
+func Test_CancelExternalWorkflowStateMachine_CarriesReason(t *testing.T) {
+	t.Parallel()
+	h := newCommandsHelper()
+
+	h.requestCancelExternalWorkflowExecution("test-namespace", "test-workflow-id", "test-run-id", "1", "because", false)
+
+	commands := h.getCommands(true)
+	require.Equal(t, 1, len(commands))
+	require.Equal(t, "because", commands[0].GetRequestCancelExternalWorkflowExecutionCommandAttributes().GetReason())
+}
+
+func Test_CancelExternalWorkflow_EnvironmentForwardsReason(t *testing.T) {
+	t.Parallel()
+	env := &workflowEnvironmentImpl{commandsHelper: newCommandsHelper()}
+	env.commandsHelper.setCurrentWorkflowTaskStartedEventID(3)
+
+	env.RequestCancelExternalWorkflow("test-namespace", "test-workflow-id", "test-run-id", "because", func(*commonpb.Payloads, error) {})
+
+	commands := env.commandsHelper.getCommands(true)
+	require.Equal(t, 1, len(commands))
+	require.Equal(t, "because", commands[0].GetRequestCancelExternalWorkflowExecutionCommandAttributes().GetReason())
+}
+
+func Test_ChildWorkflowStateMachine_CarriesCancelReason(t *testing.T) {
+	t.Parallel()
+	workflowID := "test-child-workflow"
+	h := newCommandsHelper()
+
+	_, err := h.startChildWorkflowExecution(&commandpb.StartChildWorkflowExecutionCommandAttributes{WorkflowId: workflowID}, nil)
+	require.NoError(t, err)
+	_ = h.getCommands(true)
+	h.handleStartChildWorkflowExecutionInitiated(workflowID)
+	h.handleChildWorkflowExecutionStarted(workflowID)
+
+	h.requestCancelExternalWorkflowExecution("test-namespace", workflowID, "", "", "because", true)
+
+	commands := h.getCommands(true)
+	require.Equal(t, 1, len(commands))
+	attributes := commands[0].GetRequestCancelExternalWorkflowExecutionCommandAttributes()
+	require.True(t, attributes.GetChildWorkflowOnly())
+	require.Equal(t, "because", attributes.GetReason())
 }

--- a/internal/internal_event_handlers.go
+++ b/internal/internal_event_handlers.go
@@ -153,6 +153,8 @@ type (
 		queryHandler    func(queryType string, queryArgs *commonpb.Payloads, header *commonpb.Header) (*commonpb.Payloads, error)
 		updateHandler   func(name string, id string, args *commonpb.Payloads, header *commonpb.Header, callbacks UpdateCallbacks)
 
+		cancellationReason string
+
 		logger                log.Logger
 		isReplay              bool // flag to indicate if workflow is in replay mode
 		enableLoggingInReplay bool // flag to indicate if workflow should enable logging in replay mode
@@ -414,15 +416,19 @@ func (wc *workflowEnvironmentImpl) Complete(result *commonpb.Payloads, err error
 	wc.completeHandler(result, err)
 }
 
-func (wc *workflowEnvironmentImpl) RequestCancelChildWorkflow(namespace string, workflowID string) {
-	// For cancellation of child workflow only, we do not use cancellation ID and run ID
-	wc.commandsHelper.requestCancelExternalWorkflowExecution(namespace, workflowID, "", "", true)
+func (wc *workflowEnvironmentImpl) GetCancellationReason() string {
+	return wc.cancellationReason
 }
 
-func (wc *workflowEnvironmentImpl) RequestCancelExternalWorkflow(namespace, workflowID, runID string, callback ResultHandler) {
+func (wc *workflowEnvironmentImpl) RequestCancelChildWorkflow(namespace, workflowID, reason string) {
+	// For cancellation of child workflow only, we do not use cancellation ID and run ID
+	wc.commandsHelper.requestCancelExternalWorkflowExecution(namespace, workflowID, "", "", reason, true)
+}
+
+func (wc *workflowEnvironmentImpl) RequestCancelExternalWorkflow(namespace, workflowID, runID, reason string, callback ResultHandler) {
 	// for cancellation of external workflow, we have to use cancellation ID and set isChildWorkflowOnly to false
 	cancellationID := wc.GenerateSequenceID()
-	command := wc.commandsHelper.requestCancelExternalWorkflowExecution(namespace, workflowID, runID, cancellationID, false)
+	command := wc.commandsHelper.requestCancelExternalWorkflowExecution(namespace, workflowID, runID, cancellationID, reason, false)
 	command.setData(&scheduledCancellation{callback: callback})
 }
 
@@ -1386,7 +1392,7 @@ func (weh *workflowExecutionEventHandlerImpl) ProcessEvent(
 		weh.commandsHelper.handleTimerCanceled(event.GetTimerCanceledEventAttributes().GetTimerId())
 
 	case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_CANCEL_REQUESTED:
-		weh.handleWorkflowExecutionCancelRequested()
+		weh.handleWorkflowExecutionCancelRequested(event)
 
 	case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_CANCELED:
 		// No Operation.
@@ -1689,7 +1695,8 @@ func (weh *workflowExecutionEventHandlerImpl) handleTimerFired(event *historypb.
 	timer.handle(nil, nil)
 }
 
-func (weh *workflowExecutionEventHandlerImpl) handleWorkflowExecutionCancelRequested() {
+func (weh *workflowExecutionEventHandlerImpl) handleWorkflowExecutionCancelRequested(event *historypb.HistoryEvent) {
+	weh.cancellationReason = event.GetWorkflowExecutionCancelRequestedEventAttributes().GetCause()
 	weh.cancelHandler()
 }
 

--- a/internal/internal_event_handlers_test.go
+++ b/internal/internal_event_handlers_test.go
@@ -15,6 +15,7 @@ import (
 
 	"go.temporal.io/sdk/converter"
 	iconverter "go.temporal.io/sdk/internal/converter"
+	ilog "go.temporal.io/sdk/internal/log"
 	"go.temporal.io/sdk/internal/protocol"
 )
 
@@ -550,4 +551,39 @@ func TestUpdateEventsPanic(t *testing.T) {
 			Body:               body,
 		}, false, false)
 	})
+}
+
+func TestWorkflowExecutionCancelRequestedCause(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		cause string
+	}{
+		{name: "with cause", cause: "user asked nicely"},
+		{name: "without cause", cause: ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var causeInsideHandler string
+			weh := &workflowExecutionEventHandlerImpl{
+				workflowEnvironmentImpl: &workflowEnvironmentImpl{
+					workflowInfo: &WorkflowInfo{TaskQueueName: "tq"},
+					logger:       ilog.NewNopLogger(),
+				},
+			}
+			weh.cancelHandler = func() {
+				causeInsideHandler = weh.GetCancellationReason()
+			}
+
+			require.NoError(t, weh.ProcessEvent(&historypb.HistoryEvent{
+				EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_CANCEL_REQUESTED,
+				Attributes: &historypb.HistoryEvent_WorkflowExecutionCancelRequestedEventAttributes{
+					WorkflowExecutionCancelRequestedEventAttributes: &historypb.WorkflowExecutionCancelRequestedEventAttributes{
+						Cause: tc.cause,
+					},
+				},
+			}, false, false))
+
+			require.Equal(t, tc.cause, causeInsideHandler)
+			require.Equal(t, tc.cause, weh.GetCancellationReason())
+		})
+	}
 }

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -1736,7 +1736,8 @@ func isCommandMatchEvent(d *commandpb.Command, e *historypb.HistoryEvent, obes [
 		eventAttributes := e.GetRequestCancelExternalWorkflowExecutionInitiatedEventAttributes()
 		commandAttributes := d.GetRequestCancelExternalWorkflowExecutionCommandAttributes()
 		if checkNamespacesInCommandAndEvent(eventAttributes.GetNamespace(), commandAttributes.GetNamespace()) || //lint:ignore SA1019 deprecated namespace field
-			eventAttributes.WorkflowExecution.GetWorkflowId() != commandAttributes.GetWorkflowId() {
+			eventAttributes.WorkflowExecution.GetWorkflowId() != commandAttributes.GetWorkflowId() ||
+			eventAttributes.GetReason() != commandAttributes.GetReason() {
 			return false
 		}
 

--- a/internal/internal_worker_base.go
+++ b/internal/internal_worker_base.go
@@ -110,8 +110,9 @@ type (
 		TypedSearchAttributes() SearchAttributes
 		Complete(result *commonpb.Payloads, err error)
 		RegisterCancelHandler(handler func())
-		RequestCancelChildWorkflow(namespace, workflowID string)
-		RequestCancelExternalWorkflow(namespace, workflowID, runID string, callback ResultHandler)
+		GetCancellationReason() string
+		RequestCancelChildWorkflow(namespace, workflowID, reason string)
+		RequestCancelExternalWorkflow(namespace, workflowID, runID, reason string, callback ResultHandler)
 		ExecuteChildWorkflow(params ExecuteWorkflowParams, callback ResultHandler, startedHandler func(r WorkflowExecution, e error))
 		ExecuteNexusOperation(params ExecuteNexusOperationParams, callback func(*commonpb.Payload, error), startedHandler func(token string, e error)) int64
 		RequestCancelNexusOperation(seq int64)

--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -235,6 +235,8 @@ type (
 		openSessions   map[string]*SessionInfo
 		randoms        map[string]*workflowRandomStream
 
+		cancellationReason string
+
 		// mutableSideEffect holds the last recorded value per MutableSideEffect id
 		// so the test environment can honor the user-supplied equals function the
 		// same way the real worker does (only update when the value changed).
@@ -1230,7 +1232,7 @@ func (env *testWorkflowEnvironmentImpl) handleParentClosePolicy() {
 			case enumspb.PARENT_CLOSE_POLICY_TERMINATE:
 				handle.env.Complete(nil, newTerminatedError())
 			case enumspb.PARENT_CLOSE_POLICY_REQUEST_CANCEL:
-				handle.env.cancelWorkflow(func(result *commonpb.Payloads, err error) {})
+				handle.env.cancelWorkflow("", func(result *commonpb.Payloads, err error) {})
 			}
 		}
 	}
@@ -2582,6 +2584,10 @@ func (env *testWorkflowEnvironmentImpl) RegisterCancelHandler(handler func()) {
 	env.workflowCancelHandler = handler
 }
 
+func (env *testWorkflowEnvironmentImpl) GetCancellationReason() string {
+	return env.cancellationReason
+}
+
 func (env *testWorkflowEnvironmentImpl) RegisterSignalHandler(
 	handler func(name string, input *commonpb.Payloads, header *commonpb.Header) error,
 ) {
@@ -2600,18 +2606,19 @@ func (env *testWorkflowEnvironmentImpl) RegisterQueryHandler(
 	env.queryHandler = handler
 }
 
-func (env *testWorkflowEnvironmentImpl) RequestCancelChildWorkflow(_, workflowID string) {
+func (env *testWorkflowEnvironmentImpl) RequestCancelChildWorkflow(_, workflowID, reason string) {
 	if childHandle, ok := env.runningWorkflows[workflowID]; ok && !childHandle.handled {
 		// current workflow is a parent workflow, and we are canceling a child workflow
 		childEnv := childHandle.env
-		childEnv.cancelWorkflow(func(result *commonpb.Payloads, err error) {})
+		childEnv.cancelWorkflow(reason, func(result *commonpb.Payloads, err error) {})
 		return
 	}
 }
 
-func (env *testWorkflowEnvironmentImpl) RequestCancelExternalWorkflow(namespace, workflowID, runID string, callback ResultHandler) {
+func (env *testWorkflowEnvironmentImpl) RequestCancelExternalWorkflow(namespace, workflowID, runID, reason string, callback ResultHandler) {
 	if env.workflowInfo.WorkflowExecution.ID == workflowID {
 		cancelFunc := func() {
+			env.cancellationReason = reason
 			env.workflowCancelHandler()
 
 			if env.isChildWorkflow() && env.onChildWorkflowCanceledListener != nil {
@@ -2642,7 +2649,7 @@ func (env *testWorkflowEnvironmentImpl) RequestCancelExternalWorkflow(namespace,
 		env.postCallback(func() {
 			callback(nil, nil)
 		}, true)
-		childEnv.cancelWorkflow(callback)
+		childEnv.cancelWorkflow(reason, callback)
 		return
 	}
 
@@ -2650,11 +2657,21 @@ func (env *testWorkflowEnvironmentImpl) RequestCancelExternalWorkflow(namespace,
 	// so it can block and wait on the requested delay time (if configured). If we run it in main thread, and the mock
 	// configured to delay, it will block the main loop which stops the world.
 	env.runningCount++
+	method := mockMethodForRequestCancelExternalWorkflow
+	args := []any{namespace, workflowID, runID}
+	var fn any = mockFnRequestCancelExternalWorkflow
+	for _, call := range env.workflowMock.ExpectedCalls {
+		if call.Method == mockMethodForRequestCancelExternalWorkflowWithOptions {
+			method = mockMethodForRequestCancelExternalWorkflowWithOptions
+			args = []any{namespace, workflowID, runID, reason}
+			fn = mockFnRequestCancelExternalWorkflowWithOptions
+			break
+		}
+	}
 	go func() {
-		args := []any{namespace, workflowID, runID}
 		// below call will panic if mock is not properly setup.
-		mockRet := env.workflowMock.MethodCalled(mockMethodForRequestCancelExternalWorkflow, args...)
-		m := &mockWrapper{name: mockMethodForRequestCancelExternalWorkflow, fn: mockFnRequestCancelExternalWorkflow}
+		mockRet := env.workflowMock.MethodCalled(method, args...)
+		m := &mockWrapper{name: method, fn: fn}
 		var err error
 		if mockFn := m.getMockFn(mockRet); mockFn != nil {
 			_, err = executeFunctionWithContext(context.TODO(), mockFn, args)
@@ -3383,17 +3400,18 @@ func (a *testActivityHandle) getActivityInfo() *ActivityInfo {
 	}
 }
 
-func (env *testWorkflowEnvironmentImpl) cancelWorkflow(callback ResultHandler) {
-	env.cancelWorkflowByID(env.workflowInfo.WorkflowExecution.ID, env.workflowInfo.WorkflowExecution.RunID, callback)
+func (env *testWorkflowEnvironmentImpl) cancelWorkflow(reason string, callback ResultHandler) {
+	env.cancelWorkflowByID(env.workflowInfo.WorkflowExecution.ID, env.workflowInfo.WorkflowExecution.RunID, reason, callback)
 }
 
-func (env *testWorkflowEnvironmentImpl) cancelWorkflowByID(workflowID string, runID string, callback ResultHandler) {
+func (env *testWorkflowEnvironmentImpl) cancelWorkflowByID(workflowID string, runID string, reason string, callback ResultHandler) {
 	env.postCallback(func() {
 		// RequestCancelWorkflow needs to be run in main thread
 		env.RequestCancelExternalWorkflow(
 			env.workflowInfo.Namespace,
 			workflowID,
 			runID,
+			reason,
 			callback,
 		)
 	}, true)
@@ -3642,6 +3660,11 @@ func mockFnSignalExternalWorkflow(string, string, string, string, any) error {
 
 // function signature for mock RequestCancelExternalWorkflow
 func mockFnRequestCancelExternalWorkflow(string, string, string) error {
+	return nil
+}
+
+// function signature for mock RequestCancelExternalWorkflowWithOptions
+func mockFnRequestCancelExternalWorkflowWithOptions(string, string, string, string) error {
 	return nil
 }
 

--- a/internal/nexus_operations.go
+++ b/internal/nexus_operations.go
@@ -500,19 +500,19 @@ func (t *testSuiteClientForNexusOperations) DescribeWorkflow(ctx context.Context
 
 // CancelWorkflow implements Client.
 func (t *testSuiteClientForNexusOperations) CancelWorkflow(ctx context.Context, workflowID string, runID string) error {
-	if set, ok := ctx.Value(IsWorkflowRunOpContextKey).(bool); !ok || !set {
-		panic("not implemented in the test environment")
-	}
-	doneCh := make(chan error)
-	t.env.cancelWorkflowByID(workflowID, runID, func(result *commonpb.Payloads, err error) {
-		doneCh <- err
-	})
-	return <-doneCh
+	return t.CancelWorkflowWithOptions(ctx, CancelWorkflowOptions{WorkflowID: workflowID, RunID: runID})
 }
 
 // CancelWorkflowWithOptions implements Client.
 func (t *testSuiteClientForNexusOperations) CancelWorkflowWithOptions(ctx context.Context, options CancelWorkflowOptions) error {
-	return t.CancelWorkflow(ctx, options.WorkflowID, options.RunID)
+	if set, ok := ctx.Value(IsWorkflowRunOpContextKey).(bool); !ok || !set {
+		panic("not implemented in the test environment")
+	}
+	doneCh := make(chan error)
+	t.env.cancelWorkflowByID(options.WorkflowID, options.RunID, options.Reason, func(result *commonpb.Payloads, err error) {
+		doneCh <- err
+	})
+	return <-doneCh
 }
 
 // CheckHealth implements Client.

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -438,6 +438,23 @@ type (
 	// Exposed as: [go.temporal.io/sdk/workflow.Version]
 	Version int
 
+	// RequestCancelExternalWorkflowOptions are the parameters for
+	// [RequestCancelExternalWorkflowWithOptions].
+	//
+	// Exposed as: [go.temporal.io/sdk/workflow.RequestCancelExternalWorkflowOptions]
+	RequestCancelExternalWorkflowOptions struct {
+		// WorkflowID is the workflow ID of the target workflow. Required.
+		WorkflowID string
+
+		// RunID indicates the instance of the target workflow. Optional: when empty, the currently
+		// running instance of WorkflowID is targeted.
+		RunID string
+
+		// Reason is a human readable explanation of why the cancellation is requested. Optional.
+		// The target workflow reads it through [GetCancellationReason].
+		Reason string
+	}
+
 	// ChildWorkflowOptions stores all child workflow specific parameters that will be stored inside of a Context.
 	// The current timeout resolution implementation is in seconds and uses math.Ceil(d.Seconds()) as the duration. But is
 	// subjected to change in the future.
@@ -1492,7 +1509,7 @@ func (wc *workflowEnvironmentInterceptor) ExecuteChildWorkflow(ctx Context, chil
 					assertNotInReadOnlyStateCancellation(ctx)
 					if ctx.Err() == ErrCanceled && !mainFuture.IsReady() {
 						// child workflow started, and ctx canceled
-						getWorkflowEnvironment(ctx).RequestCancelChildWorkflow(options.Namespace, r.ID)
+						getWorkflowEnvironment(ctx).RequestCancelChildWorkflow(options.Namespace, r.ID, "")
 					}
 					return false
 				}
@@ -1833,12 +1850,29 @@ func RequestCancelExternalWorkflow(ctx Context, workflowID, runID string) Future
 	return i.RequestCancelExternalWorkflow(ctx, workflowID, runID)
 }
 
+// RequestCancelExternalWorkflowWithOptions is [RequestCancelExternalWorkflow] with the addition of
+// a reason, which the target workflow observes through [GetCancellationReason].
+//
+// Exposed as: [go.temporal.io/sdk/workflow.RequestCancelExternalWorkflowWithOptions]
+func RequestCancelExternalWorkflowWithOptions(ctx Context, options RequestCancelExternalWorkflowOptions) Future {
+	assertNotInReadOnlyState(ctx)
+	i := getWorkflowOutboundInterceptor(ctx)
+	return i.RequestCancelExternalWorkflowWithOptions(ctx, options)
+}
+
 func (wc *workflowEnvironmentInterceptor) RequestCancelExternalWorkflow(ctx Context, workflowID, runID string) Future {
+	return wc.RequestCancelExternalWorkflowWithOptions(ctx, RequestCancelExternalWorkflowOptions{
+		WorkflowID: workflowID,
+		RunID:      runID,
+	})
+}
+
+func (wc *workflowEnvironmentInterceptor) RequestCancelExternalWorkflowWithOptions(ctx Context, options RequestCancelExternalWorkflowOptions) Future {
 	ctx1 := setWorkflowEnvOptionsIfNotExist(ctx)
-	options := getWorkflowEnvOptions(ctx1)
+	envOptions := getWorkflowEnvOptions(ctx1)
 	future, settable := NewFuture(ctx1)
 
-	if workflowID == "" {
+	if options.WorkflowID == "" {
 		settable.Set(nil, errWorkflowIDNotSet)
 		return future
 	}
@@ -1848,13 +1882,28 @@ func (wc *workflowEnvironmentInterceptor) RequestCancelExternalWorkflow(ctx Cont
 	}
 
 	wc.env.RequestCancelExternalWorkflow(
-		options.Namespace,
-		workflowID,
-		runID,
+		envOptions.Namespace,
+		options.WorkflowID,
+		options.RunID,
+		options.Reason,
 		resultCallback,
 	)
 
 	return future
+}
+
+// GetCancellationReason returns the reason the workflow execution was asked to cancel, as given by
+// whoever requested the cancellation. It is empty until the workflow is asked to cancel, and stays
+// empty when the cancellation carried no reason.
+//
+// Exposed as: [go.temporal.io/sdk/workflow.GetCancellationReason]
+func GetCancellationReason(ctx Context) string {
+	i := getWorkflowOutboundInterceptor(ctx)
+	return i.GetCancellationReason(ctx)
+}
+
+func (wc *workflowEnvironmentInterceptor) GetCancellationReason(ctx Context) string {
+	return wc.env.GetCancellationReason()
 }
 
 // SignalExternalWorkflow can be used to send signal info to an external workflow.

--- a/internal/workflow_testsuite.go
+++ b/internal/workflow_testsuite.go
@@ -516,6 +516,7 @@ func (e *TestWorkflowEnvironment) OnWorkflow(workflow any, args ...any) *MockCal
 
 const mockMethodForSignalExternalWorkflow = "workflow.SignalExternalWorkflow"
 const mockMethodForRequestCancelExternalWorkflow = "workflow.RequestCancelExternalWorkflow"
+const mockMethodForRequestCancelExternalWorkflowWithOptions = "workflow.RequestCancelExternalWorkflowWithOptions"
 const mockMethodForGetVersion = "workflow.GetVersion"
 const mockMethodForSideEffect = "workflow.SideEffect"
 const mockMethodForMutableSideEffect = "workflow.MutableSideEffect"
@@ -574,6 +575,19 @@ func (e *TestWorkflowEnvironment) OnSignalExternalWorkflow(namespace, workflowID
 // therefore are not concurrency-safe with workflow code.
 func (e *TestWorkflowEnvironment) OnRequestCancelExternalWorkflow(namespace, workflowID, runID string) *MockCallWrapper {
 	call := e.workflowMock.On(mockMethodForRequestCancelExternalWorkflow, namespace, workflowID, runID)
+	return e.wrapWorkflowCall(call)
+}
+
+// OnRequestCancelExternalWorkflowWithOptions setup a mock for cancellation of an external workflow
+// like OnRequestCancelExternalWorkflow, with the cancellation reason as an additional argument to
+// match on. When at least one mock is registered through this method, every external workflow
+// cancellation in the test is matched against these reason-aware mocks instead of the ones
+// registered through OnRequestCancelExternalWorkflow.
+//
+// Mock callbacks here are run on a separate goroutine than the workflow and
+// therefore are not concurrency-safe with workflow code.
+func (e *TestWorkflowEnvironment) OnRequestCancelExternalWorkflowWithOptions(namespace, workflowID, runID, reason string) *MockCallWrapper {
+	call := e.workflowMock.On(mockMethodForRequestCancelExternalWorkflowWithOptions, namespace, workflowID, runID, reason)
 	return e.wrapWorkflowCall(call)
 }
 
@@ -1177,12 +1191,26 @@ func (e *TestWorkflowEnvironment) CompleteActivity(taskToken []byte, result any,
 
 // CancelWorkflow requests cancellation (through workflow Context) to the currently running test workflow.
 func (e *TestWorkflowEnvironment) CancelWorkflow() {
-	e.impl.cancelWorkflow(func(result *commonpb.Payloads, err error) {})
+	e.CancelWorkflowWithReason("")
+}
+
+// CancelWorkflowWithReason requests cancellation (through workflow Context) to the currently
+// running test workflow, and records reason as the cancellation reason the workflow observes
+// through [go.temporal.io/sdk/workflow.GetCancellationReason].
+func (e *TestWorkflowEnvironment) CancelWorkflowWithReason(reason string) {
+	e.impl.cancelWorkflow(reason, func(result *commonpb.Payloads, err error) {})
 }
 
 // CancelWorkflowByID requests cancellation (through workflow Context) to the specified workflow.
 func (e *TestWorkflowEnvironment) CancelWorkflowByID(workflowID string, runID string) {
-	e.impl.cancelWorkflowByID(workflowID, runID, func(result *commonpb.Payloads, err error) {})
+	e.CancelWorkflowByIDWithReason(workflowID, runID, "")
+}
+
+// CancelWorkflowByIDWithReason requests cancellation (through workflow Context) to the specified
+// workflow, and records reason as the cancellation reason the workflow observes through
+// [go.temporal.io/sdk/workflow.GetCancellationReason].
+func (e *TestWorkflowEnvironment) CancelWorkflowByIDWithReason(workflowID string, runID string, reason string) {
+	e.impl.cancelWorkflowByID(workflowID, runID, reason, func(result *commonpb.Payloads, err error) {})
 }
 
 // SignalWorkflow sends signal to the currently running test workflow.

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -1002,6 +1002,27 @@ func (ts *IntegrationTestSuite) TestCancellationWithOptions() {
 	ts.True(found, "workflow history did not contain a cancellation-requested event")
 }
 
+func (ts *IntegrationTestSuite) TestCancellationReasonInWorkflow() {
+	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
+	defer cancel()
+	workflowID := "test-cancellation-reason-in-workflow"
+	reason := "test cancellation reason"
+	run, err := ts.client.ExecuteWorkflow(
+		ctx, ts.startWorkflowOptions(workflowID), ts.workflows.ReturnCancellationReason,
+	)
+	ts.NoError(err)
+
+	ts.NoError(ts.client.CancelWorkflowWithOptions(ctx, client.CancelWorkflowOptions{
+		WorkflowID: workflowID,
+		RunID:      run.GetRunID(),
+		Reason:     reason,
+	}))
+
+	var observed string
+	ts.NoError(run.Get(ctx, &observed))
+	ts.Equal(reason, observed)
+}
+
 func (ts *IntegrationTestSuite) TestTerminationWithOptions() {
 	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
 	defer cancel()

--- a/test/workflow_test.go
+++ b/test/workflow_test.go
@@ -2227,6 +2227,11 @@ func (w *Workflows) CronWorkflow(ctx workflow.Context) (int, error) {
 	return retme, nil
 }
 
+func (w *Workflows) ReturnCancellationReason(ctx workflow.Context) (string, error) {
+	ctx.Done().Receive(ctx, nil)
+	return workflow.GetCancellationReason(ctx), nil
+}
+
 func (w *Workflows) WaitForCancelWithDisconnectedContextWorkflow(ctx workflow.Context) (err error) {
 	ao := workflow.ActivityOptions{
 		StartToCloseTimeout: 1 * time.Minute,
@@ -4365,6 +4370,7 @@ func (w *Workflows) register(worker worker.Worker) {
 	worker.RegisterWorkflow(w.AwaitWithTimeoutConditionAlreadyTrue)
 	worker.RegisterWorkflow(w.CascadingCancellation)
 	worker.RegisterWorkflow(w.WaitForCancelWithDisconnectedContextWorkflow)
+	worker.RegisterWorkflow(w.ReturnCancellationReason)
 	worker.RegisterWorkflow(w.ChildWorkflowWithRetryPolicy)
 	worker.RegisterWorkflow(w.ChildWorkflowWithCustomRetryPolicy)
 	worker.RegisterWorkflow(w.ChildWorkflowRetryOnError)

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -136,6 +136,9 @@ type (
 	// ChildWorkflowOptions stores all child workflow specific parameters that will be stored inside of a Context.
 	ChildWorkflowOptions = internal.ChildWorkflowOptions
 
+	// RequestCancelExternalWorkflowOptions are the parameters for RequestCancelExternalWorkflowWithOptions.
+	RequestCancelExternalWorkflowOptions = internal.RequestCancelExternalWorkflowOptions
+
 	// RegisterOptions consists of options for registering a workflow
 	RegisterOptions = internal.RegisterWorkflowOptions
 
@@ -384,6 +387,19 @@ func GetUnhandledSignalNames(ctx Context) []string {
 // RequestCancelExternalWorkflow return Future with failure or empty success result.
 func RequestCancelExternalWorkflow(ctx Context, workflowID, runID string) Future {
 	return internal.RequestCancelExternalWorkflow(ctx, workflowID, runID)
+}
+
+// RequestCancelExternalWorkflowWithOptions is RequestCancelExternalWorkflow with the addition of a
+// reason, which the target workflow observes through GetCancellationReason.
+func RequestCancelExternalWorkflowWithOptions(ctx Context, options RequestCancelExternalWorkflowOptions) Future {
+	return internal.RequestCancelExternalWorkflowWithOptions(ctx, options)
+}
+
+// GetCancellationReason returns the reason the workflow execution was asked to cancel, as given by
+// whoever requested the cancellation. It is empty until the workflow is asked to cancel, and stays
+// empty when the cancellation carried no reason.
+func GetCancellationReason(ctx Context) string {
+	return internal.GetCancellationReason(ctx)
 }
 
 // SignalExternalWorkflow can be used to send signal info to an external workflow.


### PR DESCRIPTION

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->
 
## What was changed

Workflow cancellation now carries a reason:

- `workflow.GetCancellationReason(ctx)` returns the `cause` of the `WorkflowExecutionCancelRequested` event.
- `workflow.RequestCancelExternalWorkflowWithOptions` sends a reason when cancelling an external workflow.
- `internalbindings.WorkflowEnvironment` exposes the reason (`GetCancellationReason`, `reason` parameters on `RequestCancelExternalWorkflow` / `RequestCancelChildWorkflow`) for external SDKs built on top of the Go SDK.
- Test environment: `CancelWorkflowWithReason`, `CancelWorkflowByIDWithReason`, `OnRequestCancelExternalWorkflowWithOptions`.
- The replay matcher for `RequestCancelExternalWorkflowExecution` commands now compares `Reason`.

## Why?

The server records the cancellation reason in history, and `client.CancelWorkflowWithOptions` already sends one, but workflow code had no way to read it or to set one when cancelling another workflow. Closes the workflow-side half of temporalio/features#596; also needed by the PHP SDK, which runs on these bindings through RoadRunner.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
