### PR TITLE
Set WorkflowTaskFailedCause on legacy query failure responses

### DIFF
--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -1861,6 +1861,7 @@ func (wth *workflowTaskHandlerImpl) completeWorkflow(
 		if errors.As(workflowContext.err, &panicErr) {
 			queryCompletedRequest.CompletedType = enumspb.QUERY_RESULT_TYPE_FAILED
 			queryCompletedRequest.ErrorMessage = "Workflow panic: " + panicErr.Error()
+			queryCompletedRequest.Cause = enumspb.WORKFLOW_TASK_FAILED_CAUSE_WORKFLOW_WORKER_UNHANDLED_FAILURE
 			return workflowTaskCompletion{rawRequest: queryCompletedRequest}
 		}
 

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -959,6 +959,7 @@ func (wtp *workflowTaskProcessor) taskFailureCompletion(
 				ErrorMessage:  err.Error(),
 				Namespace:     wtp.namespace,
 				Failure:       wtp.failureConverter.ErrorToFailure(err),
+				Cause:         workflowQueryFailureCause(err),
 			},
 		}
 	}
@@ -970,6 +971,28 @@ func (wtp *workflowTaskProcessor) taskFailureCompletion(
 
 func (wtp *workflowTaskProcessor) errorToFailWorkflowTask(taskToken []byte, err error) *workflowservice.RespondWorkflowTaskFailedRequest {
 	return wtp.errorToFailWorkflowTaskWithCause(taskToken, err, workflowTaskFailureCause(err))
+}
+
+// workflowQueryFailureCause maps a task failure to a WorkflowTaskFailedCause
+// for legacy query failure responses. Unlike workflowTaskFailureCause it keeps
+// UNSPECIFIED when no cause maps cleanly.
+func workflowQueryFailureCause(err error) enumspb.WorkflowTaskFailedCause {
+	if errors.As(err, new(payloadSizeError)) {
+		return enumspb.WORKFLOW_TASK_FAILED_CAUSE_PAYLOADS_TOO_LARGE
+	}
+	if panicErr, _ := err.(*workflowPanicError); panicErr != nil {
+		if _, badStateMachine := panicErr.value.(stateMachineIllegalStatePanic); badStateMachine {
+			return enumspb.WORKFLOW_TASK_FAILED_CAUSE_NON_DETERMINISTIC_ERROR
+		}
+		return enumspb.WORKFLOW_TASK_FAILED_CAUSE_WORKFLOW_WORKER_UNHANDLED_FAILURE
+	}
+	if _, mismatch := err.(historyMismatchError); mismatch {
+		return enumspb.WORKFLOW_TASK_FAILED_CAUSE_NON_DETERMINISTIC_ERROR
+	}
+	if _, unknown := err.(unknownSdkFlagError); unknown {
+		return enumspb.WORKFLOW_TASK_FAILED_CAUSE_NON_DETERMINISTIC_ERROR
+	}
+	return enumspb.WORKFLOW_TASK_FAILED_CAUSE_UNSPECIFIED
 }
 
 func workflowTaskFailureCause(err error) enumspb.WorkflowTaskFailedCause {

--- a/internal/internal_task_pollers_query_cause_test.go
+++ b/internal/internal_task_pollers_query_cause_test.go
@@ -1,0 +1,85 @@
+package internal
+
+import (
+	"errors"
+	"testing"
+
+	commonpb "go.temporal.io/api/common/v1"
+	"go.temporal.io/api/enums/v1"
+	querypb "go.temporal.io/api/query/v1"
+	"go.temporal.io/api/workflowservice/v1"
+)
+
+func TestWorkflowQueryFailureCause(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want enums.WorkflowTaskFailedCause
+	}{
+		{
+			name: "generic error stays unspecified",
+			err:  errors.New("some handler failure"),
+			want: enums.WORKFLOW_TASK_FAILED_CAUSE_UNSPECIFIED,
+		},
+		{
+			name: "payload size error",
+			err:  payloadSizeError{message: "too large", size: 100, limit: 50},
+			want: enums.WORKFLOW_TASK_FAILED_CAUSE_PAYLOADS_TOO_LARGE,
+		},
+		{
+			name: "workflow panic",
+			err:  newWorkflowPanicError("boom", "stack"),
+			want: enums.WORKFLOW_TASK_FAILED_CAUSE_WORKFLOW_WORKER_UNHANDLED_FAILURE,
+		},
+		{
+			name: "illegal state machine panic",
+			err:  newWorkflowPanicError(stateMachineIllegalStatePanic{message: "bad state"}, "stack"),
+			want: enums.WORKFLOW_TASK_FAILED_CAUSE_NON_DETERMINISTIC_ERROR,
+		},
+		{
+			name: "history mismatch",
+			err:  historyMismatchError{},
+			want: enums.WORKFLOW_TASK_FAILED_CAUSE_NON_DETERMINISTIC_ERROR,
+		},
+		{
+			name: "unknown sdk flag",
+			err:  unknownSdkFlagError{},
+			want: enums.WORKFLOW_TASK_FAILED_CAUSE_NON_DETERMINISTIC_ERROR,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := workflowQueryFailureCause(tt.err); got != tt.want {
+				t.Fatalf("workflowQueryFailureCause() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTaskFailureCompletionQuerySetsCause(t *testing.T) {
+	wtp := &workflowTaskProcessor{
+		namespace:        "test-namespace",
+		failureConverter: GetDefaultFailureConverter(),
+	}
+	task := &workflowservice.PollWorkflowTaskQueueResponse{
+		WorkflowExecution: &commonpb.WorkflowExecution{WorkflowId: "w", RunId: "r"},
+		WorkflowType:      &commonpb.WorkflowType{Name: "wf"},
+		Query:             &querypb.WorkflowQuery{},
+		TaskToken:         []byte("token"),
+	}
+
+	completion := wtp.taskFailureCompletion(task, errors.New("visit failure"))
+	request, ok := completion.rawRequest.(*workflowservice.RespondQueryTaskCompletedRequest)
+	if !ok {
+		t.Fatalf("expected RespondQueryTaskCompletedRequest, got %T", completion.rawRequest)
+	}
+	if request.Cause != enums.WORKFLOW_TASK_FAILED_CAUSE_UNSPECIFIED {
+		t.Fatalf("generic failure cause = %v, want UNSPECIFIED", request.Cause)
+	}
+
+	completion = wtp.taskFailureCompletion(task, payloadSizeError{message: "too large", size: 100, limit: 50})
+	request = completion.rawRequest.(*workflowservice.RespondQueryTaskCompletedRequest)
+	if request.Cause != enums.WORKFLOW_TASK_FAILED_CAUSE_PAYLOADS_TOO_LARGE {
+		t.Fatalf("payload size failure cause = %v, want PAYLOADS_TOO_LARGE", request.Cause)
+	}
+}


### PR DESCRIPTION
Fixes #2648

## What

`RespondQueryTaskCompletedRequest.Cause` was only set on the gRPC message-size failure path. This sets it on the remaining legacy-query failure paths:

- `taskFailureCompletion` query branch (inbound/outbound visitor failures, payload-size failures, replay/processing failures) now sets `Cause` via a new `workflowQueryFailureCause` helper
- `completeWorkflow` query branch sets `WORKFLOW_WORKER_UNHANDLED_FAILURE` when the response reports a workflow panic
- query-handler failures keep `UNSPECIFIED`, as no cause maps cleanly (per the issue)

`workflowQueryFailureCause` mirrors the existing `workflowTaskFailureCause` mapping (payload-size → `PAYLOADS_TOO_LARGE`, illegal state-machine panic → `NON_DETERMINISTIC_ERROR`, history mismatch / unknown SDK flag → `NON_DETERMINISTIC_ERROR`, other panics → `WORKFLOW_WORKER_UNHANDLED_FAILURE`) but defaults to `UNSPECIFIED` instead of `WORKFLOW_WORKER_UNHANDLED_FAILURE`, since arbitrary visitor/handler errors have no clean classification.

## Validation

- `go build ./...` clean
- `go vet ./internal/` clean
- New tests in `internal/internal_task_pollers_query_cause_test.go`:
  - `TestWorkflowQueryFailureCause` — table test over all cause mappings including the unspecified default
  - `TestTaskFailureCompletionQuerySetsCause` — asserts the query failure request carries `PAYLOADS_TOO_LARGE` for payload-size errors and `UNSPECIFIED` for generic errors (fails before the change, passes after)