### PR TITLE
fix(test): stabilize workflow task pagination integration test

### DIFF
--- a/test/activity_test.go
+++ b/test/activity_test.go
@@ -378,6 +378,14 @@ func (a *Activities) EchoString(ctx context.Context, message string) (string, er
 	return message, nil
 }
 
+// ConsumeString accepts a (possibly large) input but returns nothing, so callers can inflate the
+// size of a workflow task completion via activity inputs without also inflating history with echoed
+// results.
+func (a *Activities) ConsumeString(ctx context.Context, message string) error {
+	a.append("ConsumeString")
+	return nil
+}
+
 func (a *Activities) WaitForWorkerStop(ctx context.Context, timeout time.Duration) (string, error) {
 	stopCh := activity.GetWorkerStopChannel(ctx)
 	// Mark activity as invoked then wait for it to be stopped

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -310,8 +310,14 @@ func (ts *IntegrationTestSuite) TestWorkflowTaskCompletionPagination() {
 	}
 
 	// The completion is larger than the gRPC request size limit, so it succeeds only if it is
-	// paginated.
-	err = ts.executeWorkflow("test-wft-completion-pagination", ts.workflows.WorkflowTaskCompletionPagination, nil)
+	// paginated. Building and paginating a ~5 MiB completion, then persisting it, is far heavier than
+	// a normal task. The suite defaults (15s run / 1s task) are too tight for it on slow CI hardware,
+	// so restore the standard 10s task timeout (which the suite helper lowers to 1s) and give the run
+	// ample headroom.
+	options := ts.startWorkflowOptions("test-wft-completion-pagination")
+	options.WorkflowExecutionTimeout = time.Minute
+	options.WorkflowTaskTimeout = 10 * time.Second
+	err = ts.executeWorkflowWithOption(options, ts.workflows.WorkflowTaskCompletionPagination, nil)
 	ts.NoError(err)
 }
 

--- a/test/workflow_test.go
+++ b/test/workflow_test.go
@@ -4313,7 +4313,7 @@ func (w *Workflows) WorkflowTaskCompletionPagination(ctx workflow.Context) error
 	input := strings.Repeat("a", 400*1024)
 	var futures []workflow.Future
 	for i := 0; i < 13; i++ {
-		futures = append(futures, workflow.ExecuteActivity(ctx, "EchoString", input))
+		futures = append(futures, workflow.ExecuteActivity(ctx, "ConsumeString", input))
 	}
 	for _, future := range futures {
 		if err := future.Get(ctx, nil); err != nil {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

- Update `TestWorkflowTaskCompletionPagination` to not echo large results via the called activity to avoid bloating history and causing deadlock detection to be signaled due to encoding and decoding.
- Adjust timeouts for the workflow execution used by the `TestWorkflowTaskCompletionPagination` test.

## Why?

Stabilize a flaky test.