### PR TITLE
test: reproducer for terminated workflows retained by the sticky cache

### DIFF
--- a/test/reproducer/terminatedcache/README.md
+++ b/test/reproducer/terminatedcache/README.md
@@ -1,0 +1,53 @@
+# Reproducer: terminated workflows are retained by the sticky cache until LRU capacity
+
+Externally terminated workflow executions are never evicted from the worker's
+sticky cache. The worker keeps the full cached execution context, including the
+parked workflow goroutine, until `defaultStickyCacheSize` (10000) newer runs
+push the dead one out. The server never dispatches a workflow task on
+termination, so the worker has no way to learn the run is closed.
+
+## Run
+
+```bash
+temporal server start-dev --headless --port 7244
+go run . 300 1024        # 300 runs, 1 MB ballast each, started + terminated
+```
+
+Observed (sdk v1.48.0, darwin/arm64):
+
+```
+baseline: heap 6.2 MB, 25 goroutines
+after 300 terminated (1024KB ballast): heap 311.2 MB, 327 goroutines
+```
+
+Every terminated run retains its ~1 MB workflow state and one parked goroutine.
+Normally completed runs are freed immediately (the worker participates in the
+completion), so this is specific to closures the worker never observes:
+terminate and server-side workflow execution timeout.
+
+## Probe: nothing reaches the worker on terminate
+
+```bash
+go run ./probe
+```
+
+```
+before terminate: 2 predicate wakeups, 28 goroutines
+terminated; waiting 10s for anything to reach the worker...
+after terminate: 2 predicate wakeups (delta 0), 28 goroutines (delta 0)
+server-side history of the terminated run:
+  WorkflowExecutionStarted
+  WorkflowTaskScheduled
+  WorkflowTaskStarted
+  WorkflowTaskCompleted
+  WorkflowExecutionTerminated
+```
+
+`WorkflowExecutionTerminated` is recorded in history, but no workflow task
+delivers it: the `workflow.Await` predicate is never re-evaluated and the
+workflow goroutine stays parked.
+
+Related: temporalio/features#573 (fine control for workflow cache eviction),
+temporalio/sdk-rust#1135 (rejected fix attempt for the same behavior in Core),
+temporalio/sdk-php#635 (the PHP report this was reduced from; PHP workers hit
+it hardest since one process holds the whole cache under `memory_limit`).

--- a/test/reproducer/terminatedcache/main.go
+++ b/test/reproducer/terminatedcache/main.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/worker"
+	"go.temporal.io/sdk/workflow"
+)
+
+func LeakWorkflow(ctx workflow.Context, ballastKb int) (string, error) {
+	ballast := strings.Repeat("x", ballastKb*1024)
+	err := workflow.Await(ctx, func() bool { return len(ballast) == 0 })
+	return "done", err
+}
+
+func heap() (heapMb float64, goroutines int) {
+	runtime.GC()
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+	return float64(m.HeapAlloc) / 1048576, runtime.NumGoroutine()
+}
+
+func main() {
+	count := 300
+	ballastKb := 1024
+	if len(os.Args) > 1 {
+		count, _ = strconv.Atoi(os.Args[1])
+	}
+	if len(os.Args) > 2 {
+		ballastKb, _ = strconv.Atoi(os.Args[2])
+	}
+
+	c, err := client.Dial(client.Options{HostPort: "127.0.0.1:7244"})
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer c.Close()
+
+	w := worker.New(c, "leak-lab-go", worker.Options{})
+	w.RegisterWorkflow(LeakWorkflow)
+	if err := w.Start(); err != nil {
+		log.Fatal(err)
+	}
+	defer w.Stop()
+
+	ctx := context.Background()
+	mb, gr := heap()
+	fmt.Printf("baseline: heap %.1f MB, %d goroutines\n", mb, gr)
+
+	for i := 0; i < count; i++ {
+		run, err := c.ExecuteWorkflow(ctx, client.StartWorkflowOptions{
+			TaskQueue:                "leak-lab-go",
+			WorkflowExecutionTimeout: 10 * time.Minute,
+		}, LeakWorkflow, ballastKb)
+		if err != nil {
+			log.Fatal(err)
+		}
+		var queryResult string
+		v, err := c.QueryWorkflow(ctx, run.GetID(), run.GetRunID(), "__stack_trace")
+		if err == nil {
+			_ = v.Get(&queryResult)
+		}
+		if err := c.TerminateWorkflow(ctx, run.GetID(), run.GetRunID(), "leak-lab"); err != nil {
+			log.Fatal(err)
+		}
+	}
+	time.Sleep(2 * time.Second)
+
+	mb, gr = heap()
+	fmt.Printf("after %d terminated (%dKB ballast): heap %.1f MB, %d goroutines\n", count, ballastKb, mb, gr)
+}

