### PR TITLE
Fix legacy query task failure reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,8 @@ to docs, or any other relevant information.
 - `temporal.IsWorkflowExecutionAlreadyStartedError` now detects wrapped
   `serviceerror.WorkflowExecutionAlreadyStarted` errors.
 - Malformed Nexus link errors now log the link URL and parse error under stable structured fields.
+- Legacy query task processing failures are now reported through `RespondQueryTaskCompleted` instead of
+  `RespondWorkflowTaskFailed`, allowing query callers to receive the failure instead of timing out.
 - Local activity results are now serialized with the local activity's `ActivitySerializationContext`
   (`IsLocal=true`) on both ends. Previously the result was encoded with the plain worker data converter
   but decoded through the workflow serialization context, so a context-aware `DataConverter` or

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -590,12 +590,11 @@ func (wtp *workflowTaskProcessor) RespondTaskCompletedWithMetrics(
 			tagAttempt, task.Attempt,
 			tagError, taskErr)
 		emitFailMetric = true
-		failWorkflowTask := wtp.errorToFailWorkflowTask(task.TaskToken, taskErr)
 		failureReason = metrics.FailureReasonWorkflowError
-		if failWorkflowTask.Cause == enumspb.WORKFLOW_TASK_FAILED_CAUSE_NON_DETERMINISTIC_ERROR {
+		if workflowTaskFailureCause(taskErr) == enumspb.WORKFLOW_TASK_FAILED_CAUSE_NON_DETERMINISTIC_ERROR {
 			failureReason = metrics.FailureReasonNonDeterminismError
 		}
-		taskCompletion = &workflowTaskCompletion{rawRequest: failWorkflowTask}
+		taskCompletion = wtp.taskFailureCompletion(task, taskErr)
 	}
 
 	uploadPayloadMetrics := &workflowTaskStorageMetrics{}
