### PR TITLE
fix(extstore): report wall-clock duration for storage metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,9 @@ to docs, or any other relevant information.
 
 ### Fixed
 
+- The `PayloadDownloadDuration` and `PayloadUploadDuration` fields on the workflow task duration log
+  now report the wall-clock time external storage was in flight. Previously each batch's duration was
+  summed, over-reporting the time whenever storage operations ran concurrently.
 - Stand-alone activities started from a redelivered Nexus operation handler now reuse the Nexus
   request ID, preventing duplicate Nexus links when an idempotent start resolves to the original run.
 - `temporal.IsWorkflowExecutionAlreadyStartedError` now detects wrapped

--- a/internal/extstore/extstore_test.go
+++ b/internal/extstore/extstore_test.go
@@ -1269,10 +1269,10 @@ type testCallback struct {
 	duration time.Duration
 }
 
-func (c *testCallback) PayloadBatchCompleted(count int, size int64, duration time.Duration, _ []string) {
+func (c *testCallback) PayloadBatchCompleted(count int, size int64, start, end time.Time, _ []string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.count = count
 	c.size = size
-	c.duration = duration
+	c.duration = end.Sub(start)
 }

--- a/internal/extstore/internal_extstore.go
+++ b/internal/extstore/internal_extstore.go
@@ -94,8 +94,11 @@ func driversEqual(a, b StorageDriver) (equal bool) {
 	return a == b
 }
 
+// StorageOperationCallback is notified as each batch of storage operations completes. Batches
+// may run concurrently, so a batch reports the start and end of its span rather than a duration,
+// leaving the caller to decide how overlapping spans combine.
 type StorageOperationCallback interface {
-	PayloadBatchCompleted(count int, size int64, duration time.Duration, driverNames []string)
+	PayloadBatchCompleted(count int, size int64, start, end time.Time, driverNames []string)
 }
 
 type contextKey string
@@ -290,7 +293,7 @@ func (v *externalRetrievalVisitor) Visit(ctx *proxy.VisitPayloadsContext, payloa
 
 	if callbackValue := ctx.Value(storageOperationCallbackContextKey); callbackValue != nil {
 		if callback, isCallback := callbackValue.(StorageOperationCallback); isCallback {
-			callback.PayloadBatchCompleted(externalCount, externalTotalSize, time.Since(startTime), driverOrder)
+			callback.PayloadBatchCompleted(externalCount, externalTotalSize, startTime, time.Now(), driverOrder)
 		}
 	}
 	return result, nil
@@ -406,7 +409,7 @@ func (v *externalStorageVisitor) Visit(ctx *proxy.VisitPayloadsContext, payloads
 
 	if callbackValue := ctx.Value(storageOperationCallbackContextKey); callbackValue != nil {
 		if callback, isCallback := callbackValue.(StorageOperationCallback); isCallback {
-			callback.PayloadBatchCompleted(externalCount, externalTotalSize, time.Since(startTime), driverOrder)
+			callback.PayloadBatchCompleted(externalCount, externalTotalSize, startTime, time.Now(), driverOrder)
 		}
 	}
 	return result, nil

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -685,7 +685,7 @@ func (wtp *workflowTaskProcessor) RespondTaskCompletedWithMetrics(
 		loggerDurationKeyVals = append(loggerDurationKeyVals,
 			tagPayloadDownloadCount, downloadPayloadMetrics.payloadCount,
 			tagPayloadDownloadSize, downloadPayloadMetrics.totalSize,
-			tagPayloadDownloadDuration, downloadPayloadMetrics.totalDuration,
+			tagPayloadDownloadDuration, downloadPayloadMetrics.TotalDuration(),
 			tagPayloadDownloadDrivers, downloadPayloadMetrics.GetDriverNames(),
 		)
 	}
@@ -693,7 +693,7 @@ func (wtp *workflowTaskProcessor) RespondTaskCompletedWithMetrics(
 		loggerDurationKeyVals = append(loggerDurationKeyVals,
 			tagPayloadUploadCount, uploadPayloadMetrics.payloadCount,
 			tagPayloadUploadSize, uploadPayloadMetrics.totalSize,
-			tagPayloadUploadDuration, uploadPayloadMetrics.totalDuration,
+			tagPayloadUploadDuration, uploadPayloadMetrics.TotalDuration(),
 			tagPayloadUploadDrivers, uploadPayloadMetrics.GetDriverNames(),
 		)
 	}
@@ -1000,26 +1000,53 @@ func (wtp *workflowTaskProcessor) errorToFailWorkflowTaskWithCause(taskToken []b
 	return builtRequest
 }
 
+// workflowTaskStorageMetrics implements extstore.StorageOperationCallback for a single workflow
+// task. Batches may complete concurrently, so mu guards every field.
 type workflowTaskStorageMetrics struct {
-	mu            sync.Mutex
-	payloadCount  int
-	totalSize     int64
-	totalDuration time.Duration
-	driverNames   map[string]struct{}
+	mu           sync.Mutex
+	payloadCount int
+	totalSize    int64
+	// Start and end of each completed batch.
+	spans       [][2]time.Time
+	driverNames map[string]struct{}
 }
 
-func (callback *workflowTaskStorageMetrics) PayloadBatchCompleted(count int, size int64, duration time.Duration, driverNames []string) {
+func (callback *workflowTaskStorageMetrics) PayloadBatchCompleted(count int, size int64, start, end time.Time, driverNames []string) {
 	callback.mu.Lock()
 	defer callback.mu.Unlock()
 	callback.payloadCount += count
 	callback.totalSize += size
-	callback.totalDuration += duration
+	callback.spans = append(callback.spans, [2]time.Time{start, end})
 	for _, name := range driverNames {
 		if callback.driverNames == nil {
 			callback.driverNames = make(map[string]struct{})
 		}
 		callback.driverNames[name] = struct{}{}
 	}
+}
+
+// TotalDuration reports the wall-clock time storage was in flight. Batches may run
+// concurrently, so overlapping spans are counted once rather than summed.
+func (callback *workflowTaskStorageMetrics) TotalDuration() time.Duration {
+	callback.mu.Lock()
+	defer callback.mu.Unlock()
+	if len(callback.spans) == 0 {
+		return 0
+	}
+	ordered := make([][2]time.Time, len(callback.spans))
+	copy(ordered, callback.spans)
+	sort.Slice(ordered, func(i, j int) bool { return ordered[i][0].Before(ordered[j][0]) })
+	var total time.Duration
+	spanStart, spanEnd := ordered[0][0], ordered[0][1]
+	for _, span := range ordered[1:] {
+		if span[0].After(spanEnd) {
+			total += spanEnd.Sub(spanStart)
+			spanStart, spanEnd = span[0], span[1]
+		} else if span[1].After(spanEnd) {
+			spanEnd = span[1]
+		}
+	}
+	return total + spanEnd.Sub(spanStart)
 }
 
 func (callback *workflowTaskStorageMetrics) GetDriverNames() []string {

--- a/internal/internal_task_pollers_test.go
+++ b/internal/internal_task_pollers_test.go
@@ -731,3 +731,39 @@ func TestDoPollGracefulShutdown(t *testing.T) {
 		})
 	}
 }
+
+func TestWorkflowTaskStorageMetricsTotalDuration(t *testing.T) {
+	base := time.Now()
+
+	t.Run("no batches", func(t *testing.T) {
+		metrics := &workflowTaskStorageMetrics{}
+		require.Equal(t, time.Duration(0), metrics.TotalDuration())
+	})
+
+	t.Run("concurrent batches counted once", func(t *testing.T) {
+		metrics := &workflowTaskStorageMetrics{}
+		metrics.PayloadBatchCompleted(2, 1024, base, base.Add(10*time.Second), []string{"s3"})
+		metrics.PayloadBatchCompleted(3, 2048, base.Add(5*time.Second), base.Add(15*time.Second), []string{"gcs"})
+
+		// Summing each batch's duration would report 20s.
+		require.Equal(t, 15*time.Second, metrics.TotalDuration())
+		require.Equal(t, 5, metrics.payloadCount)
+		require.Equal(t, int64(3072), metrics.totalSize)
+		require.Equal(t, []string{"gcs", "s3"}, metrics.GetDriverNames())
+	})
+
+	t.Run("disjoint batches summed", func(t *testing.T) {
+		metrics := &workflowTaskStorageMetrics{}
+		metrics.PayloadBatchCompleted(1, 1, base, base.Add(10*time.Second), nil)
+		metrics.PayloadBatchCompleted(1, 1, base.Add(20*time.Second), base.Add(30*time.Second), nil)
+		require.Equal(t, 20*time.Second, metrics.TotalDuration())
+	})
+
+	t.Run("adjacent and nested batches merged", func(t *testing.T) {
+		metrics := &workflowTaskStorageMetrics{}
+		metrics.PayloadBatchCompleted(1, 1, base, base.Add(10*time.Second), nil)
+		metrics.PayloadBatchCompleted(1, 1, base.Add(10*time.Second), base.Add(20*time.Second), nil)
+		metrics.PayloadBatchCompleted(1, 1, base.Add(12*time.Second), base.Add(18*time.Second), nil)
+		require.Equal(t, 20*time.Second, metrics.TotalDuration())
+	})
+}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Fix external storage duration metrics to measure wall-clock time instead of sum of each driver call.

## Why?

More accurately reflect the wall-clock time spent on storage operations in a workflow task.

## Checklist
<!--- add/delete as needed --->

1. Closes #2378

2. How was this tested: Unit tests

3. Any docs updates needed? No
