### PR TITLE
Document root workflow namespace omission

### DIFF
--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -1189,6 +1189,7 @@ type WorkflowExecutionMetadata struct {
 	// This field is only set if the workflow execution is a child of another workflow execution
 	ParentWorkflowExecution *WorkflowExecution
 	// RootWorkflowExecution is the root workflow execution
+	// Its namespace is not retained and may differ from this workflow's namespace for cross-namespace child workflows. Track it separately if needed.
 	RootWorkflowExecution *WorkflowExecution
 	// WorkflowStartTime is the time when the workflow execution started
 	WorkflowStartTime time.Time

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -1547,6 +1547,7 @@ type WorkflowInfo struct {
 	// ParentWorkflowExecution is the execution of the parent workflow.
 	ParentWorkflowExecution *WorkflowExecution
 	// RootWorkflowExecution is the first workflow execution in the chain of workflows. If a workflow is itself a root workflow, then this field is nil.
+	// Its namespace is not retained and may differ from this workflow's namespace for cross-namespace child workflows. Track it separately if needed.
 	RootWorkflowExecution *WorkflowExecution
 	// Memo can be decoded using data converter (defaultDataConverter, or custom one if set).
 	Memo *commonpb.Memo


### PR DESCRIPTION
## What was changed
Document that root workflow execution information omits its namespace. The root namespace may differ for cross-namespace child workflows and must be tracked separately.

## Why?
Completes the documentation requirement from temporalio/features#605.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only documentation updates with no logic, API, or serialization changes.
> 
> **Overview**
> Adds matching godoc on **`RootWorkflowExecution`** in workflow runtime info (`internal/workflow.go`) and in **`WorkflowExecutionMetadata`** from Describe (`internal/internal_workflow_client.go`).
> 
> The new text states that the root execution’s **namespace is not retained** on this field and may differ from the current workflow’s namespace for **cross-namespace child workflows**, so callers should **track root namespace separately** if they need it. This is documentation only; no API or runtime behavior changes (aligned with temporalio/features#605).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e224c30b53466665096a87683c2c627306a7231. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->