@@ -612,7 +611,7 @@ func (wtp *workflowTaskProcessor) RespondTaskCompletedWithMetrics(
 	}
 	if taskErr = visitProtoPayloads(ctx, outboundPayloadVisitor, taskCompletion.rawRequest, wtp.payloadVisitorConcurrency); taskErr != nil {
 		// The outbound visitor failed (e.g. storage driver error or panic). We
-		// cannot send the original response, so fall back to an explicit WFT
+		// cannot send the original response, so fall back to an explicit
 		// failure so the server records the error immediately.
 		keyvals := []any{
 			tagWorkflowType, task.WorkflowType.GetName(),
@@ -632,7 +631,7 @@ func (wtp *workflowTaskProcessor) RespondTaskCompletedWithMetrics(
 		if errors.As(taskErr, new(payloadSizeError)) {
 			failureReason = metrics.FailureReasonPayloadsTooLarge
 		}
-		taskCompletion = &workflowTaskCompletion{rawRequest: wtp.errorToFailWorkflowTask(task.TaskToken, taskErr)}
+		taskCompletion = wtp.taskFailureCompletion(task, taskErr)
 	}
 
 	// The namespace limit governs the server's recombined page buffer, so it only applies to a
@@ -940,18 +939,43 @@ func (wtp *workflowTaskProcessor) handleInboundVisitorError(task *workflowservic
 			tagPayloadSizeLimit, errPayloadSize.limit)
 	}
 	wtp.logger.Warn("Workflow task preprocess error: "+visitErr.Error(), keyvals...)
-	// Submit an explicit WFT failure so the server records the error immediately
+	// Submit an explicit failure so the server records the error immediately
 	// rather than waiting for the task to time out.
-	failReq := wtp.errorToFailWorkflowTask(task.TaskToken, visitErr)
-	if _, submitErr := wtp.sendTaskCompletedRequest(&workflowTaskCompletion{rawRequest: failReq}, task); submitErr != nil {
-		wtp.logger.Warn("Failed to submit WFT failure after inbound visitor error.", tagError, submitErr)
+	failCompletion := wtp.taskFailureCompletion(task, visitErr)
+	if _, submitErr := wtp.sendTaskCompletedRequest(failCompletion, task); submitErr != nil {
+		wtp.logger.Warn("Failed to submit failure after inbound visitor error.", tagError, submitErr)
+	}
+}
+
+func (wtp *workflowTaskProcessor) taskFailureCompletion(
+	task *workflowservice.PollWorkflowTaskQueueResponse,
+	err error,
+) *workflowTaskCompletion {
+	if task.Query != nil {
+		return &workflowTaskCompletion{
+			rawRequest: &workflowservice.RespondQueryTaskCompletedRequest{
+				TaskToken:     task.TaskToken,
+				CompletedType: enumspb.QUERY_RESULT_TYPE_FAILED,
+				ErrorMessage:  err.Error(),
+				Namespace:     wtp.namespace,
+				Failure:       wtp.failureConverter.ErrorToFailure(err),
+			},
+		}
+	}
+
+	return &workflowTaskCompletion{
+		rawRequest: wtp.errorToFailWorkflowTask(task.TaskToken, err),
 	}
 }
 
 func (wtp *workflowTaskProcessor) errorToFailWorkflowTask(taskToken []byte, err error) *workflowservice.RespondWorkflowTaskFailedRequest {
+	return wtp.errorToFailWorkflowTaskWithCause(taskToken, err, workflowTaskFailureCause(err))
+}
+
+func workflowTaskFailureCause(err error) enumspb.WorkflowTaskFailedCause {
 	cause := enumspb.WORKFLOW_TASK_FAILED_CAUSE_WORKFLOW_WORKER_UNHANDLED_FAILURE
 	// If it was a panic due to a bad state machine or if it was a history
-	// mismatch error, mark as non-deterministic
+	// mismatch error, mark as non-deterministic.
 	if panicErr, _ := err.(*workflowPanicError); panicErr != nil {
 		if _, badStateMachine := panicErr.value.(stateMachineIllegalStatePanic); badStateMachine {
 			cause = enumspb.WORKFLOW_TASK_FAILED_CAUSE_NON_DETERMINISTIC_ERROR
@@ -963,8 +987,7 @@ func (wtp *workflowTaskProcessor) errorToFailWorkflowTask(taskToken []byte, err 
 	} else if errors.As(err, new(payloadSizeError)) {
 		cause = enumspb.WORKFLOW_TASK_FAILED_CAUSE_PAYLOADS_TOO_LARGE
 	}
-
-	return wtp.errorToFailWorkflowTaskWithCause(taskToken, err, cause)
+	return cause
 }
 
 func (wtp *workflowTaskProcessor) errorToFailWorkflowTaskWithCause(taskToken []byte, err error, cause enumspb.WorkflowTaskFailedCause) *workflowservice.RespondWorkflowTaskFailedRequest {

--- a/internal/internal_task_pollers_test.go
+++ b/internal/internal_task_pollers_test.go
@@ -15,6 +15,8 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	historypb "go.temporal.io/api/history/v1"
 	protocolpb "go.temporal.io/api/protocol/v1"
+	"go.temporal.io/api/proxy"
+	querypb "go.temporal.io/api/query/v1"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	"go.temporal.io/api/update/v1"
 	"go.temporal.io/api/workflowservice/v1"
@@ -483,6 +485,189 @@ func TestWFTPanicInTaskHandler(t *testing.T) {
 	require.Error(t, poller.processWorkflowTask(&task0))
 	// Workflow should not be in cache
 	require.Nil(t, cache.getWorkflowContext(runID))
+}
+
+func TestLegacyQueryProcessingFailureReportedAsQueryFailure(t *testing.T) {
+	params := workerExecutionParameters{
+		cache:     NewWorkerCache(),
+		Namespace: "test-namespace",
+	}
+	ensureRequiredParams(&params)
+
+	ctrl := gomock.NewController(t)
+	client := workflowservicemock.NewMockWorkflowServiceClient(ctrl)
+
+	taskHandler := newWorkflowTaskHandler(params, nil, newRegistry())
+	poller := newWorkflowTaskProcessor(taskHandler, taskHandler, client, params, "")
+
+	taskToken := []byte("legacy-query-token")
+	taskErr := errors.New("failure while replaying history to serve a query")
+
+	task := &workflowservice.PollWorkflowTaskQueueResponse{
+		TaskToken: taskToken,
+		Attempt:   1,
+		WorkflowExecution: &commonpb.WorkflowExecution{
+			WorkflowId: "workflow-id",
+			RunId:      "run-id",
+		},
+		WorkflowType: &commonpb.WorkflowType{
+			Name: "workflow-type",
+		},
+		Query: &querypb.WorkflowQuery{
+			QueryType: "status",
+		},
+	}
+
+	client.EXPECT().
+		RespondQueryTaskCompleted(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(
+			_ context.Context,
+			req *workflowservice.RespondQueryTaskCompletedRequest,
+			_ ...grpc.CallOption,
+		) (*workflowservice.RespondQueryTaskCompletedResponse, error) {
+			require.Equal(t, taskToken, req.TaskToken)
+			require.Equal(t, enumspb.QUERY_RESULT_TYPE_FAILED, req.CompletedType)
+			require.Equal(t, taskErr.Error(), req.ErrorMessage)
+			require.Equal(t, "test-namespace", req.Namespace)
+			require.NotNil(t, req.Failure)
+			return &workflowservice.RespondQueryTaskCompletedResponse{}, nil
+		})
+
+	_, err := poller.RespondTaskCompletedWithMetrics(
+		nil,
+		taskErr,
+		task,
+		time.Now(),
+		&workflowTaskStorageMetrics{},
+		nil,
+	)
+	require.NoError(t, err)
+}
+
+func TestLegacyQueryOutboundVisitorFailureReportedAsQueryFailure(t *testing.T) {
+	params := workerExecutionParameters{
+		cache:     NewWorkerCache(),
+		Namespace: "test-namespace",
+	}
+	ensureRequiredParams(&params)
+
+	visitorErr := errors.New("outbound payload visitor failure")
+	params.outboundPayloadVisitor = visitorFunc(
+		func(
+			_ *proxy.VisitPayloadsContext,
+			_ []*commonpb.Payload,
+		) ([]*commonpb.Payload, error) {
+			return nil, visitorErr
+		},
+	)
+
+	ctrl := gomock.NewController(t)
+	client := workflowservicemock.NewMockWorkflowServiceClient(ctrl)
+
+	taskHandler := newWorkflowTaskHandler(params, nil, newRegistry())
+	poller := newWorkflowTaskProcessor(taskHandler, taskHandler, client, params, "")
+
+	taskToken := []byte("legacy-query-outbound-token")
+
+	task := &workflowservice.PollWorkflowTaskQueueResponse{
+		TaskToken: taskToken,
+		Attempt:   1,
+		WorkflowExecution: &commonpb.WorkflowExecution{
+			WorkflowId: "workflow-id",
+			RunId:      "run-id",
+		},
+		WorkflowType: &commonpb.WorkflowType{
+			Name: "workflow-type",
+		},
+		Query: &querypb.WorkflowQuery{
+			QueryType: "status",
+		},
+	}
+
+	taskCompletion := &workflowTaskCompletion{
+		rawRequest: &workflowservice.RespondQueryTaskCompletedRequest{
+			TaskToken: taskToken,
+			QueryResult: &commonpb.Payloads{
+				Payloads: []*commonpb.Payload{
+					{Data: []byte("query-result")},
+				},
+			},
+		},
+	}
+
+	client.EXPECT().
+		RespondQueryTaskCompleted(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(
+			_ context.Context,
+			req *workflowservice.RespondQueryTaskCompletedRequest,
+			_ ...grpc.CallOption,
+		) (*workflowservice.RespondQueryTaskCompletedResponse, error) {
+			require.Equal(t, taskToken, req.TaskToken)
+			require.Equal(t, enumspb.QUERY_RESULT_TYPE_FAILED, req.CompletedType)
+			require.Equal(t, visitorErr.Error(), req.ErrorMessage)
+			require.Equal(t, "test-namespace", req.Namespace)
+			require.NotNil(t, req.Failure)
+			return &workflowservice.RespondQueryTaskCompletedResponse{}, nil
+		})
+
+	_, err := poller.RespondTaskCompletedWithMetrics(
+		taskCompletion,
+		nil,
+		task,
+		time.Now(),
+		&workflowTaskStorageMetrics{},
+		nil,
+	)
+	require.NoError(t, err)
+}
+
+func TestLegacyQueryInboundVisitorFailureReportedAsQueryFailure(t *testing.T) {
+	params := workerExecutionParameters{
+		cache:     NewWorkerCache(),
+		Namespace: "test-namespace",
+	}
+	ensureRequiredParams(&params)
+
+	ctrl := gomock.NewController(t)
+	client := workflowservicemock.NewMockWorkflowServiceClient(ctrl)
+
+	taskHandler := newWorkflowTaskHandler(params, nil, newRegistry())
+	poller := newWorkflowTaskProcessor(taskHandler, taskHandler, client, params, "")
+
+	taskToken := []byte("legacy-query-inbound-token")
+	visitorErr := errors.New("inbound payload visitor failure")
+
+	task := &workflowservice.PollWorkflowTaskQueueResponse{
+		TaskToken: taskToken,
+		Attempt:   1,
+		WorkflowExecution: &commonpb.WorkflowExecution{
+			WorkflowId: "workflow-id",
+			RunId:      "run-id",
+		},
+		WorkflowType: &commonpb.WorkflowType{
+			Name: "workflow-type",
+		},
+		Query: &querypb.WorkflowQuery{
+			QueryType: "status",
+		},
+	}
+
+	client.EXPECT().
+		RespondQueryTaskCompleted(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(
+			_ context.Context,
+			req *workflowservice.RespondQueryTaskCompletedRequest,
+			_ ...grpc.CallOption,
+		) (*workflowservice.RespondQueryTaskCompletedResponse, error) {
+			require.Equal(t, taskToken, req.TaskToken)
+			require.Equal(t, enumspb.QUERY_RESULT_TYPE_FAILED, req.CompletedType)
+			require.Equal(t, visitorErr.Error(), req.ErrorMessage)
+			require.Equal(t, "test-namespace", req.Namespace)
+			require.NotNil(t, req.Failure)
+			return &workflowservice.RespondQueryTaskCompletedResponse{}, nil
+		})
+
+	poller.handleInboundVisitorError(task, visitorErr)
 }
 
 func TestErrorToFailWorkflowTaskCause(t *testing.T) {

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -5649,6 +5649,106 @@ func (ts *IntegrationTestSuite) TestNonDeterminismFailureCauseCommandNotFound() 
 		"[TMPRL1100] During replay, a matching Timer command was expected in history event position 8. However, the replayed code did not produce that.")
 }
 
+func legacyQueryTaskFailureWorkflow(ctx workflow.Context) error {
+	if err := workflow.SetQueryHandler(ctx, "status", func() (string, error) {
+		return "never reached", nil
+	}); err != nil {
+		return err
+	}
+
+	if workflow.IsReplaying(ctx) {
+		panic("failure while replaying history to serve a query")
+	}
+
+	return workflow.Await(ctx, func() bool { return false })
+}
+
+func (ts *IntegrationTestSuite) TestLegacyQueryTaskFailureReportedToCaller() {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	options := ts.startWorkflowOptions(
+		"test-legacy-query-task-failure-" + uuid.NewString(),
+	)
+	options.EnableEagerStart = false
+	options.WorkflowExecutionTimeout = 5 * time.Minute
+
+	run, err := ts.client.ExecuteWorkflow(
+		ctx,
+		options,
+		legacyQueryTaskFailureWorkflow,
+	)
+	ts.NoError(err)
+
+	defer func() {
+		_ = ts.client.TerminateWorkflow(
+			context.Background(),
+			run.GetID(),
+			run.GetRunID(),
+			"",
+			nil,
+		)
+	}()
+
+	// Make sure the initial workflow task has completed. Otherwise the query
+	// may be attached to a real workflow task instead of arriving as a
+	// legacy query task.
+	ts.waitForHistoryEvent(
+		run.GetID(),
+		run.GetRunID(),
+		enumspb.EVENT_TYPE_WORKFLOW_TASK_COMPLETED,
+		10*time.Second,
+	)
+
+	ts.Eventually(func() bool {
+		desc, err := ts.client.DescribeWorkflowExecution(
+			ctx,
+			run.GetID(),
+			run.GetRunID(),
+		)
+		return err == nil && desc.GetPendingWorkflowTask() == nil
+	}, 10*time.Second, 100*time.Millisecond)
+
+	// Stop the worker and clear the workflow's sticky task queue so the query
+	// is handled by a fresh worker and must replay the workflow history.
+	ts.worker.Stop()
+	ts.workerStopped = true
+
+	_, err = ts.client.WorkflowService().ResetStickyTaskQueue(
+		ctx,
+		&workflowservice.ResetStickyTaskQueueRequest{
+			Namespace: ts.config.Namespace,
+			Execution: &commonpb.WorkflowExecution{
+				WorkflowId: run.GetID(),
+				RunId:      run.GetRunID(),
+			},
+		},
+	)
+	ts.NoError(err)
+
+	nextWorker := worker.New(ts.client, ts.taskQueueName, worker.Options{
+		WorkflowPanicPolicy:              worker.BlockWorkflow,
+		MaxConcurrentWorkflowTaskPollers: 12,
+	})
+	ts.registerWorkflowsAndActivities(nextWorker)
+	ts.NoError(nextWorker.Start())
+	defer nextWorker.Stop()
+
+	queryCtx, queryCancel := context.WithTimeout(ctx, 10*time.Second)
+	defer queryCancel()
+
+	_, err = ts.client.QueryWorkflow(
+		queryCtx,
+		run.GetID(),
+		run.GetRunID(),
+		"status",
+	)
+
+	ts.Error(err)
+	ts.Contains(err.Error(), "failure while replaying history to serve a query")
+	ts.NotErrorIs(err, context.DeadlineExceeded)
+}
+
 func (ts *IntegrationTestSuite) TestNonDeterminismFailureCauseReplay() {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -7733,6 +7833,9 @@ type synchronousActivityRetryState struct {
 func (ts *IntegrationTestSuite) registerWorkflowsAndActivities(w worker.Worker) {
 	ts.workflows.register(w)
 	ts.activities.register(w)
+	if strings.Contains(ts.T().Name(), "TestLegacyQueryTaskFailure") {
+		w.RegisterWorkflow(legacyQueryTaskFailureWorkflow)
+	}
 	w.RegisterNexusService(temporalOpService)
 }
 


### PR DESCRIPTION
## What was changed

Legacy query task failures are now reported through `RespondQueryTaskCompleted`
with `QUERY_RESULT_TYPE_FAILED` instead of being sent through
`RespondWorkflowTaskFailed`.

The same query-aware failure handling is applied to:
- workflow task processing failures
- outbound payload visitor failures
- inbound payload visitor failures

Normal workflow tasks continue to use `RespondWorkflowTaskFailed`.

Workflow task failure-cause classification was also separated from request
construction so query failures do not unnecessarily construct a workflow task
failure first.

Regression tests cover all three affected legacy-query failure paths.

## Why?

Legacy query task tokens are query task tokens, not workflow task tokens.

When a legacy query fails during processing, sending its token to
`RespondWorkflowTaskFailed` causes the service to interpret it as a workflow
task token. The query is then left unanswered and eventually times out instead
of returning the actual processing failure.

Reporting the error through `RespondQueryTaskCompleted` allows the query caller
to receive the failure directly.

## Checklist

1. Closes #2616

2. How was this tested:

- Added regression tests for legacy query processing failures.
- Added regression tests for outbound payload visitor failures.
- Added regression tests for inbound payload visitor failures.
- Verified existing workflow task failure-cause behavior.
- Focused tests pass with the race detector.
- `go run . check` passes.
- `go run . unit-test` passes with the race detector.
- Verified against a local Temporal dev server using this SDK checkout. The
  reproduction query now returns `failure while replaying history to serve a
  query` instead of timing out.
- Added a server-backed integration test that fails over to a fresh worker to force replay and verifies the legacy-query replay failure is returned to the caller instead of timing out.

3. Any docs updates needed?

No documentation updates are required. Added a changelog entry under
`Unreleased` / `Fixed`.