--- a/test/reproducer/terminatedcache/probe/main.go
+++ b/test/reproducer/terminatedcache/probe/main.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"runtime"
+	"sync/atomic"
+	"time"
+
+	"go.temporal.io/api/enums/v1"
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/worker"
+	"go.temporal.io/sdk/workflow"
+)
+
+var wakeups atomic.Int64
+
+func ProbeWorkflow(ctx workflow.Context) (string, error) {
+	err := workflow.Await(ctx, func() bool {
+		wakeups.Add(1)
+		return false
+	})
+	return "done", err
+}
+
+func main() {
+	c, err := client.Dial(client.Options{HostPort: "127.0.0.1:7244"})
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer c.Close()
+
+	w := worker.New(c, "probe-go", worker.Options{})
+	w.RegisterWorkflow(ProbeWorkflow)
+	if err := w.Start(); err != nil {
+		log.Fatal(err)
+	}
+	defer w.Stop()
+
+	ctx := context.Background()
+	run, err := c.ExecuteWorkflow(ctx, client.StartWorkflowOptions{
+		TaskQueue:                "probe-go",
+		WorkflowExecutionTimeout: 10 * time.Minute,
+	}, ProbeWorkflow)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	var pong string
+	v, err := c.QueryWorkflow(ctx, run.GetID(), run.GetRunID(), "__stack_trace")
+	if err != nil {
+		log.Fatal(err)
+	}
+	_ = v.Get(&pong)
+
+	beforeWakeups := wakeups.Load()
+	beforeGoroutines := runtime.NumGoroutine()
+	fmt.Printf("before terminate: %d predicate wakeups, %d goroutines\n", beforeWakeups, beforeGoroutines)
+
+	if err := c.TerminateWorkflow(ctx, run.GetID(), run.GetRunID(), "probe"); err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println("terminated; waiting 10s for anything to reach the worker...")
+	time.Sleep(10 * time.Second)
+
+	fmt.Printf("after terminate: %d predicate wakeups (delta %d), %d goroutines (delta %d)\n",
+		wakeups.Load(), wakeups.Load()-beforeWakeups,
+		runtime.NumGoroutine(), runtime.NumGoroutine()-beforeGoroutines)
+
+	fmt.Println("server-side history of the terminated run:")
+	iter := c.GetWorkflowHistory(ctx, run.GetID(), run.GetRunID(), false, enums.HISTORY_EVENT_FILTER_TYPE_ALL_EVENT)
+	for iter.HasNext() {
+		ev, err := iter.Next()
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Printf("  %s\n", ev.GetEventType())
+	}
+}


### PR DESCRIPTION

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

Externally terminated runs keep their full cached state and a parked goroutine until LRU pressure evicts them — the server never dispatches a workflow task on termination, so the worker cannot learn the run is closed. 
300 terminated runs × 1 MB → heap 6.2 → 311 MB, +302 goroutines. 
Includes a probe: WorkflowExecutionTerminated is in history, nothing delivers it to the worker. 

Related: [temporalio/features#573](https://github.com/temporalio/features/issues/573), [temporalio/sdk-rust#1135](https://github.com/temporalio/sdk-rust/issues/1135), [temporalio/sdk-php#635](https://github.com/temporalio/sdk-php/issues/635).

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
