### PR TITLE
Report runtime environment information in worker heartbeats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ to docs, or any other relevant information.
 
 ### Added
 
+- Worker heartbeats now report the Go runtime version, detected hosting environments (Docker,
+  Kubernetes, and common cloud platforms), and the operating system and architecture. This is sent
+  once per worker with the first heartbeat accepted by the server and can be turned off with
+  `client.Options.DisableWorkerEnvironmentInfo`.
 - Added `temporal.NewPayloadValidationError` to create non-retryable application errors with
   optional structured details for payload validation failures. Passing `nil` omits details.
 - Added Go 1.27+ generic methods on the experimental `temporalnexus.NexusClient` for starting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,9 @@ to docs, or any other relevant information.
 
 ### Added
 
-- Worker heartbeats now report the Go runtime version, detected hosting environments (Docker,
-  Kubernetes, and common cloud platforms), and the operating system and architecture. This is sent
+- Worker heartbeats now report the Go runtime version (plus RoadRunner, when the SDK is embedded in
+  a RoadRunner binary), detected hosting environments (Docker, Kubernetes, and common cloud
+  platforms), and the operating system and architecture. This is sent
   once per worker with the first heartbeat accepted by the server and can be turned off with
   `client.Options.DisableWorkerEnvironmentInfo`.
 - Added `temporal.NewPayloadValidationError` to create non-retryable application errors with

--- a/internal/client.go
+++ b/internal/client.go
@@ -996,6 +996,13 @@ type (
 		// NOTE: Experimental
 		SdkVersion string
 
+		// DisableWorkerEnvironmentInfo disables reporting the runtime (Go version), detected hosting
+		// environments (Docker, Kubernetes, cloud platforms), and OS platform in worker heartbeats.
+		// This information is sent once per worker, with the first heartbeat accepted by the server.
+		//
+		// NOTE: Experimental
+		DisableWorkerEnvironmentInfo bool
+
 		// ExternalStorage configures external payload storage for this client.
 		// When set, payloads that exceed ExternalStorage.PayloadSizeThreshold
 		// are offloaded to an external store (e.g. S3, GCS) by the configured
@@ -1735,7 +1742,7 @@ func NewServiceClient(workflowServiceClient workflowservice.WorkflowServiceClien
 	}
 
 	if heartbeatInterval > 0 {
-		client.heartbeatManager = newHeartbeatManager(client, heartbeatInterval, client.logger)
+		client.heartbeatManager = newHeartbeatManager(client, heartbeatInterval, client.logger, options.DisableWorkerEnvironmentInfo)
 	}
 
 	// Create outbound interceptor by wrapping backwards through chain

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -1294,6 +1294,9 @@ type AggregatedWorker struct {
 	heartbeatMetrics             *heartbeatMetricsHandler
 	heartbeatCallback            func() *workerpb.WorkerHeartbeat
 	workerPollCompleteOnShutdown *atomic.Bool
+	// pendingEnvironment is attached to every heartbeat (periodic and shutdown) until the server
+	// accepts one, at which point heartbeatSuccess clears it.
+	pendingEnvironment atomic.Pointer[workerpb.EnvironmentInfo]
 }
 
 // RegisterWorkflow registers workflow implementation with the AggregatedWorker
@@ -1695,6 +1698,12 @@ func (aw *AggregatedWorker) unregisterHeartbeatWorker() {
 		return
 	}
 	aw.client.heartbeatManager.unregisterWorker(aw)
+}
+
+// heartbeatSuccess is invoked by the shared namespace heartbeat worker once the server has
+// accepted a heartbeat from this worker.
+func (aw *AggregatedWorker) heartbeatSuccess() {
+	aw.pendingEnvironment.Store(nil)
 }
 
 // sendShutdownWorkerRPC sends a ShutdownWorker RPC to notify the server that this worker is shutting down.
