### PR TITLE
fix: classify legacy query task failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ to docs, or any other relevant information.
 - Malformed Nexus link errors now log the link URL and parse error under stable structured fields.
 - Legacy query task processing failures are now reported through `RespondQueryTaskCompleted` instead of
   `RespondWorkflowTaskFailed`, allowing query callers to receive the failure instead of timing out.
+- Legacy query task failures now include the applicable workflow task failure cause in their response.
 - Local activity results are now serialized with the local activity's `ActivitySerializationContext`
   (`IsLocal=true`) on both ends. Previously the result was encoded with the plain worker data converter
   but decoded through the workflow serialization context, so a context-aware `DataConverter` or

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -959,6 +959,7 @@ func (wtp *workflowTaskProcessor) taskFailureCompletion(
 				ErrorMessage:  err.Error(),
 				Namespace:     wtp.namespace,
 				Failure:       wtp.failureConverter.ErrorToFailure(err),
+				Cause:         workflowTaskFailureCause(err),
 			},
 		}
 	}

--- a/internal/internal_task_pollers_test.go
+++ b/internal/internal_task_pollers_test.go
@@ -530,6 +530,7 @@ func TestLegacyQueryProcessingFailureReportedAsQueryFailure(t *testing.T) {
 			require.Equal(t, taskErr.Error(), req.ErrorMessage)
 			require.Equal(t, "test-namespace", req.Namespace)
 			require.NotNil(t, req.Failure)
+			require.Equal(t, enumspb.WORKFLOW_TASK_FAILED_CAUSE_WORKFLOW_WORKER_UNHANDLED_FAILURE, req.Cause)
 			return &workflowservice.RespondQueryTaskCompletedResponse{}, nil
 		})
 
@@ -607,6 +608,7 @@ func TestLegacyQueryOutboundVisitorFailureReportedAsQueryFailure(t *testing.T) {
 			require.Equal(t, visitorErr.Error(), req.ErrorMessage)
 			require.Equal(t, "test-namespace", req.Namespace)
 			require.NotNil(t, req.Failure)
+			require.Equal(t, enumspb.WORKFLOW_TASK_FAILED_CAUSE_WORKFLOW_WORKER_UNHANDLED_FAILURE, req.Cause)
 			return &workflowservice.RespondQueryTaskCompletedResponse{}, nil
 		})
 
@@ -664,10 +666,63 @@ func TestLegacyQueryInboundVisitorFailureReportedAsQueryFailure(t *testing.T) {
 			require.Equal(t, visitorErr.Error(), req.ErrorMessage)
 			require.Equal(t, "test-namespace", req.Namespace)
 			require.NotNil(t, req.Failure)
+			require.Equal(t, enumspb.WORKFLOW_TASK_FAILED_CAUSE_WORKFLOW_WORKER_UNHANDLED_FAILURE, req.Cause)
 			return &workflowservice.RespondQueryTaskCompletedResponse{}, nil
 		})
 
 	poller.handleInboundVisitorError(task, visitorErr)
+}
+
+func TestLegacyQueryFailureCauseClassification(t *testing.T) {
+	params := workerExecutionParameters{cache: NewWorkerCache()}
+	ensureRequiredParams(&params)
+	poller := newWorkflowTaskProcessor(
+		newWorkflowTaskHandler(params, nil, newRegistry()),
+		nil,
+		nil,
+		params,
+		"",
+	)
+	task := &workflowservice.PollWorkflowTaskQueueResponse{
+		TaskToken: []byte("legacy-query-token"),
+		Query:     &querypb.WorkflowQuery{QueryType: "status"},
+	}
+
+	tests := []struct {
+		name  string
+		err   error
+		cause enumspb.WorkflowTaskFailedCause
+	}{
+		{
+			name:  "generic error",
+			err:   errors.New("query handler failed"),
+			cause: enumspb.WORKFLOW_TASK_FAILED_CAUSE_WORKFLOW_WORKER_UNHANDLED_FAILURE,
+		},
+		{
+			name:  "history mismatch",
+			err:   historyMismatchError{},
+			cause: enumspb.WORKFLOW_TASK_FAILED_CAUSE_NON_DETERMINISTIC_ERROR,
+		},
+		{
+			name:  "unknown sdk flag",
+			err:   unknownSdkFlagError{},
+			cause: enumspb.WORKFLOW_TASK_FAILED_CAUSE_NON_DETERMINISTIC_ERROR,
+		},
+		{
+			name:  "payload size error",
+			err:   payloadSizeError{message: "too large", size: 100, limit: 50},
+			cause: enumspb.WORKFLOW_TASK_FAILED_CAUSE_PAYLOADS_TOO_LARGE,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			completion := poller.taskFailureCompletion(task, tc.err)
+			resp, ok := completion.rawRequest.(*workflowservice.RespondQueryTaskCompletedRequest)
+			require.True(t, ok)
+			require.Equal(t, tc.cause, resp.Cause)
+		})
+	}
 }
 
 func TestErrorToFailWorkflowTaskCause(t *testing.T) {


### PR DESCRIPTION
## What changed

Legacy query task failures now populate `RespondQueryTaskCompletedRequest.Cause` using the existing `workflowTaskFailureCause` classifier. The existing query-failure response and `UNSPECIFIED` fallback for unmapped errors are preserved.

## Why

Issue #2648 reports that processing, inbound-visitor, and outbound-visitor failures reach the legacy query response with `Cause=WORKFLOW_TASK_FAILED_CAUSE_UNSPECIFIED`, which loses the failure classification needed for replay and diagnostics.

## Validation

- Added regression coverage for processing, inbound-visitor, and outbound-visitor failures.
- Added classifier coverage for generic worker, non-deterministic, history-mismatch, unknown-SDK-flag, and payload-size errors.
- `GOMAXPROCS=2 go test ./internal -run 'TestLegacyQuery(ProcessingFailure|OutboundVisitorFailure|InboundVisitorFailure)ReportedAsQueryFailure|TestLegacyQueryFailureCauseClassification' -count=1`
- `go vet ./internal`
- `git diff --check`

The unchanged current-main tests fail because the response cause remains `UNSPECIFIED`; the focused suite passes with this patch. Hosted CI remains the final gate.

## Related issue

Fixes #2648

The patch was prepared by `zfaustk` with Codex assistance, and an independent non-author cross-review was completed before submission.
