### PR TITLE
Add endpoint-aware serialization for Nexus operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ to docs, or any other relevant information.
   platforms), and the operating system and architecture. This is sent
   once per worker with the first heartbeat accepted by the server and can be turned off with
   `client.Options.DisableWorkerEnvironmentInfo`.
+- Added caller-side `converter.NexusSerializationContext` support for Nexus operation inputs,
+  results, and failures. Each scheduled operation retains an isolated contextual data and failure
+  converter keyed by its endpoint, service, and resolved operation name, including across replay.
+  Nexus handlers do not yet receive this context and must use compatible static converter
+  configuration for their endpoint/task queue.
 - Added `temporal.NewPayloadValidationError` to create non-retryable application errors with
   optional structured details for payload validation failures. Passing `nil` omits details.
 - Added Go 1.27+ generic methods on the experimental `temporalnexus.NexusClient` for starting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,10 +29,10 @@ to docs, or any other relevant information.
   once per worker with the first heartbeat accepted by the server and can be turned off with
   `client.Options.DisableWorkerEnvironmentInfo`.
 - Added caller-side `converter.NexusSerializationContext` support for Nexus operation inputs,
-  results, and failures. Each scheduled operation retains an isolated contextual data and failure
-  converter keyed by its endpoint, service, and resolved operation name, including across replay.
-  Nexus handlers do not yet receive this context and must use compatible static converter
-  configuration for their endpoint/task queue.
+  results, and failures. Workflow-scheduled and standalone operations retain isolated contextual
+  data and failure converters keyed by endpoint, service, and resolved operation name, including
+  across workflow replay and standalone operation handles. Nexus handlers do not yet receive this
+  context and must use compatible static converter configuration for their endpoint/task queue.
 - Added `temporal.NewPayloadValidationError` to create non-retryable application errors with
   optional structured details for payload validation failures. Passing `nil` omits details.
 - Added Go 1.27+ generic methods on the experimental `temporalnexus.NexusClient` for starting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,11 +28,12 @@ to docs, or any other relevant information.
   platforms), and the operating system and architecture. This is sent
   once per worker with the first heartbeat accepted by the server and can be turned off with
   `client.Options.DisableWorkerEnvironmentInfo`.
-- Added caller-side `converter.NexusSerializationContext` support for Nexus operation inputs,
-  results, and failures. Workflow-scheduled and standalone operations retain isolated contextual
-  data and failure converters keyed by endpoint, service, and resolved operation name, including
-  across workflow replay and standalone operation handles. Nexus handlers do not yet receive this
-  context and must use compatible static converter configuration for their endpoint/task queue.
+- Added `converter.NexusSerializationContext` support for Nexus operation inputs, results, and
+  failures. Workflow-scheduled and standalone callers retain isolated contextual data and failure
+  converters keyed by endpoint, service, and resolved operation name, including across workflow
+  replay and standalone operation handles. Nexus handlers receive the same context when decoding
+  inputs, encoding synchronous results, and encoding failures produced while handling a Nexus task.
+  The context is not yet propagated to asynchronous operation results.
 - Added `temporal.NewPayloadValidationError` to create non-retryable application errors with
   optional structured details for payload validation failures. Passing `nil` omits details.
 - Added Go 1.27+ generic methods on the experimental `temporalnexus.NexusClient` for starting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,9 +31,11 @@ to docs, or any other relevant information.
 - Added `converter.NexusSerializationContext` support for Nexus operation inputs, results, and
   failures. Workflow-scheduled and standalone callers retain isolated contextual data and failure
   converters keyed by endpoint, service, and resolved operation name, including across workflow
-  replay and standalone operation handles. Nexus handlers receive the same context when decoding
-  inputs, encoding synchronous results, and encoding failures produced while handling a Nexus task.
-  The context is not yet propagated to asynchronous operation results.
+  replay and standalone operation handles returned by `ExecuteOperation`. Nexus handlers receive
+  the same context when decoding inputs, encoding synchronous results, and encoding failures
+  produced while handling a Nexus task. The context is not propagated to asynchronous operation
+  results. Standalone handles use the context of their start request, including when an existing
+  operation is returned, while handles created without starting an operation do not receive it.
 - Added `temporal.NewPayloadValidationError` to create non-retryable application errors with
   optional structured details for payload validation failures. Passing `nil` omits details.
 - Added Go 1.27+ generic methods on the experimental `temporalnexus.NexusClient` for starting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,14 +28,10 @@ to docs, or any other relevant information.
   platforms), and the operating system and architecture. This is sent
   once per worker with the first heartbeat accepted by the server and can be turned off with
   `client.Options.DisableWorkerEnvironmentInfo`.
-- Added `converter.NexusSerializationContext` support for Nexus operation inputs, results, and
-  failures. Workflow-scheduled and standalone callers retain isolated contextual data and failure
-  converters keyed by endpoint, service, and resolved operation name, including across workflow
-  replay and standalone operation handles returned by `ExecuteOperation`. Nexus handlers receive
-  the same context when decoding inputs, encoding synchronous results, and encoding failures
-  produced while handling a Nexus task. The context is not propagated to asynchronous operation
-  results. Standalone handles use the context of their start request, including when an existing
-  operation is returned, while handles created without starting an operation do not receive it.
+- Added `converter.NexusSerializationContext` support for Nexus callers and handlers. Callers use
+  it for inputs, results, and failures; handlers use it for inputs, synchronous results, and
+  failures. Asynchronous handler results and detached standalone handles are not yet supported.
+  Standalone `USE_EXISTING` handles use their start request's context.
 - Added `temporal.NewPayloadValidationError` to create non-retryable application errors with
   optional structured details for payload validation failures. Passing `nil` omits details.
 - Added Go 1.27+ generic methods on the experimental `temporalnexus.NexusClient` for starting

--- a/converter/serialization_context.go
+++ b/converter/serialization_context.go
@@ -2,7 +2,8 @@ package converter
 
 // SerializationContext provides metadata about where serialization is occurring.
 // Implementations include [WorkflowSerializationContext] for workflow-level
-// payloads, and [ActivitySerializationContext] for activity-level payloads.
+// payloads, [ActivitySerializationContext] for activity-level payloads, and
+// [NexusSerializationContext] for caller-side Nexus operation payloads.
 type SerializationContext interface {
 	isSerializationContext()
 }
@@ -33,6 +34,25 @@ type ActivitySerializationContext struct {
 }
 
 func (ActivitySerializationContext) isSerializationContext() {}
+
+// NexusSerializationContext is the serialization context for caller-side Nexus
+// operation input, successful result, and failure decoding. Operation summaries
+// and user metadata use the workflow serialization context instead.
+//
+// Operation is the resolved operation name. This context is not propagated to
+// Nexus handlers, which must use compatible converter configuration.
+//
+// For failures, this context is provided only to the workflow caller's
+// [FailureConverter.FailureToError], not [FailureConverter.ErrorToFailure].
+// Implementations must not assume symmetric failure conversion. Context-dependent
+// encodings should be self-describing and support legacy payloads without context.
+type NexusSerializationContext struct {
+	Endpoint  string
+	Service   string
+	Operation string
+}
+
+func (NexusSerializationContext) isSerializationContext() {}
 
 // DataConverterWithSerializationContext is an optional interface that [DataConverter]
 // implementations can implement to receive serialization context.

--- a/converter/serialization_context.go
+++ b/converter/serialization_context.go
@@ -1,9 +1,11 @@
 package converter
 
-// SerializationContext provides metadata about where serialization is occurring.
-// Implementations include [WorkflowSerializationContext] for workflow-level
-// payloads, [ActivitySerializationContext] for activity-level payloads, and
-// [NexusSerializationContext] for caller-side Nexus operation payloads.
+// SerializationContext provides metadata about where serialization is occurring,
+// with the concrete type depending on the context:
+//
+//   - [WorkflowSerializationContext] for workflow-level payloads.
+//   - [ActivitySerializationContext] for activity-level payloads.
+//   - [NexusSerializationContext] for workflows calling Nexus operations.
 type SerializationContext interface {
 	isSerializationContext()
 }
