### PR TITLE
Fix tracing test workflow collision

### DIFF
--- a/test/activity_test.go
+++ b/test/activity_test.go
@@ -510,9 +510,14 @@ func (a *Activities) InterceptorCalls(ctx context.Context, someVal string) (stri
 }
 
 func (a *Activities) ExternalSignalsAndQueries(ctx context.Context) error {
+	info := activity.GetInfo(ctx)
+
+	// SignalWithStart reuses a running workflow, so isolate concurrent activities.
+	workflowID := fmt.Sprintf("test-external-signals-and-queries-%s-%s", info.WorkflowExecution.RunID, info.ActivityID)
+
 	// Signal with start
-	workflowOpts := client.StartWorkflowOptions{TaskQueue: activity.GetInfo(ctx).TaskQueue}
-	run, err := a.client.SignalWithStartWorkflow(ctx, "test-external-signals-and-queries", "start-signal",
+	workflowOpts := client.StartWorkflowOptions{TaskQueue: info.TaskQueue}
+	run, err := a.client.SignalWithStartWorkflow(ctx, workflowID, "start-signal",
 		"signal-value", workflowOpts, new(Workflows).SignalsQueriesAndUpdate, false, false)
 	if err != nil {
 		return err
@@ -536,7 +541,6 @@ func (a *Activities) ExternalSignalsAndQueries(ctx context.Context) error {
 	}
 	return run.Get(ctx, nil)
 }
-
 func (a *Activities) CheckBaggage(ctx context.Context, key string) (string, error) {
 	return baggage.FromContext(ctx).Member(key).Value(), nil
 }


### PR DESCRIPTION
## What was changed
Give each `ExternalSignalsAndQueries` activity a unique target workflow ID using its parent run ID and activity ID.

## Why?
github.com/temporalio/sdk-go/actions/runs/33683637978 showed that the tracing tests ran multiple ExternalSignalsAndQueries activities using SignalWithStartWorkflow with the same workflow ID. When these activities overlapped, they attached to the same running workflow; one could complete it while another still used it, causing workflow execution already completed. Sequential execution started separate runs, explaining the intermittent failure.

Unique IDs isolate each activity without changing the tracing scenario.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to workflow ID generation in an integration helper; no production SDK behavior.
> 
> **Overview**
> Fixes flaky tracing/integration failures when multiple **`ExternalSignalsAndQueries`** activities run at once.
> 
> Each activity now **`SignalWithStartWorkflow`** against a **unique workflow ID** built from the parent workflow run ID and activity ID, instead of the shared **`test-external-signals-and-queries`** ID. **`SignalWithStart`** attaches to an already-running execution with the same ID, so overlapping activities could share one child workflow; one could finish it while another still queried or signaled it, causing errors like **workflow execution already completed**.
> 
> Task queue and the rest of the signal/query/finish flow are unchanged—only per-activity isolation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bfeaf07fe0beccaf5defaa985bee16765e68db3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->