### PR TITLE
Replace big LA tunnel with linked list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,9 @@ to docs, or any other relevant information.
 
 ### Fixed
 
+- Local activity scheduling no longer uses a fixed 100,000-entry task queue. The queue now grows
+  with demand, avoiding both the up-front allocation and a possible worker deadlock when the queue
+  and all local activity execution slots were full.
 - The `PayloadDownloadDuration` and `PayloadUploadDuration` fields on the workflow task duration log
   now report the wall-clock time external storage was in flight. Previously each batch's duration was
   summed, over-reporting the time whenever storage operations ran concurrently.

--- a/internal/internal_event_handlers.go
+++ b/internal/internal_event_handlers.go
@@ -181,6 +181,8 @@ type (
 
 	localActivityTask struct {
 		sync.Mutex
+		// Owned by localActivityTunnel while the task is queued.
+		nextQueuedTask  *localActivityTask
 		workflowTask    *workflowTask
 		activityID      string
 		params          *ExecuteLocalActivityParams

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -228,8 +228,13 @@ type (
 	}
 
 	localActivityTunnel struct {
-		taskCh   chan *localActivityTask
-		resultCh chan eagerOrPolledTask
+		// Task submission cannot wait for execution capacity because the submitting
+		// workflow task is also responsible for receiving local activity results.
+		taskQueueMu   sync.Mutex
+		taskQueueHead *localActivityTask
+		taskQueueTail *localActivityTask
+		taskReadyCh   chan struct{}
+		resultCh      chan eagerOrPolledTask
 		// stopCh is a read-only view of workflowWorker.localActivityStopC.
 		// It is closed by workflowWorker.Stop() after the workflow worker stops,
 		// causing tunnel sends/receives to stop accepting local activity work.
@@ -262,28 +267,89 @@ func (npm *numPollerMetric) decrement() {
 
 func newLocalActivityTunnel(stopCh <-chan struct{}) *localActivityTunnel {
 	return &localActivityTunnel{
-		taskCh:   make(chan *localActivityTask, 100000),
-		resultCh: make(chan eagerOrPolledTask),
-		stopCh:   stopCh,
+		taskReadyCh: make(chan struct{}, 1),
+		resultCh:    make(chan eagerOrPolledTask),
+		stopCh:      stopCh,
 	}
 }
 
 func (lat *localActivityTunnel) getTask() *localActivityTask {
-	select {
-	case task := <-lat.taskCh:
-		return task
-	case <-lat.stopCh:
-		return nil
+	for {
+		select {
+		case <-lat.stopCh:
+			lat.clearTasks()
+			return nil
+		default:
+		}
+
+		lat.taskQueueMu.Lock()
+		if lat.taskQueueHead != nil {
+			task := lat.taskQueueHead
+			lat.taskQueueHead = task.nextQueuedTask
+			task.nextQueuedTask = nil
+			hasMore := lat.taskQueueHead != nil
+			if !hasMore {
+				lat.taskQueueTail = nil
+			}
+			lat.taskQueueMu.Unlock()
+			if hasMore {
+				lat.notifyTaskReady()
+			}
+			return task
+		}
+		lat.taskQueueMu.Unlock()
+
+		select {
+		case <-lat.taskReadyCh:
+		case <-lat.stopCh:
+			lat.clearTasks()
+			return nil
+		}
 	}
 }
 
 func (lat *localActivityTunnel) sendTask(task *localActivityTask) bool {
 	select {
-	case lat.taskCh <- task:
-		return true
 	case <-lat.stopCh:
 		return false
+	default:
 	}
+
+	lat.taskQueueMu.Lock()
+	select {
+	case <-lat.stopCh:
+		lat.taskQueueMu.Unlock()
+		return false
+	default:
+	}
+	if lat.taskQueueTail == nil {
+		lat.taskQueueHead = task
+	} else {
+		lat.taskQueueTail.nextQueuedTask = task
+	}
+	lat.taskQueueTail = task
+	lat.taskQueueMu.Unlock()
+
+	lat.notifyTaskReady()
+	return true
+}
+
+func (lat *localActivityTunnel) notifyTaskReady() {
+	select {
+	case lat.taskReadyCh <- struct{}{}:
+	default:
+	}
+}
+
+func (lat *localActivityTunnel) clearTasks() {
+	lat.taskQueueMu.Lock()
+	for lat.taskQueueHead != nil {
+		task := lat.taskQueueHead
+		lat.taskQueueHead = task.nextQueuedTask
+		task.nextQueuedTask = nil
+	}
+	lat.taskQueueTail = nil
+	lat.taskQueueMu.Unlock()
 }
 
 func isClientSideError(err error) bool {

--- a/internal/internal_task_pollers_test.go
+++ b/internal/internal_task_pollers_test.go
@@ -35,16 +35,100 @@ type countingTaskHandler struct {
 
 func TestLocalActivityTaskPollerReturnsNilWhenTunnelStops(t *testing.T) {
 	stopCh := make(chan struct{})
+	tunnel := newLocalActivityTunnel(stopCh)
+	queuedTasks := []*localActivityTask{{}, {}}
+	require.True(t, tunnel.sendTask(queuedTasks[0]))
+	require.True(t, tunnel.sendTask(queuedTasks[1]))
 	close(stopCh)
 	poller := &localActivityTaskPoller{
-		laTunnel: newLocalActivityTunnel(stopCh),
+		laTunnel: tunnel,
 	}
 
+	require.False(t, tunnel.sendTask(&localActivityTask{}))
 	task, err := poller.PollTask()
 	require.NoError(t, err)
 	if task != nil {
 		t.Fatalf("PollTask() returned a non-nil task of type %T", task)
 	}
+	require.Nil(t, tunnel.taskQueueHead)
+	require.Nil(t, tunnel.taskQueueTail)
+	for _, task := range queuedTasks {
+		require.Nil(t, task.nextQueuedTask)
+	}
+}
+
+func TestLocalActivityTunnelTaskQueueGrowsWithDemand(t *testing.T) {
+	stopCh := make(chan struct{})
+	defer func() {
+		select {
+		case <-stopCh:
+		default:
+			close(stopCh)
+		}
+	}()
+	tunnel := newLocalActivityTunnel(stopCh)
+	const taskCount = 100001
+	tasks := make([]localActivityTask, taskCount)
+
+	enqueueDone := make(chan bool, 1)
+	go func() {
+		for i := range tasks {
+			if !tunnel.sendTask(&tasks[i]) {
+				enqueueDone <- false
+				return
+			}
+		}
+		enqueueDone <- true
+	}()
+
+	timer := time.NewTimer(10 * time.Second)
+	defer timer.Stop()
+	select {
+	case completed := <-enqueueDone:
+		require.True(t, completed)
+	case <-timer.C:
+		close(stopCh)
+		t.Fatal("local activity task submission blocked without a consumer")
+	}
+
+	for i := range tasks {
+		if received := tunnel.getTask(); received != &tasks[i] {
+			t.Fatalf("getTask() returned task %p, want %p", received, &tasks[i])
+		}
+		require.Nil(t, tasks[i].nextQueuedTask)
+	}
+	require.Nil(t, tunnel.taskQueueHead)
+	require.Nil(t, tunnel.taskQueueTail)
+}
+
+func TestLocalActivityTunnelTaskQueuePreservesOrder(t *testing.T) {
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	tunnel := newLocalActivityTunnel(stopCh)
+	tasks := make([]*localActivityTask, 32)
+	for i := range tasks {
+		tasks[i] = &localActivityTask{}
+	}
+
+	for _, task := range tasks[:16] {
+		require.True(t, tunnel.sendTask(task))
+	}
+	for _, task := range tasks[:10] {
+		require.Same(t, task, tunnel.getTask())
+	}
+	for _, task := range tasks[16:] {
+		require.True(t, tunnel.sendTask(task))
+	}
+	for _, task := range tasks[10:] {
+		require.Same(t, task, tunnel.getTask())
+		require.Nil(t, task.nextQueuedTask)
+	}
+	require.Nil(t, tunnel.taskQueueHead)
+	require.Nil(t, tunnel.taskQueueTail)
+
+	require.True(t, tunnel.sendTask(tasks[0]))
+	require.Same(t, tasks[0], tunnel.getTask())
+	require.Nil(t, tasks[0].nextQueuedTask)
 }
 
 func (wth *countingTaskHandler) ProcessWorkflowTask(


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Change the memory-hogging 100,000 LA tunnel to use a synchronized linked list instead.

## Why?
This change maintains the same semantics but eliminates the huge memory overhead that the 100,000 item reserved buffer imposed, particularly in situations where there are many workers in the same process.

I considered doing more stuff to properly exert back-pressure but that would be a much more intrusive change. This is pretty slim.

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-go/issues/2660

2. How was this tested:
Added tests

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core local-activity scheduling concurrency; behavior change is intentional but race/shutdown edge cases warrant review despite new tests.
> 
> **Overview**
> Replaces the **local activity tunnel**’s fixed **100,000-slot buffered channel** with a **mutex-backed FIFO linked list** on `localActivityTask` (`nextQueuedTask`), plus a small `taskReadyCh` to wake pollers.
> 
> **`sendTask` no longer blocks** when the queue is “full”—workflows can keep scheduling local activities while the same goroutine must still drain results—so it avoids the prior **deadlock** when the channel and all execution slots were saturated. Memory use scales with queued work instead of reserving a large buffer up front (notably when many workers share a process).
> 
> Shutdown clears the list via **`clearTasks`**; tests cover **>100k enqueues without a consumer**, **FIFO order**, and stop behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 739d3aaa7dba572999466c9801427bbf7390e524. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->