@@ -2641,6 +2650,7 @@ func NewAggregatedWorker(client *WorkflowClient, taskQueue string, options Worke
 				HeartbeatTime:     timestamppb.New(heartbeatTime),
 				Plugins:           pluginInfos,
 				Drivers:           driverInfos,
+				Environment:       aw.pendingEnvironment.Load(),
 			}
 			if !previousHeartbeatTime.IsZero() {
 				hb.ElapsedSinceLastHeartbeat = durationpb.New(heartbeatTime.Sub(previousHeartbeatTime))
@@ -2668,6 +2678,9 @@ func NewAggregatedWorker(client *WorkflowClient, taskQueue string, options Worke
 		heartbeatMetrics:             heartbeatMetrics,
 		heartbeatCallback:            heartbeatCallback,
 		workerPollCompleteOnShutdown: workerPollCompleteOnShutdown,
+	}
+	if client.heartbeatManager != nil {
+		aw.pendingEnvironment.Store(client.heartbeatManager.environmentInfo)
 	}
 
 	// Set memoized start as a once-value that invokes plugins first

--- a/internal/internal_worker_environment.go
+++ b/internal/internal_worker_environment.go
@@ -3,22 +3,71 @@ package internal
 import (
 	"os"
 	"runtime"
+	"runtime/debug"
 	"strings"
 
 	workerpb "go.temporal.io/api/worker/v1"
 )
 
+const (
+	// roadRunnerModulePrefix is the main module of every RoadRunner binary.
+	roadRunnerModulePrefix = "github.com/roadrunner-server/roadrunner"
+	// roadRunnerTemporalModulePrefix is the RoadRunner plugin through which the PHP SDK uses this SDK.
+	roadRunnerTemporalModulePrefix = "github.com/temporalio/roadrunner-temporal"
+)
+
 // detectEnvironmentInfo collects the runtime, hosting environment, and platform information
 // reported in the first accepted worker heartbeat.
 func detectEnvironmentInfo() *workerpb.EnvironmentInfo {
+	buildInfo, _ := debug.ReadBuildInfo()
 	return &workerpb.EnvironmentInfo{
-		Runtimes: []*workerpb.EnvironmentInfo_Runtime{{
-			Type:    workerpb.EnvironmentInfo_Runtime_RUNTIME_TYPE_GO,
-			Version: runtime.Version(),
-		}},
+		Runtimes:            detectRuntimes(buildInfo),
 		HostingEnvironments: detectHostingEnvironments(os.LookupEnv, isDocker),
 		Platform:            detectPlatform(),
 	}
+}
+
+// detectRuntimes always reports the Go runtime, and additionally RoadRunner when this SDK is
+// linked into a RoadRunner binary (the PHP SDK's execution model). RoadRunner is identified from
+// the binary's build info rather than from anything the PHP SDK passes in.
+func detectRuntimes(buildInfo *debug.BuildInfo) []*workerpb.EnvironmentInfo_Runtime {
+	runtimes := []*workerpb.EnvironmentInfo_Runtime{{
+		Type:    workerpb.EnvironmentInfo_Runtime_RUNTIME_TYPE_GO,
+		Version: runtime.Version(),
+	}}
+	if version, ok := roadRunnerVersion(buildInfo); ok {
+		runtimes = append(runtimes, &workerpb.EnvironmentInfo_Runtime{
+			Type:    workerpb.EnvironmentInfo_Runtime_RUNTIME_TYPE_ROADRUNNER,
+			Version: version,
+		})
+	}
+	return runtimes
+}
+
+func roadRunnerVersion(buildInfo *debug.BuildInfo) (string, bool) {
+	if buildInfo == nil {
+		return "", false
+	}
+	if isModule(buildInfo.Main.Path, roadRunnerModulePrefix) {
+		// "(devel)" is Go's placeholder for builds outside of a tagged module.
+		if buildInfo.Main.Version == "(devel)" {
+			return "", true
+		}
+		return buildInfo.Main.Version, true
+	}
+	for _, dep := range buildInfo.Deps {
+		if isModule(dep.Path, roadRunnerTemporalModulePrefix) {
+			// A RoadRunner binary built from a fork or vendored main module: RoadRunner is present,
+			// but its version is not knowable from the plugin alone.
+			return "", true
+		}
+	}
+	return "", false
+}
+
+func isModule(path, prefix string) bool {
+	rest, ok := strings.CutPrefix(path, prefix)
+	return ok && (rest == "" || strings.HasPrefix(rest, "/"))
 }
 
 // detectHostingEnvironments identifies hosting environments from well-known indicators. Several

--- a/internal/internal_worker_environment.go
+++ b/internal/internal_worker_environment.go
@@ -1,0 +1,125 @@
+package internal
+
+import (
+	"os"
+	"runtime"
+	"strings"
+
+	workerpb "go.temporal.io/api/worker/v1"
+)
+
+// detectEnvironmentInfo collects the runtime, hosting environment, and platform information
+// reported in the first accepted worker heartbeat.
+func detectEnvironmentInfo() *workerpb.EnvironmentInfo {
+	return &workerpb.EnvironmentInfo{
+		Runtimes: []*workerpb.EnvironmentInfo_Runtime{{
+			Type:    workerpb.EnvironmentInfo_Runtime_RUNTIME_TYPE_GO,
+			Version: runtime.Version(),
+		}},
+		HostingEnvironments: detectHostingEnvironments(os.LookupEnv, isDocker),
+		Platform:            detectPlatform(),
+	}
+}
+
+// detectHostingEnvironments identifies hosting environments from well-known indicators. Several
+// environments may be detected at once, e.g. Docker inside Kubernetes or Azure Functions inside
+// Azure App Service.
+func detectHostingEnvironments(
+	lookupEnv func(string) (string, bool),
+	isDocker func() bool,
+) []*workerpb.EnvironmentInfo_HostingEnvironment {
+	envValue := func(name string) string {
+		value, _ := lookupEnv(name)
+		return strings.TrimSpace(value)
+	}
+	hasAnyEnv := func(names ...string) bool {
+		for _, name := range names {
+			if envValue(name) != "" {
+				return true
+			}
+		}
+		return false
+	}
+
+	var environments []*workerpb.EnvironmentInfo_HostingEnvironment
+	add := func(t workerpb.EnvironmentInfo_HostingEnvironment_HostingEnvironmentType, version string) {
+		environments = append(environments, &workerpb.EnvironmentInfo_HostingEnvironment{Type: t, Version: version})
+	}
+
+	if isDocker() {
+		add(workerpb.EnvironmentInfo_HostingEnvironment_HOSTING_ENVIRONMENT_TYPE_DOCKER, "")
+	}
+	if hasAnyEnv("KUBERNETES_SERVICE_HOST") {
+		add(workerpb.EnvironmentInfo_HostingEnvironment_HOSTING_ENVIRONMENT_TYPE_K8S, "")
+	}
+	if hasAnyEnv("AWS_LAMBDA_FUNCTION_NAME") {
+		add(workerpb.EnvironmentInfo_HostingEnvironment_HOSTING_ENVIRONMENT_TYPE_AWS_LAMBDA, "")
+	}
+	if hasAnyEnv("ECS_CONTAINER_METADATA_URI_V4", "ECS_CONTAINER_METADATA_URI") {
+		add(workerpb.EnvironmentInfo_HostingEnvironment_HOSTING_ENVIRONMENT_TYPE_AWS_ECS, "")
+	}
+	if hasAnyEnv("K_SERVICE", "CLOUD_RUN_JOB", "CLOUD_RUN_WORKER_POOL") {
+		add(workerpb.EnvironmentInfo_HostingEnvironment_HOSTING_ENVIRONMENT_TYPE_GOOGLE_CLOUD_RUN, "")
+	}
+	if hasAnyEnv("GAE_SERVICE") {
+		add(workerpb.EnvironmentInfo_HostingEnvironment_HOSTING_ENVIRONMENT_TYPE_GOOGLE_APP_ENGINE, "")
+	}
+	if hasAnyEnv("WEBSITE_SITE_NAME") {
+		add(workerpb.EnvironmentInfo_HostingEnvironment_HOSTING_ENVIRONMENT_TYPE_AZURE_APP_SERVICE, envValue("WEBSITE_PLATFORM_VERSION"))
+	}
+	if version := envValue("FUNCTIONS_EXTENSION_VERSION"); version != "" {
+		add(workerpb.EnvironmentInfo_HostingEnvironment_HOSTING_ENVIRONMENT_TYPE_AZURE_FUNCTIONS, version)
+	}
+	if hasAnyEnv("CONTAINER_APP_NAME", "CONTAINER_APP_JOB_NAME") {
+		add(workerpb.EnvironmentInfo_HostingEnvironment_HOSTING_ENVIRONMENT_TYPE_AZURE_CONTAINER_APPS, "")
+	}
+	return environments
+}
+
+func isDocker() bool {
+	if runtime.GOOS == "windows" {
+		return false
+	}
+	if _, err := os.Stat("/.dockerenv"); err == nil {
+		return true
+	}
+	if runtime.GOOS != "linux" {
+		return false
+	}
+	cgroups, err := os.ReadFile("/proc/self/cgroup")
+	if err != nil {
+		return false
+	}
+	return cgroupsIndicateDocker(string(cgroups))
+}
+
+// cgroupsIndicateDocker reports whether any cgroup path in /proc/self/cgroup content has a
+// "docker" or "docker-<id>.scope" component.
+func cgroupsIndicateDocker(cgroups string) bool {
+	for _, line := range strings.Split(cgroups, "\n") {
+		path := line
+		if idx := strings.LastIndex(line, ":"); idx >= 0 {
+			path = line[idx+1:]
+		}
+		for _, component := range strings.Split(path, "/") {
+			if component == "docker" {
+				return true
+			}
+			if id, ok := strings.CutPrefix(component, "docker-"); ok && strings.HasSuffix(id, ".scope") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func detectArchitecture() workerpb.EnvironmentInfo_Architecture {
+	switch runtime.GOARCH {
+	case "amd64":
+		return workerpb.EnvironmentInfo_ARCHITECTURE_AMD64
+	case "arm64":
+		return workerpb.EnvironmentInfo_ARCHITECTURE_ARM64
+	default:
+		return workerpb.EnvironmentInfo_ARCHITECTURE_UNSPECIFIED
+	}
+}

--- a/internal/internal_worker_environment_darwin.go
+++ b/internal/internal_worker_environment_darwin.go
@@ -1,0 +1,24 @@
+package internal
+
+import (
+	"syscall"
+
+	workerpb "go.temporal.io/api/worker/v1"
+)
+
+func detectPlatform() *workerpb.EnvironmentInfo_Platform {
+	// kern.osproductversion holds the marketing version (e.g. "14.2"); kern.osrelease is the
+	// Darwin kernel version and is only used as a fallback.
+	version, err := syscall.Sysctl("kern.osproductversion")
+	if err != nil || version == "" {
+		version, _ = syscall.Sysctl("kern.osrelease")
+	}
+	return &workerpb.EnvironmentInfo_Platform{
+		Variant: &workerpb.EnvironmentInfo_Platform_Macos{
+			Macos: &workerpb.EnvironmentInfo_MacOSPlatform{
+				Version:      version,
+				Architecture: detectArchitecture(),
+			},
+		},
+	}
+}

--- a/internal/internal_worker_environment_linux.go
+++ b/internal/internal_worker_environment_linux.go
@@ -1,0 +1,51 @@
+package internal
+
+import (
+	"bufio"
+	"os"
+	"strings"
+
+	workerpb "go.temporal.io/api/worker/v1"
+)
+
+func detectPlatform() *workerpb.EnvironmentInfo_Platform {
+	return &workerpb.EnvironmentInfo_Platform{
+		Variant: &workerpb.EnvironmentInfo_Platform_Linux{
+			Linux: &workerpb.EnvironmentInfo_LinuxPlatform{
+				Version:      linuxVersion(),
+				Architecture: detectArchitecture(),
+			},
+		},
+	}
+}
+
+// linuxVersion prefers the distribution version from os-release and falls back to the kernel
+// release, matching what Core reports.
+func linuxVersion() string {
+	for _, path := range []string{"/etc/os-release", "/usr/lib/os-release"} {
+		if version := osReleaseValue(path, "VERSION_ID"); version != "" {
+			return version
+		}
+	}
+	release, err := os.ReadFile("/proc/sys/kernel/osrelease")
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(release))
+}
+
+func osReleaseValue(path, key string) string {
+	f, err := os.Open(path)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		k, v, ok := strings.Cut(scanner.Text(), "=")
+		if ok && k == key {
+			return strings.Trim(strings.TrimSpace(v), `"'`)
+		}
+	}
+	return ""
+}

--- a/internal/internal_worker_environment_linux.go
+++ b/internal/internal_worker_environment_linux.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"bufio"
 	"os"
 	"strings"
 
@@ -35,14 +34,12 @@ func linuxVersion() string {
 }
 
 func osReleaseValue(path, key string) string {
-	f, err := os.Open(path)
+	content, err := os.ReadFile(path)
 	if err != nil {
 		return ""
 	}
-	defer f.Close()
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		k, v, ok := strings.Cut(scanner.Text(), "=")
+	for _, line := range strings.Split(string(content), "\n") {
+		k, v, ok := strings.Cut(line, "=")
 		if ok && k == key {
 			return strings.Trim(strings.TrimSpace(v), `"'`)
 		}

--- a/internal/internal_worker_environment_other.go
+++ b/internal/internal_worker_environment_other.go
@@ -1,0 +1,9 @@
+//go:build !linux && !darwin && !windows
+
+package internal
+
+import workerpb "go.temporal.io/api/worker/v1"
+
+func detectPlatform() *workerpb.EnvironmentInfo_Platform {
+	return nil
+}

--- a/internal/internal_worker_environment_test.go
+++ b/internal/internal_worker_environment_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"runtime"
+	"runtime/debug"
 	"testing"
 
 	workerpb "go.temporal.io/api/worker/v1"
@@ -99,5 +100,84 @@ func TestCgroupsIndicateDocker(t *testing.T) {
 		if got := cgroupsIndicateDocker(cgroups); got != want {
 			t.Errorf("cgroupsIndicateDocker(%q) = %v, want %v", cgroups, got, want)
 		}
+	}
+}
+
+func TestDetectRuntimesRoadRunner(t *testing.T) {
+	t.Parallel()
+	goRuntime := workerpb.EnvironmentInfo_Runtime_RUNTIME_TYPE_GO
+	rrRuntime := workerpb.EnvironmentInfo_Runtime_RUNTIME_TYPE_ROADRUNNER
+
+	cases := []struct {
+		name      string
+		buildInfo *debug.BuildInfo
+		want      []*workerpb.EnvironmentInfo_Runtime
+	}{
+		{
+			name:      "no build info",
+			buildInfo: nil,
+			want:      []*workerpb.EnvironmentInfo_Runtime{{Type: goRuntime, Version: runtime.Version()}},
+		},
+		{
+			name: "plain go program",
+			buildInfo: &debug.BuildInfo{
+				Main: debug.Module{Path: "example.com/worker", Version: "(devel)"},
+				Deps: []*debug.Module{{Path: "go.temporal.io/sdk", Version: "v1.50.0"}},
+			},
+			want: []*workerpb.EnvironmentInfo_Runtime{{Type: goRuntime, Version: runtime.Version()}},
+		},
+		{
+			name: "roadrunner release binary",
+			buildInfo: &debug.BuildInfo{
+				Main: debug.Module{Path: "github.com/roadrunner-server/roadrunner/v2025", Version: "v2025.1.2"},
+				Deps: []*debug.Module{{Path: "github.com/temporalio/roadrunner-temporal/v6", Version: "v6.1.0"}},
+			},
+			want: []*workerpb.EnvironmentInfo_Runtime{
+				{Type: goRuntime, Version: runtime.Version()},
+				{Type: rrRuntime, Version: "v2025.1.2"},
+			},
+		},
+		{
+			name: "roadrunner built from source without tag",
+			buildInfo: &debug.BuildInfo{
+				Main: debug.Module{Path: "github.com/roadrunner-server/roadrunner/v2025", Version: "(devel)"},
+			},
+			want: []*workerpb.EnvironmentInfo_Runtime{
+				{Type: goRuntime, Version: runtime.Version()},
+				{Type: rrRuntime},
+			},
+		},
+		{
+			name: "fork embedding the temporal plugin",
+			buildInfo: &debug.BuildInfo{
+				Main: debug.Module{Path: "example.com/custom-rr", Version: "v1.0.0"},
+				Deps: []*debug.Module{{Path: "github.com/temporalio/roadrunner-temporal/v6", Version: "v6.1.0"}},
+			},
+			want: []*workerpb.EnvironmentInfo_Runtime{
+				{Type: goRuntime, Version: runtime.Version()},
+				{Type: rrRuntime},
+			},
+		},
+		{
+			name: "similarly named module is not roadrunner",
+			buildInfo: &debug.BuildInfo{
+				Main: debug.Module{Path: "github.com/roadrunner-server/roadrunner-tools", Version: "v1.0.0"},
+				Deps: []*debug.Module{{Path: "github.com/temporalio/roadrunner-temporal-docs", Version: "v1.0.0"}},
+			},
+			want: []*workerpb.EnvironmentInfo_Runtime{{Type: goRuntime, Version: runtime.Version()}},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := detectRuntimes(tc.buildInfo)
+			if len(got) != len(tc.want) {
+				t.Fatalf("runtimes = %v, want %v", got, tc.want)
+			}
+			for i := range tc.want {
+				if got[i].GetType() != tc.want[i].GetType() || got[i].GetVersion() != tc.want[i].GetVersion() {
+					t.Fatalf("runtime %d = %v, want %v", i, got[i], tc.want[i])
+				}
+			}
+		})
 	}
 }

--- a/internal/internal_worker_environment_test.go
+++ b/internal/internal_worker_environment_test.go
@@ -1,0 +1,103 @@
+package internal
+
+import (
+	"runtime"
+	"testing"
+
+	workerpb "go.temporal.io/api/worker/v1"
+)
+
+func TestDetectEnvironmentInfoReportsGoRuntimeAndPlatform(t *testing.T) {
+	t.Parallel()
+	info := detectEnvironmentInfo()
+
+	if len(info.GetRuntimes()) != 1 {
+		t.Fatalf("runtimes = %v, want exactly one", info.GetRuntimes())
+	}
+	if got := info.GetRuntimes()[0].GetType(); got != workerpb.EnvironmentInfo_Runtime_RUNTIME_TYPE_GO {
+		t.Fatalf("runtime type = %v, want GO", got)
+	}
+	if got := info.GetRuntimes()[0].GetVersion(); got != runtime.Version() {
+		t.Fatalf("runtime version = %q, want %q", got, runtime.Version())
+	}
+
+	var arch workerpb.EnvironmentInfo_Architecture
+	switch runtime.GOOS {
+	case "linux":
+		arch = info.GetPlatform().GetLinux().GetArchitecture()
+	case "darwin":
+		arch = info.GetPlatform().GetMacos().GetArchitecture()
+	case "windows":
+		arch = info.GetPlatform().GetWindows().GetArchitecture()
+	default:
+		if info.GetPlatform() != nil {
+			t.Fatalf("platform = %v, want nil on %s", info.GetPlatform(), runtime.GOOS)
+		}
+		return
+	}
+	want := workerpb.EnvironmentInfo_ARCHITECTURE_UNSPECIFIED
+	switch runtime.GOARCH {
+	case "amd64":
+		want = workerpb.EnvironmentInfo_ARCHITECTURE_AMD64
+	case "arm64":
+		want = workerpb.EnvironmentInfo_ARCHITECTURE_ARM64
+	}
+	if arch != want {
+		t.Fatalf("architecture = %v, want %v", arch, want)
+	}
+}
+
+func TestDetectHostingEnvironments(t *testing.T) {
+	t.Parallel()
+	env := map[string]string{
+		"KUBERNETES_SERVICE_HOST":     "10.0.0.1",
+		"ECS_CONTAINER_METADATA_URI":  "http://169.254.170.2/v3",
+		"WEBSITE_SITE_NAME":           "my-site",
+		"WEBSITE_PLATFORM_VERSION":    " 1.2.3 ",
+		"FUNCTIONS_EXTENSION_VERSION": "~4",
+		"GAE_SERVICE":                 "   ",
+	}
+	lookup := func(name string) (string, bool) {
+		v, ok := env[name]
+		return v, ok
+	}
+	got := detectHostingEnvironments(lookup, func() bool { return true })
+
+	type hosting = workerpb.EnvironmentInfo_HostingEnvironment
+	want := []*hosting{
+		{Type: workerpb.EnvironmentInfo_HostingEnvironment_HOSTING_ENVIRONMENT_TYPE_DOCKER},
+		{Type: workerpb.EnvironmentInfo_HostingEnvironment_HOSTING_ENVIRONMENT_TYPE_K8S},
+		{Type: workerpb.EnvironmentInfo_HostingEnvironment_HOSTING_ENVIRONMENT_TYPE_AWS_ECS},
+		{Type: workerpb.EnvironmentInfo_HostingEnvironment_HOSTING_ENVIRONMENT_TYPE_AZURE_APP_SERVICE, Version: "1.2.3"},
+		{Type: workerpb.EnvironmentInfo_HostingEnvironment_HOSTING_ENVIRONMENT_TYPE_AZURE_FUNCTIONS, Version: "~4"},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("hosting environments = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i].GetType() != want[i].GetType() || got[i].GetVersion() != want[i].GetVersion() {
+			t.Fatalf("hosting environment %d = %v, want %v", i, got[i], want[i])
+		}
+	}
+
+	if got := detectHostingEnvironments(func(string) (string, bool) { return "", false }, func() bool { return false }); len(got) != 0 {
+		t.Fatalf("hosting environments = %v, want none", got)
+	}
+}
+
+func TestCgroupsIndicateDocker(t *testing.T) {
+	t.Parallel()
+	cases := map[string]bool{
+		"0::/":                                                       false,
+		"12:pids:/docker/abc123\n0::/":                               true,
+		"0::/system.slice/docker-abc123.scope":                       true,
+		"0::/system.slice/docker-abc123.service":                     false,
+		"0::/kubepods/besteffort/pod123/dockerish":                   false,
+		"1:name=systemd:/user.slice/user-1000.slice/session-1.scope": false,
+	}
+	for cgroups, want := range cases {
+		if got := cgroupsIndicateDocker(cgroups); got != want {
+			t.Errorf("cgroupsIndicateDocker(%q) = %v, want %v", cgroups, got, want)
+		}
+	}
+}

--- a/internal/internal_worker_environment_windows.go
+++ b/internal/internal_worker_environment_windows.go
@@ -1,0 +1,22 @@
+package internal
+
+import (
+	"fmt"
+
+	workerpb "go.temporal.io/api/worker/v1"
+	"golang.org/x/sys/windows"
+)
+
+func detectPlatform() *workerpb.EnvironmentInfo_Platform {
+	info := windows.RtlGetVersion()
+	return &workerpb.EnvironmentInfo_Platform{
+		Variant: &workerpb.EnvironmentInfo_Platform_Windows{
+			Windows: &workerpb.EnvironmentInfo_WindowsPlatform{
+				Version:      fmt.Sprintf("%d.%d.%d", info.MajorVersion, info.MinorVersion, info.BuildNumber),
+				Architecture: detectArchitecture(),
+				// Go binaries do not link against a C runtime.
+				Crt: workerpb.EnvironmentInfo_WindowsPlatform_CRT_UNSPECIFIED,
+			},
+		},
+	}
+}

--- a/internal/internal_worker_heartbeat.go
+++ b/internal/internal_worker_heartbeat.go
@@ -30,21 +30,28 @@ type heartbeatManager struct {
 	client   *WorkflowClient
 	interval time.Duration
 	logger   log.Logger
+	// environmentInfo is reported once per worker, or nil when reporting is disabled.
+	environmentInfo *workerpb.EnvironmentInfo
 
 	workersMutex sync.Mutex
 	workers      map[string]*sharedNamespaceWorker // namespace -> worker
 }
 
 // newHeartbeatManager creates a new heartbeatManager.
-func newHeartbeatManager(client *WorkflowClient, interval time.Duration, logger log.Logger) *heartbeatManager {
+func newHeartbeatManager(client *WorkflowClient, interval time.Duration, logger log.Logger, disableEnvironmentInfo bool) *heartbeatManager {
 	if logger == nil {
 		logger = ilog.NewDefaultLogger()
 	}
+	var environmentInfo *workerpb.EnvironmentInfo
+	if !disableEnvironmentInfo {
+		environmentInfo = detectEnvironmentInfo()
+	}
 	return &heartbeatManager{
-		client:   client,
-		interval: interval,
-		logger:   logger,
-		workers:  make(map[string]*sharedNamespaceWorker),
+		client:          client,
+		interval:        interval,
+		logger:          logger,
+		environmentInfo: environmentInfo,
+		workers:         make(map[string]*sharedNamespaceWorker),
 	}
 }
 
@@ -73,6 +80,8 @@ func (m *heartbeatManager) sharedNamespaceWorkerForLocked(namespace string) *sha
 		workerCtx:                     heartbeatCtx,
 		heartbeatCancel:               heartbeatCancel,
 		callbacks:                     make(map[string]func() *workerpb.WorkerHeartbeat),
+		environmentInfo:               m.environmentInfo,
+		pendingEnvironment:            make(map[string]struct{}),
 		activityCancellationCallbacks: newActivityCancellationCallbacks(),
 		workerControlTaskQueue:        controlTaskQueue,
 		workerInstanceKey:             uuid.NewString(),
@@ -108,6 +117,9 @@ func (m *heartbeatManager) registerWorker(
 
 	hw.callbacksMutex.Lock()
 	hw.callbacks[worker.workerInstanceKey] = worker.heartbeatCallback
+	if hw.environmentInfo != nil {
+		hw.pendingEnvironment[worker.workerInstanceKey] = struct{}{}
+	}
 	hw.callbacksMutex.Unlock()
 
 	if hw.started.CompareAndSwap(false, true) {
@@ -132,6 +144,7 @@ func (m *heartbeatManager) unregisterWorker(worker *AggregatedWorker) {
 
 	hw.callbacksMutex.Lock()
 	delete(hw.callbacks, worker.workerInstanceKey)
+	delete(hw.pendingEnvironment, worker.workerInstanceKey)
 	remaining := len(hw.callbacks)
 	hw.callbacksMutex.Unlock()
 
@@ -154,6 +167,10 @@ type sharedNamespaceWorker struct {
 	// callbacksMutex should only be unlocked under
 	callbacksMutex sync.RWMutex
 	callbacks      map[string]func() *workerpb.WorkerHeartbeat // workerInstanceKey -> callback
+	// environmentInfo is attached to each worker's heartbeats until the server accepts one, at
+	// which point the worker is removed from pendingEnvironment. Both are guarded by callbacksMutex.
+	environmentInfo    *workerpb.EnvironmentInfo
+	pendingEnvironment map[string]struct{} // workerInstanceKey -> environment not yet delivered
 
 	activityCancellationCallbacks *activityCancellationCallbacks
 	workerCommandsSupported       bool
@@ -207,22 +224,33 @@ func (hw *sharedNamespaceWorker) run() {
 }
 
 func (hw *sharedNamespaceWorker) sendHeartbeats() error {
+	type heartbeatSource struct {
+		workerInstanceKey  string
+		callback           func() *workerpb.WorkerHeartbeat
+		includeEnvironment bool
+	}
 	hw.callbacksMutex.RLock()
-	callbacks := make([]func() *workerpb.WorkerHeartbeat, 0, len(hw.callbacks))
-	for _, cb := range hw.callbacks {
+	sources := make([]heartbeatSource, 0, len(hw.callbacks))
+	for key, cb := range hw.callbacks {
 		if cb != nil {
-			callbacks = append(callbacks, cb)
+			_, includeEnvironment := hw.pendingEnvironment[key]
+			sources = append(sources, heartbeatSource{key, cb, includeEnvironment})
 		}
 	}
 	hw.callbacksMutex.RUnlock()
 
-	if len(callbacks) == 0 {
+	if len(sources) == 0 {
 		return nil
 	}
 
-	heartbeats := make([]*workerpb.WorkerHeartbeat, 0, len(callbacks))
-	for _, cb := range callbacks {
-		hb := cb()
+	heartbeats := make([]*workerpb.WorkerHeartbeat, 0, len(sources))
+	var environmentSent []string
+	for _, source := range sources {
+		hb := source.callback()
+		if source.includeEnvironment {
+			hb.Environment = hw.environmentInfo
+			environmentSent = append(environmentSent, source.workerInstanceKey)
+		}
 		heartbeats = append(heartbeats, hb)
 	}
 
@@ -239,6 +267,15 @@ func (hw *sharedNamespaceWorker) sendHeartbeats() error {
 		}
 		// For other errors, log and continue heartbeating
 		hw.logger.Warn("Failed to send heartbeat", "Error", err)
+		return nil
+	}
+
+	if len(environmentSent) > 0 {
+		hw.callbacksMutex.Lock()
+		for _, key := range environmentSent {
+			delete(hw.pendingEnvironment, key)
+		}
+		hw.callbacksMutex.Unlock()
 	}
 	return nil
 }

--- a/internal/internal_worker_heartbeat.go
+++ b/internal/internal_worker_heartbeat.go
@@ -80,8 +80,7 @@ func (m *heartbeatManager) sharedNamespaceWorkerForLocked(namespace string) *sha
 		workerCtx:                     heartbeatCtx,
 		heartbeatCancel:               heartbeatCancel,
 		callbacks:                     make(map[string]func() *workerpb.WorkerHeartbeat),
-		environmentInfo:               m.environmentInfo,
-		pendingEnvironment:            make(map[string]struct{}),
+		heartbeatSuccessCallbacks:     make(map[string]func()),
 		activityCancellationCallbacks: newActivityCancellationCallbacks(),
 		workerControlTaskQueue:        controlTaskQueue,
 		workerInstanceKey:             uuid.NewString(),
@@ -117,9 +116,7 @@ func (m *heartbeatManager) registerWorker(
 
 	hw.callbacksMutex.Lock()
 	hw.callbacks[worker.workerInstanceKey] = worker.heartbeatCallback
-	if hw.environmentInfo != nil {
-		hw.pendingEnvironment[worker.workerInstanceKey] = struct{}{}
-	}
+	hw.heartbeatSuccessCallbacks[worker.workerInstanceKey] = worker.heartbeatSuccess
 	hw.callbacksMutex.Unlock()
 
 	if hw.started.CompareAndSwap(false, true) {
@@ -144,7 +141,7 @@ func (m *heartbeatManager) unregisterWorker(worker *AggregatedWorker) {
 
 	hw.callbacksMutex.Lock()
 	delete(hw.callbacks, worker.workerInstanceKey)
-	delete(hw.pendingEnvironment, worker.workerInstanceKey)
+	delete(hw.heartbeatSuccessCallbacks, worker.workerInstanceKey)
 	remaining := len(hw.callbacks)
 	hw.callbacksMutex.Unlock()
 
@@ -167,10 +164,9 @@ type sharedNamespaceWorker struct {
 	// callbacksMutex should only be unlocked under
 	callbacksMutex sync.RWMutex
 	callbacks      map[string]func() *workerpb.WorkerHeartbeat // workerInstanceKey -> callback
-	// environmentInfo is attached to each worker's heartbeats until the server accepts one, at
-	// which point the worker is removed from pendingEnvironment. Both are guarded by callbacksMutex.
-	environmentInfo    *workerpb.EnvironmentInfo
-	pendingEnvironment map[string]struct{} // workerInstanceKey -> environment not yet delivered
+	// heartbeatSuccessCallbacks are invoked after the server accepts a heartbeat batch that
+	// included the corresponding worker. Guarded by callbacksMutex.
+	heartbeatSuccessCallbacks map[string]func() // workerInstanceKey -> callback
 
 	activityCancellationCallbacks *activityCancellationCallbacks
 	workerCommandsSupported       bool
@@ -224,34 +220,26 @@ func (hw *sharedNamespaceWorker) run() {
 }
 
 func (hw *sharedNamespaceWorker) sendHeartbeats() error {
-	type heartbeatSource struct {
-		workerInstanceKey  string
-		callback           func() *workerpb.WorkerHeartbeat
-		includeEnvironment bool
-	}
 	hw.callbacksMutex.RLock()
-	sources := make([]heartbeatSource, 0, len(hw.callbacks))
+	callbacks := make([]func() *workerpb.WorkerHeartbeat, 0, len(hw.callbacks))
+	successCallbacks := make([]func(), 0, len(hw.callbacks))
 	for key, cb := range hw.callbacks {
 		if cb != nil {
-			_, includeEnvironment := hw.pendingEnvironment[key]
-			sources = append(sources, heartbeatSource{key, cb, includeEnvironment})
+			callbacks = append(callbacks, cb)
+			if onSuccess := hw.heartbeatSuccessCallbacks[key]; onSuccess != nil {
+				successCallbacks = append(successCallbacks, onSuccess)
+			}
 		}
 	}
 	hw.callbacksMutex.RUnlock()
 
-	if len(sources) == 0 {
+	if len(callbacks) == 0 {
 		return nil
 	}
 
-	heartbeats := make([]*workerpb.WorkerHeartbeat, 0, len(sources))
-	var environmentSent []string
-	for _, source := range sources {
-		hb := source.callback()
-		if source.includeEnvironment {
-			hb.Environment = hw.environmentInfo
-			environmentSent = append(environmentSent, source.workerInstanceKey)
-		}
-		heartbeats = append(heartbeats, hb)
+	heartbeats := make([]*workerpb.WorkerHeartbeat, 0, len(callbacks))
+	for _, cb := range callbacks {
+		heartbeats = append(heartbeats, cb())
 	}
 
 	_, err := hw.client.recordWorkerHeartbeat(hw.workerCtx, &workflowservice.RecordWorkerHeartbeatRequest{
@@ -270,12 +258,8 @@ func (hw *sharedNamespaceWorker) sendHeartbeats() error {
 		return nil
 	}
 
-	if len(environmentSent) > 0 {
-		hw.callbacksMutex.Lock()
-		for _, key := range environmentSent {
-			delete(hw.pendingEnvironment, key)
-		}
-		hw.callbacksMutex.Unlock()
+	for _, onSuccess := range successCallbacks {
+		onSuccess()
 	}
 	return nil
 }

--- a/internal/internal_worker_heartbeat_test.go
+++ b/internal/internal_worker_heartbeat_test.go
@@ -19,6 +19,8 @@ import (
 	"go.temporal.io/sdk/internal/common/metrics"
 	ilog "go.temporal.io/sdk/internal/log"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -314,4 +316,96 @@ func TestWorkerHeartbeatElapsedSinceLastHeartbeatUnsetOnInitialHeartbeat(t *test
 	if secondHeartbeat.GetElapsedSinceLastHeartbeat() == nil {
 		t.Fatal("second elapsed since last heartbeat is nil, want set")
 	}
+}
+
+func TestWorkerHeartbeatEnvironmentSentUntilAccepted(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockService := workflowservicemock.NewMockWorkflowServiceClient(ctrl)
+
+		mockService.EXPECT().GetSystemInfo(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(&workflowservice.GetSystemInfoResponse{}, nil).AnyTimes()
+
+		var requests []*workflowservice.RecordWorkerHeartbeatRequest
+		mockService.EXPECT().RecordWorkerHeartbeat(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, req *workflowservice.RecordWorkerHeartbeatRequest, _ ...grpc.CallOption) (*workflowservice.RecordWorkerHeartbeatResponse, error) {
+				requests = append(requests, req)
+				// Fail the first delivery so the environment must be retried.
+				if len(requests) == 1 {
+					return nil, status.Error(codes.Unavailable, "heartbeat retry")
+				}
+				return &workflowservice.RecordWorkerHeartbeatResponse{}, nil
+			}).AnyTimes()
+
+		wfClient := NewServiceClient(mockService, nil, ClientOptions{
+			Namespace:               "test-ns",
+			Identity:                "test-client-identity",
+			WorkerHeartbeatInterval: time.Second,
+		})
+		wfClient.namespaceData = &namespaceData{
+			capabilities: &namespacepb.NamespaceInfo_Capabilities{WorkerHeartbeats: true},
+		}
+		worker := NewAggregatedWorker(wfClient, "test-task-queue", WorkerOptions{})
+		if err := worker.registerHeartbeatWorker(); err != nil {
+			t.Fatal(err)
+		}
+		defer worker.unregisterHeartbeatWorker()
+
+		for len(requests) < 3 {
+			synctest.Wait()
+			time.Sleep(time.Second)
+		}
+
+		for i, want := range []bool{true, true, false} {
+			hb := requests[i].GetWorkerHeartbeat()[0]
+			if got := hb.GetEnvironment() != nil; got != want {
+				t.Fatalf("heartbeat %d environment present = %v, want %v", i, got, want)
+			}
+		}
+		env := requests[0].GetWorkerHeartbeat()[0].GetEnvironment()
+		if len(env.GetRuntimes()) != 1 || env.GetRuntimes()[0].GetType() != workerpb.EnvironmentInfo_Runtime_RUNTIME_TYPE_GO {
+			t.Fatalf("environment runtimes = %v, want a single GO runtime", env.GetRuntimes())
+		}
+	})
+}
+
+func TestWorkerHeartbeatEnvironmentDisabled(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockService := workflowservicemock.NewMockWorkflowServiceClient(ctrl)
+
+		mockService.EXPECT().GetSystemInfo(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(&workflowservice.GetSystemInfoResponse{}, nil).AnyTimes()
+
+		var request *workflowservice.RecordWorkerHeartbeatRequest
+		mockService.EXPECT().RecordWorkerHeartbeat(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, req *workflowservice.RecordWorkerHeartbeatRequest, _ ...grpc.CallOption) (*workflowservice.RecordWorkerHeartbeatResponse, error) {
+				request = req
+				return &workflowservice.RecordWorkerHeartbeatResponse{}, nil
+			}).AnyTimes()
+
+		wfClient := NewServiceClient(mockService, nil, ClientOptions{
+			Namespace:                    "test-ns",
+			WorkerHeartbeatInterval:      time.Minute,
+			DisableWorkerEnvironmentInfo: true,
+		})
+		wfClient.namespaceData = &namespaceData{
+			capabilities: &namespacepb.NamespaceInfo_Capabilities{WorkerHeartbeats: true},
+		}
+		worker := NewAggregatedWorker(wfClient, "test-task-queue", WorkerOptions{})
+		if err := worker.registerHeartbeatWorker(); err != nil {
+			t.Fatal(err)
+		}
+		defer worker.unregisterHeartbeatWorker()
+
+		synctest.Wait()
+		if request == nil {
+			t.Fatal("initial worker heartbeat was not sent")
+		}
+		if env := request.GetWorkerHeartbeat()[0].GetEnvironment(); env != nil {
+			t.Fatalf("environment = %v, want nil when disabled", env)
+		}
+	})
 }

--- a/internal/internal_worker_heartbeat_test.go
+++ b/internal/internal_worker_heartbeat_test.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"bytes"
 	"context"
+	"sync"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -327,9 +328,17 @@ func TestWorkerHeartbeatEnvironmentSentUntilAccepted(t *testing.T) {
 		mockService.EXPECT().GetSystemInfo(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(&workflowservice.GetSystemInfoResponse{}, nil).AnyTimes()
 
+		var requestsMu sync.Mutex
 		var requests []*workflowservice.RecordWorkerHeartbeatRequest
+		requestCount := func() int {
+			requestsMu.Lock()
+			defer requestsMu.Unlock()
+			return len(requests)
+		}
 		mockService.EXPECT().RecordWorkerHeartbeat(gomock.Any(), gomock.Any(), gomock.Any()).
 			DoAndReturn(func(_ context.Context, req *workflowservice.RecordWorkerHeartbeatRequest, _ ...grpc.CallOption) (*workflowservice.RecordWorkerHeartbeatResponse, error) {
+				requestsMu.Lock()
+				defer requestsMu.Unlock()
 				requests = append(requests, req)
 				// Fail the first delivery so the environment must be retried.
 				if len(requests) == 1 {
@@ -352,11 +361,13 @@ func TestWorkerHeartbeatEnvironmentSentUntilAccepted(t *testing.T) {
 		}
 		defer worker.unregisterHeartbeatWorker()
 
-		for len(requests) < 3 {
+		for requestCount() < 3 {
 			synctest.Wait()
 			time.Sleep(time.Second)
 		}
 
+		requestsMu.Lock()
+		defer requestsMu.Unlock()
 		for i, want := range []bool{true, true, false} {
 			hb := requests[i].GetWorkerHeartbeat()[0]
 			if got := hb.GetEnvironment() != nil; got != want {
@@ -408,4 +419,28 @@ func TestWorkerHeartbeatEnvironmentDisabled(t *testing.T) {
 			t.Fatalf("environment = %v, want nil when disabled", env)
 		}
 	})
+}
+
+func TestWorkerHeartbeatEnvironmentIncludedInShutdownHeartbeat(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	mockService := workflowservicemock.NewMockWorkflowServiceClient(ctrl)
+	mockService.EXPECT().GetSystemInfo(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(&workflowservice.GetSystemInfoResponse{}, nil).AnyTimes()
+
+	wfClient := NewServiceClient(mockService, nil, ClientOptions{
+		Namespace:               "test-ns",
+		WorkerHeartbeatInterval: time.Minute,
+	})
+	worker := NewAggregatedWorker(wfClient, "test-task-queue", WorkerOptions{})
+
+	// Without any accepted periodic heartbeat, the heartbeat built for ShutdownWorker must
+	// still carry the environment.
+	if worker.heartbeatCallback().GetEnvironment() == nil {
+		t.Fatal("heartbeat before any success has no environment, want environment")
+	}
+	worker.heartbeatSuccess()
+	if env := worker.heartbeatCallback().GetEnvironment(); env != nil {
+		t.Fatalf("heartbeat after success has environment %v, want nil", env)
+	}
 }

--- a/test/nexus_test.go
+++ b/test/nexus_test.go
@@ -3633,6 +3633,7 @@ func (t *otelTracer) spanChildren(spans []sdktrace.ReadOnlySpan, parentID trace.
 }
 
 func TestNexusTracingInterceptor(t *testing.T) {
+	skipOnCloud(t, cloudRequiresProvisioning, "creates a Nexus endpoint through Operator Service")
 	cases := []struct {
 		name   string
 		tracer func(t *testing.T) interceptortest.TestTracer


### PR DESCRIPTION
## What was changed

Worker heartbeats now include an `EnvironmentInfo` message describing the Go runtime version, detected hosting environments (Docker, Kubernetes, AWS Lambda/ECS, Google Cloud Run/App Engine, Azure App Service/Functions/Container Apps), and the OS platform (Linux/macOS/Windows version and architecture).

The information is attached to each worker's heartbeats until the server accepts one, then omitted. Delivery state is tracked in the shared-namespace heartbeat worker and cleared only after a successful `RecordWorkerHeartbeat`.

A new experimental `client.Options.DisableWorkerEnvironmentInfo` turns the reporting off.

## Why?

Port of Core's temporalio/sdk-rust#1457 so all SDKs report the same analytical information about the environments they run in.

## Checklist

1. Closes N/A

2. How was this tested:

New unit tests cover environment detection (runtime, hosting-environment env vars, cgroup parsing), retry-until-accepted delivery, and the disable option. `go vet` and the full `./internal` package pass, and the per-OS platform files cross-compile for linux, darwin, windows, and other.

3. Any docs updates needed?

No. CHANGELOG entry added.