### PR TITLE
Detect wrapped already-started errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ to docs, or any other relevant information.
 
 ### Fixed
 
+- `temporal.IsWorkflowExecutionAlreadyStartedError` now detects wrapped
+  `serviceerror.WorkflowExecutionAlreadyStarted` errors.
 - Malformed Nexus link errors now log the link URL and parse error under stable structured fields.
 - Local activity results are now serialized with the local activity's `ActivitySerializationContext`
   (`IsLocal=true`) on both ends. Previously the result was encoded with the plain worker data converter

--- a/temporal/error.go
+++ b/temporal/error.go
@@ -216,12 +216,12 @@ func IsApplicationError(err error) bool {
 	return errors.As(err, &applicationError)
 }
 
-// IsWorkflowExecutionAlreadyStartedError return if the err is a
-// WorkflowExecutionAlreadyStartedError or if an error in the chain is a
-// ChildWorkflowExecutionAlreadyStartedError.
+// IsWorkflowExecutionAlreadyStartedError returns true if an error in the chain
+// is a WorkflowExecutionAlreadyStartedError or ChildWorkflowExecutionAlreadyStartedError.
 func IsWorkflowExecutionAlreadyStartedError(err error) bool {
-	if _, ok := err.(*serviceerror.WorkflowExecutionAlreadyStarted); ok {
-		return ok
+	var alreadyStartedError *serviceerror.WorkflowExecutionAlreadyStarted
+	if errors.As(err, &alreadyStartedError) {
+		return true
 	}
 	var childError *ChildWorkflowExecutionAlreadyStartedError
 	return errors.As(err, &childError)

--- a/temporal/error_test.go
+++ b/temporal/error_test.go
@@ -1,10 +1,19 @@
 package temporal
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.temporal.io/api/serviceerror"
 )
+
+func TestIsWorkflowExecutionAlreadyStartedError(t *testing.T) {
+	err := serviceerror.NewWorkflowExecutionAlreadyStarted("already started", "workflow-id", "run-id")
+	err = fmt.Errorf("start workflow: %w", err)
+
+	require.True(t, IsWorkflowExecutionAlreadyStartedError(err))
+}
 
 func TestNewPayloadValidationError(t *testing.T) {
 	t.Run("with details", func(t *testing.T) {


### PR DESCRIPTION
## What was changed

- Detect wrapped WorkflowExecutionAlreadyStarted service errors.
- Add regression coverage for wrapped errors.
- Add a changelog entry.

Reimplements #2270 with regression coverage.

## Why?

The helper unwrapped child workflow errors but only recognized direct service errors.

## Checklist

1. Closes: N/A. Supersedes #2270.

2. How was this tested:

added regression test

3. Any docs updates needed?

No. CHANGELOG.md was updated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small helper behavior fix with no auth, data, or API contract changes beyond more accurate error classification.
> 
> **Overview**
> **`temporal.IsWorkflowExecutionAlreadyStartedError`** now uses **`errors.As`** to find **`serviceerror.WorkflowExecutionAlreadyStarted`** anywhere in the error chain, not only when that type is the top-level error. Child workflow **`ChildWorkflowExecutionAlreadyStartedError`** detection was already chain-aware; service errors from client starts (often wrapped with context) now match the same behavior.
> 
> Adds a regression test that wraps the service error with **`fmt.Errorf(..., %w)`** and documents the fix in **CHANGELOG.md**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2a1adb40fcda3e3cf8d475a8be71551fd35c5ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->