### PR TITLE
Fix/2547 random stream interleaving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,11 @@ to docs, or any other relevant information.
 
 ### Fixed
 
+- `workflow.WorkflowRandomStream`'s `Uint64` now derives its value through `Read` instead of calling
+  the underlying generator's `Uint64` directly, giving interleaved `Uint64`/`Read` calls a stable,
+  well-defined ordering. This changes the sequence `Uint64` returns for a given seed; since
+  `workflow.GetRandomStream` and `WorkflowRandomStream` remain experimental, this is not considered
+  a breaking change.
 - Workflow autoscaling now favors sticky polls when sticky work is backlogged, while allowing
   normal polls to use spare slots once sticky reaches its autoscaling target.
 - The `PayloadDownloadDuration` and `PayloadUploadDuration` fields on the workflow task duration log

--- a/internal/workflow_random.go
+++ b/internal/workflow_random.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"crypto/sha256"
+	"encoding/binary"
 	"io"
 	"math/rand/v2"
 )
@@ -37,8 +38,10 @@ type WorkflowRandomStream interface {
 // workflowRandomStream wraps ChaCha8 instead of embedding it so callers cannot
 // mutate a shared named stream through Seed or UnmarshalBinary.
 //
-// TODO(https://github.com/temporalio/sdk-go/issues/2547): Define stable
-// interleaving semantics. See [ChaCha8.Read].
+// Uint64 and Read must produce a stable, well-defined interleaving on their
+// own: ChaCha8.Read and ChaCha8.Uint64 leave the interleaving of the two
+// undefined (see [ChaCha8.Read]), so only ChaCha8.Read is ever called
+// directly; Uint64 is implemented on top of it.
 //
 // [ChaCha8.Read]: https://go.dev/src/math/rand/v2/chacha8.go#L48
 type workflowRandomStream struct {
@@ -46,7 +49,9 @@ type workflowRandomStream struct {
 }
 
 func (r *workflowRandomStream) Uint64() uint64 {
-	return r.source.Uint64()
+	var buf [8]byte
+	_, _ = r.source.Read(buf[:]) // ChaCha8.Read always returns len(p), nil
+	return binary.LittleEndian.Uint64(buf[:])
 }
 
 func (r *workflowRandomStream) Read(p []byte) (int, error) {

--- a/internal/workflow_random_test.go
+++ b/internal/workflow_random_test.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"encoding/binary"
 	"encoding/hex"
 	"math/rand/v2"
 	"testing"
@@ -50,6 +51,47 @@ func (s *workflowRandomTestSuite) TestGetRandomStreamGolden() {
 	s.Require().NoError(err)
 	s.Require().Equal(len(randomBytes), n)
 	s.Require().Equal("10861bf410d33891bef9b1f2ebddc1af2f5bceffe86c13fdcb8534a08805b1a7", hex.EncodeToString(randomBytes))
+}
+
+// TestUint64Golden pins Uint64's value for a known seed. Changing the
+// Uint64/Read derivation would break replay for existing workflows.
+func (s *workflowRandomTestSuite) TestUint64Golden() {
+	randoms := make(map[string]*workflowRandomStream)
+	v := getRandomStream(randoms, workflowRandomTestRunID, workflowRandomTestName).Uint64()
+	s.Require().Equal(uint64(0x9138d310f41b8610), v)
+}
+
+// TestInterleavedReadUint64StableOrdering verifies that interleaving Read and
+// Uint64 calls consumes the underlying byte stream in the same order, and
+// with the same byte boundaries, as a single equivalent-length Read: Uint64
+// must be equivalent to reading 8 bytes and decoding them as little-endian,
+// not a separate, independently-buffered draw from the source. This is the
+// stability guarantee tracked by
+// https://github.com/temporalio/sdk-go/issues/2547.
+func (s *workflowRandomTestSuite) TestInterleavedReadUint64StableOrdering() {
+	randomsInterleaved := make(map[string]*workflowRandomStream)
+	c := getRandomStream(randomsInterleaved, workflowRandomTestRunID, workflowRandomTestName)
+
+	read1 := make([]byte, 8)
+	_, err := c.Read(read1)
+	s.Require().NoError(err)
+
+	u := c.Uint64()
+	uBytes := make([]byte, 8)
+	binary.LittleEndian.PutUint64(uBytes, u)
+
+	read2 := make([]byte, 8)
+	_, err = c.Read(read2)
+	s.Require().NoError(err)
+
+	reconstructed := append(append(append([]byte{}, read1...), uBytes...), read2...)
+
+	randomsFull := make(map[string]*workflowRandomStream)
+	full := make([]byte, 24)
+	_, err = getRandomStream(randomsFull, workflowRandomTestRunID, workflowRandomTestName).Read(full)
+	s.Require().NoError(err)
+
+	s.Require().Equal(full, reconstructed)
 }
 
 func (s *workflowRandomTestSuite) TestDeriveSeedSeparators() {


### PR DESCRIPTION
## What was changed
`workflowRandomStream.Uint64()` (`internal/workflow_random.go`) now derives its value by calling
`Read` on the underlying `*rand.ChaCha8` and decoding the result with `binary.LittleEndian`,
instead of calling the generator's own `Uint64()` method directly.

## Why?
`ChaCha8.Read` and `ChaCha8.Uint64` leave their interleaving undefined when called on the same
instance (see the stdlib doc comment on `ChaCha8.Read`): `Read` keeps an internal leftover-byte
buffer that a direct call to `Uint64` bypasses entirely, so mixing the two can desync which bytes
each call returns. That's fine for a one-off program, but `WorkflowRandomStream` values must stay
replay-stable for the life of a workflow, potentially across Go toolchain upgrades that could
change that internal buffering. Routing `Uint64` through `Read` means there is only one code path
that ever touches the generator, so any mix of `Uint64`/`Read` calls consumes the stream in a single,
well-defined order — fixing the interleaving instability tracked in #2547.

## Checklist

1. Closes #2547

2. How was this tested:
   - `TestUint64Golden` pins `Uint64`'s output for the existing test seed.
   - `TestInterleavedReadUint64StableOrdering` proves that interleaving `Read`/`Uint64` calls
     consumes the same underlying bytes, in the same order, as one equivalent-length `Read` call —
     the property the issue asked for.
   - Existing `TestGetRandomStreamGolden`, `TestGetRandomStreamMemoizes`,
     `TestGetRandomStreamNamesAreIndependent`, and `TestChildContinueAsNewDrawsNewValues` still pass
     unchanged, since `Read`'s own behavior and byte output are untouched.
   - `go run . check` passes.
