### PR TITLE
[Issue 2673]: fix update-with-start unknown update panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,14 @@ to docs, or any other relevant information.
 
 ### Fixed
 
+- Update-with-start no longer rejects the buffered update with
+  `unknown update ... KnownUpdates=[]` when a workflow inbound interceptor awaits a
+  local activity before `Next.ExecuteWorkflow`. `DrainUnhandledUpdates` is now gated
+  on the user workflow function having started (all inbound interceptors'
+  pre-`Next.ExecuteWorkflow` work complete), so buffered updates survive the
+  interceptor's initial local activity and are dispatched once the workflow registers
+  its handlers. Genuinely unknown updates are still rejected promptly once the workflow
+  function has started.
 - Local activity scheduling no longer uses a fixed 100,000-entry task queue. The queue now grows
   with demand, avoiding both the up-front allocation and a possible worker deadlock when the queue
   and all local activity execution slots were full.

--- a/internal/internal_workflow.go
+++ b/internal/internal_workflow.go
@@ -93,6 +93,12 @@ type (
 		// NewCoroutine creates a new coroutine. To be called from within another coroutine.
 		// Used by the interceptors.
 		NewCoroutine(ctx Context, name string, highPriority bool, f func(ctx Context)) Context
+
+		// SetWorkflowFunctionStarted marks that the user workflow function has started
+		// running (all inbound interceptors have finished any pre-Next.ExecuteWorkflow
+		// work). It gates DrainUnhandledUpdates so buffered updates are only rejected
+		// after the workflow has had a chance to register handlers.
+		SetWorkflowFunctionStarted()
 	}
 
 	// Workflow is an interface that any workflow should implement.
@@ -176,6 +182,14 @@ type (
 		// returns true if the callback updated any coroutines state and there may be more work
 		allBlockedCallback func() bool
 		newEagerCoroutines []*coroutineState
+		// workflowFunctionStarted is true once the innermost interceptor has invoked
+		// the user workflow function (so all inbound interceptors have finished any
+		// pre-Next.ExecuteWorkflow work). This variable gates allBlockedCallback
+		// (DrainUnhandledUpdates) so that buffered updates are only drained/rejected
+		// after the workflow function has had a chance to register its handlers,
+		// not merely because all coroutines are temporarily blocked in an interceptor
+		// before the workflow function has run.
+		workflowFunctionStarted bool
 	}
 
 	// WorkflowOptions options passed to the workflow function
@@ -1272,6 +1286,10 @@ func (d *dispatcherImpl) newState(name string, highPriority bool) *coroutineStat
 	return c
 }
 
