### PR TITLE
💥 feat(extstore): pass a dedicated select context to the driver selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ to docs, or any other relevant information.
 ### :boom: Breaking Changes
 
 - Raised the minimum supported Go version from 1.25.4 to 1.26.0.
+- Experimental external storage: `converter.StorageDriverSelector.SelectDriver` now receives a
+  `converter.StorageDriverSelectContext` instead of a `converter.StorageDriverStoreContext`.
+  Update the parameter type; the new type carries the same `Context` and `Target` fields.
 - Local activity results are now serialized with the local activity's `ActivitySerializationContext`
   (`IsLocal=true`) instead of the workflow serialization context. Users of a context-aware
   `DataConverter` or `PayloadCodec` whose encoding depends on the serialization context (for example

--- a/converter/extstore.go
+++ b/converter/extstore.go
@@ -21,11 +21,17 @@ type StorageDriverWorkflowInfo = extstore.StorageDriverWorkflowInfo
 // NOTE: Experimental
 type StorageDriverActivityInfo = extstore.StorageDriverActivityInfo
 
-// StorageDriverStoreContext carries context passed to StorageDriver.Store and
-// StorageDriverSelector.SelectDriver operations.
+// StorageDriverStoreContext carries context passed to StorageDriver.Store
+// operations.
 //
 // NOTE: Experimental
 type StorageDriverStoreContext = extstore.StorageDriverStoreContext
+
+// StorageDriverSelectContext carries context passed to
+// StorageDriverSelector.SelectDriver operations.
+//
+// NOTE: Experimental
+type StorageDriverSelectContext = extstore.StorageDriverSelectContext
 
 // StorageDriverRetrieveContext carries context passed to StorageDriver.Retrieve
 // operations.

--- a/converter/payload_handler_test.go
+++ b/converter/payload_handler_test.go
@@ -168,7 +168,7 @@ func encoding(p *commonpb.Payload) string {
 // fixedDriverSelector always routes to the provided driver.
 type fixedDriverSelector struct{ driver converter.StorageDriver }
 
-func (s fixedDriverSelector) SelectDriver(_ converter.StorageDriverStoreContext, _ *commonpb.Payload) (converter.StorageDriver, error) {
+func (s fixedDriverSelector) SelectDriver(_ converter.StorageDriverSelectContext, _ *commonpb.Payload) (converter.StorageDriver, error) {
 	return s.driver, nil
 }
 

--- a/internal/extstore/extstore.go
+++ b/internal/extstore/extstore.go
@@ -57,12 +57,27 @@ func (StorageDriverActivityInfo) isStorageDriverTargetInfo() {}
 
 var _ StorageDriverTargetInfo = StorageDriverActivityInfo{}
 
-// StorageDriverStoreContext carries context passed to StorageDriver.Store and
-// StorageDriverSelector.SelectDriver operations.
+// StorageDriverStoreContext carries context passed to StorageDriver.Store
+// operations.
 //
 // NOTE: Experimental
 type StorageDriverStoreContext struct {
 	// Context is the context of the operation that triggered the driver call.
+	// Drivers should use it to respect cancellation and to propagate deadlines
+	// and trace information to downstream calls (e.g. cloud storage SDKs).
+	Context context.Context
+	// Target identifies the workflow or activity on whose behalf payloads are
+	// being stored. Use a type switch on [StorageDriverWorkflowInfo] and
+	// [StorageDriverActivityInfo] to access the concrete values.
+	Target StorageDriverTargetInfo
+}
+
+// StorageDriverSelectContext carries context passed to
+// StorageDriverSelector.SelectDriver operations.
+//
+// NOTE: Experimental
+type StorageDriverSelectContext struct {
+	// Context is the context of the operation that triggered the selector call.
 	// Drivers should use it to respect cancellation and to propagate deadlines
 	// and trace information to downstream calls (e.g. cloud storage SDKs).
 	Context context.Context
@@ -139,7 +154,7 @@ type StorageDriver interface {
 //
 // NOTE: Experimental
 type StorageDriverSelector interface {
-	SelectDriver(ctx StorageDriverStoreContext, payload *commonpb.Payload) (StorageDriver, error)
+	SelectDriver(ctx StorageDriverSelectContext, payload *commonpb.Payload) (StorageDriver, error)
 }
 
 // ExternalStorage configures external payload storage for a Temporal client or

--- a/internal/extstore/extstore_test.go
+++ b/internal/extstore/extstore_test.go
@@ -176,7 +176,7 @@ func TestExternalStorageToParams_PointerAndValueReceiverDrivers(t *testing.T) {
 	//valDriver := valueReceiverDriver{name: "val-driver"}
 	valDriver := newValDriver("val-driver")
 
-	selector := &funcDriverSelector{fn: func(_ StorageDriverStoreContext, _ *commonpb.Payload) (StorageDriver, error) {
+	selector := &funcDriverSelector{fn: func(_ StorageDriverSelectContext, _ *commonpb.Payload) (StorageDriver, error) {
 		return ptrDriver, nil
 	}}
 	params, err := ExternalStorageToParams(ExternalStorage{
@@ -202,7 +202,7 @@ func TestExternalStorageToParams_SingleDriverSynthesizesSelector(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NotNil(t, params.driverSelector)
-	selected, err := params.driverSelector.SelectDriver(StorageDriverStoreContext{Context: t.Context()}, nil)
+	selected, err := params.driverSelector.SelectDriver(StorageDriverSelectContext{Context: t.Context()}, nil)
 	require.NoError(t, err)
 	require.Equal(t, driver, selected)
 }
@@ -420,7 +420,7 @@ func TestStoreVisitor_MultiplePayloads_Batched(t *testing.T) {
 
 func TestStoreVisitor_SelectorNil_PayloadInline(t *testing.T) {
 	driver := newTestDriver("d")
-	selector := &funcDriverSelector{fn: func(_ StorageDriverStoreContext, _ *commonpb.Payload) (StorageDriver, error) {
+	selector := &funcDriverSelector{fn: func(_ StorageDriverSelectContext, _ *commonpb.Payload) (StorageDriver, error) {
 		return nil, nil
 	}}
 	params, err := ExternalStorageToParams(ExternalStorage{
@@ -437,10 +437,38 @@ func TestStoreVisitor_SelectorNil_PayloadInline(t *testing.T) {
 	require.Equal(t, 0, driver.storeCount)
 }
 
+func TestStoreVisitor_SelectorReceivesSelectContextWithTarget(t *testing.T) {
+	driver := newTestDriver("d")
+	target := StorageDriverWorkflowInfo{
+		Namespace:    "ns",
+		WorkflowType: "MyWorkflow",
+		WorkflowID:   "wf-id",
+		RunID:        "run-id",
+	}
+	var selectCtx StorageDriverSelectContext
+	selector := &funcDriverSelector{fn: func(ctx StorageDriverSelectContext, _ *commonpb.Payload) (StorageDriver, error) {
+		selectCtx = ctx
+		return driver, nil
+	}}
+	params, err := ExternalStorageToParams(ExternalStorage{
+		Drivers:        []StorageDriver{driver},
+		DriverSelector: selector,
+	})
+	require.NoError(t, err)
+	visitor := NewExternalStorageVisitor(params)
+
+	ctx := WithStorageTarget(t.Context(), target)
+	p := makeOversizedPayload(t, defaultPayloadSizeThreshold+1)
+	_, err = visitPayloads(ctx, visitor, []*commonpb.Payload{p})
+	require.NoError(t, err)
+	require.Equal(t, target, selectCtx.Target)
+	require.NotNil(t, selectCtx.Context)
+}
+
 func TestStoreVisitor_SelectorBelowThreshold_NotCalled(t *testing.T) {
 	driver := newTestDriver("d")
 	selectorCalled := false
-	selector := &funcDriverSelector{fn: func(_ StorageDriverStoreContext, _ *commonpb.Payload) (StorageDriver, error) {
+	selector := &funcDriverSelector{fn: func(_ StorageDriverSelectContext, _ *commonpb.Payload) (StorageDriver, error) {
 		selectorCalled = true
 		return driver, nil
 	}}
@@ -464,7 +492,7 @@ func TestStoreVisitor_SelectorRoutes_TwoDrivers(t *testing.T) {
 	d1 := newTestDriver("d1")
 	d2 := newTestDriver("d2")
 	i := 0
-	selector := &funcDriverSelector{fn: func(_ StorageDriverStoreContext, _ *commonpb.Payload) (StorageDriver, error) {
+	selector := &funcDriverSelector{fn: func(_ StorageDriverSelectContext, _ *commonpb.Payload) (StorageDriver, error) {
 		defer func() { i++ }()
 		if i%2 == 0 {
 			return d1, nil
@@ -489,7 +517,7 @@ func TestStoreVisitor_SelectorRoutes_TwoDrivers(t *testing.T) {
 
 func TestStoreVisitor_SelectorUnregisteredDriver(t *testing.T) {
 	unregistered := newTestDriver("my-unregistered-driver")
-	selector := &funcDriverSelector{fn: func(_ StorageDriverStoreContext, _ *commonpb.Payload) (StorageDriver, error) {
+	selector := &funcDriverSelector{fn: func(_ StorageDriverSelectContext, _ *commonpb.Payload) (StorageDriver, error) {
 		return unregistered, nil
 	}}
 	params, err := ExternalStorageToParams(ExternalStorage{
@@ -506,7 +534,7 @@ func TestStoreVisitor_SelectorUnregisteredDriver(t *testing.T) {
 }
 
 func TestStoreVisitor_SelectorError(t *testing.T) {
-	selector := &funcDriverSelector{fn: func(_ StorageDriverStoreContext, _ *commonpb.Payload) (StorageDriver, error) {
+	selector := &funcDriverSelector{fn: func(_ StorageDriverSelectContext, _ *commonpb.Payload) (StorageDriver, error) {
 		return nil, errors.New("selector error")
 	}}
 	params, err := ExternalStorageToParams(ExternalStorage{
@@ -574,7 +602,7 @@ func TestStoreVisitor_CancelOnError(t *testing.T) {
 	errD.storeGate = blockD.startedCh
 
 	i := 0
-	selector := &funcDriverSelector{fn: func(_ StorageDriverStoreContext, _ *commonpb.Payload) (StorageDriver, error) {
+	selector := &funcDriverSelector{fn: func(_ StorageDriverSelectContext, _ *commonpb.Payload) (StorageDriver, error) {
 		defer func() { i++ }()
 		if i%2 == 0 {
 			return errD, nil
@@ -711,7 +739,7 @@ func TestRetrievalVisitor_MultiDriver(t *testing.T) {
 	d1 := newTestDriver("d1")
 	d2 := newTestDriver("d2")
 	i := 0
-	selector := &funcDriverSelector{fn: func(_ StorageDriverStoreContext, _ *commonpb.Payload) (StorageDriver, error) {
+	selector := &funcDriverSelector{fn: func(_ StorageDriverSelectContext, _ *commonpb.Payload) (StorageDriver, error) {
 		defer func() { i++ }()
 		if i == 0 {
 			return d1, nil
@@ -823,7 +851,7 @@ func TestRetrievalVisitor_CancelOnError(t *testing.T) {
 
 	retrieveParams, err := ExternalStorageToParams(ExternalStorage{
 		Drivers: []StorageDriver{errD, blockD},
-		DriverSelector: &funcDriverSelector{fn: func(_ StorageDriverStoreContext, _ *commonpb.Payload) (StorageDriver, error) {
+		DriverSelector: &funcDriverSelector{fn: func(_ StorageDriverSelectContext, _ *commonpb.Payload) (StorageDriver, error) {
 			return errD, nil
 		}},
 	})
@@ -1072,7 +1100,7 @@ func TestStoreRetrieveRoundTrip_PointerAndValueReceiverDrivers(t *testing.T) {
 
 	// Route the first payload to ptrDriver and the second to valDriver.
 	i := 0
-	selector := &funcDriverSelector{fn: func(_ StorageDriverStoreContext, _ *commonpb.Payload) (StorageDriver, error) {
+	selector := &funcDriverSelector{fn: func(_ StorageDriverSelectContext, _ *commonpb.Payload) (StorageDriver, error) {
 		defer func() { i++ }()
 		if i == 0 {
 			return ptrDriver, nil
@@ -1165,10 +1193,10 @@ func (d *blockingDriver) Retrieve(ctx StorageDriverRetrieveContext, _ []StorageD
 }
 
 type funcDriverSelector struct {
-	fn func(StorageDriverStoreContext, *commonpb.Payload) (StorageDriver, error)
+	fn func(StorageDriverSelectContext, *commonpb.Payload) (StorageDriver, error)
 }
 
-func (s *funcDriverSelector) SelectDriver(ctx StorageDriverStoreContext, p *commonpb.Payload) (StorageDriver, error) {
+func (s *funcDriverSelector) SelectDriver(ctx StorageDriverSelectContext, p *commonpb.Payload) (StorageDriver, error) {
 	return s.fn(ctx, p)
 }
 

--- a/internal/extstore/internal_extstore.go
+++ b/internal/extstore/internal_extstore.go
@@ -77,7 +77,7 @@ type singleDriverSelector struct {
 	driver StorageDriver
 }
 
-func (s singleDriverSelector) SelectDriver(_ StorageDriverStoreContext, _ *commonpb.Payload) (StorageDriver, error) {
+func (s singleDriverSelector) SelectDriver(_ StorageDriverSelectContext, _ *commonpb.Payload) (StorageDriver, error) {
 	return s.driver, nil
 }
 
@@ -322,7 +322,7 @@ func (v *externalStorageVisitor) Visit(ctx *proxy.VisitPayloadsContext, payloads
 
 	result := make([]*commonpb.Payload, len(payloads))
 	target := StorageTargetFromContext(ctx.Context)
-	driverCtx := StorageDriverStoreContext{Context: ctx.Context, Target: target}
+	selectCtx := StorageDriverSelectContext{Context: ctx.Context, Target: target}
 
 	for i, p := range payloads {
 		if proto.Size(p) < v.params.payloadSizeThreshold {
@@ -330,7 +330,7 @@ func (v *externalStorageVisitor) Visit(ctx *proxy.VisitPayloadsContext, payloads
 			continue
 		}
 
-		selected, err := callDriverSelector(v.params.driverSelector, driverCtx, p)
+		selected, err := callDriverSelector(v.params.driverSelector, selectCtx, p)
 		if err != nil {
 			return nil, fmt.Errorf("storage driver selector failed: %w", err)
 		}
@@ -416,7 +416,7 @@ func NewExternalStorageVisitor(params StorageParameters) PayloadVisitor {
 	return &externalStorageVisitor{params: params}
 }
 
-func callDriverSelector(s StorageDriverSelector, ctx StorageDriverStoreContext, p *commonpb.Payload) (driver StorageDriver, err error) {
+func callDriverSelector(s StorageDriverSelector, ctx StorageDriverSelectContext, p *commonpb.Payload) (driver StorageDriver, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			err = fmt.Errorf("panicked: %v", r)

--- a/test/external_storage_test.go
+++ b/test/external_storage_test.go
@@ -442,7 +442,7 @@ type roundRobinSelector struct {
 	idx     *int
 }
 
-func (r *roundRobinSelector) SelectDriver(_ converter.StorageDriverStoreContext, _ *commonpb.Payload) (converter.StorageDriver, error) {
+func (r *roundRobinSelector) SelectDriver(_ converter.StorageDriverSelectContext, _ *commonpb.Payload) (converter.StorageDriver, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	d := r.drivers[*r.idx%len(r.drivers)]


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Pass a dedicated `StorageDriverSelectContext` type to the external storage driver selector instead of reusing `StorageDriverStoreContext`.

## Why?

Allow selector and store contexts to evolve independently.