### PR TITLE
Add hints that function literals aren't supported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,8 @@ to docs, or any other relevant information.
   reset-workflow failure. Previously the raw payload proto was treated as a single detail value,
   so calling `Details()` on the resulting `ApplicationError` returned `ErrTooManyArg` instead of
   decoding it.
+- Added documentation that function literals (closures) shouldn't be registered as
+  workflow functions or activity functions.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,7 +84,7 @@ to docs, or any other relevant information.
   so calling `Details()` on the resulting `ApplicationError` returned `ErrTooManyArg` instead of
   decoding it.
 - Added documentation that function literals (closures) shouldn't be registered as
-  workflow functions or activity functions.
+  workflow functions or activity functions without an alias.
 
 ### Security
 

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -10,6 +10,7 @@ import (
 	"math"
 	"os"
 	"reflect"
+	"regexp"
 	"runtime"
 	"sort"
 	"strconv"
@@ -75,6 +76,8 @@ const (
 	unlimitedDeadlockDetectionTimeout = math.MaxInt64
 
 	testTagsContextKey = "temporal-testTags"
+
+	functionLiteralRegistrationHint = "It looks like you might have registered a function literal (closure), which is not supported."
 )
 
 type (
@@ -753,7 +756,11 @@ func (r *registry) RegisterWorkflowWithOptions(
 
 	if !options.DisableAlreadyRegisteredCheck {
 		if _, ok := r.workflowFuncMap[registerName]; ok {
-			panic(fmt.Sprintf("workflow name \"%v\" is already registered", registerName))
+			message := fmt.Sprintf("workflow name \"%v\" is already registered", registerName)
+			if mightBeFunctionLiteral(wf) {
+				message += ". " + functionLiteralRegistrationHint
+			}
+			panic(message)
 		}
 	}
 	r.workflowFuncMap[registerName] = wf
@@ -835,7 +842,11 @@ func (r *registry) RegisterActivityWithOptions(
 
 	if !options.DisableAlreadyRegisteredCheck {
 		if _, ok := r.activityFuncMap[registerName]; ok {
-			panic(fmt.Sprintf("activity type \"%v\" is already registered", registerName))
+			message := fmt.Sprintf("activity type \"%v\" is already registered", registerName)
+			if mightBeFunctionLiteral(af) {
+				message += ". " + functionLiteralRegistrationHint
+			}
+			panic(message)
 		}
 	}
 	r.activityFuncMap[registerName] = &activityExecutor{name: registerName, fn: af}
@@ -2744,6 +2755,18 @@ func isValidResultType(inType reflect.Type) bool {
 func isError(inType reflect.Type) bool {
 	errorElem := reflect.TypeFor[error]()
 	return inType != nil && inType.Implements(errorElem)
+}
+
+// isFunctionLiteral matches strings that look like they could be the names
+// of function literals in Go 1.27+. Specifically, suffixes of the form funcN or
+// funcN.M for some numbers N and M.
+var functionLiteralNamePattern = regexp.MustCompile(`func\d+(?:\.\d+)?$`)
+
+// mightBeFunctionLiteral returns true if the given function looks like a function literal.
+// False positives are possible.
+func mightBeFunctionLiteral(fn any) bool {
+	fullName := runtime.FuncForPC(reflect.ValueOf(fn).Pointer()).Name()
+	return functionLiteralNamePattern.MatchString(fullName)
 }
 
 func getFunctionName(i any) (name string, isMethod bool) {

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -77,7 +77,7 @@ const (
 
 	testTagsContextKey = "temporal-testTags"
 
-	functionLiteralRegistrationHint = "It looks like you might have registered a function literal (closure), which is not supported."
+	functionLiteralRegistrationHint = "It looks like you registered a function literal (closure) without giving it an alias."
 )
 
 type (
@@ -758,7 +758,7 @@ func (r *registry) RegisterWorkflowWithOptions(
 		if _, ok := r.workflowFuncMap[registerName]; ok {
 			message := fmt.Sprintf("workflow name \"%v\" is already registered", registerName)
 			if mightBeFunctionLiteral(wf) {
-				message += ". " + functionLiteralRegistrationHint
+				message += ". " + functionLiteralRegistrationHint + " Try RegisterWorkflowWithOptions instead."
 			}
 			panic(message)
 		}
@@ -844,7 +844,7 @@ func (r *registry) RegisterActivityWithOptions(
 		if _, ok := r.activityFuncMap[registerName]; ok {
 			message := fmt.Sprintf("activity type \"%v\" is already registered", registerName)
 			if mightBeFunctionLiteral(af) {
-				message += ". " + functionLiteralRegistrationHint
+				message += ". " + functionLiteralRegistrationHint + " Try RegisterActivityWithOptions instead."
 			}
 			panic(message)
 		}

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -77,7 +77,13 @@ const (
 
 	testTagsContextKey = "temporal-testTags"
 
-	functionLiteralRegistrationHint = "It looks like you registered a function literal (closure) without giving it an alias."
+	workflowLiteralRegistrationHint =
+		"It looks like you registered a function literal (closure) without giving it an alias. " +
+		"Register it with RegisterWorkflowWithOptions and set Name to a stable, unique name."
+
+	activityLiteralRegistrationHint =
+		"It looks like you registered a function literal (closure) without giving it an alias. " +
+		"Register it with RegisterActivityWithOptions and set Name to a stable, unique name."
 )
 
 type (
@@ -757,8 +763,8 @@ func (r *registry) RegisterWorkflowWithOptions(
 	if !options.DisableAlreadyRegisteredCheck {
 		if _, ok := r.workflowFuncMap[registerName]; ok {
 			message := fmt.Sprintf("workflow name \"%v\" is already registered", registerName)
-			if mightBeFunctionLiteral(wf) {
-				message += ". " + functionLiteralRegistrationHint + " Try RegisterWorkflowWithOptions instead."
+			if mightBeFunctionLiteral(wf) && len(alias) == 0 {
+				message += ". " + workflowLiteralRegistrationHint
 			}
 			panic(message)
 		}
@@ -843,8 +849,8 @@ func (r *registry) RegisterActivityWithOptions(
 	if !options.DisableAlreadyRegisteredCheck {
 		if _, ok := r.activityFuncMap[registerName]; ok {
 			message := fmt.Sprintf("activity type \"%v\" is already registered", registerName)
-			if mightBeFunctionLiteral(af) {
-				message += ". " + functionLiteralRegistrationHint + " Try RegisterActivityWithOptions instead."
+			if mightBeFunctionLiteral(af) && len(alias) == 0 {
+				message += ". " + activityLiteralRegistrationHint
 			}
 			panic(message)
 		}
@@ -2757,14 +2763,13 @@ func isError(inType reflect.Type) bool {
 	return inType != nil && inType.Implements(errorElem)
 }
 
-// isFunctionLiteral matches strings that look like they could be the names
-// of function literals in Go 1.27+. Specifically, suffixes of the form funcN or
-// funcN.M for some numbers N and M.
-var functionLiteralNamePattern = regexp.MustCompile(`func\d+(?:\.\d+)?$`)
 
 // mightBeFunctionLiteral returns true if the given function looks like a function literal.
-// False positives are possible.
+// BEWARE: False positives are possible! Normal function declarations might look like literals.
+// BEWARE: False negatives are possible! Future versions of Go may change the naming scheme.
 func mightBeFunctionLiteral(fn any) bool {
+	// Matches suffixes of the form funcN or funcN.M for some numbers N and M.
+	var functionLiteralNamePattern = regexp.MustCompile(`func\d+(?:\.\d+)?$`)
 	fullName := runtime.FuncForPC(reflect.ValueOf(fn).Pointer()).Name()
 	return functionLiteralNamePattern.MatchString(fullName)
 }

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -3550,6 +3550,34 @@ func TestHistoryFromJSON(t *testing.T) {
 func aliasNameClash1(context.Context) (string, error) { return "func1", nil }
 func aliasNameClash2(context.Context) (string, error) { return "func2", nil }
 
+func TestFunctionLiteralDuplicateRegistrationHint(t *testing.T) {
+	t.Run("workflow", func(t *testing.T) {
+		registry := newRegistry()
+		workflowFn := func(Context) error { return nil }
+		registry.RegisterWorkflow(workflowFn)
+
+		err := runAndCatchPanic(func() { registry.RegisterWorkflow(workflowFn) })
+		require.ErrorContains(t, err, functionLiteralRegistrationHint)
+	})
+
+	t.Run("activity", func(t *testing.T) {
+		registry := newRegistry()
+		activityFn := func(context.Context) error { return nil }
+		registry.RegisterActivity(activityFn)
+
+		err := runAndCatchPanic(func() { registry.RegisterActivity(activityFn) })
+		require.ErrorContains(t, err, functionLiteralRegistrationHint)
+	})
+
+	t.Run("declared function", func(t *testing.T) {
+		registry := newRegistry()
+		registry.RegisterActivity(aliasNameClash1)
+
+		err := runAndCatchPanic(func() { registry.RegisterActivity(aliasNameClash1) })
+		require.NotContains(t, err.Error(), functionLiteralRegistrationHint)
+	})
+}
+
 type aliasNameClashStruct struct{}
 
 func (aliasNameClashStruct) aliasNameClash1(context.Context) (string, error) { return "func3", nil }

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -3550,6 +3550,8 @@ func TestHistoryFromJSON(t *testing.T) {
 func aliasNameClash1(context.Context) (string, error) { return "func1", nil }
 func aliasNameClash2(context.Context) (string, error) { return "func2", nil }
 
+// Two distinct closures might have the same FuncForPC name, causing a registry
+// collision. This can be confusing, so we try to hint at what went wrong.
 func TestFunctionLiteralDuplicateRegistrationHint(t *testing.T) {
 	t.Run("workflow", func(t *testing.T) {
 		registry := newRegistry()
@@ -3557,7 +3559,7 @@ func TestFunctionLiteralDuplicateRegistrationHint(t *testing.T) {
 		registry.RegisterWorkflow(workflowFn)
 
 		err := runAndCatchPanic(func() { registry.RegisterWorkflow(workflowFn) })
-		require.ErrorContains(t, err, functionLiteralRegistrationHint)
+		require.ErrorContains(t, err, workflowLiteralRegistrationHint)
 	})
 
 	t.Run("activity", func(t *testing.T) {
@@ -3566,15 +3568,17 @@ func TestFunctionLiteralDuplicateRegistrationHint(t *testing.T) {
 		registry.RegisterActivity(activityFn)
 
 		err := runAndCatchPanic(func() { registry.RegisterActivity(activityFn) })
-		require.ErrorContains(t, err, functionLiteralRegistrationHint)
+		require.ErrorContains(t, err, activityLiteralRegistrationHint)
 	})
 
+	// We do expect some false positives and false negatives, but most declared
+	// functions (like the one below) shouldn't print the hint.
 	t.Run("declared function", func(t *testing.T) {
 		registry := newRegistry()
 		registry.RegisterActivity(aliasNameClash1)
 
 		err := runAndCatchPanic(func() { registry.RegisterActivity(aliasNameClash1) })
-		require.NotContains(t, err.Error(), functionLiteralRegistrationHint)
+		require.NotContains(t, err.Error(), activityLiteralRegistrationHint)
 	})
 }
 

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -61,12 +61,15 @@ type (
 	// WorkflowRegistry exposes workflow registration functions to consumers.
 	WorkflowRegistry interface {
 		// RegisterWorkflow - registers a workflow function with the worker.
+		// Function literals (closures) are not supported.
 		// A workflow takes a [workflow.Context] and input and returns a (result, error) or just error.
+		//
 		// Examples:
 		//	func sampleWorkflow(ctx workflow.Context, input []byte) (result []byte, err error)
 		//	func sampleWorkflow(ctx workflow.Context, arg1 int, arg2 string) (result []byte, err error)
 		//	func sampleWorkflow(ctx workflow.Context) (result []byte, err error)
 		//	func sampleWorkflow(ctx workflow.Context, arg1 int) (result string, err error)
+		//
 		// Serialization of all primitive types, structures is supported ... except channels, functions, variadic, unsafe pointer.
 		// For global registration consider workflow.Register
 		// This method panics if workflowFunc doesn't comply with the expected format or tries to register the same workflow
@@ -88,9 +91,10 @@ type (
 	// ActivityRegistry exposes activity registration functions to consumers.
 	ActivityRegistry interface {
 		// RegisterActivity - register an activity function or a pointer to a structure with the worker.
+		// Function literals (closures) are not supported.
 		// An activity function takes a context and input and returns a (result, error) or just error.
 		//
-		// And activity struct is a structure with all its exported methods treated as activities. The default
+		// An activity struct is a structure with all its exported methods treated as activities. The default
 		// name of each activity is the method name.
 		//
 		// Examples:

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -61,7 +61,6 @@ type (
 	// WorkflowRegistry exposes workflow registration functions to consumers.
 	WorkflowRegistry interface {
 		// RegisterWorkflow - registers a workflow function with the worker.
-		// Function literals (closures) are not supported.
 		// A workflow takes a [workflow.Context] and input and returns a (result, error) or just error.
 		//
 		// Examples:
@@ -71,8 +70,9 @@ type (
 		//	func sampleWorkflow(ctx workflow.Context, arg1 int) (result string, err error)
 		//
 		// Serialization of all primitive types, structures is supported ... except channels, functions, variadic, unsafe pointer.
-		// For global registration consider workflow.Register
-		// This method panics if workflowFunc doesn't comply with the expected format or tries to register the same workflow
+		// For global registration consider workflow.Register.
+		// This method panics if workflowFunc doesn't comply with the expected format or tries to register the same workflow.
+		// To register function literals (closures), use [RegisterWorkflowWithOptions] to assign a type name explicitly.
 		RegisterWorkflow(w any)
 
 		// RegisterWorkflowWithOptions registers the workflow function with options.
@@ -119,6 +119,7 @@ type (
 		// Serialization of all primitive types, structures is supported ... except channels, functions, variadic, unsafe pointer.
 		// This method panics if activityFunc doesn't comply with the expected format or an activity with the same
 		// type name is registered more than once.
+		// To register function literals (closures), use RegisterActivityWithOptions to assign a type name explicitly.
 		RegisterActivity(a any)
 
 		// RegisterActivityWithOptions registers the activity function or struct pointer with options.

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -72,7 +72,7 @@ type (
 		// Serialization of all primitive types, structures is supported ... except channels, functions, variadic, unsafe pointer.
 		// For global registration consider workflow.Register.
 		// This method panics if workflowFunc doesn't comply with the expected format or tries to register the same workflow.
-		// To register function literals (closures), use [RegisterWorkflowWithOptions] to assign a type name explicitly.
+		// To register function literals (closures), use [WorkflowRegistry.RegisterWorkflowWithOptions] to assign a type name explicitly.
 		RegisterWorkflow(w any)
 
 		// RegisterWorkflowWithOptions registers the workflow function with options.
@@ -91,7 +91,6 @@ type (
 	// ActivityRegistry exposes activity registration functions to consumers.
 	ActivityRegistry interface {
 		// RegisterActivity - register an activity function or a pointer to a structure with the worker.
-		// Function literals (closures) are not supported.
 		// An activity function takes a context and input and returns a (result, error) or just error.
 		//
 		// An activity struct is a structure with all its exported methods treated as activities. The default
@@ -119,7 +118,7 @@ type (
 		// Serialization of all primitive types, structures is supported ... except channels, functions, variadic, unsafe pointer.
 		// This method panics if activityFunc doesn't comply with the expected format or an activity with the same
 		// type name is registered more than once.
-		// To register function literals (closures), use RegisterActivityWithOptions to assign a type name explicitly.
+		// To register function literals (closures), use [ActivityRegistry.RegisterActivityWithOptions] to assign a type name explicitly.
 		RegisterActivity(a any)
 
 		// RegisterActivityWithOptions registers the activity function or struct pointer with options.


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
- Update `RegisterWorkflow` and `RegisterActivity` to hint that function literals (closures) aren't supported.
- In case of duplicate registration, use a regex see if the user is registering a function literal. If so, emit a hint.

## Why?
<!-- Tell your future self why have you made these changes -->
Document an assumption we've been making all along. Go 1.27 changed its naming convention for function literals, making it more likely for users to run into this issue. @stephanos gave an example from the OSS server:

> The test was failing on workflow name "func1" is already registered when using
> ```
> for _, wf := range wfs {
> 	w.RegisterWorkflow(wf)
> }
> ```

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here --> nothing

2. How was this tested: Added a test case to see if the error hint is only emitted for functions that match the regex.
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed? Updated docstrings for public functions.
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