@@ -35,9 +37,8 @@ type ActivitySerializationContext struct {
 
 func (ActivitySerializationContext) isSerializationContext() {}
 
-// NexusSerializationContext is the serialization context for caller-side Nexus
-// operation input, successful result, and failure decoding. Operation summaries
-// and user metadata use the workflow serialization context instead.
+// NexusSerializationContext is used by workflows calling Nexus operations when
+// encoding operation inputs and decoding successful results or failures.
 //
 // Operation is the resolved operation name. This context is not propagated to
 // Nexus handlers, which must use compatible converter configuration.

--- a/converter/serialization_context.go
+++ b/converter/serialization_context.go
@@ -43,7 +43,9 @@ func (ActivitySerializationContext) isSerializationContext() {}
 // encoding failures produced while handling a Nexus task.
 //
 // Operation is the resolved operation name. The context is not propagated to
-// the eventual result of an asynchronous operation.
+// the eventual result of an asynchronous operation. Standalone operation handles
+// use the context of their start request, including when an existing operation is
+// returned, while handles created without starting an operation do not receive it.
 //
 // For failures, callers receive this context in [FailureConverter.FailureToError],
 // while handlers receive it in [FailureConverter.ErrorToFailure]. Implementations

--- a/converter/serialization_context.go
+++ b/converter/serialization_context.go
@@ -5,7 +5,7 @@ package converter
 //
 //   - [WorkflowSerializationContext] for workflow-level payloads.
 //   - [ActivitySerializationContext] for activity-level payloads.
-//   - [NexusSerializationContext] for workflows calling Nexus operations.
+//   - [NexusSerializationContext] for Nexus-level payloads.
 type SerializationContext interface {
 	isSerializationContext()
 }
@@ -37,19 +37,24 @@ type ActivitySerializationContext struct {
 
 func (ActivitySerializationContext) isSerializationContext() {}
 
-// NexusSerializationContext is used by workflows calling Nexus operations when
-// encoding operation inputs and decoding successful results or failures.
+// NexusSerializationContext is used by callers of Nexus operations when encoding
+// operation inputs and decoding successful results or failures.
 //
 // Operation is the resolved operation name. This context is not propagated to
 // Nexus handlers, which must use compatible converter configuration.
 //
-// For failures, this context is provided only to the workflow caller's
+// For failures, this context is provided only to the caller's
 // [FailureConverter.FailureToError], not [FailureConverter.ErrorToFailure].
 // Implementations must not assume symmetric failure conversion. Context-dependent
 // encodings should be self-describing and support legacy payloads without context.
+//
+// NOTE: Experimental
 type NexusSerializationContext struct {
-	Endpoint  string
-	Service   string
+	// Endpoint is the Nexus endpoint name.
+	Endpoint string
+	// Service is the Nexus service name.
+	Service string
+	// Operation is the resolved Nexus operation name.
 	Operation string
 }
 

--- a/converter/serialization_context.go
+++ b/converter/serialization_context.go
@@ -37,16 +37,18 @@ type ActivitySerializationContext struct {
 
 func (ActivitySerializationContext) isSerializationContext() {}
 
-// NexusSerializationContext is used by callers of Nexus operations when encoding
-// operation inputs and decoding successful results or failures.
+// NexusSerializationContext is used when serializing Nexus operation payloads.
+// Callers receive it when encoding inputs and decoding results or failures.
+// Handlers receive it when decoding inputs, encoding synchronous results, and
+// encoding failures produced while handling a Nexus task.
 //
-// Operation is the resolved operation name. This context is not propagated to
-// Nexus handlers, which must use compatible converter configuration.
+// Operation is the resolved operation name. The context is not propagated to
+// the eventual result of an asynchronous operation.
 //
-// For failures, this context is provided only to the caller's
-// [FailureConverter.FailureToError], not [FailureConverter.ErrorToFailure].
-// Implementations must not assume symmetric failure conversion. Context-dependent
-// encodings should be self-describing and support legacy payloads without context.
+// For failures, callers receive this context in [FailureConverter.FailureToError],
+// while handlers receive it in [FailureConverter.ErrorToFailure]. Implementations
+// must not assume symmetric failure conversion. Context-dependent encodings should
+// be self-describing and support legacy payloads without context.
 //
 // NOTE: Experimental
 type NexusSerializationContext struct {

--- a/converter/serialization_context_test.go
+++ b/converter/serialization_context_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	commonpb "go.temporal.io/api/common/v1"
+	failurepb "go.temporal.io/api/failure/v1"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -21,6 +22,8 @@ func (c *signingCodec) WithSerializationContext(ctx SerializationContext) Payloa
 		return &signingCodec{signature: sc.WorkflowID}
 	case ActivitySerializationContext:
 		return &signingCodec{signature: sc.WorkflowID + ":" + sc.ActivityType}
+	case NexusSerializationContext:
+		return &signingCodec{signature: sc.Endpoint + ":" + sc.Service + ":" + sc.Operation}
 	}
 	return c
 }
@@ -203,6 +206,61 @@ func TestCodecDataConverter_SigningMismatchFailsDecode_ActivityContext(t *testin
 	err = wrapped2.FromPayload(payload, &result)
 	require.Error(err)
 	require.Contains(err.Error(), "signature mismatch")
+}
+
+func TestCodecDataConverter_NexusSerializationContext(t *testing.T) {
+	require := require.New(t)
+	codec := &signingCodec{}
+	dc := NewCodecDataConverter(GetDefaultDataConverter(), codec)
+	nexusCtx := NexusSerializationContext{
+		Endpoint:  "payments-endpoint",
+		Service:   "payments-service",
+		Operation: "charge-card",
+	}
+
+	wrapped := WithDataConverterSerializationContext(dc, nexusCtx)
+	payload, err := wrapped.ToPayload("input")
+	require.NoError(err)
+	require.Equal("payments-endpoint:payments-service:charge-card", string(payload.Metadata["ctx-signature"]))
+
+	var result string
+	require.NoError(wrapped.FromPayload(payload, &result))
+	require.Equal("input", result)
+}
+
+type contextCapturingFailureConverter struct {
+	contexts *[]SerializationContext
+}
+
+func (c *contextCapturingFailureConverter) ErrorToFailure(error) *failurepb.Failure {
+	return nil
+}
+
+func (c *contextCapturingFailureConverter) FailureToError(*failurepb.Failure) error {
+	return nil
+}
+
+func (c *contextCapturingFailureConverter) WithSerializationContext(ctx SerializationContext) FailureConverter {
+	*c.contexts = append(*c.contexts, ctx)
+	return &contextCapturingFailureConverter{contexts: c.contexts}
+}
+
+func TestNexusSerializationContextReachesDataAndFailureConverters(t *testing.T) {
+	nexusCtx := NexusSerializationContext{
+		Endpoint:  "endpoint",
+		Service:   "service",
+		Operation: "operation",
+	}
+
+	dc := newCapturingDC()
+	WithDataConverterSerializationContext(dc, nexusCtx)
+	require.Equal(t, []SerializationContext{nexusCtx}, dc.getCapturedContexts())
+
+	contexts := make([]SerializationContext, 0)
+	fc := &contextCapturingFailureConverter{contexts: &contexts}
+	result := WithFailureConverterSerializationContext(fc, nexusCtx)
+	require.NotSame(t, fc, result)
+	require.Equal(t, []SerializationContext{nexusCtx}, contexts)
 }
 
 // nilReturningDC implements DataConverterWithSerializationContext but returns nil.

--- a/internal/interceptor.go
+++ b/internal/interceptor.go
@@ -881,8 +881,8 @@ type ClientPollNexusOperationResultInput struct {
 	OperationID string
 	// RunID is the run ID of the Nexus operation to poll results for.
 	RunID string
-	// nexusSerializationContext is set by SDK-created operation handles.
-	nexusSerializationContext converter.NexusSerializationContext
+	// nexusSerializationContext is set by handles returned from ExecuteOperation.
+	nexusSerializationContext *converter.NexusSerializationContext
 }
 
 // ClientPollNexusOperationResultOutput is the output of

--- a/internal/interceptor.go
+++ b/internal/interceptor.go
@@ -881,6 +881,8 @@ type ClientPollNexusOperationResultInput struct {
 	OperationID string
 	// RunID is the run ID of the Nexus operation to poll results for.
 	RunID string
+	// nexusSerializationContext is set by SDK-created operation handles.
+	nexusSerializationContext converter.NexusSerializationContext
 }
 
 // ClientPollNexusOperationResultOutput is the output of

--- a/internal/internal_event_handlers.go
+++ b/internal/internal_event_handlers.go
@@ -2054,14 +2054,14 @@ func (weh *workflowExecutionEventHandlerImpl) handleChildWorkflowExecutionTermin
 func (weh *workflowExecutionEventHandlerImpl) handleNexusOperationStarted(event *historypb.HistoryEvent) error {
 	attributes := event.GetNexusOperationStartedEventAttributes()
 	command := weh.commandsHelper.handleNexusOperationStarted(attributes.ScheduledEventId)
-	state := command.getData().(*scheduledNexusOperation)
-	if state.startedCallback != nil {
+	scheduledOperation := command.getData().(*scheduledNexusOperation)
+	if scheduledOperation.startedCallback != nil {
 		token := attributes.OperationToken
 		if token == "" {
 			token = attributes.OperationId //lint:ignore SA1019 this field is sent by servers older than 1.27.0.
 		}
-		state.startedCallback(token, nil)
-		state.startedCallback = nil
+		scheduledOperation.startedCallback(token, nil)
+		scheduledOperation.startedCallback = nil
 	}
 	return nil
 }
@@ -2093,19 +2093,19 @@ func (weh *workflowExecutionEventHandlerImpl) handleNexusOperationCompleted(even
 		panic(fmt.Errorf("invalid event type, not a Nexus Operation resolution: %v", event.EventType))
 	}
 	command := weh.commandsHelper.handleNexusOperationCompleted(scheduledEventId)
-	state := command.getData().(*scheduledNexusOperation)
+	scheduledOperation := command.getData().(*scheduledNexusOperation)
 	var err error
 	if failure != nil {
-		err = state.failureConverter.FailureToError(failure)
+		err = scheduledOperation.failureConverter.FailureToError(failure)
 	}
 	// Also unblock the start future
-	if state.startedCallback != nil {
-		state.startedCallback("", err) // We didn't get a started event, the operation completed synchronously.
-		state.startedCallback = nil
+	if scheduledOperation.startedCallback != nil {
+		scheduledOperation.startedCallback("", err) // We didn't get a started event, the operation completed synchronously.
+		scheduledOperation.startedCallback = nil
 	}
-	if state.completedCallback != nil {
-		state.completedCallback(result, err)
-		state.completedCallback = nil
+	if scheduledOperation.completedCallback != nil {
+		scheduledOperation.completedCallback(result, err)
+		scheduledOperation.completedCallback = nil
 	}
 	return nil
 }
@@ -2115,16 +2115,16 @@ func (weh *workflowExecutionEventHandlerImpl) handleNexusOperationCancelRequeste
 	scheduledEventId := attrs.GetScheduledEventId()
 
 	command := weh.commandsHelper.handleNexusOperationCancelRequested(scheduledEventId)
-	state := command.getData().(*scheduledNexusOperation)
+	scheduledOperation := command.getData().(*scheduledNexusOperation)
 	err := ErrCanceled
-	if state.cancellationType == NexusOperationCancellationTypeTryCancel {
-		if state.startedCallback != nil {
-			state.startedCallback("", err)
-			state.startedCallback = nil
+	if scheduledOperation.cancellationType == NexusOperationCancellationTypeTryCancel {
+		if scheduledOperation.startedCallback != nil {
+			scheduledOperation.startedCallback("", err)
+			scheduledOperation.startedCallback = nil
 		}
-		if state.completedCallback != nil {
-			state.completedCallback(nil, err)
-			state.completedCallback = nil
+		if scheduledOperation.completedCallback != nil {
+			scheduledOperation.completedCallback(nil, err)
+			scheduledOperation.completedCallback = nil
 		}
 	}
 	return nil
@@ -2154,20 +2154,20 @@ func (weh *workflowExecutionEventHandlerImpl) handleNexusOperationCancelRequestD
 	}
 
 	command := weh.commandsHelper.handleNexusOperationCancelRequestDelivered(scheduledEventID)
-	state := command.getData().(*scheduledNexusOperation)
+	scheduledOperation := command.getData().(*scheduledNexusOperation)
 	err := ErrCanceled
 	if failure != nil {
-		err = state.failureConverter.FailureToError(failure)
+		err = scheduledOperation.failureConverter.FailureToError(failure)
 	}
 
-	if state.cancellationType == NexusOperationCancellationTypeWaitRequested {
-		if state.startedCallback != nil {
-			state.startedCallback("", err)
-			state.startedCallback = nil
+	if scheduledOperation.cancellationType == NexusOperationCancellationTypeWaitRequested {
+		if scheduledOperation.startedCallback != nil {
+			scheduledOperation.startedCallback("", err)
+			scheduledOperation.startedCallback = nil
 		}
-		if state.completedCallback != nil {
-			state.completedCallback(nil, err)
-			state.completedCallback = nil
+		if scheduledOperation.completedCallback != nil {
+			scheduledOperation.completedCallback(nil, err)
+			scheduledOperation.completedCallback = nil
 		}
 	}
 

--- a/internal/internal_event_handlers.go
+++ b/internal/internal_event_handlers.go
@@ -72,6 +72,7 @@ type (
 		endpoint          string
 		service           string
 		operation         string
+		failureConverter  converter.FailureConverter
 	}
 
 	scheduledChildWorkflow struct {
@@ -669,6 +670,10 @@ func (wc *workflowEnvironmentImpl) ExecuteNexusOperation(params ExecuteNexusOper
 	}
 
 	command := wc.commandsHelper.scheduleNexusOperation(seq, scheduleTaskAttr, startMetadata)
+	failureConverter := params.failureConverter
+	if failureConverter == nil {
+		failureConverter = wc.failureConverter
+	}
 	command.setData(&scheduledNexusOperation{
 		startedCallback:   startedHandler,
 		completedCallback: callback,
@@ -676,6 +681,7 @@ func (wc *workflowEnvironmentImpl) ExecuteNexusOperation(params ExecuteNexusOper
 		endpoint:          params.client.Endpoint(),
 		service:           params.client.Service(),
 		operation:         params.operation,
+		failureConverter:  failureConverter,
 	})
 
 	wc.logger.Debug("ScheduleNexusOperation",
@@ -2090,7 +2096,7 @@ func (weh *workflowExecutionEventHandlerImpl) handleNexusOperationCompleted(even
 	state := command.getData().(*scheduledNexusOperation)
 	var err error
 	if failure != nil {
-		err = weh.failureConverter.FailureToError(failure)
+		err = state.failureConverter.FailureToError(failure)
 	}
 	// Also unblock the start future
 	if state.startedCallback != nil {
@@ -2151,7 +2157,7 @@ func (weh *workflowExecutionEventHandlerImpl) handleNexusOperationCancelRequestD
 	state := command.getData().(*scheduledNexusOperation)
 	err := ErrCanceled
 	if failure != nil {
-		err = weh.failureConverter.FailureToError(failure)
+		err = state.failureConverter.FailureToError(failure)
 	}
 
 	if state.cancellationType == NexusOperationCancellationTypeWaitRequested {

--- a/internal/internal_nexus_client.go
+++ b/internal/internal_nexus_client.go
@@ -747,6 +747,7 @@ func (w *workflowClientInterceptor) ExecuteNexusOperation(
 		return nil, err
 	}
 	var nsc *converter.NexusSerializationContext
+	// USE_EXISTING may return an operation with different nexus context; Describe resolves its actual context.
 	if resp.Started || in.Options.IDConflictPolicy != enumspb.NEXUS_OPERATION_ID_CONFLICT_POLICY_USE_EXISTING {
 		nsc = &nexusContext
 	}

--- a/internal/internal_nexus_client.go
+++ b/internal/internal_nexus_client.go
@@ -353,7 +353,6 @@ type (
 		client                    *WorkflowClient
 		id                        string
 		runID                     string
-		resolvedRunID             string
 		nexusSerializationContext *converter.NexusSerializationContext
 		result                    *ClientPollNexusOperationResultOutput
 	}
@@ -486,18 +485,13 @@ func (h *clientNexusOperationHandleImpl) Get(ctx context.Context, valuePtr any) 
 	if err := h.client.ensureInitialized(ctx); err != nil {
 		return err
 	}
-	if h.nexusSerializationContext == nil {
-		if _, err := h.Describe(ctx, ClientDescribeNexusOperationOptions{}); err != nil {
-			return err
-		}
-	}
 
 	// repeatedly poll, the loop repeats until there's an outcome
 	for {
 		resp, err := h.client.interceptor.PollNexusOperationResult(ctx, &ClientPollNexusOperationResultInput{
 			OperationID:               h.id,
-			RunID:                     h.resolvedRunID,
-			nexusSerializationContext: *h.nexusSerializationContext,
+			RunID:                     h.runID,
+			nexusSerializationContext: h.nexusSerializationContext,
 		})
 		if err != nil {
 			return err
@@ -526,12 +520,6 @@ func (h *clientNexusOperationHandleImpl) Describe(ctx context.Context, options C
 	})
 	if err != nil {
 		return nil, err
-	}
-	h.resolvedRunID = out.Description.OperationRunID
-	h.nexusSerializationContext = &converter.NexusSerializationContext{
-		Endpoint:  out.Description.Endpoint,
-		Service:   out.Description.Service,
-		Operation: out.Description.Operation,
 	}
 	return out.Description, nil
 }
@@ -746,18 +734,12 @@ func (w *workflowClientInterceptor) ExecuteNexusOperation(
 	if err != nil {
 		return nil, err
 	}
-	var nsc *converter.NexusSerializationContext
-	// USE_EXISTING may return an operation with different nexus context; Describe resolves its actual context.
-	if resp.Started || in.Options.IDConflictPolicy != enumspb.NEXUS_OPERATION_ID_CONFLICT_POLICY_USE_EXISTING {
-		nsc = &nexusContext
-	}
 
 	return &clientNexusOperationHandleImpl{
 		client:                    w.client,
 		id:                        in.Options.ID,
 		runID:                     resp.RunId,
-		resolvedRunID:             resp.RunId,
-		nexusSerializationContext: nsc,
+		nexusSerializationContext: &nexusContext,
 	}, nil
 }
 
@@ -779,8 +761,11 @@ func (w *workflowClientInterceptor) PollNexusOperationResult(
 	if dataConverter == nil {
 		dataConverter = converter.GetDefaultDataConverter()
 	}
-	dataConverter = converter.WithDataConverterSerializationContext(dataConverter, in.nexusSerializationContext)
-	failureConverter := converter.WithFailureConverterSerializationContext(w.client.failureConverter, in.nexusSerializationContext)
+	failureConverter := w.client.failureConverter
+	if in.nexusSerializationContext != nil {
+		dataConverter = converter.WithDataConverterSerializationContext(dataConverter, *in.nexusSerializationContext)
+		failureConverter = converter.WithFailureConverterSerializationContext(failureConverter, *in.nexusSerializationContext)
+	}
 
 	request := &workflowservice.PollNexusOperationExecutionRequest{
 		Namespace:   w.client.namespace,

--- a/internal/internal_nexus_client.go
+++ b/internal/internal_nexus_client.go
@@ -350,10 +350,12 @@ type (
 
 	// clientNexusOperationHandleImpl is the default implementation of ClientNexusOperationHandle.
 	clientNexusOperationHandleImpl struct {
-		client *WorkflowClient
-		id     string
-		runID  string
-		result *ClientPollNexusOperationResultOutput
+		client                    *WorkflowClient
+		id                        string
+		runID                     string
+		resolvedRunID             string
+		nexusSerializationContext *converter.NexusSerializationContext
+		result                    *ClientPollNexusOperationResultOutput
 	}
 )
 
@@ -484,12 +486,18 @@ func (h *clientNexusOperationHandleImpl) Get(ctx context.Context, valuePtr any) 
 	if err := h.client.ensureInitialized(ctx); err != nil {
 		return err
 	}
+	if h.nexusSerializationContext == nil {
+		if _, err := h.Describe(ctx, ClientDescribeNexusOperationOptions{}); err != nil {
+			return err
+		}
+	}
 
 	// repeatedly poll, the loop repeats until there's an outcome
 	for {
 		resp, err := h.client.interceptor.PollNexusOperationResult(ctx, &ClientPollNexusOperationResultInput{
-			OperationID: h.id,
-			RunID:       h.runID,
+			OperationID:               h.id,
+			RunID:                     h.resolvedRunID,
+			nexusSerializationContext: *h.nexusSerializationContext,
 		})
 		if err != nil {
 			return err
@@ -518,6 +526,12 @@ func (h *clientNexusOperationHandleImpl) Describe(ctx context.Context, options C
 	})
 	if err != nil {
 		return nil, err
+	}
+	h.resolvedRunID = out.Description.OperationRunID
+	h.nexusSerializationContext = &converter.NexusSerializationContext{
+		Endpoint:  out.Description.Endpoint,
+		Service:   out.Description.Service,
+		Operation: out.Description.Operation,
 	}
 	return out.Description, nil
 }
@@ -667,6 +681,12 @@ func (w *workflowClientInterceptor) ExecuteNexusOperation(
 	if dataConverter == nil {
 		dataConverter = converter.GetDefaultDataConverter()
 	}
+	nexusContext := converter.NexusSerializationContext{
+		Endpoint:  in.Endpoint,
+		Service:   in.Service,
+		Operation: in.OperationType,
+	}
+	inputDataConverter := converter.WithDataConverterSerializationContext(dataConverter, nexusContext)
 
 	if in.Options.ID == "" {
 		return nil, errors.New("operation ID is required")
@@ -676,7 +696,7 @@ func (w *workflowClientInterceptor) ExecuteNexusOperation(
 	}
 
 	// Encode input as a single Payload (not Payloads)
-	inputPayload, err := dataConverter.ToPayload(in.Input)
+	inputPayload, err := inputDataConverter.ToPayload(in.Input)
 	if err != nil {
 		return nil, err
 	}
@@ -726,11 +746,17 @@ func (w *workflowClientInterceptor) ExecuteNexusOperation(
 	if err != nil {
 		return nil, err
 	}
+	var nsc *converter.NexusSerializationContext
+	if resp.Started || in.Options.IDConflictPolicy != enumspb.NEXUS_OPERATION_ID_CONFLICT_POLICY_USE_EXISTING {
+		nsc = &nexusContext
+	}
 
 	return &clientNexusOperationHandleImpl{
-		client: w.client,
-		id:     in.Options.ID,
-		runID:  resp.RunId,
+		client:                    w.client,
+		id:                        in.Options.ID,
+		runID:                     resp.RunId,
+		resolvedRunID:             resp.RunId,
+		nexusSerializationContext: nsc,
 	}, nil
 }
 
@@ -748,6 +774,13 @@ func (w *workflowClientInterceptor) PollNexusOperationResult(
 	ctx context.Context,
 	in *ClientPollNexusOperationResultInput,
 ) (*ClientPollNexusOperationResultOutput, error) {
+	dataConverter := WithContext(ctx, w.client.dataConverter)
+	if dataConverter == nil {
+		dataConverter = converter.GetDefaultDataConverter()
+	}
+	dataConverter = converter.WithDataConverterSerializationContext(dataConverter, in.nexusSerializationContext)
+	failureConverter := converter.WithFailureConverterSerializationContext(w.client.failureConverter, in.nexusSerializationContext)
+
 	request := &workflowservice.PollNexusOperationExecutionRequest{
 		Namespace:   w.client.namespace,
 		OperationId: in.OperationID,
@@ -774,9 +807,9 @@ func (w *workflowClientInterceptor) PollNexusOperationResult(
 	case *workflowservice.PollNexusOperationExecutionResponse_Result:
 		// Wrap single Payload in Payloads for EncodedValue compatibility
 		payloads := &commonpb.Payloads{Payloads: []*commonpb.Payload{v.Result}}
-		return &ClientPollNexusOperationResultOutput{Result: newEncodedValue(payloads, w.client.dataConverter)}, nil
+		return &ClientPollNexusOperationResultOutput{Result: newEncodedValue(payloads, dataConverter)}, nil
 	case *workflowservice.PollNexusOperationExecutionResponse_Failure:
-		return &ClientPollNexusOperationResultOutput{Error: w.client.failureConverter.FailureToError(v.Failure)}, nil
+		return &ClientPollNexusOperationResultOutput{Error: failureConverter.FailureToError(v.Failure)}, nil
 	default:
 		return nil, fmt.Errorf("unexpected nexus operation outcome type: %T", v)
 	}
@@ -802,6 +835,12 @@ func (w *workflowClientInterceptor) DescribeNexusOperation(
 	if info == nil {
 		return nil, errors.New("DescribeNexusOperationExecution response doesn't contain info")
 	}
+	nexusContext := converter.NexusSerializationContext{
+		Endpoint:  info.Endpoint,
+		Service:   info.Service,
+		Operation: info.Operation,
+	}
+	failureConverter := converter.WithFailureConverterSerializationContext(w.client.failureConverter, nexusContext)
 
 	var cancellationInfo *ClientNexusOperationCancellationInfo
 	if info.CancellationInfo != nil {
@@ -815,7 +854,7 @@ func (w *workflowClientInterceptor) DescribeNexusOperation(
 			BlockedReason:           info.CancellationInfo.BlockedReason,
 			Reason:                  info.CancellationInfo.Reason,
 			lastAttemptFailure:      info.CancellationInfo.LastAttemptFailure,
-			failureConverter:        w.client.failureConverter,
+			failureConverter:        failureConverter,
 			inboundPayloadVisitor:   w.inboundPayloadVisitor,
 		}
 	}
@@ -851,7 +890,7 @@ func (w *workflowClientInterceptor) DescribeNexusOperation(
 			Identity:                info.Identity,
 			CancellationInfo:        cancellationInfo,
 			dc:                      WithContext(ctx, w.client.dataConverter),
-			failureConverter:        w.client.failureConverter,
+			failureConverter:        failureConverter,
 			inboundPayloadVisitor:   w.inboundPayloadVisitor,
 		},
 	}, nil

--- a/internal/internal_nexus_task_handler.go
+++ b/internal/internal_nexus_task_handler.go
@@ -98,18 +98,22 @@ func (h *nexusTaskHandler) Execute(task *workflowservice.PollNexusTaskQueueRespo
 	failureReasonSupport := getEffectiveTemporalFailureResponses(task.GetRequest().GetCapabilities().GetTemporalFailureResponses())
 	nctx, handlerErr := h.newNexusOperationContext(task)
 	if handlerErr != nil {
-		failureRequest, err := h.fillInFailure(task.TaskToken, handlerErr, failureReasonSupport)
+		failureRequest, err := h.fillInFailure(task.TaskToken, handlerErr, failureReasonSupport, h.failureConverter)
 		if err != nil {
 			return nil, nil, err
 		}
 		return nil, failureRequest, nil
 	}
+	failureConverter := converter.WithFailureConverterSerializationContext(
+		h.failureConverter,
+		nctx.nexusSerializationContext,
+	)
 	res, handlerErr, err := h.execute(nctx, task)
 	if err != nil {
 		return nil, nil, err
 	}
 	if handlerErr != nil {
-		failureRequest, err := h.fillInFailure(task.TaskToken, handlerErr, failureReasonSupport)
+		failureRequest, err := h.fillInFailure(task.TaskToken, handlerErr, failureReasonSupport, failureConverter)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -124,12 +128,16 @@ func (h *nexusTaskHandler) Execute(task *workflowservice.PollNexusTaskQueueRespo
 
 func (h *nexusTaskHandler) ExecuteContext(nctx *NexusOperationContext, task *workflowservice.PollNexusTaskQueueResponse) (*workflowservice.RespondNexusTaskCompletedRequest, *workflowservice.RespondNexusTaskFailedRequest, error) {
 	failureReasonSupport := getEffectiveTemporalFailureResponses(task.GetRequest().GetCapabilities().GetTemporalFailureResponses())
+	failureConverter := converter.WithFailureConverterSerializationContext(
+		h.failureConverter,
+		nctx.nexusSerializationContext,
+	)
 	res, handlerErr, err := h.execute(nctx, task)
 	if err != nil {
 		return nil, nil, err
 	}
 	if handlerErr != nil {
-		failureRequest, err := h.fillInFailure(task.TaskToken, handlerErr, failureReasonSupport)
+		failureRequest, err := h.fillInFailure(task.TaskToken, handlerErr, failureReasonSupport, failureConverter)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -173,8 +181,16 @@ func (h *nexusTaskHandler) handleStartOperation(
 	req *nexuspb.StartOperationRequest,
 	header nexus.Header,
 ) (*nexuspb.Response, *nexus.HandlerError, error) {
+	dataConverter := converter.WithDataConverterSerializationContext(
+		h.dataConverter,
+		nctx.nexusSerializationContext,
+	)
+	failureConverter := converter.WithFailureConverterSerializationContext(
+		h.failureConverter,
+		nctx.nexusSerializationContext,
+	)
 	serializer := &payloadSerializer{
-		converter: h.dataConverter,
+		converter: dataConverter,
 		payload:   req.GetPayload(),
 	}
 	// Create a fake lazy value, Temporal server already converts Nexus content into payloads.
@@ -292,7 +308,7 @@ func (h *nexusTaskHandler) handleStartOperation(
 				Variant: &nexuspb.Response_StartOperation{
 					StartOperation: &nexuspb.StartOperationResponse{
 						Variant: &nexuspb.StartOperationResponse_Failure{
-							Failure: h.failureConverter.ErrorToFailure(tempoErr),
+							Failure: failureConverter.ErrorToFailure(tempoErr),
 						},
 					},
 				},
@@ -345,7 +361,7 @@ func (h *nexusTaskHandler) handleStartOperation(
 		links = append(links, h.responseLinks(nctx)...)
 		// *nexus.HandlerStartOperationResultSync is generic, we can't type switch unfortunately.
 		value := reflect.ValueOf(t).Elem().FieldByName("Value").Interface()
-		payload, err := h.dataConverter.ToPayload(value)
+		payload, err := dataConverter.ToPayload(value)
 		if err != nil {
 			nctx.log.Error("Cannot convert Nexus sync result", tagError, err)
 			return nil, nexus.NewHandlerErrorf(
@@ -486,10 +502,15 @@ func (h *nexusTaskHandler) newNexusOperationContext(response *workflowservice.Po
 	metricsHandler := h.metricsHandler.WithTags(metrics.NexusTags(service, operation, h.taskQueueName))
 
 	return &NexusOperationContext{
-		client:         h.client,
-		Endpoint:       response.GetRequest().GetEndpoint(),
-		Namespace:      h.namespace,
-		TaskQueue:      h.taskQueueName,
+		client:    h.client,
+		Endpoint:  response.GetRequest().GetEndpoint(),
+		Namespace: h.namespace,
+		TaskQueue: h.taskQueueName,
+		nexusSerializationContext: converter.NexusSerializationContext{
+			Endpoint:  response.GetRequest().GetEndpoint(),
+			Service:   service,
+			Operation: operation,
+		},
 		metricsHandler: metricsHandler,
 		log:            logger,
 		registry:       h.registry,
@@ -533,16 +554,21 @@ func (h *nexusTaskHandler) fillInCompletion(taskToken []byte, res *nexuspb.Respo
 	}, nil
 }
 
-func (h *nexusTaskHandler) fillInFailure(taskToken []byte, handlerError *nexus.HandlerError, failureReasonSupport bool) (*workflowservice.RespondNexusTaskFailedRequest, error) {
+func (h *nexusTaskHandler) fillInFailure(
+	taskToken []byte,
+	handlerError *nexus.HandlerError,
+	failureReasonSupport bool,
+	failureConverter converter.FailureConverter,
+) (*workflowservice.RespondNexusTaskFailedRequest, error) {
 	r := &workflowservice.RespondNexusTaskFailedRequest{
 		Identity:  h.identity,
 		Namespace: h.namespace,
 		TaskToken: taskToken,
 	}
 	if failureReasonSupport {
-		r.Failure = h.failureConverter.ErrorToFailure(handlerError)
+		r.Failure = failureConverter.ErrorToFailure(handlerError)
 	} else {
-		he, err := h.nexusHandlerErrorToProto(handlerError)
+		he, err := h.nexusHandlerErrorToProto(handlerError, failureConverter)
 		if err != nil {
 			return nil, err
 		}
@@ -555,8 +581,8 @@ func (h *nexusTaskHandler) fillInFailure(taskToken []byte, handlerError *nexus.H
 var nexusFailureTypeString = string((&failurepb.Failure{}).ProtoReflect().Descriptor().FullName())
 var nexusFailureMetadata = map[string]string{"type": nexusFailureTypeString}
 
-func (h *nexusTaskHandler) errorToFailure(err error) (*nexuspb.Failure, error) {
-	failure := h.failureConverter.ErrorToFailure(err)
+func (h *nexusTaskHandler) errorToFailure(err error, failureConverter converter.FailureConverter) (*nexuspb.Failure, error) {
+	failure := failureConverter.ErrorToFailure(err)
 	if failure == nil {
 		return nil, nil
 	}
@@ -591,8 +617,11 @@ func (h *nexusTaskHandler) temporalFailureToNexusFailure(failure *failurepb.Fail
 	}, nil
 }
 
-func (h *nexusTaskHandler) nexusHandlerErrorToProto(handlerErr *nexus.HandlerError) (*nexuspb.HandlerError, error) {
-	failure, err := h.errorToFailure(handlerErr.Cause)
+func (h *nexusTaskHandler) nexusHandlerErrorToProto(
+	handlerErr *nexus.HandlerError,
+	failureConverter converter.FailureConverter,
+) (*nexuspb.HandlerError, error) {
+	failure, err := h.errorToFailure(handlerErr.Cause, failureConverter)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/internal_nexus_task_poller.go
+++ b/internal/internal_nexus_task_poller.go
@@ -143,7 +143,12 @@ func (ntp *nexusTaskPoller) ProcessTask(task any) error {
 	nctx, handlerErr := ntp.taskHandler.newNexusOperationContext(response)
 	if handlerErr != nil {
 		// context wasn't propagated to us, use a background context.
-		failedRequest, err := ntp.taskHandler.fillInFailure(response.TaskToken, handlerErr, getEffectiveTemporalFailureResponses(response.GetRequest().GetCapabilities().GetTemporalFailureResponses()))
+		failedRequest, err := ntp.taskHandler.fillInFailure(
+			response.TaskToken,
+			handlerErr,
+			getEffectiveTemporalFailureResponses(response.GetRequest().GetCapabilities().GetTemporalFailureResponses()),
+			ntp.taskHandler.failureConverter,
+		)
 		if err != nil {
 			return err
 		}
@@ -280,6 +285,7 @@ func (ntp *nexusTaskPoller) reportExternalStorageFailure(
 		response.TaskToken,
 		handlerErr,
 		getEffectiveTemporalFailureResponses(response.GetRequest().GetCapabilities().GetTemporalFailureResponses()),
+		ntp.taskHandler.failureConverter,
 	)
 	if err != nil {
 		return err

--- a/internal/internal_worker_base.go
+++ b/internal/internal_worker_base.go
@@ -67,11 +67,13 @@ type (
 	}
 
 	ExecuteNexusOperationParams struct {
-		client      NexusClient
-		operation   string
-		input       *commonpb.Payload
-		options     NexusOperationOptions
-		nexusHeader map[string]string
+		client           NexusClient
+		operation        string
+		input            *commonpb.Payload
+		options          NexusOperationOptions
+		nexusHeader      map[string]string
+		dataConverter    converter.DataConverter
+		failureConverter converter.FailureConverter
 	}
 )
 

--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -2780,6 +2780,10 @@ func (env *testWorkflowEnvironmentImpl) ExecuteNexusOperation(
 	callback func(*commonpb.Payload, error),
 	startedHandler func(opID string, e error),
 ) int64 {
+	failureConverter := params.failureConverter
+	if failureConverter == nil {
+		failureConverter = env.failureConverter
+	}
 	seq := env.nextID()
 	// Use lower case header values to simulate how the Nexus SDK (used internally by the "real" server) would transmit
 	// these headers over the wire.
@@ -2812,7 +2816,7 @@ func (env *testWorkflowEnvironmentImpl) ExecuteNexusOperation(
 			params.options.ScheduleToCloseTimeout,
 			TimerOptions{},
 			func(result *commonpb.Payloads, err error) {
-				timeoutErr := env.failureConverter.FailureToError(nexusOperationFailure(
+				timeoutErr := failureConverter.FailureToError(nexusOperationFailure(
 					params,
 					token,
 					&failurepb.Failure{
@@ -2845,7 +2849,7 @@ func (env *testWorkflowEnvironmentImpl) ExecuteNexusOperation(
 				env.postCallback(func() {
 					// Only timeout if operation hasn't started yet
 					if !handle.started {
-						timeoutErr := env.failureConverter.FailureToError(nexusOperationFailure(
+						timeoutErr := failureConverter.FailureToError(nexusOperationFailure(
 							params,
 							"",
 							&failurepb.Failure{
@@ -2889,7 +2893,7 @@ func (env *testWorkflowEnvironmentImpl) ExecuteNexusOperation(
 
 			// To simulate the server flow, convert to failure and then back to a Go error.
 			// This ensures that the error's `Failure` is set, the same way as it would outside of the test env.
-			err = env.failureConverter.FailureToError(
+			err = failureConverter.FailureToError(
 				nexusOperationFailure(params, "", env.failureConverter.ErrorToFailure(handlerErr)),
 			)
 
@@ -2917,7 +2921,7 @@ func (env *testWorkflowEnvironmentImpl) ExecuteNexusOperation(
 				}
 			}, true)
 		case *nexuspb.StartOperationResponse_Failure:
-			err := env.failureConverter.FailureToError(
+			err := failureConverter.FailureToError(
 				nexusOperationFailure(params, "", v.Failure),
 			)
 			env.postCallback(func() {
@@ -2935,7 +2939,7 @@ func (env *testWorkflowEnvironmentImpl) ExecuteNexusOperation(
 				}, true)
 				return
 			}
-			err = env.failureConverter.FailureToError(
+			err = failureConverter.FailureToError(
 				nexusOperationFailure(params, "", failure),
 			)
 			env.postCallback(func() {
@@ -3073,7 +3077,11 @@ func (env *testWorkflowEnvironmentImpl) scheduleNexusAsyncOperationCompletion(
 	)
 	var nexusErr error
 	if completionHandle.err != nil {
-		nexusErr = env.failureConverter.FailureToError(nexusOperationFailure(
+		failureConverter := handle.params.failureConverter
+		if failureConverter == nil {
+			failureConverter = env.failureConverter
+		}
+		nexusErr = failureConverter.FailureToError(nexusOperationFailure(
 			handle.params,
 			handle.operationToken,
 			&failurepb.Failure{
@@ -3100,8 +3108,13 @@ func (env *testWorkflowEnvironmentImpl) resolveNexusOperation(seq int64, token s
 			panic(fmt.Errorf("no running operation found for sequence: %d", seq))
 		}
 		if err != nil {
+			// Encode as the handler, then decode with the caller's operation converter.
 			failure := env.failureConverter.ErrorToFailure(err)
-			err = env.failureConverter.FailureToError(nexusOperationFailure(handle.params, handle.operationToken, failure))
+			failureConverter := handle.params.failureConverter
+			if failureConverter == nil {
+				failureConverter = env.failureConverter
+			}
+			err = failureConverter.FailureToError(nexusOperationFailure(handle.params, handle.operationToken, failure))
 		}
 		// Populate the token in case the operation completes before it marked as started.
 		// startedCallback is idempotent and will be a noop in case the operation has already been marked as started.
@@ -3784,7 +3797,11 @@ func (h *testNexusOperationHandle) startedCallback(token string, e error) {
 				h.env.postCallback(func() {
 					// Only timeout if operation hasn't completed yet
 					if !h.done {
-						timeoutErr := h.env.failureConverter.FailureToError(nexusOperationFailure(
+						failureConverter := h.params.failureConverter
+						if failureConverter == nil {
+							failureConverter = h.env.failureConverter
+						}
+						timeoutErr := failureConverter.FailureToError(nexusOperationFailure(
 							h.params,
 							h.operationToken,
 							&failurepb.Failure{

--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -2780,10 +2781,7 @@ func (env *testWorkflowEnvironmentImpl) ExecuteNexusOperation(
 	callback func(*commonpb.Payload, error),
 	startedHandler func(opID string, e error),
 ) int64 {
-	failureConverter := params.failureConverter
-	if failureConverter == nil {
-		failureConverter = env.failureConverter
-	}
+	failureConverter := cmp.Or(params.failureConverter, env.failureConverter)
 	seq := env.nextID()
 	// Use lower case header values to simulate how the Nexus SDK (used internally by the "real" server) would transmit
 	// these headers over the wire.

--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -2874,7 +2874,12 @@ func (env *testWorkflowEnvironmentImpl) ExecuteNexusOperation(
 		if err != nil {
 			// No retries for operations, fail the operation immediately.
 			//lint:ignore SA4006 fillInFailure cannot fail for a handler error without a cause.
-			failure, err = taskHandler.fillInFailure(task.TaskToken, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeInternal, "%s", err.Error()), false)
+			failure, err = taskHandler.fillInFailure(
+				task.TaskToken,
+				nexus.NewHandlerErrorf(nexus.HandlerErrorTypeInternal, "%s", err.Error()),
+				false,
+				taskHandler.failureConverter,
+			)
 		}
 		if failure != nil {
 			// Convert to a nexus HandlerError first to simulate the flow in the server.

--- a/internal/nexus_operations.go
+++ b/internal/nexus_operations.go
@@ -37,14 +37,15 @@ type NexusOperationInfo struct {
 
 // NexusOperationContext is an internal only struct that holds fields used by the temporalnexus functions.
 type NexusOperationContext struct {
-	client         Client
-	RequestID      string
-	Namespace      string
-	TaskQueue      string
-	Endpoint       string
-	metricsHandler metrics.Handler
-	log            log.Logger
-	registry       *registry
+	client                    Client
+	RequestID                 string
+	Namespace                 string
+	TaskQueue                 string
+	Endpoint                  string
+	nexusSerializationContext converter.NexusSerializationContext
+	metricsHandler            metrics.Handler
+	log                       log.Logger
+	registry                  *registry
 
 	// responseLinksMu guards responseLinks. A Nexus operation handler is invoked from a single
 	// goroutine, but handlers are free to issue RPCs from other goroutines they spawn, so the

--- a/internal/nexus_serialization_context_test.go
+++ b/internal/nexus_serialization_context_test.go
@@ -1,0 +1,333 @@
+package internal
+
+import (
+	"errors"
+	"reflect"
+	"sync"
+	"testing"
+
+	"github.com/nexus-rpc/sdk-go/nexus"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	failurepb "go.temporal.io/api/failure/v1"
+	historypb "go.temporal.io/api/history/v1"
+	"go.temporal.io/sdk/converter"
+	ilog "go.temporal.io/sdk/internal/log"
+)
+
+type capturedNexusSerializationCall struct {
+	params    ExecuteNexusOperationParams
+	started   func(string, error)
+	completed func(*commonpb.Payload, error)
+}
+
+type captureNexusSerializationEnv struct {
+	WorkflowEnvironment
+	calls []*capturedNexusSerializationCall
+}
+
+func (e *captureNexusSerializationEnv) ExecuteNexusOperation(
+	params ExecuteNexusOperationParams,
+	completed func(*commonpb.Payload, error),
+	started func(string, error),
+) int64 {
+	e.calls = append(e.calls, &capturedNexusSerializationCall{
+		params:    params,
+		started:   started,
+		completed: completed,
+	})
+	return int64(len(e.calls))
+}
+
+func TestNexusSerializationContextInputAndResultIsolation(t *testing.T) {
+	testEnv := new(WorkflowUnitTest).NewTestWorkflowEnvironment()
+	testEnv.SetDataConverter(converter.NewCodecDataConverter(
+		converter.GetDefaultDataConverter(),
+		&serCtxSigningCodec{},
+	))
+	interceptor, ctx, err := newWorkflowContext(testEnv.impl, testEnv.impl.GetRegistry().interceptors)
+	require.NoError(t, err)
+	capture := &captureNexusSerializationEnv{WorkflowEnvironment: interceptor.env}
+	interceptor.env = capture
+
+	operationRef := mockOperationReference{name: "typed-operation", inputType: reflect.TypeFor[string]()}
+	var results [2]string
+	d, _ := newDispatcher(ctx, interceptor, func(ctx Context) {
+		first := NewNexusClient("endpoint-a", "service-a").ExecuteOperation(
+			ctx, operationRef, "input-a", NexusOperationOptions{},
+		)
+		second := NewNexusClient("endpoint-b", "service-b").ExecuteOperation(
+			ctx, "string-operation", "input-b", NexusOperationOptions{},
+		)
+
+		// Complete in reverse order to prove that each future retains the
+		// converter selected for its own operation.
+		for i := len(capture.calls) - 1; i >= 0; i-- {
+			call := capture.calls[i]
+			payload, encodeErr := call.params.dataConverter.ToPayload("result-" + call.params.operation)
+			if encodeErr != nil {
+				panic(encodeErr)
+			}
+			call.started("token-"+call.params.operation, nil)
+			call.completed(payload, nil)
+		}
+
+		if getErr := first.Get(ctx, &results[0]); getErr != nil {
+			panic(getErr)
+		}
+		if getErr := second.Get(ctx, &results[1]); getErr != nil {
+			panic(getErr)
+		}
+	}, func() bool { return false })
+	d.interceptor = interceptor
+	defer d.Close()
+
+	requireNoExecuteErr(t, d.ExecuteUntilAllBlocked(defaultDeadlockDetectionTimeout))
+	require.Len(t, capture.calls, 2)
+
+	expected := []converter.NexusSerializationContext{
+		{Endpoint: "endpoint-a", Service: "service-a", Operation: "typed-operation"},
+		{Endpoint: "endpoint-b", Service: "service-b", Operation: "string-operation"},
+	}
+	for i, call := range capture.calls {
+		require.Equal(t, expected[i].Operation, call.params.operation)
+		require.Equal(
+			t,
+			expected[i].Endpoint+":"+expected[i].Service+":"+expected[i].Operation,
+			string(call.params.input.Metadata["ctx-signature"]),
+		)
+		var input string
+		require.NoError(t, call.params.dataConverter.FromPayload(call.params.input, &input))
+		require.Equal(t, []string{"input-a", "input-b"}[i], input)
+	}
+	require.Equal(t, [2]string{"result-typed-operation", "result-string-operation"}, results)
+}
+
+type nexusFailureConversion struct {
+	context   converter.SerializationContext
+	direction string
+}
+
+type nexusCapturingFailureConverter struct {
+	converter.FailureConverter
+	mu          *sync.Mutex
+	conversions *[]nexusFailureConversion
+	context     converter.SerializationContext
+}
+
+func newNexusCapturingFailureConverter() *nexusCapturingFailureConverter {
+	conversions := make([]nexusFailureConversion, 0)
+	return &nexusCapturingFailureConverter{
+		FailureConverter: GetDefaultFailureConverter(),
+		mu:               &sync.Mutex{},
+		conversions:      &conversions,
+	}
+}
+
+func (c *nexusCapturingFailureConverter) WithSerializationContext(
+	ctx converter.SerializationContext,
+) converter.FailureConverter {
+	return &nexusCapturingFailureConverter{
+		FailureConverter: c.FailureConverter,
+		mu:               c.mu,
+		conversions:      c.conversions,
+		context:          ctx,
+	}
+}
+
+func (c *nexusCapturingFailureConverter) record(direction string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	*c.conversions = append(*c.conversions, nexusFailureConversion{
+		context:   c.context,
+		direction: direction,
+	})
+}
+
+func (c *nexusCapturingFailureConverter) ErrorToFailure(err error) *failurepb.Failure {
+	c.record("encode")
+	return c.FailureConverter.ErrorToFailure(err)
+}
+
+func (c *nexusCapturingFailureConverter) FailureToError(failure *failurepb.Failure) error {
+	c.record("decode")
+	return c.FailureConverter.FailureToError(failure)
+}
+
+func (c *nexusCapturingFailureConverter) captured() []nexusFailureConversion {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	result := make([]nexusFailureConversion, len(*c.conversions))
+	copy(result, *c.conversions)
+	return result
+}
+
+func TestNexusSerializationContextFailureConverterInTestEnvironment(t *testing.T) {
+	env := new(WorkflowUnitTest).NewTestWorkflowEnvironment()
+	failureConverter := newNexusCapturingFailureConverter()
+	env.SetFailureConverter(failureConverter)
+	op := nexus.NewOperationReference[string, string]("failed-operation")
+	env.OnNexusOperation("failure-service", op, "input", mock.Anything).
+		Return(nil, errors.New("handler failed"))
+
+	env.ExecuteWorkflow(func(ctx Context) error {
+		return NewNexusClient("failure-endpoint", "failure-service").
+			ExecuteOperation(ctx, op, "input", NexusOperationOptions{}).
+			Get(ctx, nil)
+	})
+	require.True(t, env.IsWorkflowCompleted())
+	require.Error(t, env.GetWorkflowError())
+
+	expected := converter.NexusSerializationContext{
+		Endpoint:  "failure-endpoint",
+		Service:   "failure-service",
+		Operation: "failed-operation",
+	}
+	var found bool
+	for _, conversion := range failureConverter.captured() {
+		if conversion.direction == "decode" && conversion.context == expected {
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "Nexus failure should be decoded with its operation context")
+}
+
+type nexusEventFailureConverter struct {
+	err                 error
+	failureToErrorCalls int
+}
+
+func (c *nexusEventFailureConverter) ErrorToFailure(error) *failurepb.Failure {
+	return nil
+}
+
+func (c *nexusEventFailureConverter) FailureToError(*failurepb.Failure) error {
+	c.failureToErrorCalls++
+	return c.err
+}
+
+func TestNexusOperationFailureEventsUseScheduledFailureConverter(t *testing.T) {
+	tests := []struct {
+		name          string
+		cancelRequest bool
+		event         func(int64, *failurepb.Failure) *historypb.HistoryEvent
+	}{
+		{
+			name: "failed",
+			event: func(scheduledEventID int64, failure *failurepb.Failure) *historypb.HistoryEvent {
+				return &historypb.HistoryEvent{
+					EventType: enumspb.EVENT_TYPE_NEXUS_OPERATION_FAILED,
+					Attributes: &historypb.HistoryEvent_NexusOperationFailedEventAttributes{
+						NexusOperationFailedEventAttributes: &historypb.NexusOperationFailedEventAttributes{
+							ScheduledEventId: scheduledEventID,
+							Failure:          failure,
+						},
+					},
+				}
+			},
+		},
+		{
+			name: "canceled",
+			event: func(scheduledEventID int64, failure *failurepb.Failure) *historypb.HistoryEvent {
+				return &historypb.HistoryEvent{
+					EventType: enumspb.EVENT_TYPE_NEXUS_OPERATION_CANCELED,
+					Attributes: &historypb.HistoryEvent_NexusOperationCanceledEventAttributes{
+						NexusOperationCanceledEventAttributes: &historypb.NexusOperationCanceledEventAttributes{
+							ScheduledEventId: scheduledEventID,
+							Failure:          failure,
+						},
+					},
+				}
+			},
+		},
+		{
+			name: "timed out",
+			event: func(scheduledEventID int64, failure *failurepb.Failure) *historypb.HistoryEvent {
+				return &historypb.HistoryEvent{
+					EventType: enumspb.EVENT_TYPE_NEXUS_OPERATION_TIMED_OUT,
+					Attributes: &historypb.HistoryEvent_NexusOperationTimedOutEventAttributes{
+						NexusOperationTimedOutEventAttributes: &historypb.NexusOperationTimedOutEventAttributes{
+							ScheduledEventId: scheduledEventID,
+							Failure:          failure,
+						},
+					},
+				}
+			},
+		},
+		{
+			name:          "cancel request failed",
+			cancelRequest: true,
+			event: func(scheduledEventID int64, failure *failurepb.Failure) *historypb.HistoryEvent {
+				return &historypb.HistoryEvent{
+					EventType: enumspb.EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUEST_FAILED,
+					Attributes: &historypb.HistoryEvent_NexusOperationCancelRequestFailedEventAttributes{
+						NexusOperationCancelRequestFailedEventAttributes: &historypb.NexusOperationCancelRequestFailedEventAttributes{
+							ScheduledEventId: scheduledEventID,
+							Failure:          failure,
+						},
+					},
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			commandsHelper := newCommandsHelper()
+			commandsHelper.setCurrentWorkflowTaskStartedEventID(1)
+			selectedErr := errors.New("selected Nexus failure converter")
+			selectedConverter := &nexusEventFailureConverter{err: selectedErr}
+			fallbackConverter := &nexusEventFailureConverter{err: errors.New("fallback failure converter")}
+			env := &workflowEnvironmentImpl{
+				commandsHelper:   commandsHelper,
+				dataConverter:    converter.GetDefaultDataConverter(),
+				failureConverter: fallbackConverter,
+				logger:           ilog.NewNopLogger(),
+			}
+
+			var callbackErr error
+			seq := env.ExecuteNexusOperation(ExecuteNexusOperationParams{
+				client:           NewNexusClient("endpoint", "service"),
+				operation:        "operation",
+				options:          NexusOperationOptions{CancellationType: NexusOperationCancellationTypeWaitRequested},
+				failureConverter: selectedConverter,
+			}, func(_ *commonpb.Payload, err error) {
+				callbackErr = err
+			}, nil)
+
+			commandsHelper.getCommands(true)
+			const scheduledEventID = 10
+			commandsHelper.handleNexusOperationScheduled(&historypb.HistoryEvent{
+				EventId:   scheduledEventID,
+				EventType: enumspb.EVENT_TYPE_NEXUS_OPERATION_SCHEDULED,
+			})
+			weh := &workflowExecutionEventHandlerImpl{workflowEnvironmentImpl: env}
+			if test.cancelRequest {
+				env.RequestCancelNexusOperation(seq)
+				commandsHelper.getCommands(true)
+				require.NoError(t, weh.handleNexusOperationCancelRequested(&historypb.HistoryEvent{
+					EventType: enumspb.EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUESTED,
+					Attributes: &historypb.HistoryEvent_NexusOperationCancelRequestedEventAttributes{
+						NexusOperationCancelRequestedEventAttributes: &historypb.NexusOperationCancelRequestedEventAttributes{
+							ScheduledEventId: scheduledEventID,
+						},
+					},
+				}))
+				require.NoError(t, weh.handleNexusOperationCancelRequestDelivered(
+					test.event(scheduledEventID, &failurepb.Failure{Message: "failure"}),
+				))
+			} else {
+				require.NoError(t, weh.handleNexusOperationCompleted(
+					test.event(scheduledEventID, &failurepb.Failure{Message: "failure"}),
+				))
+			}
+
+			require.ErrorIs(t, callbackErr, selectedErr)
+			require.Equal(t, 1, selectedConverter.failureToErrorCalls)
+			require.Zero(t, fallbackConverter.failureToErrorCalls)
+		})
+	}
+}

--- a/internal/nexus_serialization_context_test.go
+++ b/internal/nexus_serialization_context_test.go
@@ -458,39 +458,6 @@ func TestStandaloneNexusSerializationContextFailure(t *testing.T) {
 	}}, failureConverter.captured())
 }
 
-func TestStandaloneNexusDetachedHandleDoesNotDescribe(t *testing.T) {
-	service := workflowservicemock.NewMockWorkflowServiceClient(gomock.NewController(t))
-	dataConverter := converter.GetDefaultDataConverter()
-	client := NewServiceClient(service, nil, ClientOptions{DataConverter: dataConverter})
-	client.capabilities = &workflowservice.GetSystemInfoResponse_Capabilities{}
-
-	resultPayload, err := dataConverter.ToPayload("detached-result")
-	require.NoError(t, err)
-
-	service.EXPECT().
-		PollNexusOperationExecution(gomock.Any(), gomock.Any(), gomock.Any()).
-		DoAndReturn(func(
-			_ context.Context,
-			request *workflowservice.PollNexusOperationExecutionRequest,
-			_ ...grpc.CallOption,
-		) (*workflowservice.PollNexusOperationExecutionResponse, error) {
-			require.Empty(t, request.RunId)
-			return &workflowservice.PollNexusOperationExecutionResponse{
-				Outcome: &workflowservice.PollNexusOperationExecutionResponse_Result{
-					Result: resultPayload,
-				},
-			}, nil
-		})
-
-	handle := client.GetNexusOperationHandle(ClientGetNexusOperationHandleOptions{
-		OperationID: "detached-operation-id",
-	})
-	var result string
-	require.NoError(t, handle.Get(t.Context(), &result))
-	require.Equal(t, "detached-result", result)
-	require.Empty(t, handle.GetRunID())
-}
-
 func TestStandaloneNexusSerializationContextUseExisting(t *testing.T) {
 	service := workflowservicemock.NewMockWorkflowServiceClient(gomock.NewController(t))
 	dataConverter := converter.NewCodecDataConverter(

--- a/internal/nexus_serialization_context_test.go
+++ b/internal/nexus_serialization_context_test.go
@@ -1,11 +1,13 @@
 package internal
 
 import (
+	"context"
 	"errors"
 	"reflect"
 	"sync"
 	"testing"
 
+	"github.com/golang/mock/gomock"
 	"github.com/nexus-rpc/sdk-go/nexus"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -13,8 +15,12 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	failurepb "go.temporal.io/api/failure/v1"
 	historypb "go.temporal.io/api/history/v1"
+	nexuspb "go.temporal.io/api/nexus/v1"
+	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/api/workflowservicemock/v1"
 	"go.temporal.io/sdk/converter"
 	ilog "go.temporal.io/sdk/internal/log"
+	"google.golang.org/grpc"
 )
 
 type capturedNexusSerializationCall struct {
@@ -193,6 +199,275 @@ func TestNexusSerializationContextFailureConverterInTestEnvironment(t *testing.T
 		}
 	}
 	require.True(t, found, "Nexus failure should be decoded with its operation context")
+}
+
+func TestStandaloneNexusSerializationContextInputAndResult(t *testing.T) {
+	service := workflowservicemock.NewMockWorkflowServiceClient(gomock.NewController(t))
+	dataConverter := converter.NewCodecDataConverter(
+		converter.GetDefaultDataConverter(),
+		&serCtxSigningCodec{},
+	)
+	client := NewServiceClient(service, nil, ClientOptions{DataConverter: dataConverter})
+	client.capabilities = &workflowservice.GetSystemInfoResponse_Capabilities{}
+
+	expectedContext := converter.NexusSerializationContext{
+		Endpoint:  "standalone-endpoint",
+		Service:   "standalone-service",
+		Operation: "standalone-operation",
+	}
+	resultPayload, err := converter.WithDataConverterSerializationContext(
+		dataConverter,
+		expectedContext,
+	).ToPayload("standalone-result")
+	require.NoError(t, err)
+
+	service.EXPECT().
+		StartNexusOperationExecution(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(
+			_ context.Context,
+			request *workflowservice.StartNexusOperationExecutionRequest,
+			_ ...grpc.CallOption,
+		) (*workflowservice.StartNexusOperationExecutionResponse, error) {
+			require.Equal(t, "standalone-endpoint:standalone-service:standalone-operation", string(request.Input.Metadata["ctx-signature"]))
+			require.Empty(t, request.UserMetadata.GetSummary().Metadata["ctx-signature"])
+			return &workflowservice.StartNexusOperationExecutionResponse{RunId: "standalone-run-id"}, nil
+		})
+	service.EXPECT().
+		PollNexusOperationExecution(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(&workflowservice.PollNexusOperationExecutionResponse{
+			Outcome: &workflowservice.PollNexusOperationExecutionResponse_Result{
+				Result: resultPayload,
+			},
+		}, nil)
+
+	nexusClient, err := client.NewNexusClient(ClientNexusClientOptions{
+		Endpoint: expectedContext.Endpoint,
+		Service:  expectedContext.Service,
+	})
+	require.NoError(t, err)
+	handle, err := nexusClient.ExecuteOperation(
+		t.Context(),
+		expectedContext.Operation,
+		"standalone-input",
+		ClientStartNexusOperationOptions{
+			ID:      "standalone-operation-id",
+			Summary: "standalone-summary",
+		},
+	)
+	require.NoError(t, err)
+
+	var result string
+	require.NoError(t, handle.Get(t.Context(), &result))
+	require.Equal(t, "standalone-result", result)
+}
+
+func TestStandaloneNexusSerializationContextFailure(t *testing.T) {
+	service := workflowservicemock.NewMockWorkflowServiceClient(gomock.NewController(t))
+	failureConverter := newNexusCapturingFailureConverter()
+	client := NewServiceClient(service, nil, ClientOptions{FailureConverter: failureConverter})
+	client.capabilities = &workflowservice.GetSystemInfoResponse_Capabilities{}
+
+	expectedContext := converter.NexusSerializationContext{
+		Endpoint:  "failure-endpoint",
+		Service:   "failure-service",
+		Operation: "failure-operation",
+	}
+	failure := GetDefaultFailureConverter().ErrorToFailure(
+		NewApplicationError("operation failed", "FailureType", true, nil),
+	)
+	service.EXPECT().
+		StartNexusOperationExecution(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(&workflowservice.StartNexusOperationExecutionResponse{RunId: "failure-run-id"}, nil)
+	service.EXPECT().
+		PollNexusOperationExecution(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(&workflowservice.PollNexusOperationExecutionResponse{
+			Outcome: &workflowservice.PollNexusOperationExecutionResponse_Failure{
+				Failure: failure,
+			},
+		}, nil)
+
+	nexusClient, err := client.NewNexusClient(ClientNexusClientOptions{
+		Endpoint: expectedContext.Endpoint,
+		Service:  expectedContext.Service,
+	})
+	require.NoError(t, err)
+	handle, err := nexusClient.ExecuteOperation(
+		t.Context(),
+		expectedContext.Operation,
+		"input",
+		ClientStartNexusOperationOptions{ID: "failure-operation-id"},
+	)
+	require.NoError(t, err)
+	require.Error(t, handle.Get(t.Context(), nil))
+	require.Equal(t, []nexusFailureConversion{{
+		context:   expectedContext,
+		direction: "decode",
+	}}, failureConverter.captured())
+}
+
+func TestStandaloneNexusSerializationContextDetachedHandle(t *testing.T) {
+	service := workflowservicemock.NewMockWorkflowServiceClient(gomock.NewController(t))
+	dataConverter := converter.NewCodecDataConverter(
+		converter.GetDefaultDataConverter(),
+		&serCtxSigningCodec{},
+	)
+	client := NewServiceClient(service, nil, ClientOptions{DataConverter: dataConverter})
+	client.capabilities = &workflowservice.GetSystemInfoResponse_Capabilities{}
+
+	expectedContext := converter.NexusSerializationContext{
+		Endpoint:  "detached-endpoint",
+		Service:   "detached-service",
+		Operation: "detached-operation",
+	}
+	resultPayload, err := converter.WithDataConverterSerializationContext(
+		dataConverter,
+		expectedContext,
+	).ToPayload("detached-result")
+	require.NoError(t, err)
+
+	service.EXPECT().
+		DescribeNexusOperationExecution(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(&workflowservice.DescribeNexusOperationExecutionResponse{
+			Info: &nexuspb.NexusOperationExecutionInfo{
+				OperationId: "detached-operation-id",
+				RunId:       "resolved-run-id",
+				Endpoint:    expectedContext.Endpoint,
+				Service:     expectedContext.Service,
+				Operation:   expectedContext.Operation,
+			},
+		}, nil)
+	service.EXPECT().
+		PollNexusOperationExecution(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(
+			_ context.Context,
+			request *workflowservice.PollNexusOperationExecutionRequest,
+			_ ...grpc.CallOption,
+		) (*workflowservice.PollNexusOperationExecutionResponse, error) {
+			require.Equal(t, "resolved-run-id", request.RunId)
+			return &workflowservice.PollNexusOperationExecutionResponse{
+				Outcome: &workflowservice.PollNexusOperationExecutionResponse_Result{
+					Result: resultPayload,
+				},
+			}, nil
+		})
+
+	handle := client.GetNexusOperationHandle(ClientGetNexusOperationHandleOptions{
+		OperationID: "detached-operation-id",
+	})
+	var result string
+	require.NoError(t, handle.Get(t.Context(), &result))
+	require.Equal(t, "detached-result", result)
+	require.Empty(t, handle.GetRunID())
+}
+
+func TestStandaloneNexusSerializationContextUseExisting(t *testing.T) {
+	service := workflowservicemock.NewMockWorkflowServiceClient(gomock.NewController(t))
+	dataConverter := converter.NewCodecDataConverter(
+		converter.GetDefaultDataConverter(),
+		&serCtxSigningCodec{},
+	)
+	client := NewServiceClient(service, nil, ClientOptions{DataConverter: dataConverter})
+	client.capabilities = &workflowservice.GetSystemInfoResponse_Capabilities{}
+
+	existingContext := converter.NexusSerializationContext{
+		Endpoint:  "existing-endpoint",
+		Service:   "existing-service",
+		Operation: "existing-operation",
+	}
+	resultPayload, err := converter.WithDataConverterSerializationContext(
+		dataConverter,
+		existingContext,
+	).ToPayload("existing-result")
+	require.NoError(t, err)
+
+	service.EXPECT().
+		StartNexusOperationExecution(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(&workflowservice.StartNexusOperationExecutionResponse{
+			RunId:   "existing-run-id",
+			Started: false,
+		}, nil)
+	service.EXPECT().
+		DescribeNexusOperationExecution(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(&workflowservice.DescribeNexusOperationExecutionResponse{
+			Info: &nexuspb.NexusOperationExecutionInfo{
+				OperationId: "existing-operation-id",
+				RunId:       "existing-run-id",
+				Endpoint:    existingContext.Endpoint,
+				Service:     existingContext.Service,
+				Operation:   existingContext.Operation,
+			},
+		}, nil)
+	service.EXPECT().
+		PollNexusOperationExecution(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(&workflowservice.PollNexusOperationExecutionResponse{
+			Outcome: &workflowservice.PollNexusOperationExecutionResponse_Result{
+				Result: resultPayload,
+			},
+		}, nil)
+
+	nexusClient, err := client.NewNexusClient(ClientNexusClientOptions{
+		Endpoint: "requested-endpoint",
+		Service:  "requested-service",
+	})
+	require.NoError(t, err)
+	handle, err := nexusClient.ExecuteOperation(
+		t.Context(),
+		"requested-operation",
+		"input",
+		ClientStartNexusOperationOptions{
+			ID:               "existing-operation-id",
+			IDConflictPolicy: enumspb.NEXUS_OPERATION_ID_CONFLICT_POLICY_USE_EXISTING,
+		},
+	)
+	require.NoError(t, err)
+
+	var result string
+	require.NoError(t, handle.Get(t.Context(), &result))
+	require.Equal(t, "existing-result", result)
+}
+
+func TestStandaloneNexusSerializationContextDescribeFailures(t *testing.T) {
+	service := workflowservicemock.NewMockWorkflowServiceClient(gomock.NewController(t))
+	failureConverter := newNexusCapturingFailureConverter()
+	client := NewServiceClient(service, nil, ClientOptions{FailureConverter: failureConverter})
+	client.capabilities = &workflowservice.GetSystemInfoResponse_Capabilities{}
+
+	expectedContext := converter.NexusSerializationContext{
+		Endpoint:  "describe-endpoint",
+		Service:   "describe-service",
+		Operation: "describe-operation",
+	}
+	failure := GetDefaultFailureConverter().ErrorToFailure(
+		NewApplicationError("attempt failed", "AttemptFailureType", true, nil),
+	)
+	service.EXPECT().
+		DescribeNexusOperationExecution(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(&workflowservice.DescribeNexusOperationExecutionResponse{
+			Info: &nexuspb.NexusOperationExecutionInfo{
+				OperationId:        "describe-operation-id",
+				RunId:              "describe-run-id",
+				Endpoint:           expectedContext.Endpoint,
+				Service:            expectedContext.Service,
+				Operation:          expectedContext.Operation,
+				LastAttemptFailure: failure,
+				CancellationInfo: &nexuspb.NexusOperationExecutionCancellationInfo{
+					LastAttemptFailure: failure,
+				},
+			},
+		}, nil)
+
+	handle := client.GetNexusOperationHandle(ClientGetNexusOperationHandleOptions{
+		OperationID: "describe-operation-id",
+		RunID:       "describe-run-id",
+	})
+	description, err := handle.Describe(t.Context(), ClientDescribeNexusOperationOptions{})
+	require.NoError(t, err)
+	require.Error(t, description.GetLastAttemptFailure())
+	require.Error(t, description.CancellationInfo.GetLastAttemptFailure())
+	require.Equal(t, []nexusFailureConversion{
+		{context: expectedContext, direction: "decode"},
+		{context: expectedContext, direction: "decode"},
+	}, failureConverter.captured())
 }
 
 type nexusEventFailureConverter struct {

--- a/internal/nexus_serialization_context_test.go
+++ b/internal/nexus_serialization_context_test.go
@@ -19,6 +19,7 @@ import (
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/api/workflowservicemock/v1"
 	"go.temporal.io/sdk/converter"
+	"go.temporal.io/sdk/internal/common/metrics"
 	ilog "go.temporal.io/sdk/internal/log"
 	"google.golang.org/grpc"
 )
@@ -168,6 +169,158 @@ func (c *nexusCapturingFailureConverter) captured() []nexusFailureConversion {
 	result := make([]nexusFailureConversion, len(*c.conversions))
 	copy(result, *c.conversions)
 	return result
+}
+
+func TestNexusTaskHandlerSerializationContextInputAndSyncResult(t *testing.T) {
+	expectedContext := converter.NexusSerializationContext{
+		Endpoint:  "handler-endpoint",
+		Service:   "handler-service",
+		Operation: "handler-operation",
+	}
+	dataConverter := converter.NewCodecDataConverter(
+		converter.GetDefaultDataConverter(),
+		&serCtxSigningCodec{},
+	)
+	contextualDataConverter := converter.WithDataConverterSerializationContext(dataConverter, expectedContext)
+	inputPayload, err := contextualDataConverter.ToPayload("handler-input")
+	require.NoError(t, err)
+
+	operation := nexus.NewSyncOperation(
+		expectedContext.Operation,
+		func(_ context.Context, input string, _ nexus.StartOperationOptions) (string, error) {
+			require.Equal(t, "handler-input", input)
+			return "handler-result", nil
+		},
+	)
+	service := nexus.NewService(expectedContext.Service)
+	require.NoError(t, service.Register(operation))
+	registry := nexus.NewServiceRegistry()
+	require.NoError(t, registry.Register(service))
+	registry.Use(nexusMiddleware(nil))
+	handler, err := registry.NewHandler()
+	require.NoError(t, err)
+
+	taskHandler := newNexusTaskHandler(
+		handler,
+		"identity",
+		"namespace",
+		"task-queue",
+		nil,
+		dataConverter,
+		GetDefaultFailureConverter(),
+		ilog.NewNopLogger(),
+		metrics.NopHandler,
+		newRegistry(),
+	)
+	completed, failed, err := taskHandler.Execute(&workflowservice.PollNexusTaskQueueResponse{
+		TaskToken: []byte("task-token"),
+		Request: &nexuspb.Request{
+			Endpoint: expectedContext.Endpoint,
+			Variant: &nexuspb.Request_StartOperation{
+				StartOperation: &nexuspb.StartOperationRequest{
+					Service:   expectedContext.Service,
+					Operation: expectedContext.Operation,
+					Payload:   inputPayload,
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Nil(t, failed)
+
+	resultPayload := completed.GetResponse().GetStartOperation().GetSyncSuccess().GetPayload()
+	require.Equal(t, "handler-endpoint:handler-service:handler-operation", string(resultPayload.Metadata["ctx-signature"]))
+	var result string
+	require.NoError(t, contextualDataConverter.FromPayload(resultPayload, &result))
+	require.Equal(t, "handler-result", result)
+}
+
+func TestNexusTaskHandlerFailureSerializationContext(t *testing.T) {
+	expectedContext := converter.NexusSerializationContext{
+		Endpoint:  "handler-endpoint",
+		Service:   "handler-service",
+		Operation: "handler-operation",
+	}
+	inputPayload, err := converter.GetDefaultDataConverter().ToPayload("handler-input")
+	require.NoError(t, err)
+
+	tests := []struct {
+		name             string
+		err              error
+		expectCompletion bool
+	}{
+		{
+			name:             "operation failure",
+			err:              nexus.NewOperationFailedErrorf("operation failed"),
+			expectCompletion: true,
+		},
+		{
+			name: "handler failure",
+			err: &nexus.HandlerError{
+				Type:  nexus.HandlerErrorTypeBadRequest,
+				Cause: errors.New("handler failed"),
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			failureConverter := newNexusCapturingFailureConverter()
+			operation := nexus.NewSyncOperation(
+				expectedContext.Operation,
+				func(context.Context, string, nexus.StartOperationOptions) (string, error) {
+					return "", test.err
+				},
+			)
+			service := nexus.NewService(expectedContext.Service)
+			require.NoError(t, service.Register(operation))
+			registry := nexus.NewServiceRegistry()
+			require.NoError(t, registry.Register(service))
+			registry.Use(nexusMiddleware(nil))
+			handler, err := registry.NewHandler()
+			require.NoError(t, err)
+
+			taskHandler := newNexusTaskHandler(
+				handler,
+				"identity",
+				"namespace",
+				"task-queue",
+				nil,
+				converter.GetDefaultDataConverter(),
+				failureConverter,
+				ilog.NewNopLogger(),
+				metrics.NopHandler,
+				newRegistry(),
+			)
+			completed, failed, err := taskHandler.Execute(&workflowservice.PollNexusTaskQueueResponse{
+				TaskToken: []byte("task-token"),
+				Request: &nexuspb.Request{
+					Endpoint: expectedContext.Endpoint,
+					Capabilities: &nexuspb.Request_Capabilities{
+						TemporalFailureResponses: true,
+					},
+					Variant: &nexuspb.Request_StartOperation{
+						StartOperation: &nexuspb.StartOperationRequest{
+							Service:   expectedContext.Service,
+							Operation: expectedContext.Operation,
+							Payload:   inputPayload,
+						},
+					},
+				},
+			})
+			require.NoError(t, err)
+			if test.expectCompletion {
+				require.NotNil(t, completed)
+				require.Nil(t, failed)
+			} else {
+				require.Nil(t, completed)
+				require.NotNil(t, failed)
+			}
+			require.Equal(t, []nexusFailureConversion{{
+				context:   expectedContext,
+				direction: "encode",
+			}}, failureConverter.captured())
+		})
+	}
 }
 
 func TestNexusSerializationContextFailureConverterInTestEnvironment(t *testing.T) {

--- a/internal/nexus_serialization_context_test.go
+++ b/internal/nexus_serialization_context_test.go
@@ -458,37 +458,15 @@ func TestStandaloneNexusSerializationContextFailure(t *testing.T) {
 	}}, failureConverter.captured())
 }
 
-func TestStandaloneNexusSerializationContextDetachedHandle(t *testing.T) {
+func TestStandaloneNexusDetachedHandleDoesNotDescribe(t *testing.T) {
 	service := workflowservicemock.NewMockWorkflowServiceClient(gomock.NewController(t))
-	dataConverter := converter.NewCodecDataConverter(
-		converter.GetDefaultDataConverter(),
-		&serCtxSigningCodec{},
-	)
+	dataConverter := converter.GetDefaultDataConverter()
 	client := NewServiceClient(service, nil, ClientOptions{DataConverter: dataConverter})
 	client.capabilities = &workflowservice.GetSystemInfoResponse_Capabilities{}
 
-	expectedContext := converter.NexusSerializationContext{
-		Endpoint:  "detached-endpoint",
-		Service:   "detached-service",
-		Operation: "detached-operation",
-	}
-	resultPayload, err := converter.WithDataConverterSerializationContext(
-		dataConverter,
-		expectedContext,
-	).ToPayload("detached-result")
+	resultPayload, err := dataConverter.ToPayload("detached-result")
 	require.NoError(t, err)
 
-	service.EXPECT().
-		DescribeNexusOperationExecution(gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(&workflowservice.DescribeNexusOperationExecutionResponse{
-			Info: &nexuspb.NexusOperationExecutionInfo{
-				OperationId: "detached-operation-id",
-				RunId:       "resolved-run-id",
-				Endpoint:    expectedContext.Endpoint,
-				Service:     expectedContext.Service,
-				Operation:   expectedContext.Operation,
-			},
-		}, nil)
 	service.EXPECT().
 		PollNexusOperationExecution(gomock.Any(), gomock.Any(), gomock.Any()).
 		DoAndReturn(func(
@@ -496,7 +474,7 @@ func TestStandaloneNexusSerializationContextDetachedHandle(t *testing.T) {
 			request *workflowservice.PollNexusOperationExecutionRequest,
 			_ ...grpc.CallOption,
 		) (*workflowservice.PollNexusOperationExecutionResponse, error) {
-			require.Equal(t, "resolved-run-id", request.RunId)
+			require.Empty(t, request.RunId)
 			return &workflowservice.PollNexusOperationExecutionResponse{
 				Outcome: &workflowservice.PollNexusOperationExecutionResponse_Result{
 					Result: resultPayload,
@@ -522,14 +500,14 @@ func TestStandaloneNexusSerializationContextUseExisting(t *testing.T) {
 	client := NewServiceClient(service, nil, ClientOptions{DataConverter: dataConverter})
 	client.capabilities = &workflowservice.GetSystemInfoResponse_Capabilities{}
 
-	existingContext := converter.NexusSerializationContext{
-		Endpoint:  "existing-endpoint",
-		Service:   "existing-service",
-		Operation: "existing-operation",
+	requestContext := converter.NexusSerializationContext{
+		Endpoint:  "requested-endpoint",
+		Service:   "requested-service",
+		Operation: "requested-operation",
 	}
 	resultPayload, err := converter.WithDataConverterSerializationContext(
 		dataConverter,
-		existingContext,
+		requestContext,
 	).ToPayload("existing-result")
 	require.NoError(t, err)
 
@@ -540,17 +518,6 @@ func TestStandaloneNexusSerializationContextUseExisting(t *testing.T) {
 			Started: false,
 		}, nil)
 	service.EXPECT().
-		DescribeNexusOperationExecution(gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(&workflowservice.DescribeNexusOperationExecutionResponse{
-			Info: &nexuspb.NexusOperationExecutionInfo{
-				OperationId: "existing-operation-id",
-				RunId:       "existing-run-id",
-				Endpoint:    existingContext.Endpoint,
-				Service:     existingContext.Service,
-				Operation:   existingContext.Operation,
-			},
-		}, nil)
-	service.EXPECT().
 		PollNexusOperationExecution(gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(&workflowservice.PollNexusOperationExecutionResponse{
 			Outcome: &workflowservice.PollNexusOperationExecutionResponse_Result{
@@ -559,13 +526,13 @@ func TestStandaloneNexusSerializationContextUseExisting(t *testing.T) {
 		}, nil)
 
 	nexusClient, err := client.NewNexusClient(ClientNexusClientOptions{
-		Endpoint: "requested-endpoint",
-		Service:  "requested-service",
+		Endpoint: requestContext.Endpoint,
+		Service:  requestContext.Service,
 	})
 	require.NoError(t, err)
 	handle, err := nexusClient.ExecuteOperation(
 		t.Context(),
-		"requested-operation",
+		requestContext.Operation,
 		"input",
 		ClientStartNexusOperationOptions{
 			ID:               "existing-operation-id",

--- a/internal/serialization_context_test.go
+++ b/internal/serialization_context_test.go
@@ -29,6 +29,8 @@ func (c *serCtxSigningCodec) WithSerializationContext(ctx converter.Serializatio
 		return &serCtxSigningCodec{signature: sc.WorkflowID}
 	case converter.ActivitySerializationContext:
 		return &serCtxSigningCodec{signature: sc.WorkflowID + ":" + sc.ActivityType}
+	case converter.NexusSerializationContext:
+		return &serCtxSigningCodec{signature: sc.Endpoint + ":" + sc.Service + ":" + sc.Operation}
 	}
 	return c
 }

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -3134,6 +3134,7 @@ func (wc *workflowEnvironmentInterceptor) prepareNexusOperationParams(ctx Contex
 		return ExecuteNexusOperationParams{}, fmt.Errorf("invalid 'operation' parameter, must be an OperationReference or a string")
 	}
 
+	// Nexus context and data converters.
 	nsc := converter.NexusSerializationContext{
 		Endpoint:  input.Client.Endpoint(),
 		Service:   input.Client.Service(),

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -3118,8 +3118,6 @@ func (c nexusClient) ExecuteOperation(ctx Context, operation any, input any, opt
 }
 
 func (wc *workflowEnvironmentInterceptor) prepareNexusOperationParams(ctx Context, input ExecuteNexusOperationInput) (ExecuteNexusOperationParams, error) {
-	dc := WithWorkflowContext(ctx, wc.env.GetDataConverter())
-
 	var ok bool
 	var operationName string
 	if operationName, ok = input.Operation.(string); ok {
@@ -3136,6 +3134,14 @@ func (wc *workflowEnvironmentInterceptor) prepareNexusOperationParams(ctx Contex
 		return ExecuteNexusOperationParams{}, fmt.Errorf("invalid 'operation' parameter, must be an OperationReference or a string")
 	}
 
+	nsc := converter.NexusSerializationContext{
+		Endpoint:  input.Client.Endpoint(),
+		Service:   input.Client.Service(),
+		Operation: operationName,
+	}
+	dc := withRootDataConverterSerializationContext(ctx, nsc)
+	fc := converter.WithFailureConverterSerializationContext(getRootFailureConverterFromWorkflowContext(ctx), nsc)
+
 	payload, err := dc.ToPayload(input.Input)
 	if err != nil {
 		return ExecuteNexusOperationParams{}, err
@@ -3146,11 +3152,13 @@ func (wc *workflowEnvironmentInterceptor) prepareNexusOperationParams(ctx Contex
 	}
 
 	return ExecuteNexusOperationParams{
-		client:      input.Client,
-		operation:   operationName,
-		input:       payload,
-		options:     input.Options,
-		nexusHeader: input.NexusHeader,
+		client:           input.Client,
+		operation:        operationName,
+		input:            payload,
+		options:          input.Options,
+		nexusHeader:      input.NexusHeader,
+		dataConverter:    dc,
+		failureConverter: fc,
 	}, nil
 }
 
@@ -3178,6 +3186,7 @@ func (wc *workflowEnvironmentInterceptor) ExecuteNexusOperation(ctx Context, inp
 		mainSettable.Set(nil, err)
 		return result
 	}
+	result.dataConverter = params.dataConverter
 
 	var operationToken string
 	seq := wc.env.ExecuteNexusOperation(params, func(r *commonpb.Payload, e error) {

--- a/test/replaytests/replay_test.go
+++ b/test/replaytests/replay_test.go
@@ -24,6 +24,63 @@ type replayTestSigningCodec struct {
 	signature string
 }
 
+type replayNexusLegacyFallbackCodecState struct {
+	legacyDecodedContexts []converter.NexusSerializationContext
+}
+
+type replayNexusLegacyFallbackCodec struct {
+	state   *replayNexusLegacyFallbackCodecState
+	context *converter.NexusSerializationContext
+}
+
+func (c *replayNexusLegacyFallbackCodec) WithSerializationContext(
+	ctx converter.SerializationContext,
+) converter.PayloadCodec {
+	nexusCtx, ok := ctx.(converter.NexusSerializationContext)
+	if !ok {
+		return c
+	}
+	return &replayNexusLegacyFallbackCodec{state: c.state, context: &nexusCtx}
+}
+
+func (c *replayNexusLegacyFallbackCodec) Encode(payloads []*commonpb.Payload) ([]*commonpb.Payload, error) {
+	if c.context == nil {
+		return payloads, nil
+	}
+	result := make([]*commonpb.Payload, len(payloads))
+	for i, payload := range payloads {
+		result[i] = proto.Clone(payload).(*commonpb.Payload)
+		if result[i].Metadata == nil {
+			result[i].Metadata = make(map[string][]byte)
+		}
+		result[i].Metadata["nexus-context"] = []byte(
+			c.context.Endpoint + ":" + c.context.Service + ":" + c.context.Operation,
+		)
+	}
+	return result, nil
+}
+
+func (c *replayNexusLegacyFallbackCodec) Decode(payloads []*commonpb.Payload) ([]*commonpb.Payload, error) {
+	if c.context == nil {
+		return payloads, nil
+	}
+	result := make([]*commonpb.Payload, len(payloads))
+	for i, payload := range payloads {
+		result[i] = proto.Clone(payload).(*commonpb.Payload)
+		signature, ok := result[i].Metadata["nexus-context"]
+		if !ok {
+			c.state.legacyDecodedContexts = append(c.state.legacyDecodedContexts, *c.context)
+			continue
+		}
+		expected := c.context.Endpoint + ":" + c.context.Service + ":" + c.context.Operation
+		if string(signature) != expected {
+			return nil, fmt.Errorf("Nexus context mismatch: got %q, want %q", signature, expected)
+		}
+		delete(result[i].Metadata, "nexus-context")
+	}
+	return result, nil
+}
+
 func (c *replayTestSigningCodec) WithSerializationContext(ctx converter.SerializationContext) converter.PayloadCodec {
 	switch sc := ctx.(type) {
 	case converter.WorkflowSerializationContext:
@@ -607,6 +664,30 @@ func (s *replayTestSuite) TestCancelNexusOperation() {
 	replayer.RegisterWorkflow(CancelNexusOperationAfterCompleteWorkflow)
 	err = replayer.ReplayWorkflowHistoryFromJSONFile(ilog.NewDefaultLogger(), "nexus-cancel-after-complete.json")
 	s.NoErrorf(err, "Encountered error replaying cancel after Nexus operation is completed")
+}
+
+func (s *replayTestSuite) TestNexusSerializationContextReplayWithLegacyFallback() {
+	state := &replayNexusLegacyFallbackCodecState{}
+	codecDC := converter.NewCodecDataConverter(
+		converter.GetDefaultDataConverter(),
+		&replayNexusLegacyFallbackCodec{state: state},
+	)
+	replayer, err := worker.NewWorkflowReplayerWithOptions(worker.WorkflowReplayerOptions{
+		DataConverter: codecDC,
+	})
+	s.Require().NoError(err)
+	replayer.RegisterWorkflow(CancelNexusOperationAfterCompleteWorkflow)
+
+	err = replayer.ReplayWorkflowHistoryFromJSONFile(
+		ilog.NewDefaultLogger(),
+		"nexus-cancel-after-complete.json",
+	)
+	s.Require().NoError(err)
+	s.Contains(state.legacyDecodedContexts, converter.NexusSerializationContext{
+		Endpoint:  "replay-endpoint",
+		Service:   "replay-service",
+		Operation: CancelOp.Name(),
+	})
 }
 
 func (s *replayTestSuite) TestAwaitWithTimeoutNoTimerCancel() {

--- a/test/replaytests/workflows.go
+++ b/test/replaytests/workflows.go
@@ -765,7 +765,10 @@ func CancelNexusOperationAfterCompleteWorkflow(ctx workflow.Context) (string, er
 	nc := workflow.NewNexusClient("replay-endpoint", "replay-service")
 	opCtx, cancel := workflow.WithCancel(ctx)
 	op := nc.ExecuteOperation(opCtx, CancelOp, "succeed", workflow.NexusOperationOptions{})
-	_ = op.Get(opCtx, nil)
+	var result any
+	if err := op.Get(opCtx, &result); err != nil {
+		return "", err
+	}
 	cancel()
 	return generateUUID(ctx, "nxs-cancel-after-complete-id")
 }

--- a/test/serialization_context_test.go
+++ b/test/serialization_context_test.go
@@ -6,11 +6,17 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
+	"github.com/nexus-rpc/sdk-go/nexus"
 	commonpb "go.temporal.io/api/common/v1"
+	failurepb "go.temporal.io/api/failure/v1"
+	nexuspb "go.temporal.io/api/nexus/v1"
+	operatorservice "go.temporal.io/api/operatorservice/v1"
 	"google.golang.org/protobuf/proto"
 
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/converter"
+	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/worker"
 	"go.temporal.io/sdk/workflow"
 )
@@ -132,4 +138,237 @@ func (ts *IntegrationTestSuite) TestSerializationContext_EndToEnd() {
 	var result string
 	ts.NoError(run.Get(ctx, &result))
 	ts.Equal("side|child:HELLO", result)
+}
+
+type intTestNexusInput struct {
+	Value string
+	Fail  bool
+}
+
+var intTestNexusOperation = nexus.NewSyncOperation(
+	"serialization-context-operation",
+	func(_ context.Context, input intTestNexusInput, _ nexus.StartOperationOptions) (string, error) {
+		if input.Fail {
+			return "", &nexus.OperationError{
+				State:   nexus.OperationStateFailed,
+				Message: "expected Nexus failure",
+				Cause:   fmt.Errorf("expected Nexus failure cause"),
+			}
+		}
+		return input.Value, nil
+	},
+)
+
+type intTestNexusCodec struct {
+	key string
+}
+
+func (c *intTestNexusCodec) WithSerializationContext(ctx converter.SerializationContext) converter.PayloadCodec {
+	switch sc := ctx.(type) {
+	case converter.WorkflowSerializationContext:
+		return &intTestNexusCodec{key: "workflow:" + sc.WorkflowID}
+	case converter.NexusSerializationContext:
+		return &intTestNexusCodec{key: "endpoint:" + sc.Endpoint}
+	default:
+		return c
+	}
+}
+
+func (c *intTestNexusCodec) Encode(payloads []*commonpb.Payload) ([]*commonpb.Payload, error) {
+	result := make([]*commonpb.Payload, len(payloads))
+	for i, payload := range payloads {
+		result[i] = proto.Clone(payload).(*commonpb.Payload)
+		if result[i].Metadata == nil {
+			result[i].Metadata = make(map[string][]byte)
+		}
+		result[i].Metadata["nexus-endpoint-key"] = []byte(c.key)
+	}
+	return result, nil
+}
+
+func (c *intTestNexusCodec) Decode(payloads []*commonpb.Payload) ([]*commonpb.Payload, error) {
+	result := make([]*commonpb.Payload, len(payloads))
+	for i, payload := range payloads {
+		key := string(payload.Metadata["nexus-endpoint-key"])
+		if key != c.key {
+			return nil, fmt.Errorf("Nexus endpoint key mismatch: got %q, want %q", key, c.key)
+		}
+		result[i] = proto.Clone(payload).(*commonpb.Payload)
+		delete(result[i].Metadata, "nexus-endpoint-key")
+	}
+	return result, nil
+}
+
+type intTestNexusFailureConverter struct {
+	converter.FailureConverter
+	key string
+}
+
+func (c *intTestNexusFailureConverter) WithSerializationContext(
+	ctx converter.SerializationContext,
+) converter.FailureConverter {
+	if nexusCtx, ok := ctx.(converter.NexusSerializationContext); ok {
+		return &intTestNexusFailureConverter{
+			FailureConverter: c.FailureConverter,
+			key:              "endpoint:" + nexusCtx.Endpoint,
+		}
+	}
+	return c
+}
+
+func (c *intTestNexusFailureConverter) ErrorToFailure(err error) *failurepb.Failure {
+	failure := c.FailureConverter.ErrorToFailure(err)
+	if failure == nil || c.key == "" {
+		return failure
+	}
+	failure = proto.Clone(failure).(*failurepb.Failure)
+	failure.Source = c.key
+	return failure
+}
+
+func (c *intTestNexusFailureConverter) FailureToError(failure *failurepb.Failure) error {
+	if c.key == "" {
+		return c.FailureConverter.FailureToError(failure)
+	}
+	for current := failure; current != nil; current = current.Cause {
+		if current.Source == c.key {
+			return c.FailureConverter.FailureToError(failure)
+		}
+	}
+	return fmt.Errorf("Nexus failure key mismatch: missing %q", c.key)
+}
+
+func intTestNexusCallerWorkflow(ctx workflow.Context, endpoints []string) (string, error) {
+	first := workflow.NewNexusClient(endpoints[0], "serialization-context-service").ExecuteOperation(
+		ctx,
+		intTestNexusOperation,
+		intTestNexusInput{Value: "first"},
+		workflow.NexusOperationOptions{},
+	)
+	second := workflow.NewNexusClient(endpoints[1], "serialization-context-service").ExecuteOperation(
+		ctx,
+		intTestNexusOperation.Name(),
+		intTestNexusInput{Value: "second"},
+		workflow.NexusOperationOptions{},
+	)
+
+	var results []string
+	var operationErr error
+	selector := workflow.NewSelector(ctx)
+	for _, future := range []workflow.Future{first, second} {
+		selector.AddFuture(future, func(f workflow.Future) {
+			var result string
+			if err := f.Get(ctx, &result); err != nil {
+				operationErr = err
+				return
+			}
+			results = append(results, result)
+		})
+	}
+	for len(results) < 2 && operationErr == nil {
+		selector.Select(ctx)
+	}
+	return strings.Join(results, "|"), operationErr
+}
+
+func intTestNexusFailureWorkflow(ctx workflow.Context, endpoint string) error {
+	return workflow.NewNexusClient(endpoint, "serialization-context-service").ExecuteOperation(
+		ctx,
+		intTestNexusOperation,
+		intTestNexusInput{Fail: true},
+		workflow.NexusOperationOptions{},
+	).Get(ctx, nil)
+}
+
+func (ts *IntegrationTestSuite) TestSerializationContext_NexusCallerEndpointIsolation() {
+	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
+	defer cancel()
+
+	callerDC := converter.NewCodecDataConverter(converter.GetDefaultDataConverter(), &intTestNexusCodec{})
+	callerClient, err := ts.newDefaultClient(func(options *client.Options) {
+		options.DataConverter = callerDC
+		options.FailureConverter = &intTestNexusFailureConverter{
+			FailureConverter: temporal.GetDefaultFailureConverter(),
+		}
+	})
+	ts.NoError(err)
+	defer callerClient.Close()
+
+	endpointNames := []string{"nexus-ser-ctx-a-" + uuid.NewString(), "nexus-ser-ctx-b-" + uuid.NewString()}
+	handlerTaskQueues := []string{"nexus-ser-ctx-handler-a-" + uuid.NewString(), "nexus-ser-ctx-handler-b-" + uuid.NewString()}
+	for i := range endpointNames {
+		response, err := callerClient.OperatorService().CreateNexusEndpoint(ctx, &operatorservice.CreateNexusEndpointRequest{
+			Spec: &nexuspb.EndpointSpec{
+				Name: endpointNames[i],
+				Target: &nexuspb.EndpointTarget{Variant: &nexuspb.EndpointTarget_Worker_{
+					Worker: &nexuspb.EndpointTarget_Worker{
+						Namespace: ts.config.Namespace,
+						TaskQueue: handlerTaskQueues[i],
+					},
+				}},
+			},
+		})
+		ts.NoError(err)
+		defer func(endpoint *nexuspb.Endpoint) {
+			_, _ = callerClient.OperatorService().DeleteNexusEndpoint(ctx, &operatorservice.DeleteNexusEndpointRequest{
+				Id: endpoint.Id, Version: endpoint.Version,
+			})
+		}(response.Endpoint)
+	}
+
+	var handlerWorkers []worker.Worker
+	for i := range endpointNames {
+		handlerDC := converter.NewCodecDataConverter(
+			converter.GetDefaultDataConverter(),
+			&intTestNexusCodec{key: "endpoint:" + endpointNames[i]},
+		)
+		handlerClient, err := ts.newDefaultClient(func(options *client.Options) {
+			options.DataConverter = handlerDC
+			options.FailureConverter = &intTestNexusFailureConverter{
+				FailureConverter: temporal.GetDefaultFailureConverter(),
+				key:              "endpoint:" + endpointNames[i],
+			}
+		})
+		ts.NoError(err)
+		defer handlerClient.Close()
+
+		handlerWorker := worker.New(handlerClient, handlerTaskQueues[i], worker.Options{
+			DisableWorkflowWorker: true,
+		})
+		service := nexus.NewService("serialization-context-service")
+		ts.NoError(service.Register(intTestNexusOperation))
+		handlerWorker.RegisterNexusService(service)
+		ts.NoError(handlerWorker.Start())
+		handlerWorkers = append(handlerWorkers, handlerWorker)
+	}
+	defer func() {
+		for _, handlerWorker := range handlerWorkers {
+			handlerWorker.Stop()
+		}
+	}()
+
+	callerTaskQueue := "nexus-ser-ctx-caller-" + uuid.NewString()
+	callerWorker := worker.New(callerClient, callerTaskQueue, worker.Options{})
+	callerWorker.RegisterWorkflow(intTestNexusCallerWorkflow)
+	callerWorker.RegisterWorkflow(intTestNexusFailureWorkflow)
+	ts.NoError(callerWorker.Start())
+	defer callerWorker.Stop()
+
+	run, err := callerClient.ExecuteWorkflow(ctx, client.StartWorkflowOptions{
+		ID:        "nexus-ser-ctx-caller-" + uuid.NewString(),
+		TaskQueue: callerTaskQueue,
+	}, intTestNexusCallerWorkflow, endpointNames)
+	ts.NoError(err)
+	var result string
+	ts.NoError(run.Get(ctx, &result))
+	ts.ElementsMatch([]string{"first", "second"}, strings.Split(result, "|"))
+
+	failureRun, err := callerClient.ExecuteWorkflow(ctx, client.StartWorkflowOptions{
+		ID:        "nexus-ser-ctx-failure-" + uuid.NewString(),
+		TaskQueue: callerTaskQueue,
+	}, intTestNexusFailureWorkflow, endpointNames[1])
+	ts.NoError(err)
+	err = failureRun.Get(ctx, nil)
+	ts.ErrorContains(err, "expected Nexus failure")
+	ts.NotContains(err.Error(), "Nexus failure key mismatch")
 }

--- a/test/serialization_context_test.go
+++ b/test/serialization_context_test.go
@@ -278,6 +278,8 @@ func intTestNexusCallerWorkflow(ctx workflow.Context, hmacEndpointName, zlibEndp
 }
 
 func (ts *IntegrationTestSuite) TestSerializationContext_NexusCallerEndpointIsolation() {
+	skipOnCloud(ts.T(), cloudRequiresProvisioning, "test creates Nexus endpoints through Operator Service")
+
 	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
 	defer cancel()
 

--- a/test/serialization_context_test.go
+++ b/test/serialization_context_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/nexus-rpc/sdk-go/nexus"
 	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
 	nexuspb "go.temporal.io/api/nexus/v1"
 	operatorservice "go.temporal.io/api/operatorservice/v1"
 	"google.golang.org/protobuf/proto"
@@ -170,7 +171,7 @@ type intTestNexusHMACCodec struct {
 
 const intTestNexusHMACEncoding = "binary/nexus-hmac-test"
 
-func intTestNexusContextKey(endpoint, service, operation string) string {
+func intTestNexusCodecKey(endpoint, service, operation string) string {
 	return "endpoint:" + endpoint + "|service:" + service + "|operation:" + operation
 }
 
@@ -179,7 +180,7 @@ func (c *intTestNexusCodecSelector) WithSerializationContext(ctx converter.Seria
 	if !ok {
 		return c
 	}
-	key := intTestNexusContextKey(sc.Endpoint, sc.Service, sc.Operation)
+	key := intTestNexusCodecKey(sc.Endpoint, sc.Service, sc.Operation)
 	// Select payload codec based on the Nexus service, endpoint, and operation.
 	if codec, ok := c.codecs[key]; ok {
 		return codec
@@ -242,39 +243,35 @@ func (c *intTestNexusHMACCodec) Decode(payloads []*commonpb.Payload) ([]*commonp
 	return result, nil
 }
 
-func intTestNexusCallerWorkflow(ctx workflow.Context, hmacEndpointName, zlibEndpointName string) (string, error) {
+type intTestNexusCallerResult struct {
+	HMAC string
+	Zlib string
+}
+
+func intTestNexusCallerWorkflow(ctx workflow.Context, hmacEndpointName, zlibEndpointName string) (intTestNexusCallerResult, error) {
 	// Schedule both operations before awaiting either result. Each future must
 	// retain the converter selected for its own Nexus operation context.
 	hmacFuture := workflow.NewNexusClient(hmacEndpointName, intTestNexusService).ExecuteOperation(
 		ctx,
 		intTestNexusOperation,
-		intTestNexusInput{Value: "hmac"},
+		intTestNexusInput{Value: "result"},
 		workflow.NexusOperationOptions{},
 	)
 	zlibFuture := workflow.NewNexusClient(zlibEndpointName, intTestNexusService).ExecuteOperation(
 		ctx,
 		intTestNexusOperation.Name(),
-		intTestNexusInput{Value: "zlib"},
+		intTestNexusInput{Value: "result"},
 		workflow.NexusOperationOptions{},
 	)
 
-	var results []string
-	var operationErr error
-	selector := workflow.NewSelector(ctx)
-	handleFuture := func(f workflow.Future) {
-		var result string
-		if err := f.Get(ctx, &result); err != nil {
-			operationErr = err
-			return
-		}
-		results = append(results, result)
+	var result intTestNexusCallerResult
+	if err := hmacFuture.Get(ctx, &result.HMAC); err != nil {
+		return result, err
 	}
-	selector.AddFuture(hmacFuture, handleFuture)
-	selector.AddFuture(zlibFuture, handleFuture)
-	for len(results) < 2 && operationErr == nil {
-		selector.Select(ctx)
+	if err := zlibFuture.Get(ctx, &result.Zlib); err != nil {
+		return result, err
 	}
-	return strings.Join(results, "|"), operationErr
+	return result, nil
 }
 
 func (ts *IntegrationTestSuite) TestSerializationContext_NexusCallerEndpointIsolation() {
@@ -288,8 +285,8 @@ func (ts *IntegrationTestSuite) TestSerializationContext_NexusCallerEndpointIsol
 	hmacCodec := &intTestNexusHMACCodec{key: []byte("nexus-hmac-key")}
 	zlibCodec := converter.NewZlibCodec(converter.ZlibCodecOptions{AlwaysEncode: true})
 	codecSelector := &intTestNexusCodecSelector{codecs: map[string]converter.PayloadCodec{
-		intTestNexusContextKey(hmacEndpointName, intTestNexusService, intTestNexusOperation.Name()): hmacCodec,
-		intTestNexusContextKey(zlibEndpointName, intTestNexusService, intTestNexusOperation.Name()): zlibCodec,
+		intTestNexusCodecKey(hmacEndpointName, intTestNexusService, intTestNexusOperation.Name()): hmacCodec,
+		intTestNexusCodecKey(zlibEndpointName, intTestNexusService, intTestNexusOperation.Name()): zlibCodec,
 	}}
 
 	callerDC := converter.NewCodecDataConverter(converter.GetDefaultDataConverter(), codecSelector)
@@ -375,7 +372,36 @@ func (ts *IntegrationTestSuite) TestSerializationContext_NexusCallerEndpointIsol
 		TaskQueue: callerTaskQueue,
 	}, intTestNexusCallerWorkflow, hmacEndpointName, zlibEndpointName)
 	ts.NoError(err)
-	var result string
+	var result intTestNexusCallerResult
 	ts.NoError(run.Get(ctx, &result))
-	ts.ElementsMatch([]string{"hmac", "zlib"}, strings.Split(result, "|"))
+	// Both endpoint-specific codecs must decode the same logical result.
+	ts.Equal(intTestNexusCallerResult{HMAC: "result", Zlib: "result"}, result)
+
+	// Compare the raw results in history to verify that the same logical value
+	// was encoded differently for each endpoint.
+	scheduledEndpoints := map[int64]string{}
+	encodedResults := map[string]*commonpb.Payload{}
+	history := callerClient.GetWorkflowHistory(
+		ctx, run.GetID(), run.GetRunID(), false, enumspb.HISTORY_EVENT_FILTER_TYPE_ALL_EVENT,
+	)
+	for history.HasNext() {
+		event, err := history.Next()
+		ts.Require().NoError(err)
+		switch event.GetEventType() {
+		case enumspb.EVENT_TYPE_NEXUS_OPERATION_SCHEDULED:
+			scheduledEndpoints[event.GetEventId()] = event.GetNexusOperationScheduledEventAttributes().GetEndpoint()
+		case enumspb.EVENT_TYPE_NEXUS_OPERATION_COMPLETED:
+			attrs := event.GetNexusOperationCompletedEventAttributes()
+			encodedResults[scheduledEndpoints[attrs.GetScheduledEventId()]] = attrs.GetResult()
+		}
+	}
+	hmacEncodedResult := encodedResults[hmacEndpointName]
+	zlibEncodedResult := encodedResults[zlibEndpointName]
+	ts.Require().NotNil(hmacEncodedResult)
+	ts.Require().NotNil(zlibEncodedResult)
+	// Each endpoint must use the codec selected from its Nexus context.
+	ts.Equal(intTestNexusHMACEncoding, string(hmacEncodedResult.Metadata[converter.MetadataEncoding]))
+	ts.Equal("binary/zlib", string(zlibEncodedResult.Metadata[converter.MetadataEncoding]))
+	// HMAC and zlib must produce different bytes for the same input.
+	ts.NotEqual(hmacEncodedResult.Data, zlibEncodedResult.Data)
 }

--- a/test/serialization_context_test.go
+++ b/test/serialization_context_test.go
@@ -2,6 +2,9 @@ package test_test
 
 import (
 	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -9,14 +12,12 @@ import (
 	"github.com/google/uuid"
 	"github.com/nexus-rpc/sdk-go/nexus"
 	commonpb "go.temporal.io/api/common/v1"
-	failurepb "go.temporal.io/api/failure/v1"
 	nexuspb "go.temporal.io/api/nexus/v1"
 	operatorservice "go.temporal.io/api/operatorservice/v1"
 	"google.golang.org/protobuf/proto"
 
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/converter"
-	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/worker"
 	"go.temporal.io/sdk/workflow"
 )
@@ -142,233 +143,237 @@ func (ts *IntegrationTestSuite) TestSerializationContext_EndToEnd() {
 
 type intTestNexusInput struct {
 	Value string
-	Fail  bool
 }
 
+const (
+	intTestNexusService       = "serialization-context-service"
+	intTestNexusOperationName = "serialization-context-operation"
+)
+
 var intTestNexusOperation = nexus.NewSyncOperation(
-	"serialization-context-operation",
+	intTestNexusOperationName,
 	func(_ context.Context, input intTestNexusInput, _ nexus.StartOperationOptions) (string, error) {
-		if input.Fail {
-			return "", &nexus.OperationError{
-				State:   nexus.OperationStateFailed,
-				Message: "expected Nexus failure",
-				Cause:   fmt.Errorf("expected Nexus failure cause"),
-			}
-		}
 		return input.Value, nil
 	},
 )
 
-type intTestNexusCodec struct {
-	key string
+// intTestNexusCodecSelector selects a codec using the endpoint, service, and
+// resolved operation name. It passes through non-Nexus payloads unchanged.
+type intTestNexusCodecSelector struct {
+	codecs map[string]converter.PayloadCodec
+	err    error
 }
 
-func (c *intTestNexusCodec) WithSerializationContext(ctx converter.SerializationContext) converter.PayloadCodec {
-	switch sc := ctx.(type) {
-	case converter.WorkflowSerializationContext:
-		return &intTestNexusCodec{key: "workflow:" + sc.WorkflowID}
-	case converter.NexusSerializationContext:
-		return &intTestNexusCodec{key: "endpoint:" + sc.Endpoint}
-	default:
+type intTestNexusHMACCodec struct {
+	key []byte
+}
+
+const intTestNexusHMACEncoding = "binary/nexus-hmac-test"
+
+func intTestNexusContextKey(endpoint, service, operation string) string {
+	return "endpoint:" + endpoint + "|service:" + service + "|operation:" + operation
+}
+
+func (c *intTestNexusCodecSelector) WithSerializationContext(ctx converter.SerializationContext) converter.PayloadCodec {
+	sc, ok := ctx.(converter.NexusSerializationContext)
+	if !ok {
 		return c
 	}
+	key := intTestNexusContextKey(sc.Endpoint, sc.Service, sc.Operation)
+	// Select payload codec based on the Nexus service, endpoint, and operation.
+	if codec, ok := c.codecs[key]; ok {
+		return codec
+	}
+	return &intTestNexusCodecSelector{err: fmt.Errorf("no Nexus payload codec configured for %q", key)}
 }
 
-func (c *intTestNexusCodec) Encode(payloads []*commonpb.Payload) ([]*commonpb.Payload, error) {
+func (c *intTestNexusCodecSelector) Encode(payloads []*commonpb.Payload) ([]*commonpb.Payload, error) {
+	if c.err != nil {
+		return nil, c.err
+	}
+	return payloads, nil
+}
+
+func (c *intTestNexusCodecSelector) Decode(payloads []*commonpb.Payload) ([]*commonpb.Payload, error) {
+	if c.err != nil {
+		return nil, c.err
+	}
+	return payloads, nil
+}
+
+func (c *intTestNexusHMACCodec) Encode(payloads []*commonpb.Payload) ([]*commonpb.Payload, error) {
 	result := make([]*commonpb.Payload, len(payloads))
 	for i, payload := range payloads {
-		result[i] = proto.Clone(payload).(*commonpb.Payload)
-		if result[i].Metadata == nil {
-			result[i].Metadata = make(map[string][]byte)
+		payloadBytes, err := (proto.MarshalOptions{Deterministic: true}).Marshal(payload)
+		if err != nil {
+			return nil, fmt.Errorf("marshal Nexus payload: %w", err)
 		}
-		result[i].Metadata["nexus-endpoint-key"] = []byte(c.key)
+		mac := hmac.New(sha256.New, c.key)
+		_, _ = mac.Write(payloadBytes)
+		result[i] = &commonpb.Payload{
+			Metadata: map[string][]byte{converter.MetadataEncoding: []byte(intTestNexusHMACEncoding)},
+			Data:     append(mac.Sum(nil), payloadBytes...),
+		}
 	}
 	return result, nil
 }
 
-func (c *intTestNexusCodec) Decode(payloads []*commonpb.Payload) ([]*commonpb.Payload, error) {
+func (c *intTestNexusHMACCodec) Decode(payloads []*commonpb.Payload) ([]*commonpb.Payload, error) {
 	result := make([]*commonpb.Payload, len(payloads))
 	for i, payload := range payloads {
-		key := string(payload.Metadata["nexus-endpoint-key"])
-		if key != c.key {
-			return nil, fmt.Errorf("Nexus endpoint key mismatch: got %q, want %q", key, c.key)
+		encoding := string(payload.Metadata[converter.MetadataEncoding])
+		if encoding != intTestNexusHMACEncoding {
+			return nil, fmt.Errorf("Nexus payload encoding mismatch: got %q, want %q", encoding, intTestNexusHMACEncoding)
 		}
-		result[i] = proto.Clone(payload).(*commonpb.Payload)
-		delete(result[i].Metadata, "nexus-endpoint-key")
+		if len(payload.Data) < sha256.Size {
+			return nil, fmt.Errorf("Nexus HMAC payload is too short: got %d bytes", len(payload.Data))
+		}
+		signature, payloadBytes := payload.Data[:sha256.Size], payload.Data[sha256.Size:]
+		mac := hmac.New(sha256.New, c.key)
+		_, _ = mac.Write(payloadBytes)
+		if !hmac.Equal(signature, mac.Sum(nil)) {
+			return nil, errors.New("Nexus payload HMAC mismatch")
+		}
+		result[i] = &commonpb.Payload{}
+		if err := proto.Unmarshal(payloadBytes, result[i]); err != nil {
+			return nil, fmt.Errorf("unmarshal Nexus payload: %w", err)
+		}
 	}
 	return result, nil
 }
 
-type intTestNexusFailureConverter struct {
-	converter.FailureConverter
-	key string
-}
-
-func (c *intTestNexusFailureConverter) WithSerializationContext(
-	ctx converter.SerializationContext,
-) converter.FailureConverter {
-	if nexusCtx, ok := ctx.(converter.NexusSerializationContext); ok {
-		return &intTestNexusFailureConverter{
-			FailureConverter: c.FailureConverter,
-			key:              "endpoint:" + nexusCtx.Endpoint,
-		}
-	}
-	return c
-}
-
-func (c *intTestNexusFailureConverter) ErrorToFailure(err error) *failurepb.Failure {
-	failure := c.FailureConverter.ErrorToFailure(err)
-	if failure == nil || c.key == "" {
-		return failure
-	}
-	failure = proto.Clone(failure).(*failurepb.Failure)
-	failure.Source = c.key
-	return failure
-}
-
-func (c *intTestNexusFailureConverter) FailureToError(failure *failurepb.Failure) error {
-	if c.key == "" {
-		return c.FailureConverter.FailureToError(failure)
-	}
-	for current := failure; current != nil; current = current.Cause {
-		if current.Source == c.key {
-			return c.FailureConverter.FailureToError(failure)
-		}
-	}
-	return fmt.Errorf("Nexus failure key mismatch: missing %q", c.key)
-}
-
-func intTestNexusCallerWorkflow(ctx workflow.Context, endpoints []string) (string, error) {
-	first := workflow.NewNexusClient(endpoints[0], "serialization-context-service").ExecuteOperation(
+func intTestNexusCallerWorkflow(ctx workflow.Context, hmacEndpointName, zlibEndpointName string) (string, error) {
+	// Schedule both operations before awaiting either result. Each future must
+	// retain the converter selected for its own Nexus operation context.
+	hmacFuture := workflow.NewNexusClient(hmacEndpointName, intTestNexusService).ExecuteOperation(
 		ctx,
 		intTestNexusOperation,
-		intTestNexusInput{Value: "first"},
+		intTestNexusInput{Value: "hmac"},
 		workflow.NexusOperationOptions{},
 	)
-	second := workflow.NewNexusClient(endpoints[1], "serialization-context-service").ExecuteOperation(
+	zlibFuture := workflow.NewNexusClient(zlibEndpointName, intTestNexusService).ExecuteOperation(
 		ctx,
 		intTestNexusOperation.Name(),
-		intTestNexusInput{Value: "second"},
+		intTestNexusInput{Value: "zlib"},
 		workflow.NexusOperationOptions{},
 	)
 
 	var results []string
 	var operationErr error
 	selector := workflow.NewSelector(ctx)
-	for _, future := range []workflow.Future{first, second} {
-		selector.AddFuture(future, func(f workflow.Future) {
-			var result string
-			if err := f.Get(ctx, &result); err != nil {
-				operationErr = err
-				return
-			}
-			results = append(results, result)
-		})
+	handleFuture := func(f workflow.Future) {
+		var result string
+		if err := f.Get(ctx, &result); err != nil {
+			operationErr = err
+			return
+		}
+		results = append(results, result)
 	}
+	selector.AddFuture(hmacFuture, handleFuture)
+	selector.AddFuture(zlibFuture, handleFuture)
 	for len(results) < 2 && operationErr == nil {
 		selector.Select(ctx)
 	}
 	return strings.Join(results, "|"), operationErr
 }
 
-func intTestNexusFailureWorkflow(ctx workflow.Context, endpoint string) error {
-	return workflow.NewNexusClient(endpoint, "serialization-context-service").ExecuteOperation(
-		ctx,
-		intTestNexusOperation,
-		intTestNexusInput{Fail: true},
-		workflow.NexusOperationOptions{},
-	).Get(ctx, nil)
-}
-
 func (ts *IntegrationTestSuite) TestSerializationContext_NexusCallerEndpointIsolation() {
 	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
 	defer cancel()
 
-	callerDC := converter.NewCodecDataConverter(converter.GetDefaultDataConverter(), &intTestNexusCodec{})
+	hmacEndpointName := "nexus-ser-ctx-hmac-" + uuid.NewString()
+	zlibEndpointName := "nexus-ser-ctx-zlib-" + uuid.NewString()
+	hmacCodec := &intTestNexusHMACCodec{key: []byte("nexus-hmac-key")}
+	zlibCodec := converter.NewZlibCodec(converter.ZlibCodecOptions{AlwaysEncode: true})
+	codecSelector := &intTestNexusCodecSelector{codecs: map[string]converter.PayloadCodec{
+		intTestNexusContextKey(hmacEndpointName, intTestNexusService, intTestNexusOperation.Name()): hmacCodec,
+		intTestNexusContextKey(zlibEndpointName, intTestNexusService, intTestNexusOperation.Name()): zlibCodec,
+	}}
+
+	callerDC := converter.NewCodecDataConverter(converter.GetDefaultDataConverter(), codecSelector)
 	callerClient, err := ts.newDefaultClient(func(options *client.Options) {
 		options.DataConverter = callerDC
-		options.FailureConverter = &intTestNexusFailureConverter{
-			FailureConverter: temporal.GetDefaultFailureConverter(),
-		}
 	})
 	ts.NoError(err)
 	defer callerClient.Close()
 
-	endpointNames := []string{"nexus-ser-ctx-a-" + uuid.NewString(), "nexus-ser-ctx-b-" + uuid.NewString()}
-	handlerTaskQueues := []string{"nexus-ser-ctx-handler-a-" + uuid.NewString(), "nexus-ser-ctx-handler-b-" + uuid.NewString()}
-	for i := range endpointNames {
-		response, err := callerClient.OperatorService().CreateNexusEndpoint(ctx, &operatorservice.CreateNexusEndpointRequest{
-			Spec: &nexuspb.EndpointSpec{
-				Name: endpointNames[i],
-				Target: &nexuspb.EndpointTarget{Variant: &nexuspb.EndpointTarget_Worker_{
-					Worker: &nexuspb.EndpointTarget_Worker{
-						Namespace: ts.config.Namespace,
-						TaskQueue: handlerTaskQueues[i],
-					},
-				}},
-			},
-		})
-		ts.NoError(err)
-		defer func(endpoint *nexuspb.Endpoint) {
-			_, _ = callerClient.OperatorService().DeleteNexusEndpoint(ctx, &operatorservice.DeleteNexusEndpointRequest{
-				Id: endpoint.Id, Version: endpoint.Version,
-			})
-		}(response.Endpoint)
-	}
-
-	var handlerWorkers []worker.Worker
-	for i := range endpointNames {
-		handlerDC := converter.NewCodecDataConverter(
-			converter.GetDefaultDataConverter(),
-			&intTestNexusCodec{key: "endpoint:" + endpointNames[i]},
-		)
-		handlerClient, err := ts.newDefaultClient(func(options *client.Options) {
-			options.DataConverter = handlerDC
-			options.FailureConverter = &intTestNexusFailureConverter{
-				FailureConverter: temporal.GetDefaultFailureConverter(),
-				key:              "endpoint:" + endpointNames[i],
-			}
-		})
-		ts.NoError(err)
-		defer handlerClient.Close()
-
-		handlerWorker := worker.New(handlerClient, handlerTaskQueues[i], worker.Options{
-			DisableWorkflowWorker: true,
-		})
-		service := nexus.NewService("serialization-context-service")
-		ts.NoError(service.Register(intTestNexusOperation))
-		handlerWorker.RegisterNexusService(service)
-		ts.NoError(handlerWorker.Start())
-		handlerWorkers = append(handlerWorkers, handlerWorker)
-	}
+	hmacHandlerTaskQueue := "nexus-ser-ctx-handler-hmac-" + uuid.NewString()
+	zlibHandlerTaskQueue := "nexus-ser-ctx-handler-zlib-" + uuid.NewString()
+	hmacEndpointResponse, err := callerClient.OperatorService().CreateNexusEndpoint(ctx, &operatorservice.CreateNexusEndpointRequest{
+		Spec: &nexuspb.EndpointSpec{
+			Name: hmacEndpointName,
+			Target: &nexuspb.EndpointTarget{Variant: &nexuspb.EndpointTarget_Worker_{
+				Worker: &nexuspb.EndpointTarget_Worker{
+					Namespace: ts.config.Namespace,
+					TaskQueue: hmacHandlerTaskQueue,
+				},
+			}},
+		},
+	})
+	ts.NoError(err)
 	defer func() {
-		for _, handlerWorker := range handlerWorkers {
-			handlerWorker.Stop()
-		}
+		_, _ = callerClient.OperatorService().DeleteNexusEndpoint(ctx, &operatorservice.DeleteNexusEndpointRequest{
+			Id: hmacEndpointResponse.Endpoint.Id, Version: hmacEndpointResponse.Endpoint.Version,
+		})
 	}()
+	zlibEndpointResponse, err := callerClient.OperatorService().CreateNexusEndpoint(ctx, &operatorservice.CreateNexusEndpointRequest{
+		Spec: &nexuspb.EndpointSpec{
+			Name: zlibEndpointName,
+			Target: &nexuspb.EndpointTarget{Variant: &nexuspb.EndpointTarget_Worker_{
+				Worker: &nexuspb.EndpointTarget_Worker{
+					Namespace: ts.config.Namespace,
+					TaskQueue: zlibHandlerTaskQueue,
+				},
+			}},
+		},
+	})
+	ts.NoError(err)
+	defer func() {
+		_, _ = callerClient.OperatorService().DeleteNexusEndpoint(ctx, &operatorservice.DeleteNexusEndpointRequest{
+			Id: zlibEndpointResponse.Endpoint.Id, Version: zlibEndpointResponse.Endpoint.Version,
+		})
+	}()
+
+	// Each handler uses the codec selected for its endpoint. Inputs and results
+	// round trip only if the caller selects and retains that same codec.
+	hmacHandlerDC := converter.NewCodecDataConverter(converter.GetDefaultDataConverter(), hmacCodec)
+	hmacHandlerClient, err := ts.newDefaultClient(func(options *client.Options) {
+		options.DataConverter = hmacHandlerDC
+	})
+	ts.NoError(err)
+	defer hmacHandlerClient.Close()
+	hmacHandlerWorker := worker.New(hmacHandlerClient, hmacHandlerTaskQueue, worker.Options{DisableWorkflowWorker: true})
+	hmacService := nexus.NewService(intTestNexusService)
+	ts.NoError(hmacService.Register(intTestNexusOperation))
+	hmacHandlerWorker.RegisterNexusService(hmacService)
+	ts.NoError(hmacHandlerWorker.Start())
+	defer hmacHandlerWorker.Stop()
+
+	zlibHandlerDC := converter.NewCodecDataConverter(converter.GetDefaultDataConverter(), zlibCodec)
+	zlibHandlerClient, err := ts.newDefaultClient(func(options *client.Options) {
+		options.DataConverter = zlibHandlerDC
+	})
+	ts.NoError(err)
+	defer zlibHandlerClient.Close()
+	zlibHandlerWorker := worker.New(zlibHandlerClient, zlibHandlerTaskQueue, worker.Options{DisableWorkflowWorker: true})
+	zlibService := nexus.NewService(intTestNexusService)
+	ts.NoError(zlibService.Register(intTestNexusOperation))
+	zlibHandlerWorker.RegisterNexusService(zlibService)
+	ts.NoError(zlibHandlerWorker.Start())
+	defer zlibHandlerWorker.Stop()
 
 	callerTaskQueue := "nexus-ser-ctx-caller-" + uuid.NewString()
 	callerWorker := worker.New(callerClient, callerTaskQueue, worker.Options{})
 	callerWorker.RegisterWorkflow(intTestNexusCallerWorkflow)
-	callerWorker.RegisterWorkflow(intTestNexusFailureWorkflow)
 	ts.NoError(callerWorker.Start())
 	defer callerWorker.Stop()
 
 	run, err := callerClient.ExecuteWorkflow(ctx, client.StartWorkflowOptions{
 		ID:        "nexus-ser-ctx-caller-" + uuid.NewString(),
 		TaskQueue: callerTaskQueue,
-	}, intTestNexusCallerWorkflow, endpointNames)
+	}, intTestNexusCallerWorkflow, hmacEndpointName, zlibEndpointName)
 	ts.NoError(err)
 	var result string
 	ts.NoError(run.Get(ctx, &result))
-	ts.ElementsMatch([]string{"first", "second"}, strings.Split(result, "|"))
-
-	failureRun, err := callerClient.ExecuteWorkflow(ctx, client.StartWorkflowOptions{
-		ID:        "nexus-ser-ctx-failure-" + uuid.NewString(),
-		TaskQueue: callerTaskQueue,
-	}, intTestNexusFailureWorkflow, endpointNames[1])
-	ts.NoError(err)
-	err = failureRun.Get(ctx, nil)
-	ts.ErrorContains(err, "expected Nexus failure")
-	ts.NotContains(err.Error(), "Nexus failure key mismatch")
+	ts.ElementsMatch([]string{"hmac", "zlib"}, strings.Split(result, "|"))
 }

--- a/test/serialization_context_test.go
+++ b/test/serialization_context_test.go
@@ -529,13 +529,4 @@ func (ts *IntegrationTestSuite) TestSerializationContext_StandaloneNexusCallerEn
 	// Both endpoint-specific codecs must decode their logical results.
 	ts.Equal("standalone-hmac", hmacStandaloneResult)
 	ts.Equal("standalone-zlib", zlibStandaloneResult)
-
-	// A reconstructed handle must recover the operation context before decoding.
-	detachedHandle := callerClient.GetNexusOperationHandle(client.GetNexusOperationHandleOptions{
-		OperationID: hmacHandle.GetID(),
-		RunID:       hmacHandle.GetRunID(),
-	})
-	var detachedResult string
-	ts.NoError(detachedHandle.Get(ctx, &detachedResult))
-	ts.Equal("standalone-hmac", detachedResult)
 }

--- a/test/serialization_context_test.go
+++ b/test/serialization_context_test.go
@@ -6,11 +6,13 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/nexus-rpc/sdk-go/nexus"
+	"github.com/stretchr/testify/require"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	nexuspb "go.temporal.io/api/nexus/v1"
@@ -404,4 +406,136 @@ func (ts *IntegrationTestSuite) TestSerializationContext_NexusCallerEndpointIsol
 	ts.Equal("binary/zlib", string(zlibEncodedResult.Metadata[converter.MetadataEncoding]))
 	// HMAC and zlib must produce different bytes for the same input.
 	ts.NotEqual(hmacEncodedResult.Data, zlibEncodedResult.Data)
+}
+
+func (ts *IntegrationTestSuite) TestSerializationContext_StandaloneNexusCallerEndpointIsolation() {
+	skipOnCloud(ts.T(), cloudRequiresProvisioning, "standalone Nexus tests create namespace endpoints through Operator Service")
+	if os.Getenv("DISABLE_STANDALONE_NEXUS_TESTS") != "" {
+		ts.T().SkipNow()
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
+	defer cancel()
+
+	hmacEndpointName := "nexus-ser-ctx-standalone-hmac-" + uuid.NewString()
+	zlibEndpointName := "nexus-ser-ctx-standalone-zlib-" + uuid.NewString()
+	hmacCodec := &intTestNexusHMACCodec{key: []byte("nexus-hmac-key")}
+	zlibCodec := converter.NewZlibCodec(converter.ZlibCodecOptions{AlwaysEncode: true})
+	codecSelector := &intTestNexusCodecSelector{codecs: map[string]converter.PayloadCodec{
+		intTestNexusCodecKey(hmacEndpointName, intTestNexusService, intTestNexusOperation.Name()): hmacCodec,
+		intTestNexusCodecKey(zlibEndpointName, intTestNexusService, intTestNexusOperation.Name()): zlibCodec,
+	}}
+
+	callerDC := converter.NewCodecDataConverter(converter.GetDefaultDataConverter(), codecSelector)
+	callerClient, err := ts.newDefaultClient(func(options *client.Options) {
+		options.DataConverter = callerDC
+	})
+	ts.Require().NoError(err)
+	ts.T().Cleanup(callerClient.Close)
+
+	// Each handler uses the codec selected for its endpoint. Inputs and results
+	// round trip only if the caller selects and retains that same codec.
+	startHandler := func(endpointName string, codec converter.PayloadCodec) {
+		handlerTaskQueue := "nexus-ser-ctx-standalone-handler-" + uuid.NewString()
+		endpointResponse, err := callerClient.OperatorService().CreateNexusEndpoint(ctx, &operatorservice.CreateNexusEndpointRequest{
+			Spec: &nexuspb.EndpointSpec{
+				Name: endpointName,
+				Target: &nexuspb.EndpointTarget{Variant: &nexuspb.EndpointTarget_Worker_{
+					Worker: &nexuspb.EndpointTarget_Worker{
+						Namespace: ts.config.Namespace,
+						TaskQueue: handlerTaskQueue,
+					},
+				}},
+			},
+		})
+		ts.Require().NoError(err)
+		ts.T().Cleanup(func() {
+			cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), ctxTimeout)
+			defer cleanupCancel()
+			_, _ = callerClient.OperatorService().DeleteNexusEndpoint(cleanupCtx, &operatorservice.DeleteNexusEndpointRequest{
+				Id: endpointResponse.Endpoint.Id, Version: endpointResponse.Endpoint.Version,
+			})
+		})
+
+		handlerDC := converter.NewCodecDataConverter(converter.GetDefaultDataConverter(), codec)
+		handlerClient, err := ts.newDefaultClient(func(options *client.Options) {
+			options.DataConverter = handlerDC
+		})
+		ts.Require().NoError(err)
+		ts.T().Cleanup(handlerClient.Close)
+
+		handlerWorker := worker.New(handlerClient, handlerTaskQueue, worker.Options{DisableWorkflowWorker: true})
+		service := nexus.NewService(intTestNexusService)
+		ts.Require().NoError(service.Register(intTestNexusOperation))
+		handlerWorker.RegisterNexusService(service)
+		ts.Require().NoError(handlerWorker.Start())
+		ts.T().Cleanup(handlerWorker.Stop)
+	}
+	startHandler(hmacEndpointName, hmacCodec)
+	startHandler(zlibEndpointName, zlibCodec)
+
+	hmacStandaloneClient, err := callerClient.NewNexusClient(client.NexusClientOptions{
+		Endpoint: hmacEndpointName,
+		Service:  intTestNexusService,
+	})
+	ts.Require().NoError(err)
+	zlibStandaloneClient, err := callerClient.NewNexusClient(client.NexusClientOptions{
+		Endpoint: zlibEndpointName,
+		Service:  intTestNexusService,
+	})
+	ts.Require().NoError(err)
+
+	// Standalone starts fail immediately while the eventually consistent endpoint
+	// registry propagates, so retry the direct RPC as the other standalone tests do.
+	executeOperation := func(
+		nexusClient client.NexusClient,
+		operation any,
+		input any,
+		options client.StartNexusOperationOptions,
+	) client.NexusOperationHandle {
+		ts.T().Helper()
+		var handle client.NexusOperationHandle
+		require.Eventually(ts.T(), func() bool {
+			var executeErr error
+			handle, executeErr = nexusClient.ExecuteOperation(ctx, operation, input, options)
+			return executeErr == nil
+		}, 10*time.Second, 100*time.Millisecond, "timed out waiting for endpoint to propagate")
+		return handle
+	}
+
+	// Exercise both a typed operation reference and a resolved operation name.
+	hmacHandle := executeOperation(
+		hmacStandaloneClient,
+		intTestNexusOperation,
+		intTestNexusInput{Value: "standalone-hmac"},
+		client.StartNexusOperationOptions{
+			ID:                     "nexus-ser-ctx-standalone-hmac-" + uuid.NewString(),
+			ScheduleToCloseTimeout: 10 * time.Second,
+		},
+	)
+	zlibHandle := executeOperation(
+		zlibStandaloneClient,
+		intTestNexusOperation.Name(),
+		intTestNexusInput{Value: "standalone-zlib"},
+		client.StartNexusOperationOptions{
+			ID:                     "nexus-ser-ctx-standalone-zlib-" + uuid.NewString(),
+			ScheduleToCloseTimeout: 10 * time.Second,
+		},
+	)
+
+	var hmacStandaloneResult, zlibStandaloneResult string
+	ts.NoError(hmacHandle.Get(ctx, &hmacStandaloneResult))
+	ts.NoError(zlibHandle.Get(ctx, &zlibStandaloneResult))
+	// Both endpoint-specific codecs must decode their logical results.
+	ts.Equal("standalone-hmac", hmacStandaloneResult)
+	ts.Equal("standalone-zlib", zlibStandaloneResult)
+
+	// A reconstructed handle must recover the operation context before decoding.
+	detachedHandle := callerClient.GetNexusOperationHandle(client.GetNexusOperationHandleOptions{
+		OperationID: hmacHandle.GetID(),
+		RunID:       hmacHandle.GetRunID(),
+	})
+	var detachedResult string
+	ts.NoError(detachedHandle.Get(ctx, &detachedResult))
+	ts.Equal("standalone-hmac", detachedResult)
 }

--- a/test/serialization_context_test.go
+++ b/test/serialization_context_test.go
@@ -337,7 +337,7 @@ func (ts *IntegrationTestSuite) TestSerializationContext_NexusCallerEndpointIsol
 
 	// Each handler uses the codec selected for its endpoint. Inputs and results
 	// round trip only if the caller selects and retains that same codec.
-	hmacHandlerDC := converter.NewCodecDataConverter(converter.GetDefaultDataConverter(), hmacCodec)
+	hmacHandlerDC := converter.NewCodecDataConverter(converter.GetDefaultDataConverter(), codecSelector)
 	hmacHandlerClient, err := ts.newDefaultClient(func(options *client.Options) {
 		options.DataConverter = hmacHandlerDC
 	})
@@ -350,7 +350,7 @@ func (ts *IntegrationTestSuite) TestSerializationContext_NexusCallerEndpointIsol
 	ts.NoError(hmacHandlerWorker.Start())
 	defer hmacHandlerWorker.Stop()
 
-	zlibHandlerDC := converter.NewCodecDataConverter(converter.GetDefaultDataConverter(), zlibCodec)
+	zlibHandlerDC := converter.NewCodecDataConverter(converter.GetDefaultDataConverter(), codecSelector)
 	zlibHandlerClient, err := ts.newDefaultClient(func(options *client.Options) {
 		options.DataConverter = zlibHandlerDC
 	})
@@ -435,7 +435,7 @@ func (ts *IntegrationTestSuite) TestSerializationContext_StandaloneNexusCallerEn
 
 	// Each handler uses the codec selected for its endpoint. Inputs and results
 	// round trip only if the caller selects and retains that same codec.
-	startHandler := func(endpointName string, codec converter.PayloadCodec) {
+	startHandler := func(endpointName string) {
 		handlerTaskQueue := "nexus-ser-ctx-standalone-handler-" + uuid.NewString()
 		endpointResponse, err := callerClient.OperatorService().CreateNexusEndpoint(ctx, &operatorservice.CreateNexusEndpointRequest{
 			Spec: &nexuspb.EndpointSpec{
@@ -457,7 +457,7 @@ func (ts *IntegrationTestSuite) TestSerializationContext_StandaloneNexusCallerEn
 			})
 		})
 
-		handlerDC := converter.NewCodecDataConverter(converter.GetDefaultDataConverter(), codec)
+		handlerDC := converter.NewCodecDataConverter(converter.GetDefaultDataConverter(), codecSelector)
 		handlerClient, err := ts.newDefaultClient(func(options *client.Options) {
 			options.DataConverter = handlerDC
 		})
@@ -471,8 +471,8 @@ func (ts *IntegrationTestSuite) TestSerializationContext_StandaloneNexusCallerEn
 		ts.Require().NoError(handlerWorker.Start())
 		ts.T().Cleanup(handlerWorker.Stop)
 	}
-	startHandler(hmacEndpointName, hmacCodec)
-	startHandler(zlibEndpointName, zlibCodec)
+	startHandler(hmacEndpointName)
+	startHandler(zlibEndpointName)
 
 	hmacStandaloneClient, err := callerClient.NewNexusClient(client.NexusClientOptions{
 		Endpoint: hmacEndpointName,


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Added caller side `converter.NexusSerializationContext` support for workflow-scheduled Nexus operations.
This context gives the Nexus Endpoint, Service, and operation name to the data/failure converters

## Why?
<!-- Tell your future self why have you made these changes -->
This enables codecs to select serialization behavior or encryption keys by Nexus endpoint, service, or operation.

For example, workflows calling two Nexus endpoints can encrypt each endpoint’s payloads with a different key while ensuring that inputs, results, and failures are decoded with the converter selected for the corresponding operation.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Added unit/functional tests to verify that NexusSerializationContext works as expected.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