+func (d *dispatcherImpl) SetWorkflowFunctionStarted() {
+	d.workflowFunctionStarted = true
+}
+
 func (d *dispatcherImpl) IsClosed() bool {
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
@@ -1296,8 +1314,12 @@ func (d *dispatcherImpl) ExecuteUntilAllBlocked(deadlockDetectionTimeout time.Du
 		d.mutex.Unlock()
 	}()
 	allBlocked := false
-	// Keep executing until at least one goroutine made some progress
-	for !allBlocked || d.allBlockedCallback() {
+	// Keep executing until at least one goroutine made some progress.
+	// Only invoke allBlockedCallback (DrainUnhandledUpdates) once the user
+	// workflow function has started (all inbound interceptors have finished).
+	// Draining earlier would reject buffered updates that are still waiting
+	// for the workflow to register their handlers.
+	for !allBlocked || (d.workflowFunctionStarted && d.allBlockedCallback()) {
 		d.coroutines = append(d.newEagerCoroutines, d.coroutines...)
 		d.newEagerCoroutines = nil
 		// Give every coroutine chance to execute removing closed ones
@@ -1839,6 +1861,8 @@ func setUpdateHandler(ctx Context, updateName string, handler any, opts UpdateHa
 	uh.dataConverter = GetWorkflowEnvironment(ctx).GetDataConverter()
 	uh.failureConverter = GetWorkflowEnvironment(ctx).GetFailureConverter()
 	eo.updateHandlers[updateName] = uh
+	// Mark that the workflow function has started registering handlers.
+	getWorkflowEnvironmentInterceptor(ctx).dispatcher.SetWorkflowFunctionStarted()
 	if GetWorkflowEnvironment(ctx).TryUse(SDKPriorityUpdateHandling) {
 		GetWorkflowEnvironment(ctx).HandleQueuedUpdates(updateName)
 		state := getState(ctx)

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -981,6 +981,10 @@ func (wc *workflowEnvironmentInterceptor) HandleQuery(ctx Context, in *HandleQue
 }
 
 func (wc *workflowEnvironmentInterceptor) ExecuteWorkflow(ctx Context, in *ExecuteWorkflowInput) (any, error) {
+	// Mark that the user workflow function is about to run. All inbound
+	// interceptors have finished any pre-Next.ExecuteWorkflow work.
+	wc.dispatcher.SetWorkflowFunctionStarted()
+
 	// Remove header from the context
 	ctx = workflowContextWithoutHeader(ctx)
 

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -247,7 +247,8 @@ func (ts *IntegrationTestSuite) SetupTest() {
 		options.WorkerStopTimeout = 10 * time.Second
 	}
 
-	if strings.Contains(ts.T().Name(), "ReplayerWithInterceptor") {
+	if strings.Contains(ts.T().Name(), "ReplayerWithInterceptor") ||
+		strings.Contains(ts.T().Name(), "UpdateWithStartWorkflowWithInterceptor") {
 		options.Interceptors = append(options.Interceptors, &localActivityInterceptor{})
 	}
 
@@ -5349,6 +5350,73 @@ func (ts *IntegrationTestSuite) TestUpdateWithStartWorkflow() {
 			"child_propagatedValue1", "child_propagatedValue2", "child_activity_propagatedValue1", "child_activity_propagatedValue2",
 		}, propagatedValues)
 	})
+}
+
+func (ts *IntegrationTestSuite) TestUpdateWithStartWorkflowWithInterceptor() {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	opts := ts.startWorkflowOptions("test-update-with-start-interceptor-" + uuid.NewString())
+	opts.WorkflowIDConflictPolicy = enumspb.WORKFLOW_ID_CONFLICT_POLICY_FAIL
+
+	startOp := ts.client.NewWithStartWorkflowOperation(opts, ts.workflows.UpdateEntityWorkflow)
+	updHandle, err := ts.client.UpdateWithStartWorkflow(ctx, client.UpdateWithStartWorkflowOptions{
+		UpdateOptions: client.UpdateWorkflowOptions{
+			UpdateName:   "update",
+			Args:         []any{1},
+			WaitForStage: client.WorkflowUpdateStageCompleted,
+		},
+		StartWorkflowOperation: startOp,
+	})
+	ts.NoError(err)
+
+	var updateResult int
+	ts.NoError(updHandle.Get(ctx, &updateResult))
+	ts.Equal(1, updateResult)
+
+	run, err := startOp.Get(ctx)
+	ts.NoError(err)
+	var workflowResult int
+	ts.NoError(run.Get(ctx, &workflowResult))
+	ts.Equal(1, workflowResult)
+}
+
+func (ts *IntegrationTestSuite) TestUpdateWithStartWorkflowWithInterceptorUnknownUpdate() {
+	// Regression test to verify that actually invalid update requests still fail
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	opts := ts.startWorkflowOptions("test-update-with-start-interceptor-unknown-" + uuid.NewString())
+	opts.WorkflowIDConflictPolicy = enumspb.WORKFLOW_ID_CONFLICT_POLICY_FAIL
+
+	startOp := ts.client.NewWithStartWorkflowOperation(opts, ts.workflows.UpdateEntityWorkflow)
+	handle, err := ts.client.UpdateWithStartWorkflow(ctx, client.UpdateWithStartWorkflowOptions{
+		UpdateOptions: client.UpdateWorkflowOptions{
+			UpdateName:   "bad update", // not registered by UpdateEntityWorkflow
+			Args:         []any{1},
+			WaitForStage: client.WorkflowUpdateStageCompleted,
+		},
+		StartWorkflowOperation: startOp,
+	})
+	ts.NoError(err)
+	ts.ErrorContains(handle.Get(ctx, nil), "unknown update")
+
+	// Clean up: drive the workflow to completion via the registered update.
+	run, err := startOp.Get(ctx)
+	ts.NoError(err)
+	updHandle, err := ts.client.UpdateWorkflow(ctx, client.UpdateWorkflowOptions{
+		WorkflowID:   run.GetID(),
+		RunID:        run.GetRunID(),
+		UpdateName:   "update",
+		Args:         []any{1},
+		WaitForStage: client.WorkflowUpdateStageCompleted,
+	})
+	ts.NoError(err)
+	var workflowResult int
+	ts.NoError(updHandle.Get(ctx, &workflowResult))
+	ts.Equal(1, workflowResult)
+	ts.NoError(run.Get(ctx, &workflowResult))
+	ts.Equal(1, workflowResult)
 }
 
 func (ts *IntegrationTestSuite) TestSessionOnWorkerFailure() {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Gated `DrainUnhandledUpdates` (the dispatcher's `allBlockedCallback`) on the user workflow function having started, so that buffered updates are only drained/rejected after the workflow has had a chance to register its update handlers.

Concretely, the dispatcher now tracks a `workflowFunctionStarted` flag that is set in two places:

- `workflowEnvironmentInterceptor.ExecuteWorkflow` — the innermost interceptor, right before it invokes the user workflow function via `executeFunction`. By this point all inbound interceptors have finished any pre-`Next.ExecuteWorkflow` work.
- `setUpdateHandler` — as a backup signal, so unit tests that exercise `defaultUpdateHandler`/`DrainUnhandledUpdates` directly (bypassing `ExecuteWorkflow`) still gate the drain correctly.

`ExecuteUntilAllBlocked` now invokes `allBlockedCallback` only when `workflowFunctionStarted` is true:

```go
for !allBlocked || (d.workflowFunctionStarted && d.allBlockedCallback()) {
```

A new `SetWorkflowFunctionStarted()` method was added to the `dispatcher` interface so the interceptor can set the flag without depending on the concrete `dispatcherImpl`.

## Why?
<!-- Tell your future self why have you made these changes -->

When a workflow inbound interceptor awaits a local activity in `ExecuteWorkflow` before calling `Next.ExecuteWorkflow` (a pattern Datadog uses for authorization checks), update-with-start fails on a fresh workflow with:

```
unknown update <name>. KnownUpdates=[]
```

Root cause: on the first (non-replay) workflow task of a fresh workflow, `TryUse(SDKPriorityUpdateHandling)` returns true, so `defaultUpdateHandler` queues the update rather than spawning `updateRunner`. The root coroutine then blocks on the interceptor's local activity before the user workflow function runs and registers its handlers. When all coroutines are blocked, `ExecuteUntilAllBlocked` invokes `allBlockedCallback` (`DrainUnhandledUpdates`), which unconditionally spawns the queued `updateRunner`. Because `priorityUpdateHandling` is true, `updateRunner` skips the "yield for initial handler registration" guard and rejects immediately — `eo.updateHandlers` is still empty.

The update is rejected by the SDK's own drain logic moments before the workflow function would have registered the handler, even though the local activity (e.g. a NoOp authz check) resolves instantly and the workflow function would have run in the same WFT.

This affects any setup where an inbound interceptor does blocking work before `Next.ExecuteWorkflow`, not just authorization. The previous behavior drained on every all-coroutines-blocked boundary (i.e. every WFT), which was too eager: it rejected updates that were legitimately still waiting for handler registration.

The narrower `workflowFunctionStarted` signal preserves the intent of `DrainUnhandledUpdates` (rejecting genuinely orphaned updates) while not rejecting updates the SDK just queued moments ago. Once the workflow function has started, any update not matching a registered handler is genuinely unknown and is still rejected promptly — including for long-running workflows that never return.

## Checklist
<!--- add/delete as needed --->

1. Closes [2673](https://github.com/temporalio/sdk-go/issues/2673)

2. How was this tested:
- Added `TestUpdateWithStartWorkflowWithInterceptor` — reproduces the bug using the existing `localActivityInterceptor` (which awaits a local activity before `Next.ExecuteWorkflow`) + `UpdateWithStartWorkflow` against `UpdateEntityWorkflow` (which registers an update handler as the first thing). Fails without the fix (`unknown update update. KnownUpdates=[]`), passes with it.
- Added `TestUpdateWithStartWorkflowWithInterceptorUnknownUpdate` — regression test for the too-broad alternative (gating on root coroutine completion). Sends an update-with-start with a name the workflow never registers against a long-running workflow (`UpdateEntityWorkflow` awaits `counter >= 1`). Must be rejected promptly with `unknown update`, not hang. Passes with `workflowFunctionStarted`; fails (server-side `UnprocessedUpdate` timeout) with a `rootClosed` gate.
- `go test ./internal/` (full unit suite) passes, including `TestDefaultUpdateHandler` which exercises `DrainUnhandledUpdates` directly (this required the `setUpdateHandler` backup signal).
- `go run . integration-test -dev-server -run "TestIntegrationSuite/TestUpdateWithStartWorkflowWithInterceptor"` passes.

3. Any docs updates needed?
- No public API changes. The `dispatcher` interface gained a method but it is internal. The behavior change is a bug fix and is covered by the existing guidance that update handlers should be registered early in the workflow function; this fix makes that guidance hold even when an interceptor blocks before the workflow function runs.
