### PR TITLE
Fix task handler cache teardown

### DIFF
--- a/internal/internal_task_handlers_test.go
+++ b/internal/internal_task_handlers_test.go
@@ -125,9 +125,7 @@ func (t *TaskHandlersTestSuite) SetupSuite() {
 }
 
 func (t *TaskHandlersTestSuite) TearDownTest() {
-	if cache := *sharedWorkerCachePtr.workflowCache; cache != nil {
-		cache.Clear()
-	}
+	PurgeStickyWorkflowCache()
 }
 
 func TestTaskHandlersTestSuite(t *testing.T) {


### PR DESCRIPTION
## What was changed
Fixed a test flake from https://github.com/temporalio/sdk-go/actions/runs/33103730819/job/98955429573?pr=2632, we were clearing the workflow cache in an unsafe way (without the mutex)

## Why?
Old bug from 2023, not sure exactly why we're hitting this now, could be because of 1.27 bump? or maybe other recent test changes

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only teardown change; production cache behavior is unchanged and uses the existing safe purge helper.
> 
> **Overview**
> Fixes flaky **task handler** tests by replacing direct `sharedWorkerCachePtr.workflowCache` clearing in `TaskHandlersTestSuite.TearDownTest` with **`PurgeStickyWorkflowCache()`**, which clears the sticky workflow cache under **`sharedWorkerCacheLock`**.
> 
> The old teardown bypassed the mutex documented for shared worker cache access, which could race with concurrent cache use and leave inconsistent state between tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48e80328c50ae5489dffe18674eea44cb60250ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->