### PR TITLE
Add workflow local

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ to docs, or any other relevant information.
   platforms), and the operating system and architecture. This is sent
   once per worker with the first heartbeat accepted by the server and can be turned off with
   `client.Options.DisableWorkerEnvironmentInfo`.
+- Added `workflow.NewLocalVar[T](ctx)` for type-safe values bound to a workflow run that can be
+  accessed from workflow code and workflow interceptors. Copies of a `workflow.LocalVar[T]` share
+  identity.
 - Added `temporal.NewPayloadValidationError` to create non-retryable application errors with
   optional structured details for payload validation failures. Passing `nil` omits details.
 - Added Go 1.27+ generic methods on the experimental `temporalnexus.NexusClient` for starting

--- a/internal/cmd/tools/doclink/doclink.go
+++ b/internal/cmd/tools/doclink/doclink.go
@@ -267,6 +267,10 @@ func extractTypeValue(expr ast.Expr) string {
 		if ident, ok := t.X.(*ast.Ident); ok && ident.Name == "internal" {
 			return t.Sel.Name
 		}
+	case *ast.IndexExpr:
+		return extractTypeValue(t.X)
+	case *ast.IndexListExpr:
+		return extractTypeValue(t.X)
 	case *ast.BasicLit:
 	// Do nothing
 	default:
@@ -333,13 +337,7 @@ func checkFunction(funcDecl *ast.FuncDecl) string {
 
 // Check if a call expression is calling an internal function
 func isInternalFunctionCall(callExpr *ast.CallExpr) string {
-	// Check if the function being called is a SelectorExpr (e.g., "internal.SomeFunction")
-	if selExpr, ok := callExpr.Fun.(*ast.SelectorExpr); ok {
-		if pkgIdent, ok := selExpr.X.(*ast.Ident); ok && pkgIdent.Name == "internal" {
-			return selExpr.Sel.Name
-		}
-	}
-	return ""
+	return extractTypeValue(callExpr.Fun)
 }
 
 // Check for type assertions like `var _ = internal.SomeType(nil)`

--- a/internal/cmd/tools/doclink/doclink_test.go
+++ b/internal/cmd/tools/doclink/doclink_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"go/ast"
+	"go/parser"
 	"os"
 	"path/filepath"
 	"strings"
@@ -149,5 +151,38 @@ type (
 	unwanted := "// Exposed as: [go.temporal.io/sdk/workflow.SendChannel]"
 	if strings.Contains(updated, unwanted) {
 		t.Fatalf("did not expect generated doc link %q in:\n%s", unwanted, updated)
+	}
+}
+
+func TestExtractTypeValueGeneric(t *testing.T) {
+	tests := []struct {
+		expression string
+		want       string
+	}{
+		{expression: "internal.LocalVar[T]", want: "LocalVar"},
+		{expression: "internal.Pair[K, V]", want: "Pair"},
+	}
+	for _, test := range tests {
+		expr, err := parser.ParseExpr(test.expression)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if value := extractTypeValue(expr); value != test.want {
+			t.Fatalf("extractTypeValue(%q) = %q, want %q", test.expression, value, test.want)
+		}
+	}
+}
+
+func TestIsInternalFunctionCallGeneric(t *testing.T) {
+	expr, err := parser.ParseExpr("internal.NewLocalVar[T](ctx)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	call, ok := expr.(*ast.CallExpr)
+	if !ok {
+		t.Fatalf("parsed expression is %T, want *ast.CallExpr", expr)
+	}
+	if value := isInternalFunctionCall(call); value != "NewLocalVar" {
+		t.Fatalf("isInternalFunctionCall() = %q, want NewLocalVar", value)
 	}
 }

--- a/internal/internal_workflow.go
+++ b/internal/internal_workflow.go
@@ -499,6 +499,7 @@ func newWorkflowContext(
 ) (*workflowEnvironmentInterceptor, Context, error) {
 	// Create context with default values
 	ctx := WithValue(background, workflowEnvironmentContextKey, env)
+	ctx = workflowContextWithLocalStore(ctx)
 	var resultPtr *workflowResult
 	ctx = WithValue(ctx, workflowResultContextKey, &resultPtr)
 	info := env.WorkflowInfo()

--- a/internal/workflow_local.go
+++ b/internal/workflow_local.go
@@ -1,0 +1,84 @@
+package internal
+
+// LocalVar is a value local to a single workflow run.
+//
+// Exposed as: [go.temporal.io/sdk/workflow.LocalVar]
+type LocalVar[T any] struct {
+	key   *workflowLocalKey
+	store *workflowLocalStore
+}
+
+type workflowLocalKey struct {
+	// Keep keys non-zero-sized so distinct allocations have distinct addresses.
+	_ byte
+}
+
+// NewLocalVar creates a LocalVar bound to the workflow run for ctx.
+//
+// Exposed as: [go.temporal.io/sdk/workflow.NewLocalVar]
+func NewLocalVar[T any](ctx Context) LocalVar[T] {
+	return LocalVar[T]{
+		key:   &workflowLocalKey{},
+		store: getWorkflowLocalStore(ctx),
+	}
+}
+
+// Get returns the value associated with v in the workflow run for ctx, or the
+// zero value of T if v has not been set.
+func (v LocalVar[T]) Get(ctx Context) T {
+	store := v.storeFor(ctx)
+	value, ok := store.values[v.key]
+	if !ok || value == nil {
+		var zero T
+		return zero
+	}
+	return value.(T)
+}
+
+// Set associates value with v in the workflow run for ctx.
+func (v LocalVar[T]) Set(ctx Context, value T) {
+	store := v.storeFor(ctx)
+	assertWorkflowLocalWritable(ctx)
+	store.values[v.key] = value
+}
+
+func (v LocalVar[T]) storeFor(ctx Context) *workflowLocalStore {
+	if v.key == nil || v.store == nil {
+		panic("workflow.LocalVar is not initialized; use workflow.NewLocalVar(ctx)")
+	}
+	store := getWorkflowLocalStore(ctx)
+	if store != v.store {
+		panic("workflow.LocalVar: context belongs to a different workflow run")
+	}
+	return store
+}
+
+type workflowLocalStore struct {
+	values map[*workflowLocalKey]any
+}
+
+type workflowLocalStoreContextKey struct{}
+
+func workflowContextWithLocalStore(ctx Context) Context {
+	return WithValue(ctx, workflowLocalStoreContextKey{}, &workflowLocalStore{
+		values: make(map[*workflowLocalKey]any),
+	})
+}
+
+func getWorkflowLocalStore(ctx Context) *workflowLocalStore {
+	if ctx == nil {
+		panic("workflow.LocalVar: nil workflow context")
+	}
+	store, ok := ctx.Value(workflowLocalStoreContextKey{}).(*workflowLocalStore)
+	if !ok {
+		panic("workflow.LocalVar: context is not associated with a workflow run")
+	}
+	return store
+}
+
+func assertWorkflowLocalWritable(ctx Context) {
+	state, _ := ctx.Value(coroutinesContextKey).(*coroutineState)
+	if state != nil && state.dispatcher.getIsReadOnly() {
+		panic(panicIllegalAccessCoroutineState)
+	}
+}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -891,6 +891,72 @@ func (ts *IntegrationTestSuite) TestContinueAsNew() {
 	ts.Equal(999, result)
 }
 
+func (ts *IntegrationTestSuite) TestWorkflowLocalVar() {
+	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
+	defer cancel()
+
+	first, err := ts.client.ExecuteWorkflow(
+		ctx,
+		ts.startWorkflowOptions("test-workflow-local-var-first"),
+		ts.workflows.WorkflowLocalVar,
+		"first",
+	)
+	ts.NoError(err)
+	second, err := ts.client.ExecuteWorkflow(
+		ctx,
+		ts.startWorkflowOptions("test-workflow-local-var-second"),
+		ts.workflows.WorkflowLocalVar,
+		"second",
+	)
+	ts.NoError(err)
+
+	query := func(run client.WorkflowRun) string {
+		value, err := ts.client.QueryWorkflow(ctx, run.GetID(), run.GetRunID(), workflowLocalVarQueryName)
+		ts.NoError(err)
+		var result string
+		ts.NoError(value.Get(&result))
+		return result
+	}
+	ts.Equal("first", query(first))
+	ts.Equal("second", query(second))
+
+	update, err := ts.client.UpdateWorkflow(ctx, client.UpdateWorkflowOptions{
+		WorkflowID:   first.GetID(),
+		RunID:        first.GetRunID(),
+		UpdateName:   workflowLocalVarUpdateName,
+		Args:         []any{"updated"},
+		WaitForStage: client.WorkflowUpdateStageCompleted,
+	})
+	ts.NoError(err)
+	var updateResult string
+	ts.NoError(update.Get(ctx, &updateResult))
+	ts.Equal("updated", updateResult)
+	ts.Equal("updated", query(first))
+	ts.Equal("second", query(second))
+
+	ts.NoError(ts.client.SignalWorkflow(ctx, first.GetID(), first.GetRunID(), workflowLocalVarFinishSignal, nil))
+	ts.NoError(ts.client.SignalWorkflow(ctx, second.GetID(), second.GetRunID(), workflowLocalVarFinishSignal, nil))
+	var firstResult string
+	var secondResult string
+	ts.NoError(first.Get(ctx, &firstResult))
+	ts.NoError(second.Get(ctx, &secondResult))
+	ts.Equal("updated", firstResult)
+	ts.Equal("second", secondResult)
+
+	var parentResult string
+	ts.NoError(ts.executeWorkflow("test-workflow-local-var-parent", ts.workflows.WorkflowLocalVarParent, &parentResult))
+	ts.Equal("parent", parentResult)
+
+	var continuedResult string
+	ts.NoError(ts.executeWorkflow(
+		"test-workflow-local-var-continue-as-new",
+		ts.workflows.WorkflowLocalVarContinueAsNew,
+		&continuedResult,
+		false,
+	))
+	ts.Empty(continuedResult)
+}
+
 func (ts *IntegrationTestSuite) TestContinueAsNewCarryOver() {
 	skipOnCloud(ts.T(), cloudNeedsAdaptation, "requires custom namespace search attributes")
 	var result string

--- a/test/workflow_test.go
+++ b/test/workflow_test.go
@@ -29,7 +29,10 @@ import (
 )
 
 const (
-	consistentQuerySignalCh = "consistent-query-signal-chan"
+	consistentQuerySignalCh      = "consistent-query-signal-chan"
+	workflowLocalVarQueryName    = "workflow-local-var-query"
+	workflowLocalVarUpdateName   = "workflow-local-var-update"
+	workflowLocalVarFinishSignal = "workflow-local-var-finish"
 )
 
 type Workflows struct{}
@@ -518,6 +521,57 @@ func (w *Workflows) ContinueAsNew(ctx workflow.Context, count int, taskQueue str
 	}
 	ctx = workflow.WithTaskQueue(ctx, taskQueue)
 	return -1, workflow.NewContinueAsNewError(ctx, w.ContinueAsNew, count-1, taskQueue)
+}
+
+func (w *Workflows) WorkflowLocalVar(ctx workflow.Context, value string) (string, error) {
+	local := workflow.NewLocalVar[string](ctx)
+	if existing := local.Get(ctx); existing != "" {
+		return "", fmt.Errorf("workflow LocalVar was already set to %q at run start", existing)
+	}
+	local.Set(ctx, value)
+	if err := workflow.SetQueryHandler(ctx, workflowLocalVarQueryName, func() (string, error) {
+		return local.Get(ctx), nil
+	}); err != nil {
+		return "", err
+	}
+	if err := workflow.SetUpdateHandler(ctx, workflowLocalVarUpdateName, func(ctx workflow.Context, value string) (string, error) {
+		local.Set(ctx, value)
+		return local.Get(ctx), nil
+	}); err != nil {
+		return "", err
+	}
+	workflow.GetSignalChannel(ctx, workflowLocalVarFinishSignal).Receive(ctx, nil)
+	return local.Get(ctx), nil
+}
+
+func (w *Workflows) WorkflowLocalVarChild(ctx workflow.Context) (string, error) {
+	return workflow.NewLocalVar[string](ctx).Get(ctx), nil
+}
+
+func (w *Workflows) WorkflowLocalVarParent(ctx workflow.Context) (string, error) {
+	local := workflow.NewLocalVar[string](ctx)
+	local.Set(ctx, "parent")
+	var childValue string
+	if err := workflow.ExecuteChildWorkflow(ctx, w.WorkflowLocalVarChild).Get(ctx, &childValue); err != nil {
+		return "", err
+	}
+	if childValue != "" {
+		return "", fmt.Errorf("child workflow LocalVar = %q, want empty", childValue)
+	}
+	return local.Get(ctx), nil
+}
+
+func (w *Workflows) WorkflowLocalVarContinueAsNew(ctx workflow.Context, continued bool) (string, error) {
+	local := workflow.NewLocalVar[string](ctx)
+	value := local.Get(ctx)
+	if continued {
+		return value, nil
+	}
+	if value != "" {
+		return "", fmt.Errorf("initial workflow LocalVar = %q, want empty", value)
+	}
+	local.Set(ctx, "previous run")
+	return "", workflow.NewContinueAsNewError(ctx, w.WorkflowLocalVarContinueAsNew, true)
 }
 
 func (w *Workflows) ContinueAsNewWithOptions(ctx workflow.Context, count int, taskQueue string) (string, error) {
@@ -4560,6 +4614,10 @@ func (w *Workflows) register(worker worker.Worker) {
 	worker.RegisterWorkflow(w.ConsistentQueryWorkflow)
 	worker.RegisterWorkflow(w.ContextPropagator)
 	worker.RegisterWorkflow(w.ContinueAsNew)
+	worker.RegisterWorkflow(w.WorkflowLocalVar)
+	worker.RegisterWorkflow(w.WorkflowLocalVarChild)
+	worker.RegisterWorkflow(w.WorkflowLocalVarParent)
+	worker.RegisterWorkflow(w.WorkflowLocalVarContinueAsNew)
 	worker.RegisterWorkflow(w.UpsertSearchAttributesConditional)
 	worker.RegisterWorkflow(w.UpsertMemoConditional)
 	worker.RegisterWorkflow(w.ContinueAsNewAfterUnsetSearchAttribute)

--- a/workflow/context.go
+++ b/workflow/context.go
@@ -12,6 +12,37 @@ import (
 // Context's methods may be called by multiple goroutines simultaneously.
 type Context = internal.Context
 
+// LocalVar is a handle to a value local to a single workflow run. The handle can
+// be passed by value between workflow code and workflow interceptors while
+// retaining access to the same run-local value.
+//
+// Create a LocalVar with NewLocalVar from within a workflow or workflow
+// interceptor. Get returns the zero value of T until Set is called. LocalVar
+// values are in-memory workflow state: they are rebuilt by replay and are not
+// propagated to activities, child workflows, or continue-as-new runs. The zero
+// LocalVar is invalid.
+//
+// LocalVar is a handle. Copies of a LocalVar share the same identity and access
+// the same per-run value. Calls to Set must follow the same determinism
+// requirements as other workflow state mutations and are not allowed in
+// read-only workflow code such as queries, update validators, or side-effect
+// callbacks.
+//
+// Example:
+//
+//	func MyWorkflow(ctx workflow.Context) error {
+//		currentUser := workflow.NewLocalVar[string](ctx)
+//		currentUser.Set(ctx, "alice")
+//		return useCurrentUser(currentUser.Get(ctx))
+//	}
+type LocalVar[T any] = internal.LocalVar[T]
+
+// NewLocalVar creates a LocalVar bound to the workflow run for ctx. Copies of
+// the returned handle access the same value in that run.
+func NewLocalVar[T any](ctx Context) LocalVar[T] {
+	return internal.NewLocalVar[T](ctx)
+}
+
 // ContextAware is an optional interface that can be implemented alongside
 // DataConverter. This interface allows Temporal to pass Workflow/Activity
 // contexts to the DataConverter so that it may tailor its behavior.

--- a/workflow/context_test.go
+++ b/workflow/context_test.go
@@ -1,0 +1,217 @@
+package workflow_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/workflow"
+)
+
+type localVarContextKey struct{}
+
+func TestLocalVarRequiresInitialization(t *testing.T) {
+	var local workflow.LocalVar[string]
+	require.PanicsWithValue(t, "workflow.LocalVar is not initialized; use workflow.NewLocalVar(ctx)", func() {
+		local.Get(nil)
+	})
+	require.PanicsWithValue(t, "workflow.LocalVar is not initialized; use workflow.NewLocalVar(ctx)", func() {
+		local.Set(nil, "value")
+	})
+}
+
+func TestLocalVar(t *testing.T) {
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+	env.ExecuteWorkflow(func(ctx workflow.Context) error {
+		localVarString := workflow.NewLocalVar[string](ctx)
+		localVarOther := workflow.NewLocalVar[string](ctx)
+		localVarPointer := workflow.NewLocalVar[*int](ctx)
+		localVarAny := workflow.NewLocalVar[any](ctx)
+
+		if value := localVarString.Get(ctx); value != "" {
+			return fmt.Errorf("unset string LocalVar = %q, want empty", value)
+		}
+		if value := localVarPointer.Get(ctx); value != nil {
+			return fmt.Errorf("unset pointer LocalVar = %v, want nil", value)
+		}
+		if value := localVarAny.Get(ctx); value != nil {
+			return fmt.Errorf("unset any LocalVar = %v, want nil", value)
+		}
+
+		localVarString.Set(ctx, "root")
+		localVarOther.Set(ctx, "other")
+		copied := localVarString
+		if value := copied.Get(ctx); value != "root" {
+			return fmt.Errorf("copied LocalVar = %q, want root", value)
+		}
+		copied.Set(ctx, "copy")
+		if value := localVarString.Get(ctx); value != "copy" {
+			return fmt.Errorf("original LocalVar after setting copy = %q, want copy", value)
+		}
+		if value := localVarString.Get(workflow.WithValue(ctx, localVarContextKey{}, true)); value != "copy" {
+			return fmt.Errorf("LocalVar through WithValue = %q, want copy", value)
+		}
+
+		cancelCtx, cancel := workflow.WithCancel(ctx)
+		defer cancel()
+		if value := localVarString.Get(cancelCtx); value != "copy" {
+			return fmt.Errorf("LocalVar through WithCancel = %q, want copy", value)
+		}
+
+		disconnectedCtx, cancelDisconnected := workflow.NewDisconnectedContext(ctx)
+		defer cancelDisconnected()
+		if value := localVarString.Get(disconnectedCtx); value != "copy" {
+			return fmt.Errorf("LocalVar through NewDisconnectedContext = %q, want copy", value)
+		}
+
+		done := workflow.NewChannel(ctx)
+		workflow.Go(cancelCtx, func(ctx workflow.Context) {
+			localVarString.Set(ctx, "coroutine")
+			done.Send(ctx, nil)
+		})
+		done.Receive(ctx, nil)
+		if value := localVarString.Get(ctx); value != "coroutine" {
+			return fmt.Errorf("LocalVar after coroutine Set = %q, want coroutine", value)
+		}
+		if value := localVarOther.Get(ctx); value != "other" {
+			return fmt.Errorf("second LocalVar = %q, want other", value)
+		}
+
+		pointerValue := 42
+		localVarPointer.Set(ctx, &pointerValue)
+		if value := localVarPointer.Get(ctx); value == nil || *value != pointerValue {
+			return fmt.Errorf("pointer LocalVar = %v, want %d", value, pointerValue)
+		}
+		localVarAny.Set(ctx, nil)
+		if value := localVarAny.Get(ctx); value != nil {
+			return fmt.Errorf("nil any LocalVar = %v, want nil", value)
+		}
+		return nil
+	})
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+}
+
+func TestLocalVarRejectsContextFromAnotherWorkflowRun(t *testing.T) {
+	var suite testsuite.WorkflowTestSuite
+	var local workflow.LocalVar[string]
+	first := suite.NewTestWorkflowEnvironment()
+	first.ExecuteWorkflow(func(ctx workflow.Context) (string, error) {
+		local = workflow.NewLocalVar[string](ctx)
+		local.Set(ctx, "first")
+		return local.Get(ctx), nil
+	})
+	require.NoError(t, first.GetWorkflowError())
+	var firstResult string
+	require.NoError(t, first.GetWorkflowResult(&firstResult))
+	require.Equal(t, "first", firstResult)
+
+	second := suite.NewTestWorkflowEnvironment()
+	second.ExecuteWorkflow(func(ctx workflow.Context) (string, error) {
+		return local.Get(ctx), nil
+	})
+	require.ErrorContains(t, second.GetWorkflowError(), "context belongs to a different workflow run")
+}
+
+func TestLocalVarQueryReadAndWrite(t *testing.T) {
+	const (
+		getQuery = "get-local-var"
+		setQuery = "set-local-var"
+	)
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+	var setQueryErr error
+	env.RegisterDelayedCallback(func() {
+		value, err := env.QueryWorkflow(getQuery)
+		require.NoError(t, err)
+		var result string
+		require.NoError(t, value.Get(&result))
+		require.Equal(t, "workflow", result)
+
+		_, setQueryErr = env.QueryWorkflow(setQuery)
+		env.SignalWorkflow("finish", nil)
+	}, time.Hour)
+
+	env.ExecuteWorkflow(func(ctx workflow.Context) error {
+		localVarString := workflow.NewLocalVar[string](ctx)
+		localVarString.Set(ctx, "workflow")
+		if err := workflow.SetQueryHandler(ctx, getQuery, func() (string, error) {
+			return localVarString.Get(ctx), nil
+		}); err != nil {
+			return err
+		}
+		if err := workflow.SetQueryHandler(ctx, setQuery, func() (string, error) {
+			localVarString.Set(ctx, "query")
+			return localVarString.Get(ctx), nil
+		}); err != nil {
+			return err
+		}
+		workflow.GetSignalChannel(ctx, "finish").Receive(ctx, nil)
+		return nil
+	})
+
+	require.NoError(t, env.GetWorkflowError())
+	require.Error(t, setQueryErr)
+	require.Contains(t, setQueryErr.Error(), "query handler must not use temporal context")
+}
+
+func TestLocalVarSetInSideEffectIsRejected(t *testing.T) {
+	tests := map[string]func(workflow.Context){
+		"SideEffect": func(ctx workflow.Context) {
+			localVarString := workflow.NewLocalVar[string](ctx)
+			workflow.SideEffect(ctx, func(ctx workflow.Context) any {
+				localVarString.Set(ctx, "side effect")
+				return nil
+			})
+		},
+		"MutableSideEffect": func(ctx workflow.Context) {
+			localVarString := workflow.NewLocalVar[string](ctx)
+			workflow.MutableSideEffect(ctx, "local-var", func(ctx workflow.Context) any {
+				localVarString.Set(ctx, "mutable side effect")
+				return nil
+			}, func(a, b any) bool { return a == b })
+		},
+	}
+
+	for name, run := range tests {
+		t.Run(name, func(t *testing.T) {
+			var suite testsuite.WorkflowTestSuite
+			env := suite.NewTestWorkflowEnvironment()
+			env.ExecuteWorkflow(func(ctx workflow.Context) error {
+				run(ctx)
+				return nil
+			})
+			require.Error(t, env.GetWorkflowError())
+		})
+	}
+}
+
+func TestLocalVarSetInUpdateValidatorIsRejected(t *testing.T) {
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+	env.RegisterDelayedCallback(func() {
+		env.UpdateWorkflow("update", "id", &testsuite.TestUpdateCallback{})
+	}, time.Second)
+	env.ExecuteWorkflow(func(ctx workflow.Context) error {
+		localVarString := workflow.NewLocalVar[string](ctx)
+		if err := workflow.SetUpdateHandlerWithOptions(ctx, "update", func(ctx workflow.Context) (string, error) {
+			return localVarString.Get(ctx), nil
+		}, workflow.UpdateHandlerOptions{
+			Validator: func(ctx workflow.Context) error {
+				localVarString.Set(ctx, "validator")
+				return nil
+			},
+		}); err != nil {
+			return err
+		}
+		return workflow.Sleep(ctx, time.Minute)
+	})
+
+	require.Error(t, env.GetWorkflowError())
+}

--- a/workflow/local_var_interceptor_test.go
+++ b/workflow/local_var_interceptor_test.go
@@ -1,0 +1,268 @@
+package workflow_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/interceptor"
+	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/worker"
+	"go.temporal.io/sdk/workflow"
+)
+
+const (
+	localVarQueryName    = "local-var"
+	localVarSetSignal    = "set-local-var"
+	localVarFinishSignal = "finish"
+)
+
+type localVarInterceptorContextKey struct{}
+
+func localVarFromInterceptorContext(ctx workflow.Context) workflow.LocalVar[string] {
+	return ctx.Value(localVarInterceptorContextKey{}).(workflow.LocalVar[string])
+}
+
+type executeLocalVarInterceptor struct {
+	interceptor.WorkerInterceptorBase
+	interceptValue string
+	executeValue   string
+}
+
+type executeLocalVarInboundInterceptor struct {
+	interceptor.WorkflowInboundInterceptorBase
+	control *executeLocalVarInterceptor
+	local   workflow.LocalVar[string]
+}
+
+func (i *executeLocalVarInterceptor) InterceptWorkflow(
+	ctx workflow.Context,
+	next interceptor.WorkflowInboundInterceptor,
+) interceptor.WorkflowInboundInterceptor {
+	local := workflow.NewLocalVar[string](ctx)
+	i.interceptValue = local.Get(ctx)
+	local.Set(ctx, "set-in-intercept")
+	return &executeLocalVarInboundInterceptor{
+		WorkflowInboundInterceptorBase: interceptor.WorkflowInboundInterceptorBase{Next: next},
+		control:                        i,
+		local:                          local,
+	}
+}
+
+func (i *executeLocalVarInboundInterceptor) ExecuteWorkflow(
+	ctx workflow.Context,
+	in *interceptor.ExecuteWorkflowInput,
+) (any, error) {
+	i.control.executeValue = i.local.Get(ctx)
+	i.local.Set(ctx, "set-in-execute")
+	return i.Next.ExecuteWorkflow(workflow.WithValue(ctx, localVarInterceptorContextKey{}, i.local), in)
+}
+
+type signalLocalVarInterceptor struct {
+	interceptor.WorkerInterceptorBase
+	beforeValue string
+	afterValue  string
+}
+
+type signalLocalVarInboundInterceptor struct {
+	interceptor.WorkflowInboundInterceptorBase
+	control *signalLocalVarInterceptor
+	local   workflow.LocalVar[string]
+}
+
+func (i *signalLocalVarInterceptor) InterceptWorkflow(
+	ctx workflow.Context,
+	next interceptor.WorkflowInboundInterceptor,
+) interceptor.WorkflowInboundInterceptor {
+	return &signalLocalVarInboundInterceptor{
+		WorkflowInboundInterceptorBase: interceptor.WorkflowInboundInterceptorBase{Next: next},
+		control:                        i,
+		local:                          workflow.NewLocalVar[string](ctx),
+	}
+}
+
+func (i *signalLocalVarInboundInterceptor) ExecuteWorkflow(
+	ctx workflow.Context,
+	in *interceptor.ExecuteWorkflowInput,
+) (any, error) {
+	return i.Next.ExecuteWorkflow(workflow.WithValue(ctx, localVarInterceptorContextKey{}, i.local), in)
+}
+
+func (i *signalLocalVarInboundInterceptor) HandleSignal(
+	ctx workflow.Context,
+	in *interceptor.HandleSignalInput,
+) error {
+	if in.SignalName == localVarSetSignal {
+		i.control.beforeValue = i.local.Get(ctx)
+		i.local.Set(ctx, "set-in-signal")
+		i.control.afterValue = i.local.Get(ctx)
+	}
+	return i.Next.HandleSignal(ctx, in)
+}
+
+type queryLocalVarInterceptor struct {
+	interceptor.WorkerInterceptorBase
+	queryRead string
+}
+
+type queryLocalVarInboundInterceptor struct {
+	interceptor.WorkflowInboundInterceptorBase
+	control *queryLocalVarInterceptor
+	local   workflow.LocalVar[string]
+}
+
+func (i *queryLocalVarInterceptor) InterceptWorkflow(
+	ctx workflow.Context,
+	next interceptor.WorkflowInboundInterceptor,
+) interceptor.WorkflowInboundInterceptor {
+	return &queryLocalVarInboundInterceptor{
+		WorkflowInboundInterceptorBase: interceptor.WorkflowInboundInterceptorBase{Next: next},
+		control:                        i,
+		local:                          workflow.NewLocalVar[string](ctx),
+	}
+}
+
+func (i *queryLocalVarInboundInterceptor) ExecuteWorkflow(
+	ctx workflow.Context,
+	in *interceptor.ExecuteWorkflowInput,
+) (any, error) {
+	return i.Next.ExecuteWorkflow(workflow.WithValue(ctx, localVarInterceptorContextKey{}, i.local), in)
+}
+
+func (i *queryLocalVarInboundInterceptor) HandleQuery(
+	ctx workflow.Context,
+	in *interceptor.HandleQueryInput,
+) (any, error) {
+	i.control.queryRead = i.local.Get(ctx)
+	return i.Next.HandleQuery(ctx, in)
+}
+
+func TestLocalVarExecuteWorkflowInterceptorValueIsVisibleToWorkflowCode(t *testing.T) {
+	workflowInterceptor := &executeLocalVarInterceptor{}
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+	env.SetWorkerOptions(worker.Options{
+		Interceptors: []interceptor.WorkerInterceptor{workflowInterceptor},
+	})
+
+	env.RegisterDelayedCallback(func() {
+		value, err := env.QueryWorkflow(localVarQueryName)
+		require.NoError(t, err)
+
+		var queried string
+		require.NoError(t, value.Get(&queried))
+		require.Equal(t, "set-in-execute", queried)
+
+		env.SignalWorkflow(localVarFinishSignal, nil)
+	}, time.Hour)
+
+	env.ExecuteWorkflow(func(ctx workflow.Context) (string, error) {
+		local := localVarFromInterceptorContext(ctx)
+		if err := workflow.SetQueryHandler(ctx, localVarQueryName, func() (string, error) {
+			return local.Get(ctx), nil
+		}); err != nil {
+			return "", err
+		}
+
+		workflow.GetSignalChannel(ctx, localVarFinishSignal).Receive(ctx, nil)
+		return local.Get(ctx), nil
+	})
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+
+	var result string
+	require.NoError(t, env.GetWorkflowResult(&result))
+	require.Equal(t, "set-in-execute", result)
+	require.Equal(t, "", workflowInterceptor.interceptValue)
+	require.Equal(t, "set-in-intercept", workflowInterceptor.executeValue)
+}
+func TestLocalVarSignalInterceptorWriteSurvivesDefaultSignalHandling(t *testing.T) {
+	signalInterceptor := &signalLocalVarInterceptor{}
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+	env.SetWorkerOptions(worker.Options{
+		Interceptors: []interceptor.WorkerInterceptor{signalInterceptor},
+	})
+
+	env.RegisterDelayedCallback(func() {
+		env.SignalWorkflow(localVarSetSignal, nil)
+	}, time.Hour)
+	env.RegisterDelayedCallback(func() {
+		value, err := env.QueryWorkflow(localVarQueryName)
+		require.NoError(t, err)
+
+		var queried string
+		require.NoError(t, value.Get(&queried))
+		require.Equal(t, "set-in-signal", queried)
+
+		env.SignalWorkflow(localVarFinishSignal, nil)
+	}, 2*time.Hour)
+
+	env.ExecuteWorkflow(func(ctx workflow.Context) (string, error) {
+		local := localVarFromInterceptorContext(ctx)
+		if err := workflow.SetQueryHandler(ctx, localVarQueryName, func() (string, error) {
+			return local.Get(ctx), nil
+		}); err != nil {
+			return "", err
+		}
+
+		workflow.GetSignalChannel(ctx, localVarSetSignal).Receive(ctx, nil)
+		workflow.GetSignalChannel(ctx, localVarFinishSignal).Receive(ctx, nil)
+		return local.Get(ctx), nil
+	})
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+
+	var result string
+	require.NoError(t, env.GetWorkflowResult(&result))
+	require.Equal(t, "set-in-signal", result)
+	require.Equal(t, "", signalInterceptor.beforeValue)
+	require.Equal(t, "set-in-signal", signalInterceptor.afterValue)
+}
+
+func TestLocalVarQueryInterceptorCanReadWorkflowScopedValue(t *testing.T) {
+	queryInterceptor := &queryLocalVarInterceptor{}
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+	env.SetWorkerOptions(worker.Options{
+		Interceptors: []interceptor.WorkerInterceptor{queryInterceptor},
+	})
+
+	env.RegisterDelayedCallback(func() {
+		value, err := env.QueryWorkflow(localVarQueryName)
+		require.NoError(t, err)
+
+		var queried string
+		require.NoError(t, value.Get(&queried))
+		require.Equal(t, "set-in-workflow", queried)
+		require.Equal(t, "set-in-workflow", queryInterceptor.queryRead)
+
+		env.SignalWorkflow(localVarFinishSignal, nil)
+	}, time.Hour)
+
+	env.ExecuteWorkflow(func(ctx workflow.Context) (string, error) {
+		local := localVarFromInterceptorContext(ctx)
+		local.Set(ctx, "set-in-workflow")
+
+		if err := workflow.SetQueryHandler(ctx, localVarQueryName, func() (string, error) {
+			return local.Get(ctx), nil
+		}); err != nil {
+			return "", err
+		}
+
+		workflow.GetSignalChannel(ctx, localVarFinishSignal).Receive(ctx, nil)
+		return local.Get(ctx), nil
+	})
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+
+	var result string
+	require.NoError(t, env.GetWorkflowResult(&result))
+	require.Equal(t, "set-in-workflow", result)
+}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Add workflow local

Fixes #1760 

## Why?
Support passing values between interceptors or the workflow

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New workflow state API affects determinism and interceptor patterns; incorrect use of Set in read-only handlers panics, and values are easy to misuse across runs if handles leak outside a single execution.
> 
> **Overview**
> Adds **`workflow.LocalVar[T]`** and **`workflow.NewLocalVar[T](ctx)`** so workflow code and workflow interceptors can share a type-safe, per-run value via a copyable handle (copies share identity).
> 
> Values live in an in-memory store attached when the workflow context is created; **`Set`** is blocked in read-only paths (queries, update validators, side effects), and misuse (uninitialized handle, wrong run’s context) panics. State is **not** carried into child workflows or **continue-as-new** runs.
> 
> The **doclink** tool now unwraps generic `internal.*[T]` types so exposed APIs like `NewLocalVar` get correct doc links. **CHANGELOG** documents the feature; coverage includes unit tests, interceptor tests, and integration tests (queries, updates, signals, parent/child isolation).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2be37d8156d72c284c5a3a46afa597c380127a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->